### PR TITLE
examples: add CrewAI + Memanto memory demo

### DIFF
--- a/examples/crewai_memanto_memory_demo/.env.example
+++ b/examples/crewai_memanto_memory_demo/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env for local testing if you prefer not to export variables.
+# Never commit your real .env file.
+
+MOORCHEH_API_KEY=replace-with-your-moorcheh-api-key
+
+# Optional. Required only for:
+#   python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --use-real-crewai
+OPENAI_API_KEY=replace-with-your-openai-api-key

--- a/examples/crewai_memanto_memory_demo/CURSOR.md
+++ b/examples/crewai_memanto_memory_demo/CURSOR.md
@@ -1,0 +1,28 @@
+# Cursor Notes
+
+Open the repository root in Cursor, then focus on:
+
+- `examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py`
+- `examples/crewai_memanto_memory_demo/README.md`
+- `examples/crewai_memanto_memory_demo/demo_transcript.txt`
+
+Safe prompt to extend the demo:
+
+```text
+Improve the CrewAI + Memanto demo without changing repo-wide config. Keep all
+changes inside examples/crewai_memanto_memory_demo. Preserve the real Memanto
+SDK/service integration, keep credentials in environment variables, and update
+README.md plus SUBMISSION_NOTES.md for any behavior changes.
+```
+
+How Cursor can use Memanto notes for this project:
+
+1. Run the store phase after setting `MOORCHEH_API_KEY`.
+2. Ask Cursor to inspect the recalled context from the terminal output.
+3. If you add a new scenario, store the decision or outcome with
+   `memory_type="decision"` or `memory_type="artifact"`.
+4. Keep any generated `.env`, casts, logs, or recordings out of git unless they
+   are intentional documentation artifacts.
+
+No global Cursor configuration is required for this bonus. This file is scoped
+to the example so it does not affect contributors who do not use Cursor.

--- a/examples/crewai_memanto_memory_demo/README.md
+++ b/examples/crewai_memanto_memory_demo/README.md
@@ -1,0 +1,205 @@
+# CrewAI + Memanto Agentic Memory Demo
+
+This example demonstrates a CrewAI-style two-agent workflow where Memanto is the
+durable memory layer:
+
+- Session 1: a Research Agent stores findings, a user preference, and a task
+  outcome in Memanto.
+- Session 2: a Writer Agent starts later, receives no Python variables from
+  Session 1, recalls the prior context through Memanto, and drafts from that
+  recalled context.
+- Contradiction test: an old tone preference is superseded by a corrected
+  preference. The demo uses Memanto's real storage and current-only recall path.
+
+The default path is deterministic and recording-friendly. It does not require an
+LLM key. The optional `--use-real-crewai` path runs a real CrewAI kickoff after
+Memanto recall and requires an LLM configuration such as `OPENAI_API_KEY`.
+
+## Why Memanto Helps CrewAI
+
+CrewAI's standard memory is useful during a crew run, but long-lived agent
+workflows often need memory that survives process exits, separate sessions, and
+handoffs between agents. Memanto gives the crew a persistent, searchable memory
+namespace:
+
+1. Before a task, call Memanto recall and hydrate the task context.
+2. After a task, call Memanto remember and persist findings, preferences,
+   decisions, and task outcomes.
+3. For changed facts, store a corrected memory and prefer current-only recall.
+
+## Setup
+
+Requirements:
+
+- Python 3.10 to 3.12
+- A Moorcheh API key for Memanto storage and recall
+- Optional: `OPENAI_API_KEY` for the LLM-backed CrewAI kickoff
+
+From the repository root:
+
+```bash
+python -m venv .venv
+.venv\Scripts\activate
+python -m pip install -e .
+python -m pip install -r examples/crewai_memanto_memory_demo/requirements.txt
+```
+
+Set credentials in your shell. Do not commit `.env` or real keys.
+
+PowerShell:
+
+```powershell
+$env:MOORCHEH_API_KEY="your-moorcheh-api-key"
+$env:OPENAI_API_KEY="your-openai-api-key" # optional
+```
+
+macOS/Linux:
+
+```bash
+export MOORCHEH_API_KEY="your-moorcheh-api-key"
+export OPENAI_API_KEY="your-openai-api-key" # optional
+```
+
+You can also copy `.env.example` to `.env` for local testing. Keep `.env`
+untracked.
+
+## Run Commands
+
+Full deterministic demo:
+
+```bash
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase full-demo --simulate-24h
+```
+
+Separate cross-session flow:
+
+```bash
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase store
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall --simulate-24h
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase update
+```
+
+Use an isolated namespace while recording:
+
+```bash
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase full-demo --namespace crewai-memanto-recording
+```
+
+Optional LLM-backed CrewAI kickoff:
+
+```bash
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall --use-real-crewai
+```
+
+## Expected Output
+
+The store phase prints lines like:
+
+```text
+[Session 1] Research Agent storing findings in Memanto
+[Memanto] Stored memory: fact id=...
+[Memanto] Stored memory: preference id=...
+[Memanto] Stored memory: artifact id=...
+```
+
+The recall phase prints lines like:
+
+```text
+[Session 2] Writer Agent recalling Memanto memory (24 hours later)
+[Boundary] No Session 1 Python variables are used in this phase.
+[Memanto] Retrieved memories from durable storage:
+[Writer Agent] Draft based only on recalled Memanto context:
+```
+
+If credentials are missing, the script exits cleanly with setup instructions
+instead of a stack trace.
+
+## Recording Visual Proof
+
+Recommended Loom flow:
+
+1. Open a terminal at the repository root.
+2. Start a 30 to 60 second Loom recording.
+3. Run:
+
+```bash
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase store --namespace crewai-memanto-recording
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall --simulate-24h --namespace crewai-memanto-recording
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase update --namespace crewai-memanto-recording
+```
+
+Asciinema alternative:
+
+```bash
+asciinema rec crewai_memanto_demo.cast
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase store --namespace crewai-memanto-recording
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall --simulate-24h --namespace crewai-memanto-recording
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase update --namespace crewai-memanto-recording
+exit
+```
+
+## Swapping CrewAI Memory For Memanto
+
+Before, standard CrewAI memory is configured on the crew:
+
+```python
+from crewai import Crew, Process
+
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, writing_task],
+    process=Process.sequential,
+    memory=True,
+)
+```
+
+After, Memanto becomes the durable memory layer around each task:
+
+```python
+memory = MemantoCrewMemory(
+    agent_id="crewai-production-memory",
+    api_key=os.environ["MOORCHEH_API_KEY"],
+)
+
+recalled = memory.recall(
+    "customer support automation research findings and preferences",
+    memory_types=["fact", "preference", "artifact"],
+)
+context = "\n".join(item["content"] for item in recalled)
+
+writing_task.description = (
+    "Use this recalled Memanto context before drafting:\n"
+    f"{context}\n\n"
+    f"{writing_task.description}"
+)
+
+result = crew.kickoff()
+
+memory.remember(
+    MemoryPayload(
+        title="Writer task outcome",
+        content=f"Writer Agent completed the launch note: {result}",
+        memory_type="artifact",
+        tags=["writer", "task-outcome"],
+        source="writer-agent",
+    )
+)
+```
+
+For changed facts, this demo stores a corrected memory with supersession
+metadata and uses current-only recall. The high-level `memanto remember` command
+does not expose every supersession field yet, so the example uses Memanto's real
+`MemoryRecord` and `MemoryWriteService` for that small metadata step.
+
+## Limitations
+
+- `MOORCHEH_API_KEY` is required for real Memanto storage and recall.
+- `OPENAI_API_KEY` is required only for `--use-real-crewai`.
+- The deterministic mode proves the memory layer without paying for LLM calls.
+- The example does not delete cloud memories. Use a unique `--namespace` for
+  repeat recordings.
+- Visual proof still needs to be recorded manually with Loom, Asciinema, or GIF
+  tooling after credentials are configured.
+- Local no-key validation covered `compileall`, `--help`, and graceful
+  `MOORCHEH_API_KEY` setup failure. Credentialed store/recall/update phases must
+  be run after configuring a real key.

--- a/examples/crewai_memanto_memory_demo/SUBMISSION_NOTES.md
+++ b/examples/crewai_memanto_memory_demo/SUBMISSION_NOTES.md
@@ -1,0 +1,105 @@
+# Submission Notes
+
+## Files Added
+
+- `crewai_memanto_memory_demo.py`: runnable CLI demo for store, recall, update,
+  and full-demo phases.
+- `README.md`: setup, run commands, expected output, recording instructions, and
+  CrewAI memory swap guide.
+- `requirements.txt`: optional demo dependency on CrewAI and dotenv.
+- `.env.example`: safe environment variable template with no secrets.
+- `demo_transcript.txt`: exact command flow and expected terminal proof shape.
+- `CURSOR.md`: Cursor bonus guidance for opening and extending the example.
+
+## What Changed And Why
+
+The change is scoped to a new example folder. It does not alter Memanto core
+behavior. The example uses Memanto's real SDK client and service layer to store
+and recall memories, then shows how a CrewAI task can be hydrated with recalled
+Memanto context.
+
+## Bounty Criteria Mapping
+
+- Working script: `crewai_memanto_memory_demo.py` exposes `--phase store`,
+  `--phase recall`, `--phase update`, and `--phase full-demo`.
+- Memory test: the store and recall phases are separate commands. The recall
+  phase re-instantiates the adapter and prints that it does not use Session 1
+  Python variables.
+- Visual proof support: `README.md` and `demo_transcript.txt` include the exact
+  Loom/Asciinema command sequence to record.
+- How-to README: the README includes before/after CrewAI memory code and the
+  Memanto recall-before-task, remember-after-task adapter pattern.
+- Contradictory memories bonus: `--phase update` stores an old preference,
+  stores a corrected preference with supersession metadata, and recalls current
+  preferences.
+- Cursor bonus: `CURSOR.md` explains safe Cursor usage without repo-wide config.
+
+## Commands Run During Testing
+
+Local environment: Windows PowerShell, Python 3.11.0.
+
+```bash
+python -m compileall examples/crewai_memanto_memory_demo
+```
+
+Result: passed after allowing normal bytecode atomic writes. The sandboxed
+attempt failed because Windows rename operations were blocked.
+
+```bash
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --help
+```
+
+Result: passed. The CLI showed `--phase`, `--namespace`, `--topic`,
+`--simulate-24h`, `--use-real-crewai`, and `--limit`.
+
+```powershell
+$env:MOORCHEH_API_KEY='';
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase store
+```
+
+Result: expected graceful setup failure. The script printed instructions for
+setting `MOORCHEH_API_KEY` and did not show a stack trace.
+
+```bash
+python -m ruff check examples/crewai_memanto_memory_demo
+```
+
+Result: not run. `ruff` is not installed in this Python environment.
+
+```bash
+pytest
+python -m pytest
+```
+
+Result: not run. `pytest` is not installed in this Python environment.
+
+Credentialed commands not run in this environment because `MOORCHEH_API_KEY` is
+not configured:
+
+```bash
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase store
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall --simulate-24h
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase update
+python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase full-demo
+```
+
+## Known Limitations
+
+- A real `MOORCHEH_API_KEY` is required to prove cloud-backed Memanto storage
+  and recall.
+- `OPENAI_API_KEY` is required only for `--use-real-crewai`.
+- The deterministic mode proves the memory layer and agent handoff without LLM
+  spend.
+- The high-level Memanto CLI does not expose every supersession metadata field,
+  so the demo uses the real lower-level Memanto `MemoryRecord` and
+  `MemoryWriteService` for corrected memory metadata.
+- Visual proof still must be recorded manually after credentials are configured.
+
+## What Must Not Be Claimed
+
+- Do not claim the Loom/Asciinema proof is complete until the recording link is
+  added.
+- Do not claim LLM-backed CrewAI kickoff was tested unless
+  `--use-real-crewai` was run with an LLM key.
+- Do not claim real Memanto storage/recall passed unless the store, recall, and
+  update phases were run with a valid `MOORCHEH_API_KEY`.

--- a/examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py
+++ b/examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""CrewAI + Memanto durable memory demo.
+
+This example keeps imports lazy so ``--help`` works before optional demo
+dependencies are installed. Real Memanto calls are made through this repo's
+SDK client and service layer when ``MOORCHEH_API_KEY`` is configured.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import textwrap
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_NAMESPACE = "crewai-memanto-bounty-demo"
+DEFAULT_TOPIC = "AI customer support automation"
+VALID_PHASES = ("store", "recall", "update", "full-demo")
+
+
+class DemoSetupError(RuntimeError):
+    """Raised when the local environment is not ready to run the demo."""
+
+
+@dataclass(frozen=True)
+class MemoryPayload:
+    """A typed memory the demo persists in Memanto."""
+
+    title: str
+    content: str
+    memory_type: str
+    tags: list[str]
+    source: str
+    confidence: float = 0.9
+    provenance: str = "explicit_statement"
+
+
+class MemantoCrewMemory:
+    """Small adapter that uses Memanto as CrewAI's durable memory layer.
+
+    CrewAI's built-in memory is useful inside a Crew run. This adapter shows the
+    swap pattern: recall Memanto context before a task, and remember task output
+    after a task. It intentionally delegates storage/search to real Memanto code.
+    """
+
+    def __init__(self, agent_id: str, api_key: str) -> None:
+        self.agent_id = sanitize_agent_id(agent_id)
+        self.api_key = api_key
+        self.namespace = f"memanto_agent_{self.agent_id}"
+        self.client = self._build_client()
+        self._ensure_agent_session()
+
+    def remember(self, payload: MemoryPayload) -> dict[str, Any]:
+        """Store a normal memory through Memanto's public SDK client method."""
+        return self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=payload.memory_type,
+            title=payload.title,
+            content=payload.content,
+            confidence=payload.confidence,
+            tags=payload.tags,
+            source=payload.source,
+            provenance=payload.provenance,
+        )
+
+    def remember_with_supersession(
+        self,
+        payload: MemoryPayload,
+        *,
+        supersedes_memory_id: str,
+        superseded_payload: MemoryPayload,
+    ) -> dict[str, Any]:
+        """Store a corrected memory and mark the older memory as superseded.
+
+        Memanto exposes temporal/current-only recall and supports supersession
+        metadata on ``MemoryRecord``. The high-level ``remember`` command does
+        not currently accept supersession fields, so this example uses the repo's
+        real lower-level ``MemoryWriteService`` for that metadata and documents
+        the limitation in README.md.
+        """
+        from memanto.app.core import MemoryRecord
+
+        self.client._get_validated_session_for_agent(self.agent_id)
+        write_service = self.client._get_write_service()
+
+        corrected = MemoryRecord(
+            type=payload.memory_type,
+            title=payload.title,
+            content=payload.content,
+            scope_type="agent",
+            scope_id=self.agent_id,
+            actor_id=self.agent_id,
+            confidence=payload.confidence,
+            tags=payload.tags,
+            source=payload.source,
+            provenance=payload.provenance,
+            supersedes=supersedes_memory_id,
+        )
+        result = write_service.store_memory(corrected)
+        new_memory_id = str(result["id"])
+
+        superseded = MemoryRecord(
+            id=supersedes_memory_id,
+            type=superseded_payload.memory_type,
+            title=superseded_payload.title,
+            content=superseded_payload.content,
+            scope_type="agent",
+            scope_id=self.agent_id,
+            actor_id=self.agent_id,
+            confidence=0.2,
+            status="superseded",
+            tags=superseded_payload.tags + ["superseded"],
+            source=superseded_payload.source,
+            provenance="corrected",
+            superseded_by=new_memory_id,
+            contradiction_detected=True,
+        )
+
+        warning = None
+        try:
+            write_service.delete_memory(supersedes_memory_id, self.namespace)
+        except Exception as exc:  # pragma: no cover - depends on remote service
+            warning = f"Old memory delete was not confirmed: {exc}"
+
+        write_service.store_memory(superseded)
+
+        return {
+            "memory_id": new_memory_id,
+            "supersedes": supersedes_memory_id,
+            "namespace": self.namespace,
+            "warning": warning,
+        }
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int = 6,
+        memory_types: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Recall memories through Memanto semantic search."""
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            memory_types=memory_types,
+        )
+        return list(result.get("memories", []))
+
+    def recall_current(
+        self,
+        query: str,
+        *,
+        limit: int = 6,
+        memory_types: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Recall current, non-superseded memories through Memanto."""
+        result = self.client.recall_current(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            memory_types=memory_types,
+        )
+        return list(result.get("memories", []))
+
+    def _build_client(self) -> Any:
+        try:
+            from memanto.cli.client.sdk_client import SdkClient
+        except ImportError as exc:
+            raise DemoSetupError(
+                "Memanto dependencies are not installed. From the repo root run:\n"
+                "  python -m pip install -e .\n"
+                "  python -m pip install -r "
+                "examples/crewai_memanto_memory_demo/requirements.txt"
+            ) from exc
+
+        os.environ["MOORCHEH_API_KEY"] = self.api_key
+        return SdkClient(self.api_key)
+
+    def _ensure_agent_session(self) -> None:
+        try:
+            self.client.get_agent(self.agent_id)
+        except Exception:
+            self.client.create_agent(
+                self.agent_id,
+                pattern="project",
+                description="CrewAI + Memanto cross-session bounty demo",
+            )
+
+        self.client.activate_agent(self.agent_id, duration_hours=6)
+
+
+def sanitize_agent_id(raw_agent_id: str) -> str:
+    """Keep agent IDs compatible with Memanto namespace constraints."""
+    cleaned = []
+    for char in raw_agent_id.strip():
+        if char.isalnum() or char in {"-", "_"}:
+            cleaned.append(char)
+        elif char.isspace():
+            cleaned.append("-")
+    agent_id = "".join(cleaned).strip("-_")
+    if not agent_id:
+        raise DemoSetupError("Namespace must contain letters or numbers.")
+    return agent_id
+
+
+def load_dotenv_if_present() -> None:
+    """Load .env for local demos when python-dotenv is installed."""
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
+    load_dotenv()
+
+
+def build_adapter(namespace: str) -> MemantoCrewMemory:
+    api_key = os.environ.get("MOORCHEH_API_KEY", "").strip()
+    if not api_key:
+        raise DemoSetupError(
+            "MOORCHEH_API_KEY is not set.\n"
+            "Create a Moorcheh API key, then set it only in your shell:\n"
+            "  PowerShell: $env:MOORCHEH_API_KEY=\"your-moorcheh-api-key\"\n"
+            "  macOS/Linux: export MOORCHEH_API_KEY=\"your-moorcheh-api-key\"\n"
+            "No API key is required for --help."
+        )
+    return MemantoCrewMemory(namespace, api_key)
+
+
+def research_memories(topic: str) -> list[MemoryPayload]:
+    safe_topic = topic.strip()
+    return [
+        MemoryPayload(
+            title=f"{safe_topic}: automation findings",
+            content=(
+                f"Research finding for {safe_topic}: support teams should route "
+                "refund, onboarding, and billing questions through separate agent "
+                "tools. Escalation rules should be explicit before automation."
+            ),
+            memory_type="fact",
+            tags=["crewai-demo", "research", "memory-test"],
+            source="research-agent",
+            confidence=0.92,
+        ),
+        MemoryPayload(
+            title=f"{safe_topic}: writer preference",
+            content=(
+                f"User preference for {safe_topic}: write the final brief in a "
+                "concise founder-friendly tone with concrete implementation steps."
+            ),
+            memory_type="preference",
+            tags=["crewai-demo", "preference", "writer-brief"],
+            source="research-agent",
+            confidence=0.95,
+        ),
+        MemoryPayload(
+            title=f"{safe_topic}: task outcome",
+            content=(
+                f"Task outcome for {safe_topic}: Research Agent completed the "
+                "discovery pass and asked Writer Agent to draft a buyer-facing "
+                "launch note using recalled Memanto context."
+            ),
+            memory_type="artifact",
+            tags=["crewai-demo", "task-outcome", "handoff"],
+            source="research-agent",
+            confidence=0.9,
+        ),
+    ]
+
+
+def print_banner(title: str) -> None:
+    print()
+    print("=" * 72)
+    print(title)
+    print("=" * 72)
+
+
+def print_memory(memory: dict[str, Any], index: int) -> None:
+    title = memory.get("title") or "Untitled"
+    memory_type = memory.get("type") or "unknown"
+    memory_id = memory.get("id") or "unknown"
+    score = memory.get("score")
+    content = compact(memory.get("content") or memory.get("text") or "")
+    print(f"  {index}. [{memory_type}] {title}")
+    print(f"     id={memory_id}")
+    if score is not None:
+        print(f"     score={score}")
+    print(f"     {content}")
+
+
+def compact(value: str, width: int = 120) -> str:
+    return textwrap.shorten(" ".join(value.split()), width=width, placeholder="...")
+
+
+def phase_store(args: argparse.Namespace) -> None:
+    memory = build_adapter(args.namespace)
+    print_banner("[Session 1] Research Agent storing findings in Memanto")
+    print("[CrewAI role] Research Agent")
+    print(f"[Memanto] agent={memory.agent_id} namespace={memory.namespace}")
+    print(f"[Topic] {args.topic}")
+
+    for payload in research_memories(args.topic):
+        result = memory.remember(payload)
+        print(
+            "[Memanto] Stored memory: "
+            f"{payload.memory_type} id={result.get('memory_id', 'unknown')}"
+        )
+
+    print()
+    print("[Session 1] Complete. Start a later run with:")
+    print(
+        "  python examples/crewai_memanto_memory_demo/"
+        "crewai_memanto_memory_demo.py --phase recall"
+    )
+
+
+def phase_recall(args: argparse.Namespace) -> None:
+    memory = build_adapter(args.namespace)
+    delay_label = "24 hours later" if args.simulate_24h else "later session"
+    print_banner(f"[Session 2] Writer Agent recalling Memanto memory ({delay_label})")
+    print("[CrewAI role] Writer Agent")
+    print("[Boundary] No Session 1 Python variables are used in this phase.")
+    print("[Memanto] Running semantic recall for prior research and preferences.")
+
+    query = (
+        f"{args.topic} research findings writer preference task outcome "
+        "founder-friendly launch note"
+    )
+    memories = memory.recall(query, limit=args.limit)
+    if not memories:
+        print("[Memanto] No memories found.")
+        print("Run --phase store first with the same --namespace and --topic.")
+        return
+
+    print("[Memanto] Retrieved memories from durable storage:")
+    for index, item in enumerate(memories, 1):
+        print_memory(item, index)
+
+    print()
+    current_preferences = memory.recall_current(
+        f"{args.topic} writer tone preference",
+        limit=3,
+        memory_types=["preference"],
+    )
+    chosen_preference = choose_current_preference(current_preferences or memories)
+    print("[Writer Agent] Current preference used:")
+    print(f"  {compact(chosen_preference)}")
+
+    writer_brief = build_writer_brief(args.topic, memories, chosen_preference)
+    print()
+    print("[Writer Agent] Draft based only on recalled Memanto context:")
+    print(textwrap.indent(writer_brief, "  "))
+
+    if args.use_real_crewai:
+        run_real_crewai_writer(args.topic, memories, chosen_preference)
+
+
+def phase_update(args: argparse.Namespace) -> None:
+    memory = build_adapter(args.namespace)
+    print_banner("[Contradiction Test] Updating an old preference in Memanto")
+    print("[Memanto] Storing old preference first.")
+
+    old_preference = MemoryPayload(
+        title=f"{args.topic}: old tone preference",
+        content=(
+            f"Preference key demo-tone for {args.topic}: Writer Agent should "
+            "use a technical deep-dive tone with detailed implementation notes."
+        ),
+        memory_type="preference",
+        tags=["crewai-demo", "demo-tone", "old-preference"],
+        source="research-agent",
+        confidence=0.86,
+    )
+    old_result = memory.remember(old_preference)
+    old_memory_id = str(old_result.get("memory_id", "unknown"))
+    print(f"[Memanto] Stored old preference id={old_memory_id}")
+
+    print("[Memanto] Storing corrected preference with supersession metadata.")
+    new_preference = MemoryPayload(
+        title=f"{args.topic}: current tone preference",
+        content=(
+            f"Preference key demo-tone for {args.topic}: CURRENT preference is "
+            "a concise founder-friendly tone with concrete next steps. This "
+            f"supersedes memory {old_memory_id}."
+        ),
+        memory_type="preference",
+        tags=["crewai-demo", "demo-tone", "current-preference"],
+        source="writer-agent",
+        confidence=0.97,
+        provenance="corrected",
+    )
+    new_result = memory.remember_with_supersession(
+        new_preference,
+        supersedes_memory_id=old_memory_id,
+        superseded_payload=old_preference,
+    )
+    print(
+        "[Memanto] Stored corrected preference "
+        f"id={new_result.get('memory_id', 'unknown')}"
+    )
+    if new_result.get("warning"):
+        print(f"[Memanto] Warning: {new_result['warning']}")
+
+    print("[Memanto] Recalling current-only preferences.")
+    current = memory.recall_current(
+        f"{args.topic} demo-tone current preference",
+        limit=args.limit,
+        memory_types=["preference"],
+    )
+    if not current:
+        print("[Memanto] No current preferences found.")
+        return
+
+    print("[Result] Current preferences returned by Memanto:")
+    for index, item in enumerate(current, 1):
+        print_memory(item, index)
+
+    print()
+    print("[Result] Latest preference used:")
+    print(f"  {compact(choose_current_preference(current))}")
+
+
+def phase_full_demo(args: argparse.Namespace) -> None:
+    print_banner("[Full Demo] CrewAI + Memanto durable memory")
+    phase_store(args)
+    print()
+    print("[Demo] Re-instantiating adapter to simulate a new run/session.")
+    if args.simulate_24h:
+        print("[Demo] Simulating the recall step as 24 hours later.")
+    phase_recall(args)
+    phase_update(args)
+
+
+def choose_current_preference(memories: list[dict[str, Any]]) -> str:
+    if not memories:
+        return "No preference recalled."
+
+    def rank(memory: dict[str, Any]) -> tuple[int, str]:
+        content = str(memory.get("content") or memory.get("text") or "")
+        title = str(memory.get("title") or "")
+        tags = ",".join(str(tag) for tag in memory.get("tags") or [])
+        haystack = f"{title} {content} {tags}".lower()
+        current_score = 1 if "current" in haystack else 0
+        created = str(memory.get("created_at") or memory.get("updated_at") or "")
+        return current_score, created
+
+    selected = sorted(memories, key=rank, reverse=True)[0]
+    return str(selected.get("content") or selected.get("text") or selected)
+
+
+def build_writer_brief(
+    topic: str,
+    memories: list[dict[str, Any]],
+    preference: str,
+) -> str:
+    bullets = []
+    for memory in memories[:3]:
+        content = memory.get("content") or memory.get("text") or ""
+        if content:
+            bullets.append(f"- {compact(str(content), width=100)}")
+    if not bullets:
+        bullets.append("- No recalled research was available.")
+
+    return "\n".join(
+        [
+            f"Brief for {topic}:",
+            f"Preference: {compact(preference, width=100)}",
+            "Use these recalled points:",
+            *bullets,
+            "Recommendation: ship a scoped agent workflow, persist outcomes in "
+            "Memanto, and recall them before Writer Agent drafts follow-ups.",
+        ]
+    )
+
+
+def run_real_crewai_writer(
+    topic: str,
+    memories: list[dict[str, Any]],
+    preference: str,
+) -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise DemoSetupError(
+            "--use-real-crewai requires OPENAI_API_KEY or a CrewAI-supported "
+            "LLM configuration. Deterministic Memanto recall already ran."
+        )
+
+    try:
+        from crewai import Agent, Crew, Process, Task
+    except ImportError as exc:
+        raise DemoSetupError(
+            "CrewAI is not installed. Run:\n"
+            "  python -m pip install -r "
+            "examples/crewai_memanto_memory_demo/requirements.txt"
+        ) from exc
+
+    recalled_context = "\n".join(
+        f"- {item.get('content') or item.get('text')}" for item in memories[:5]
+    )
+    writer = Agent(
+        role="Writer Agent",
+        goal="Write a concise brief from durable Memanto memory.",
+        backstory=(
+            "You are a careful writer. You only use the recalled Memanto "
+            "context passed into the task."
+        ),
+        verbose=True,
+    )
+    task = Task(
+        description=(
+            f"Topic: {topic}\n"
+            f"Current preference: {preference}\n"
+            f"Memanto recalled context:\n{recalled_context}\n\n"
+            "Write a short launch brief grounded in the recalled context."
+        ),
+        expected_output="A concise launch brief with 3 bullets.",
+        agent=writer,
+    )
+    crew = Crew(
+        agents=[writer],
+        tasks=[task],
+        process=Process.sequential,
+        memory=False,
+        verbose=True,
+    )
+    print()
+    print("[CrewAI] Running optional LLM-backed Crew kickoff.")
+    result = crew.kickoff()
+    print("[CrewAI] Result:")
+    print(textwrap.indent(str(result), "  "))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="CrewAI + Memanto cross-session memory demo",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """
+            Examples:
+              python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase store
+              python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall --simulate-24h
+              python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase update
+              python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase full-demo
+            """
+        ).strip(),
+    )
+    parser.add_argument(
+        "--phase",
+        choices=VALID_PHASES,
+        default="full-demo",
+        help="Which demo phase to run.",
+    )
+    parser.add_argument(
+        "--namespace",
+        default=DEFAULT_NAMESPACE,
+        help="Memanto agent id/namespace suffix for isolating demo memories.",
+    )
+    parser.add_argument(
+        "--topic",
+        default=DEFAULT_TOPIC,
+        help="Research topic used for stored and recalled memories.",
+    )
+    parser.add_argument(
+        "--simulate-24h",
+        action="store_true",
+        help="Label recall output as a later 24-hour session.",
+    )
+    parser.add_argument(
+        "--use-real-crewai",
+        action="store_true",
+        help="After Memanto recall, run an optional LLM-backed CrewAI kickoff.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=6,
+        help="Maximum Memanto recall results to display.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_dotenv_if_present()
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.phase == "store":
+            phase_store(args)
+        elif args.phase == "recall":
+            phase_recall(args)
+        elif args.phase == "update":
+            phase_update(args)
+        elif args.phase == "full-demo":
+            phase_full_demo(args)
+        else:  # pragma: no cover - argparse prevents this
+            parser.error(f"Unknown phase: {args.phase}")
+    except DemoSetupError as exc:
+        print()
+        print("[Setup Required]")
+        print(str(exc))
+        return 2
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/crewai_memanto_memory_demo/demo_transcript.txt
+++ b/examples/crewai_memanto_memory_demo/demo_transcript.txt
@@ -1,0 +1,66 @@
+Sample recording transcript. This is the intended flow to record after setting
+MOORCHEH_API_KEY. Memory IDs and scores will differ on each run.
+
+$ python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase store --namespace crewai-memanto-recording
+
+========================================================================
+[Session 1] Research Agent storing findings in Memanto
+========================================================================
+[CrewAI role] Research Agent
+[Memanto] agent=crewai-memanto-recording namespace=memanto_agent_crewai-memanto-recording
+[Topic] AI customer support automation
+[Memanto] Stored memory: fact id=<memory-id>
+[Memanto] Stored memory: preference id=<memory-id>
+[Memanto] Stored memory: artifact id=<memory-id>
+
+[Session 1] Complete. Start a later run with:
+  python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall
+
+$ python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall --simulate-24h --namespace crewai-memanto-recording
+
+========================================================================
+[Session 2] Writer Agent recalling Memanto memory (24 hours later)
+========================================================================
+[CrewAI role] Writer Agent
+[Boundary] No Session 1 Python variables are used in this phase.
+[Memanto] Running semantic recall for prior research and preferences.
+[Memanto] Retrieved memories from durable storage:
+  1. [fact] AI customer support automation: automation findings
+     id=<memory-id>
+     Research finding for AI customer support automation: ...
+  2. [preference] AI customer support automation: writer preference
+     id=<memory-id>
+     User preference for AI customer support automation: ...
+  3. [artifact] AI customer support automation: task outcome
+     id=<memory-id>
+     Task outcome for AI customer support automation: ...
+
+[Writer Agent] Current preference used:
+  User preference for AI customer support automation: write the final brief...
+
+[Writer Agent] Draft based only on recalled Memanto context:
+  Brief for AI customer support automation:
+  Preference: User preference for AI customer support automation...
+  Use these recalled points:
+  - Research finding for AI customer support automation...
+  - User preference for AI customer support automation...
+  - Task outcome for AI customer support automation...
+  Recommendation: ship a scoped agent workflow, persist outcomes in Memanto...
+
+$ python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase update --namespace crewai-memanto-recording
+
+========================================================================
+[Contradiction Test] Updating an old preference in Memanto
+========================================================================
+[Memanto] Storing old preference first.
+[Memanto] Stored old preference id=<old-memory-id>
+[Memanto] Storing corrected preference with supersession metadata.
+[Memanto] Stored corrected preference id=<new-memory-id>
+[Memanto] Recalling current-only preferences.
+[Result] Current preferences returned by Memanto:
+  1. [preference] AI customer support automation: current tone preference
+     id=<new-memory-id>
+     Preference key demo-tone for AI customer support automation: CURRENT...
+
+[Result] Latest preference used:
+  Preference key demo-tone for AI customer support automation: CURRENT...

--- a/examples/crewai_memanto_memory_demo/requirements.txt
+++ b/examples/crewai_memanto_memory_demo/requirements.txt
@@ -1,0 +1,2 @@
+crewai>=0.150.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
Closes #37

## Summary

- Add a CrewAI + Memanto example demonstrating durable cross-session memory.
- Session 1 stores research findings, preference, and task outcome.
- Session 2 recalls via Memanto and drafts from retrieved context.
- Add contradictory preference update using supersession metadata/current-only recall.
- Include recording flow, README swap guide, and Cursor notes.

## Testing

- `python -m compileall examples/crewai_memanto_memory_demo`
- `python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --help`
- `python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase store --namespace princess-bounty37-demo`
- `python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase recall --namespace princess-bounty37-demo --simulate-24h`
- `python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase update --namespace princess-bounty37-demo`
- `python examples/crewai_memanto_memory_demo/crewai_memanto_memory_demo.py --phase full-demo --namespace princess-bounty37-demo --simulate-24h`

Visual proof: https://www.loom.com/share/8ddb1a8329294ab8bde913a128c57277