### PR TITLE
Add LangGraph Memanto example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ cython_debug/
 *.db
 *.sqlite
 *.sqlite3
+examples/langgraph-memanto/.local_memanto_review_store.json
 
 # Logs
 logs/

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,80 @@
+# LangGraph + Memanto: Cross-Session Recall
+
+This example shows a LangGraph agent using Memanto as its long-term memory
+layer. The graph runs in two simulated sessions:
+
+1. Session 1 stores user preferences and support context in Memanto.
+2. Session 2 starts with an empty LangGraph state and recalls those memories
+   from Memanto before generating a response.
+
+The important point is that the remembered facts are not passed through
+LangGraph state. They live outside the graph in Memanto and are retrieved in a
+later session.
+
+## What It Demonstrates
+
+- Cross-session recall with fresh LangGraph state.
+- Memanto as an external memory layer, not a state checkpoint.
+- Typed memories for preference, fact, and goal records.
+- A deterministic demo that can run without an LLM key.
+- A local fallback store for quick review when `MOORCHEH_API_KEY` is not set.
+
+## Install
+
+From the repository root:
+
+```bash
+python -m venv .venv
+.venv\Scripts\activate
+pip install -e .
+pip install -r examples/langgraph-memanto/requirements.txt
+```
+
+On macOS/Linux, use `source .venv/bin/activate`.
+
+## Run With Memanto
+
+Set your Moorcheh key, then run the demo:
+
+```bash
+set MOORCHEH_API_KEY=your_key_here
+python examples/langgraph-memanto/run_demo.py
+```
+
+On macOS/Linux:
+
+```bash
+export MOORCHEH_API_KEY=your_key_here
+python examples/langgraph-memanto/run_demo.py
+```
+
+The script creates or reuses the `langgraph-customer-success-demo` Memanto
+agent, stores memories in one session, then creates a new graph state and
+recalls them in another session.
+
+## Run In Local Review Mode
+
+If `MOORCHEH_API_KEY` is missing, the example automatically uses a small local
+JSON memory store at `.local_memanto_review_store.json`. This keeps the graph
+easy to review while preserving the same `remember`, `recall`, and `answer`
+interface used by the real Memanto-backed adapter.
+
+```bash
+python examples/langgraph-memanto/run_demo.py
+```
+
+## Expected Output
+
+The second session should answer with details from the first session, including:
+
+- the customer prefers concise updates,
+- the customer is on the Pro plan,
+- the current goal is resolving invoice export errors.
+
+Those facts are not present in the second session's initial graph state.
+
+## Files
+
+- `run_demo.py` - LangGraph workflow and demo runner.
+- `memanto_memory.py` - Memanto adapter plus local review fallback.
+- `requirements.txt` - Extra dependencies for this example.

--- a/examples/langgraph-memanto/memanto_memory.py
+++ b/examples/langgraph-memanto/memanto_memory.py
@@ -1,0 +1,156 @@
+"""Memory adapter used by the LangGraph + Memanto example.
+
+The real adapter delegates to Memanto's SdkClient. The fallback adapter keeps
+the example runnable for reviewers who do not have a Moorcheh API key handy.
+Both adapters expose the same tiny surface: remember, recall, and answer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class MemoryClient(Protocol):
+    """Small memory interface consumed by the LangGraph nodes."""
+
+    def remember(
+        self,
+        memory_type: str,
+        title: str,
+        content: str,
+        tags: list[str] | None = None,
+    ) -> None:
+        """Persist one memory."""
+
+    def recall(self, query: str, limit: int = 5) -> list[dict[str, Any]]:
+        """Return relevant memories."""
+
+    def answer(self, question: str, limit: int = 5) -> str:
+        """Answer a question from memory context."""
+
+
+@dataclass
+class MemantoMemoryClient:
+    """Adapter around the repository's Memanto SDK client."""
+
+    api_key: str
+    agent_id: str
+    _client: Any = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self._client = SdkClient(self.api_key)
+        try:
+            self._client.create_agent(
+                agent_id=self.agent_id,
+                pattern="support",
+                description="LangGraph customer-success demo memory.",
+            )
+        except Exception:
+            # Reusing an existing demo agent is expected during repeated runs.
+            pass
+        self._client.activate_agent(self.agent_id)
+
+    def remember(
+        self,
+        memory_type: str,
+        title: str,
+        content: str,
+        tags: list[str] | None = None,
+    ) -> None:
+        self._client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory_type,
+            title=title,
+            content=content,
+            confidence=0.9,
+            tags=tags or ["langgraph-demo"],
+            source="langgraph-demo",
+        )
+
+    def recall(self, query: str, limit: int = 5) -> list[dict[str, Any]]:
+        result = self._client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+        )
+        return result.get("memories", [])
+
+    def answer(self, question: str, limit: int = 5) -> str:
+        result = self._client.answer(
+            agent_id=self.agent_id,
+            question=question,
+            limit=limit,
+        )
+        return result.get("answer", "No answer generated.")
+
+
+@dataclass
+class LocalReviewMemoryClient:
+    """Tiny local fallback with the same interface as the Memanto adapter."""
+
+    store_path: Path
+    agent_id: str
+
+    def _load(self) -> list[dict[str, Any]]:
+        if not self.store_path.exists():
+            return []
+        return json.loads(self.store_path.read_text(encoding="utf-8"))
+
+    def _save(self, memories: list[dict[str, Any]]) -> None:
+        self.store_path.write_text(json.dumps(memories, indent=2), encoding="utf-8")
+
+    def remember(
+        self,
+        memory_type: str,
+        title: str,
+        content: str,
+        tags: list[str] | None = None,
+    ) -> None:
+        memories = self._load()
+        memories.append(
+            {
+                "agent_id": self.agent_id,
+                "type": memory_type,
+                "title": title,
+                "content": content,
+                "tags": tags or ["langgraph-demo"],
+            }
+        )
+        self._save(memories)
+
+    def recall(self, query: str, limit: int = 5) -> list[dict[str, Any]]:
+        query_terms = {term.lower() for term in query.split() if len(term) > 2}
+        scored = []
+        for memory in self._load():
+            text = f"{memory['title']} {memory['content']}".lower()
+            score = sum(1 for term in query_terms if term in text)
+            if score:
+                scored.append((score, memory))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+    def answer(self, question: str, limit: int = 5) -> str:
+        memories = self.recall(question, limit=limit)
+        if not memories:
+            return "I do not have any relevant memories yet."
+        facts = "; ".join(memory["content"] for memory in memories)
+        return f"Based on persistent memory: {facts}"
+
+
+def create_memory_client(agent_id: str) -> MemoryClient:
+    """Create a real Memanto client when possible, otherwise local review mode."""
+
+    api_key = os.getenv("MOORCHEH_API_KEY")
+    if api_key:
+        return MemantoMemoryClient(api_key=api_key, agent_id=agent_id)
+
+    return LocalReviewMemoryClient(
+        store_path=Path(__file__).with_name(".local_memanto_review_store.json"),
+        agent_id=agent_id,
+    )

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,2 @@
+langgraph>=0.2.60
+langchain-core>=0.3.0

--- a/examples/langgraph-memanto/run_demo.py
+++ b/examples/langgraph-memanto/run_demo.py
@@ -1,0 +1,107 @@
+"""LangGraph workflow backed by Memanto long-term memory."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from langgraph.graph import END, StateGraph
+
+from memanto_memory import MemoryClient, create_memory_client
+
+
+AGENT_ID = "langgraph-customer-success-demo"
+
+
+class SupportState(TypedDict, total=False):
+    """State carried by one LangGraph run."""
+
+    user_message: str
+    recalled_memories: list[dict]
+    response: str
+
+
+def build_graph(memory: MemoryClient):
+    """Build the support-agent graph with Memanto memory nodes."""
+
+    def remember_customer_context(state: SupportState) -> SupportState:
+        memory.remember(
+            "preference",
+            "Customer communication style",
+            "The customer prefers concise status updates with next steps first.",
+            tags=["customer-success", "preference"],
+        )
+        memory.remember(
+            "fact",
+            "Customer plan",
+            "The customer is on the Pro plan and exports invoices weekly.",
+            tags=["customer-success", "billing"],
+        )
+        memory.remember(
+            "goal",
+            "Current support goal",
+            "Resolve invoice export errors before the customer's Friday finance review.",
+            tags=["customer-success", "invoice-export"],
+        )
+        return state
+
+    def recall_customer_context(state: SupportState) -> SupportState:
+        query = state["user_message"]
+        memories = memory.recall(query, limit=5)
+        return {**state, "recalled_memories": memories}
+
+    def draft_response(state: SupportState) -> SupportState:
+        question = (
+            "How should we respond to this customer using their remembered "
+            f"context? Customer message: {state['user_message']}"
+        )
+        answer = memory.answer(question, limit=5)
+        return {**state, "response": answer}
+
+    graph = StateGraph(SupportState)
+    graph.add_node("remember_customer_context", remember_customer_context)
+    graph.add_node("recall_customer_context", recall_customer_context)
+    graph.add_node("draft_response", draft_response)
+
+    graph.set_entry_point("remember_customer_context")
+    graph.add_edge("remember_customer_context", END)
+
+    memory_graph = graph.compile()
+
+    recall_graph = StateGraph(SupportState)
+    recall_graph.add_node("recall_customer_context", recall_customer_context)
+    recall_graph.add_node("draft_response", draft_response)
+    recall_graph.set_entry_point("recall_customer_context")
+    recall_graph.add_edge("recall_customer_context", "draft_response")
+    recall_graph.add_edge("draft_response", END)
+
+    return memory_graph, recall_graph.compile()
+
+
+def run_demo() -> None:
+    """Run two sessions to prove the memory is outside LangGraph state."""
+
+    memory = create_memory_client(AGENT_ID)
+    store_graph, recall_graph = build_graph(memory)
+
+    print("Session 1: storing customer context in Memanto")
+    store_graph.invoke({"user_message": "Store support context for ACME Finance."})
+
+    print("\nSession 2: new graph state, recalling yesterday's context")
+    second_session_state = {
+        "user_message": (
+            "The customer asks for an update about invoice export errors. "
+            "What should we say?"
+        )
+    }
+    result = recall_graph.invoke(second_session_state)
+
+    print("\nRecalled memories:")
+    for memory_item in result.get("recalled_memories", []):
+        print(f"- [{memory_item.get('type', 'memory')}] {memory_item.get('content')}")
+
+    print("\nResponse:")
+    print(result["response"])
+
+
+if __name__ == "__main__":
+    run_demo()


### PR DESCRIPTION
## Summary

Adds `examples/langgraph-memanto`, a LangGraph example that uses Memanto as the external long-term memory layer for a customer-success agent.

The demo runs in two sessions:

- Session 1 stores typed customer memories in Memanto.
- Session 2 starts with a fresh LangGraph state, recalls the stored memories, and drafts a response from the recalled context.

This directly demonstrates cross-session recall without passing the remembered facts through LangGraph state.

## Details

- Adds a `MemoryClient` protocol consumed by LangGraph nodes.
- Adds a real `MemantoMemoryClient` adapter around the repository's `SdkClient`.
- Adds a local review fallback so maintainers can run the example without a `MOORCHEH_API_KEY`.
- Documents install steps, real Memanto mode, and local review mode.

## Verification

```bash
python -m py_compile examples/langgraph-memanto/memanto_memory.py examples/langgraph-memanto/run_demo.py
python examples/langgraph-memanto/run_demo.py
```

Local review-mode output confirms the second session recalls:

- concise status update preference,
- Pro plan / weekly invoice export context,
- invoice export error resolution goal.

## Bounty

For BountyHub issue #397: LangGraph + Memanto integration challenge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a LangGraph + Memanto example demonstrating long-term memory integration across sessions.
  * Includes a runnable demo with optional local fallback mode for testing without an API key.

* **Documentation**
  * Added README documenting the example setup, installation, and usage instructions.

* **Chores**
  * Updated dependencies and gitignore configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->