### PR TITLE
Fix/inline with docs

### DIFF
--- a/memanto/app/clients/moorcheh.py
+++ b/memanto/app/clients/moorcheh.py
@@ -43,7 +43,7 @@ class MoorchehClientSingleton:
             if self._async_client is None:
                 self._async_client = AsyncMoorchehClient(api_key=settings.MOORCHEH_API_KEY)
             return self._async_client
-            
+
         return AsyncMoorchehClient(api_key=key_to_use)
 
     def reset_client(self):

--- a/memanto/app/clients/moorcheh.py
+++ b/memanto/app/clients/moorcheh.py
@@ -41,7 +41,9 @@ class MoorchehClientSingleton:
         # If using default key, use singleton
         if key_to_use == settings.MOORCHEH_API_KEY:
             if self._async_client is None:
-                self._async_client = AsyncMoorchehClient(api_key=settings.MOORCHEH_API_KEY)
+                self._async_client = AsyncMoorchehClient(
+                    api_key=settings.MOORCHEH_API_KEY
+                )
             return self._async_client
 
         return AsyncMoorchehClient(api_key=key_to_use)
@@ -56,15 +58,15 @@ class MoorchehClientSingleton:
 moorcheh_client = MoorchehClientSingleton()
 
 
-def get_moorcheh_client(api_key: str | DependsType = Depends(get_moorcheh_api_key)) -> MoorchehClient:
+def get_moorcheh_client(
+    api_key: str = Depends(get_moorcheh_api_key),
+) -> MoorchehClient:
     """Dependency injection function"""
-    if isinstance(api_key, DependsType):
-        api_key = None
     return moorcheh_client.get_client(api_key)
 
 
-def get_async_moorcheh_client(api_key: str | DependsType = Depends(get_moorcheh_api_key)) -> AsyncMoorchehClient:
+def get_async_moorcheh_client(
+    api_key: str = Depends(get_moorcheh_api_key),
+) -> AsyncMoorchehClient:
     """Dependency injection function for async client"""
-    if isinstance(api_key, DependsType):
-        api_key = None
     return moorcheh_client.get_async_client(api_key)

--- a/memanto/app/clients/moorcheh.py
+++ b/memanto/app/clients/moorcheh.py
@@ -3,7 +3,6 @@ Moorcheh Client Singleton
 """
 
 from fastapi import Depends
-from fastapi.params import Depends as DependsType
 from moorcheh_sdk import AsyncMoorchehClient, MoorchehClient
 
 from memanto.app.config import settings

--- a/memanto/app/clients/moorcheh.py
+++ b/memanto/app/clients/moorcheh.py
@@ -2,9 +2,12 @@
 Moorcheh Client Singleton
 """
 
+from fastapi import Depends
+from fastapi.params import Depends as DependsType
 from moorcheh_sdk import AsyncMoorchehClient, MoorchehClient
 
 from memanto.app.config import settings
+from memanto.app.routes.auth_deps import get_moorcheh_api_key
 
 
 class MoorchehClientSingleton:
@@ -19,17 +22,29 @@ class MoorchehClientSingleton:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def get_client(self) -> MoorchehClient:
+    def get_client(self, api_key: str | None = None) -> MoorchehClient:
         """Get or create Moorcheh client"""
-        if self._client is None:
-            self._client = MoorchehClient(api_key=settings.MOORCHEH_API_KEY)
-        return self._client
+        key_to_use = api_key or settings.MOORCHEH_API_KEY
 
-    def get_async_client(self) -> AsyncMoorchehClient:
+        # If using default key, use singleton
+        if key_to_use == settings.MOORCHEH_API_KEY:
+            if self._client is None:
+                self._client = MoorchehClient(api_key=settings.MOORCHEH_API_KEY)
+            return self._client
+
+        return MoorchehClient(api_key=key_to_use)
+
+    def get_async_client(self, api_key: str | None = None) -> AsyncMoorchehClient:
         """Get or create Async Moorcheh client"""
-        if self._async_client is None:
-            self._async_client = AsyncMoorchehClient(api_key=settings.MOORCHEH_API_KEY)
-        return self._async_client
+        key_to_use = api_key or settings.MOORCHEH_API_KEY
+
+        # If using default key, use singleton
+        if key_to_use == settings.MOORCHEH_API_KEY:
+            if self._async_client is None:
+                self._async_client = AsyncMoorchehClient(api_key=settings.MOORCHEH_API_KEY)
+            return self._async_client
+            
+        return AsyncMoorchehClient(api_key=key_to_use)
 
     def reset_client(self):
         """Reset client (useful for testing)"""
@@ -41,11 +56,15 @@ class MoorchehClientSingleton:
 moorcheh_client = MoorchehClientSingleton()
 
 
-def get_moorcheh_client() -> MoorchehClient:
+def get_moorcheh_client(api_key: str | DependsType = Depends(get_moorcheh_api_key)) -> MoorchehClient:
     """Dependency injection function"""
-    return moorcheh_client.get_client()
+    if isinstance(api_key, DependsType):
+        api_key = None
+    return moorcheh_client.get_client(api_key)
 
 
-def get_async_moorcheh_client() -> AsyncMoorchehClient:
+def get_async_moorcheh_client(api_key: str | DependsType = Depends(get_moorcheh_api_key)) -> AsyncMoorchehClient:
     """Dependency injection function for async client"""
-    return moorcheh_client.get_async_client()
+    if isinstance(api_key, DependsType):
+        api_key = None
+    return moorcheh_client.get_async_client(api_key)

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -41,9 +41,7 @@ app.include_router(
     namespaces.router, prefix="/api/v1/namespaces", tags=["Namespaces (Internal)"]
 )
 app.include_router(memory.router, prefix="/api/v1/memory", tags=["Memory (Internal)"])
-app.include_router(
-    context.router, prefix="/api/v2/context", tags=["Context"]
-)
+app.include_router(context.router, prefix="/api/v2/context", tags=["Context"])
 
 # Web UI Dashboard
 app.include_router(ui_router, tags=["Web UI"])

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -42,7 +42,7 @@ app.include_router(
 )
 app.include_router(memory.router, prefix="/api/v1/memory", tags=["Memory (Internal)"])
 app.include_router(
-    context.router, prefix="/api/v1/context", tags=["Context (Internal)"]
+    context.router, prefix="/api/v2/context", tags=["Context"]
 )
 
 # Web UI Dashboard

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -16,9 +16,9 @@ from memanto.app.utils.errors import (
 )
 
 
-def get_moorcheh_api_key(authorization: str = Header(...)) -> str:
+def get_moorcheh_api_key(authorization: str | None = Header(None)) -> str:
     """
-    Extract Moorcheh API key from Authorization header
+    Extract Moorcheh API key from Authorization header or use configured default
 
     Args:
         authorization: Authorization header (Bearer {api_key})
@@ -27,25 +27,31 @@ def get_moorcheh_api_key(authorization: str = Header(...)) -> str:
         API key
 
     Raises:
-        HTTPException: If authorization header is invalid
+        HTTPException: If authorization header is invalid or no key is found
     """
-    if not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid authorization header. Use: Bearer {api_key}",
-        )
+    if authorization:
+        if not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid authorization header. Use: Bearer {api_key}",
+            )
 
-    api_key = authorization.replace("Bearer ", "").strip()
-    if not api_key:
-        raise HTTPException(
-            status_code=401, detail="Missing API key in authorization header"
-        )
+        api_key = authorization.replace("Bearer ", "").strip()
+        if api_key:
+            return api_key
 
-    return api_key
+    from memanto.app.config import settings
+
+    if settings.MOORCHEH_API_KEY:
+        return settings.MOORCHEH_API_KEY
+
+    raise HTTPException(
+        status_code=401, detail="Missing API key in authorization header and no configured default"
+    )
 
 
 def get_current_session(
-    authorization: str = Header(...), x_session_token: str | None = Header(None)
+    authorization: str | None = Header(None), x_session_token: str | None = Header(None)
 ) -> Session:
     """
     Get and validate current session

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -46,13 +46,12 @@ def get_moorcheh_api_key(authorization: str | None = Header(None)) -> str:
         return settings.MOORCHEH_API_KEY
 
     raise HTTPException(
-        status_code=401, detail="Missing API key in authorization header and no configured default"
+        status_code=401,
+        detail="Missing API key in authorization header and no configured default",
     )
 
 
-async def verify_moorcheh_api_key(
-    api_key: str = Depends(get_moorcheh_api_key)
-) -> str:
+async def verify_moorcheh_api_key(api_key: str = Depends(get_moorcheh_api_key)) -> str:
     """
     Verify Moorcheh API key by making a lightweight request.
 
@@ -61,25 +60,22 @@ async def verify_moorcheh_api_key(
 
     Returns:
         The verified API key
-        
+
     Raises:
         HTTPException: If the API key is invalid or request fails
     """
-    from memanto.app.clients.moorcheh import get_async_moorcheh_client
     from moorcheh_sdk.exceptions import AuthenticationError
+
+    from memanto.app.clients.moorcheh import get_async_moorcheh_client
 
     client = get_async_moorcheh_client(api_key)
     try:
         await client.namespaces.list()
     except AuthenticationError:
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid Moorcheh API key"
-        )
+        raise HTTPException(status_code=401, detail="Invalid Moorcheh API key")
     except Exception as e:
         raise HTTPException(
-            status_code=500,
-            detail=f"Failed to verify Moorcheh API key: {str(e)}"
+            status_code=500, detail=f"Failed to verify Moorcheh API key: {str(e)}"
         )
     return api_key
 

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,7 +4,7 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
-from fastapi import Header, HTTPException
+from fastapi import Depends, Header, HTTPException
 
 from memanto.app.models.session import Session
 from memanto.app.services.session_service import get_session_service
@@ -48,6 +48,40 @@ def get_moorcheh_api_key(authorization: str | None = Header(None)) -> str:
     raise HTTPException(
         status_code=401, detail="Missing API key in authorization header and no configured default"
     )
+
+
+async def verify_moorcheh_api_key(
+    api_key: str = Depends(get_moorcheh_api_key)
+) -> str:
+    """
+    Verify Moorcheh API key by making a lightweight request.
+
+    Args:
+        api_key: The API key to verify
+
+    Returns:
+        The verified API key
+        
+    Raises:
+        HTTPException: If the API key is invalid or request fails
+    """
+    from memanto.app.clients.moorcheh import get_async_moorcheh_client
+    from moorcheh_sdk.exceptions import AuthenticationError
+
+    client = get_async_moorcheh_client(api_key)
+    try:
+        await client.namespaces.list()
+    except AuthenticationError:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid Moorcheh API key"
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to verify Moorcheh API key: {str(e)}"
+        )
+    return api_key
 
 
 def get_current_session(

--- a/memanto/app/routes/memory_v2.py
+++ b/memanto/app/routes/memory_v2.py
@@ -29,8 +29,8 @@ router = APIRouter()
 @router.post("/{agent_id}/remember")
 async def remember(
     agent_id: str,
+    content: str = Body(..., embed=True, description="Memory content"),
     memory_type: str = Query(..., description="Type of memory"),
-    content: str = Query(..., description="Memory content"),
     title: str | None = Query(None, description="Memory title (optional, defaults to truncated content)"),
     confidence: float = Query(0.8, description="Confidence score (0-1)"),
     tags: str | None = Query(None, description="Comma-separated tags"),

--- a/memanto/app/routes/memory_v2.py
+++ b/memanto/app/routes/memory_v2.py
@@ -30,7 +30,7 @@ router = APIRouter()
 async def remember(
     agent_id: str,
     content: str = Body(..., embed=True, description="Memory content"),
-    memory_type: str = Query(..., description="Type of memory"),
+    memory_type: str = Query("fact", description="Type of memory"),
     title: str | None = Query(
         None, description="Memory title (optional, defaults to truncated content)"
     ),

--- a/memanto/app/routes/memory_v2.py
+++ b/memanto/app/routes/memory_v2.py
@@ -31,7 +31,9 @@ async def remember(
     agent_id: str,
     content: str = Body(..., embed=True, description="Memory content"),
     memory_type: str = Query(..., description="Type of memory"),
-    title: str | None = Query(None, description="Memory title (optional, defaults to truncated content)"),
+    title: str | None = Query(
+        None, description="Memory title (optional, defaults to truncated content)"
+    ),
     confidence: float = Query(0.8, description="Confidence score (0-1)"),
     tags: str | None = Query(None, description="Comma-separated tags"),
     source: str = Query("agent", description="Source of memory"),
@@ -75,7 +77,9 @@ async def remember(
 
         from memanto.app.constants import MemoryType, ProvenanceType
 
-        resolved_title = title or (f"{content[:50]}..." if len(content) > 50 else content)
+        resolved_title = title or (
+            f"{content[:50]}..." if len(content) > 50 else content
+        )
 
         # Create memory record with scope fields and provenance
         memory = MemoryRecord(

--- a/memanto/app/routes/memory_v2.py
+++ b/memanto/app/routes/memory_v2.py
@@ -30,8 +30,8 @@ router = APIRouter()
 async def remember(
     agent_id: str,
     memory_type: str = Query(..., description="Type of memory"),
-    title: str = Query(..., description="Memory title"),
     content: str = Query(..., description="Memory content"),
+    title: str | None = Query(None, description="Memory title (optional, defaults to truncated content)"),
     confidence: float = Query(0.8, description="Confidence score (0-1)"),
     tags: str | None = Query(None, description="Comma-separated tags"),
     source: str = Query("agent", description="Source of memory"),
@@ -75,10 +75,12 @@ async def remember(
 
         from memanto.app.constants import MemoryType, ProvenanceType
 
+        resolved_title = title or (f"{content[:50]}..." if len(content) > 50 else content)
+
         # Create memory record with scope fields and provenance
         memory = MemoryRecord(
             type=cast(MemoryType, memory_type),
-            title=title,
+            title=resolved_title,
             content=content,
             scope_type="agent",
             scope_id=agent_id,

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -100,7 +100,7 @@ async def get_agent(
     return agent
 
 
-@router.delete("/agents/{agent_id}", status_code=204)
+@router.delete("/agents/{agent_id}", status_code=200)
 async def delete_agent(
     agent_id: str, moorcheh_api_key: str = Depends(get_moorcheh_api_key)
 ):
@@ -112,6 +112,7 @@ async def delete_agent(
     """
     try:
         agent_service.delete_agent(agent_id)
+        return {"message": f"Agent '{agent_id}' successfully deleted"}
     except AgentNotFoundError as e:
         raise map_error_to_http_exception(e)
 

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -33,7 +33,7 @@ router = APIRouter()
 from memanto.app.routes import memory_v2  # noqa: E402
 from memanto.app.routes.auth_deps import (  # noqa: E402
     get_current_session,
-    get_moorcheh_api_key,
+    verify_moorcheh_api_key,
     get_session_service,
 )
 
@@ -57,7 +57,7 @@ def get_agent_service():
 
 @router.post("/agents", response_model=AgentInfo, status_code=201)
 async def create_agent(
-    agent_create: AgentCreate, moorcheh_api_key: str = Depends(get_moorcheh_api_key)
+    agent_create: AgentCreate, moorcheh_api_key: str = Depends(verify_moorcheh_api_key)
 ):
     """
     Create a new MEMANTO agent
@@ -76,7 +76,7 @@ async def create_agent(
 
 
 @router.get("/agents", response_model=AgentList)
-async def list_agents(moorcheh_api_key: str = Depends(get_moorcheh_api_key)):
+async def list_agents(moorcheh_api_key: str = Depends(verify_moorcheh_api_key)):
     """
     List all agents for this Moorcheh account
 
@@ -87,7 +87,7 @@ async def list_agents(moorcheh_api_key: str = Depends(get_moorcheh_api_key)):
 
 @router.get("/agents/{agent_id}", response_model=AgentInfo)
 async def get_agent(
-    agent_id: str, moorcheh_api_key: str = Depends(get_moorcheh_api_key)
+    agent_id: str, moorcheh_api_key: str = Depends(verify_moorcheh_api_key)
 ):
     """
     Get agent information
@@ -102,7 +102,7 @@ async def get_agent(
 
 @router.delete("/agents/{agent_id}", status_code=200)
 async def delete_agent(
-    agent_id: str, moorcheh_api_key: str = Depends(get_moorcheh_api_key)
+    agent_id: str, moorcheh_api_key: str = Depends(verify_moorcheh_api_key)
 ):
     """
     Delete agent
@@ -126,7 +126,7 @@ async def delete_agent(
 async def activate_agent(
     agent_id: str,
     session_create: SessionCreate | None = None,
-    moorcheh_api_key: str = Depends(get_moorcheh_api_key),
+    moorcheh_api_key: str = Depends(verify_moorcheh_api_key),
 ):
     """
     Activate agent and start session
@@ -175,7 +175,7 @@ async def activate_agent(
 
 @router.post("/agents/{agent_id}/deactivate", response_model=SessionSummary)
 async def deactivate_agent(
-    agent_id: str, moorcheh_api_key: str = Depends(get_moorcheh_api_key)
+    agent_id: str, moorcheh_api_key: str = Depends(verify_moorcheh_api_key)
 ):
     """
     Deactivate agent and end session
@@ -230,7 +230,7 @@ async def extend_session(
 
 
 @router.get("/sessions", response_model=list[Session])
-async def list_sessions(moorcheh_api_key: str = Depends(get_moorcheh_api_key)):
+async def list_sessions(moorcheh_api_key: str = Depends(verify_moorcheh_api_key)):
     """
     List all sessions
 

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -33,8 +33,8 @@ router = APIRouter()
 from memanto.app.routes import memory_v2  # noqa: E402
 from memanto.app.routes.auth_deps import (  # noqa: E402
     get_current_session,
-    verify_moorcheh_api_key,
     get_session_service,
+    verify_moorcheh_api_key,
 )
 
 router.include_router(

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -44,7 +44,6 @@ async def get_ui_config():
 
     return {
         "api_key_configured": bool(api_key),
-        "api_key": api_key,
         "api_key_preview": f"{api_key[:8]}...{api_key[-4:]}"
         if api_key and len(api_key) > 12
         else ("***" if api_key else None),
@@ -60,7 +59,6 @@ async def get_ui_config():
         "schedule_time": schedule_time,
         "active_agent_id": active_agent_id,
         "has_active_session": bool(active_session_token),
-        "session_token": active_session_token,
     }
 
 

--- a/memanto/cli/commands/connect.py
+++ b/memanto/cli/commands/connect.py
@@ -431,9 +431,6 @@ def connect_remove(
     all_agents: bool = typer.Option(
         False, "--all", help="Remove MEMANTO from all agents"
     ),
-    force: bool = typer.Option(
-        False, "--force", "-f", help="Skip confirmation"
-    ),
 ):
     """Remove MEMANTO integration from an agent.
 
@@ -443,10 +440,7 @@ def connect_remove(
         memanto connect remove --all
     """
     if all_agents:
-        scope = "globally" if is_global else f"in {Path(project_dir).resolve()}"
-        if not force and not typer.confirm(f"Remove MEMANTO from ALL agents {scope}?"):
-            raise typer.Exit(0)
-
+        "globally" if is_global else f"in {Path(project_dir).resolve()}"
         agents_to_remove = [a.name for a in list_agents()]
     elif agent_name:
         if agent_name not in AGENT_REGISTRY:

--- a/memanto/cli/commands/connect.py
+++ b/memanto/cli/commands/connect.py
@@ -431,6 +431,9 @@ def connect_remove(
     all_agents: bool = typer.Option(
         False, "--all", help="Remove MEMANTO from all agents"
     ),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Skip confirmation"
+    ),
 ):
     """Remove MEMANTO integration from an agent.
 
@@ -441,7 +444,7 @@ def connect_remove(
     """
     if all_agents:
         scope = "globally" if is_global else f"in {Path(project_dir).resolve()}"
-        if not typer.confirm(f"Remove MEMANTO from ALL agents {scope}?"):
+        if not force and not typer.confirm(f"Remove MEMANTO from ALL agents {scope}?"):
             raise typer.Exit(0)
 
         agents_to_remove = [a.name for a in list_agents()]

--- a/memanto/cli/commands/schedule.py
+++ b/memanto/cli/commands/schedule.py
@@ -2,6 +2,7 @@
 MEMANTO CLI - Schedule commands (enable, disable, status).
 """
 
+import typer
 from rich.panel import Panel
 
 from memanto.cli.commands._shared import (
@@ -32,8 +33,13 @@ def schedule_enable():
 
 
 @schedule_app.command("disable")
-def schedule_disable():
+def schedule_disable(
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+):
     """Disable auto-generated daily summaries."""
+
+    if not force and not typer.confirm("Disable automatic daily summaries?"):
+        raise typer.Exit(0)
 
     manager = ScheduleManager()
     result = manager.disable()

--- a/memanto/cli/commands/schedule.py
+++ b/memanto/cli/commands/schedule.py
@@ -2,7 +2,6 @@
 MEMANTO CLI - Schedule commands (enable, disable, status).
 """
 
-import typer
 from rich.panel import Panel
 
 from memanto.cli.commands._shared import (
@@ -33,13 +32,8 @@ def schedule_enable():
 
 
 @schedule_app.command("disable")
-def schedule_disable(
-    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
-):
+def schedule_disable():
     """Disable auto-generated daily summaries."""
-
-    if not force and not typer.confirm("Disable automatic daily summaries?"):
-        raise typer.Exit(0)
 
     manager = ScheduleManager()
     result = manager.disable()

--- a/memanto/cli/commands/session.py
+++ b/memanto/cli/commands/session.py
@@ -68,9 +68,13 @@ def session_info():
 
 @session_app.command("extend")
 def session_extend(
-    hours: int = typer.Option(4, "--hours", "-h", help="Number of hours to extend"),
+    hours: int = typer.Option(6, "--hours", "-h", help="Number of hours to extend"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
 ):
     """Extend the current session."""
+    if not force and not typer.confirm(f"Extend current session by {hours} hours?"):
+        raise typer.Exit(0)
+
     active_agent_id, _ = config_manager.get_active_session()
 
     if not active_agent_id:

--- a/memanto/cli/commands/session.py
+++ b/memanto/cli/commands/session.py
@@ -69,12 +69,8 @@ def session_info():
 @session_app.command("extend")
 def session_extend(
     hours: int = typer.Option(6, "--hours", "-h", help="Number of hours to extend"),
-    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
 ):
     """Extend the current session."""
-    if not force and not typer.confirm(f"Extend current session by {hours} hours?"):
-        raise typer.Exit(0)
-
     active_agent_id, _ = config_manager.get_active_session()
 
     if not active_agent_id:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -75,15 +75,17 @@ def mock_moorcheh():
     with (
         patch("memanto.app.services.agent_service.MoorchehClient") as mock_agent_client,
         patch("memanto.app.clients.moorcheh.MoorchehClient") as mock_moorcheh_cls,
+        patch("memanto.app.clients.moorcheh.AsyncMoorchehClient") as mock_async_moorcheh_cls,
     ):
         # Setup mock instance
         mock_instance = MagicMock()
         mock_agent_client.return_value = mock_instance
         mock_moorcheh_cls.return_value = mock_instance
+        mock_async_moorcheh_cls.return_value = mock_instance
 
         # Default mock returns
         mock_instance.namespaces.create.return_value = {"status": "created"}
-        mock_instance.namespaces.list.return_value = {"namespaces": []}
+        mock_instance.namespaces.list = AsyncMock(return_value={"namespaces": []})
 
         yield mock_instance
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -75,7 +75,9 @@ def mock_moorcheh():
     with (
         patch("memanto.app.services.agent_service.MoorchehClient") as mock_agent_client,
         patch("memanto.app.clients.moorcheh.MoorchehClient") as mock_moorcheh_cls,
-        patch("memanto.app.clients.moorcheh.AsyncMoorchehClient") as mock_async_moorcheh_cls,
+        patch(
+            "memanto.app.clients.moorcheh.AsyncMoorchehClient"
+        ) as mock_async_moorcheh_cls,
     ):
         # Setup mock instance
         mock_instance = MagicMock()
@@ -167,10 +169,14 @@ class TestMEMANTOAPI:
         params = {
             "memory_type": "fact",
             "title": "API Test",
-            "content": "Testing the API with mocks",
             "confidence": 0.9,
         }
-        response = await client.post(remember_url, headers=headers, params=params)
+        json_body = {
+            "content": "Testing the API with mocks",
+        }
+        response = await client.post(
+            remember_url, headers=headers, params=params, json=json_body
+        )
 
         assert response.status_code == 200
         assert response.json()["status"] == "queued"
@@ -258,7 +264,7 @@ class TestMEMANTOAPI:
             "/api/v2/agents", headers=auth_headers, json={"agent_id": "to-delete"}
         )
         response = await client.delete("/api/v2/agents/to-delete", headers=auth_headers)
-        assert response.status_code == 204
+        assert response.status_code == 200
 
     @pytest.mark.asyncio
     async def test_deactivate_agent(self, client, auth_headers):


### PR DESCRIPTION
- Remember api optional title and memory type, title defaults to first 50 characters of content
- Remember api moves query from query param to json body
- Expose context endpoints as v2 over v1
- Remove untruncated api key and session token from config
- Give response for api agent deletion
- Api key now authorized for calls which don't use SDK
- Api key optional, defaults to memanto configuration