### PR TITLE
feat(examples): add LangGraph Memanto demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ MANIFEST
 # Virtual environments
 venv/
 .venv/
+.venv-*/
 ENV/
 env/
 .env/
@@ -101,6 +102,7 @@ temp/
 *.bak
 *.swp
 *.swo
+.local_memanto_demo.json
 
 # Generated version file
 **/_version.py

--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,0 +1,8 @@
+MOORCHEH_API_KEY=your_moorcheh_api_key_here
+
+# Optional: switch to local JSON storage for a no-key dry run.
+# The real bounty demo should leave this unset so Memanto is used.
+# MEMANTO_DEMO_BACKEND=local
+
+# Optional: isolate demo memories per fork, PR, or recording.
+# MEMANTO_AGENT_ID=langgraph-support-agent

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,144 @@
+# LangGraph + Memanto: Cross-Session Agent Memory
+
+This example shows a LangGraph support agent using **Memanto** as its
+long-term memory layer. LangGraph manages the current turn state, while
+Memanto stores durable memories that survive across separate Python
+processes and separate graph invocations.
+
+## What This Demonstrates
+
+- **Cross-session recall**: `run_day2_recall.py` starts with an empty graph
+  state but remembers facts stored by `run_day1_store.py`.
+- **Memory outside LangGraph state**: durable customer preferences live in
+  Memanto, not in the `SupportState` object.
+- **Typed semantic memory**: preferences, facts, and events are stored with
+  Memanto memory types, confidence scores, and tags.
+- **Minimal LangGraph wiring**: a small `StateGraph` keeps the example focused
+  on the integration pattern.
+- **No external LLM key required**: the graph uses deterministic nodes so the
+  memory behavior is easy to inspect and record.
+
+## Architecture
+
+```text
+Session 1                         Persistent Memory              Session 2
+---------                         -----------------              ---------
+LangGraph state                   Memanto namespace              New LangGraph state
+  incoming message  ----remember-> customer facts/preferences
+  generated reply                                                 incoming message
+                                                                  recall ---->
+                                                                  personalized reply
+```
+
+The graph uses one shared Memanto agent ID, `langgraph-support-agent` by
+default. You can override it with `MEMANTO_AGENT_ID` to isolate your own demo
+runs.
+
+## Prerequisites
+
+- Python 3.10+
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys)
+
+## Setup
+
+```bash
+git clone https://github.com/moorcheh-ai/memanto.git
+cd memanto/examples/langgraph-memanto
+
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+
+pip install -r requirements.txt
+cp .env.example .env
+# Edit .env and add MOORCHEH_API_KEY
+```
+
+## Quick Start
+
+Run both sessions:
+
+```bash
+python run_full_demo.py
+```
+
+Or run them separately to make the persistence boundary obvious:
+
+```bash
+python run_day1_store.py
+
+# Later, in a fresh terminal or after clearing local LangGraph state:
+python run_day2_recall.py
+```
+
+Expected behavior:
+
+1. Day 1 stores stable customer details such as name, plan, timezone, and
+   escalation preference.
+2. Day 2 starts with no prior LangGraph messages, recalls those details from
+   Memanto, and answers with personalized context.
+
+## No-Key Dry Run
+
+The bounty demo should use real Memanto storage. For reviewers who only want
+to inspect the graph flow without an API key, the same scripts can use a local
+JSON backend:
+
+```bash
+MEMANTO_DEMO_BACKEND=local python run_full_demo.py
+```
+
+The local backend writes `.local_memanto_demo.json` in this folder and exposes
+the same small interface used by the LangGraph nodes.
+
+## Files
+
+```text
+examples/langgraph-memanto/
+|-- README.md              # This guide
+|-- requirements.txt       # Python dependencies
+|-- .env.example           # Configuration template
+|-- memory_adapter.py      # Memanto client wrapper + optional local backend
+|-- graph.py               # LangGraph StateGraph and node functions
+|-- run_day1_store.py      # Session 1: store memories
+|-- run_day2_recall.py     # Session 2: recall from an empty graph state
+`-- run_full_demo.py       # Runs both sessions in sequence
+```
+
+## How to Record the 30-Second Demo
+
+Suggested terminal flow:
+
+```bash
+python run_day1_store.py
+python run_day2_recall.py
+```
+
+The recording should show that the second script starts a new run and still
+recalls the customer's stored preferences. Add your GIF or video URL here when
+submitting the PR:
+
+Demo video: TODO
+
+## Integration Pattern
+
+LangGraph state is intentionally short-lived:
+
+```python
+class SupportState(TypedDict):
+    customer_id: str
+    message: str
+    recalled_memories: list[dict[str, Any]]
+    response: str
+    memories_to_store: list[dict[str, Any]]
+```
+
+Memanto is injected as a dependency when building the graph:
+
+```python
+memory = create_memory_backend()
+graph = build_support_graph(memory)
+result = graph.invoke({"customer_id": "acme-001", "message": "..."})
+```
+
+This separation keeps LangGraph responsible for orchestration while Memanto
+owns durable semantic memory.

--- a/examples/langgraph-memanto/graph.py
+++ b/examples/langgraph-memanto/graph.py
@@ -1,0 +1,198 @@
+"""
+LangGraph support-agent workflow backed by Memanto memory.
+
+The graph deliberately keeps only current-turn information in state. Stable
+customer facts and preferences are stored in and recalled from Memanto.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+from memory_adapter import MemoryBackend
+
+
+CUSTOMER_ID = "acme-001"
+DAY_1_MESSAGE = (
+    "Hi, this is Priya from Acme Robotics. We are on the enterprise plan, "
+    "work in Pacific time, and prefer concise bullet updates. If checkout "
+    "latency crosses 300ms, escalate to Sam on the platform team."
+)
+DAY_2_MESSAGE = (
+    "Can you help me prepare a status reply about checkout latency?"
+)
+
+
+class SupportState(TypedDict, total=False):
+    """Current-turn LangGraph state."""
+
+    customer_id: str
+    message: str
+    recalled_memories: list[dict[str, Any]]
+    memories_to_store: list[dict[str, Any]]
+    response: str
+    stored_memory_ids: list[str]
+
+
+def extract_memories(state: SupportState) -> SupportState:
+    """Extract stable facts from the current message."""
+    message = state["message"]
+    memories: list[dict[str, Any]] = []
+
+    if "Priya" in message:
+        memories.append(
+            {
+                "type": "fact",
+                "title": "Primary contact is Priya",
+                "content": "Priya is the primary support contact for Acme Robotics.",
+                "confidence": 0.98,
+                "tags": ["customer", "contact", "acme"],
+            }
+        )
+
+    if "enterprise plan" in message:
+        memories.append(
+            {
+                "type": "fact",
+                "title": "Acme Robotics plan",
+                "content": "Acme Robotics is on the enterprise plan.",
+                "confidence": 0.95,
+                "tags": ["customer", "plan", "acme"],
+            }
+        )
+
+    if "Pacific time" in message:
+        memories.append(
+            {
+                "type": "preference",
+                "title": "Acme timezone",
+                "content": "Acme Robotics works in Pacific time.",
+                "confidence": 0.9,
+                "tags": ["customer", "timezone", "acme"],
+            }
+        )
+
+    if "concise bullet updates" in message:
+        memories.append(
+            {
+                "type": "preference",
+                "title": "Acme communication style",
+                "content": "Acme Robotics prefers concise bullet updates.",
+                "confidence": 0.93,
+                "tags": ["customer", "communication", "acme"],
+            }
+        )
+
+    if "checkout latency crosses 300ms" in message:
+        memories.append(
+            {
+                "type": "instruction",
+                "title": "Checkout latency escalation",
+                "content": (
+                    "If checkout latency crosses 300ms for Acme Robotics, "
+                    "escalate to Sam on the platform team."
+                ),
+                "confidence": 0.97,
+                "tags": ["customer", "latency", "escalation", "acme"],
+            }
+        )
+
+    return {"memories_to_store": memories}
+
+
+def make_store_memories(memory: MemoryBackend):
+    """Create a LangGraph node that stores extracted memories."""
+
+    def store_memories(state: SupportState) -> SupportState:
+        stored_ids: list[str] = []
+        for item in state.get("memories_to_store", []):
+            result = memory.remember(
+                memory_type=item["type"],
+                title=item["title"],
+                content=item["content"],
+                confidence=item["confidence"],
+                tags=item["tags"],
+            )
+            stored_ids.append(str(result.get("memory_id", "unknown")))
+        return {"stored_memory_ids": stored_ids}
+
+    return store_memories
+
+
+def make_recall_customer_context(memory: MemoryBackend):
+    """Create a LangGraph node that recalls long-term customer context."""
+
+    def recall_customer_context(state: SupportState) -> SupportState:
+        query = (
+            f"Customer {state['customer_id']} contact plan timezone communication "
+            "preference checkout latency escalation"
+        )
+        memories = memory.recall(
+            query=query,
+            limit=6,
+            memory_types=["fact", "preference", "instruction"],
+        )
+        return {"recalled_memories": memories}
+
+    return recall_customer_context
+
+
+def draft_response(state: SupportState) -> SupportState:
+    """Draft a deterministic support reply from recalled memories."""
+    memories = state.get("recalled_memories", [])
+    memory_text = " ".join(memory.get("content", "") for memory in memories)
+
+    contact = "there"
+    if "Priya" in memory_text:
+        contact = "Priya"
+
+    style = "a concise update"
+    if "concise bullet updates" in memory_text:
+        style = "concise bullets"
+
+    escalation = ""
+    if "Sam on the platform team" in memory_text:
+        escalation = " I will escalate to Sam if latency crosses 300ms."
+
+    plan = ""
+    if "enterprise plan" in memory_text:
+        plan = " I see Acme is on the enterprise plan."
+
+    response = (
+        f"Hi {contact}, here is {style} for checkout latency.{plan}{escalation} "
+        "Current status: I will verify the latest latency numbers and share next "
+        "steps in Pacific time."
+    )
+    return {"response": response}
+
+
+def build_support_graph(memory: MemoryBackend):
+    """Build the LangGraph workflow used by the demo scripts."""
+    builder = StateGraph(SupportState)
+    builder.add_node("extract_memories", extract_memories)
+    builder.add_node("store_memories", make_store_memories(memory))
+    builder.add_node("recall_customer_context", make_recall_customer_context(memory))
+    builder.add_node("draft_response", draft_response)
+
+    builder.add_edge(START, "extract_memories")
+    builder.add_edge("extract_memories", "store_memories")
+    builder.add_edge("store_memories", "recall_customer_context")
+    builder.add_edge("recall_customer_context", "draft_response")
+    builder.add_edge("draft_response", END)
+    return builder.compile()
+
+
+def print_run_summary(label: str, result: SupportState) -> None:
+    """Pretty-print the demo result without requiring Rich."""
+    print(f"\n{'=' * 72}")
+    print(label)
+    print(f"{'=' * 72}")
+    print(f"Stored memory IDs: {result.get('stored_memory_ids', [])}")
+    print("\nRecalled memories:")
+    for memory in result.get("recalled_memories", []):
+        print(f"- [{memory.get('type', 'unknown')}] {memory.get('title', 'Untitled')}")
+        print(f"  {memory.get('content', '')}")
+    print("\nAgent response:")
+    print(result.get("response", ""))

--- a/examples/langgraph-memanto/memory_adapter.py
+++ b/examples/langgraph-memanto/memory_adapter.py
@@ -1,0 +1,209 @@
+"""
+Memory adapters for the LangGraph + Memanto example.
+
+The default adapter uses Memanto through SdkClient. A tiny local JSON adapter is
+also provided so reviewers can run the LangGraph flow without API credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from dotenv import load_dotenv
+
+from memanto.cli.client.sdk_client import SdkClient
+
+
+DEFAULT_AGENT_ID = "langgraph-support-agent"
+LOCAL_STORE_PATH = Path(__file__).with_name(".local_memanto_demo.json")
+
+
+class MemoryBackend(Protocol):
+    """Small memory interface used by the LangGraph nodes."""
+
+    agent_id: str
+
+    def setup(self) -> None:
+        """Prepare the memory backend for reads and writes."""
+
+    def remember(
+        self,
+        *,
+        memory_type: str,
+        title: str,
+        content: str,
+        confidence: float,
+        tags: list[str],
+    ) -> dict[str, Any]:
+        """Store one durable memory."""
+
+    def recall(
+        self,
+        *,
+        query: str,
+        limit: int = 5,
+        memory_types: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return relevant memories."""
+
+    def close(self) -> None:
+        """Release any session resources."""
+
+
+@dataclass
+class MemantoMemory:
+    """Memanto-backed implementation of the demo memory interface."""
+
+    api_key: str
+    agent_id: str = DEFAULT_AGENT_ID
+    description: str = "LangGraph support agent long-term memory demo"
+
+    def __post_init__(self) -> None:
+        self.client = SdkClient(api_key=self.api_key)
+
+    def setup(self) -> None:
+        try:
+            self.client.create_agent(
+                agent_id=self.agent_id,
+                pattern="support",
+                description=self.description,
+            )
+        except Exception:
+            # The demo is intentionally rerunnable; an existing agent is fine.
+            pass
+
+        self.client.activate_agent(self.agent_id, duration_hours=6)
+
+    def remember(
+        self,
+        *,
+        memory_type: str,
+        title: str,
+        content: str,
+        confidence: float,
+        tags: list[str],
+    ) -> dict[str, Any]:
+        return self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory_type,
+            title=title,
+            content=content,
+            confidence=confidence,
+            tags=tags,
+            source="langgraph-agent",
+            provenance="explicit_statement",
+        )
+
+    def recall(
+        self,
+        *,
+        query: str,
+        limit: int = 5,
+        memory_types: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            type=memory_types,
+        )
+        return list(result.get("memories", []))
+
+    def close(self) -> None:
+        try:
+            self.client.deactivate_agent(self.agent_id)
+        except Exception:
+            pass
+
+
+@dataclass
+class LocalJsonMemory:
+    """
+    Local no-key memory backend for dry runs.
+
+    This is not a replacement for Memanto. It exists only so the LangGraph
+    example can be smoke-tested without network credentials.
+    """
+
+    agent_id: str = DEFAULT_AGENT_ID
+    path: Path = LOCAL_STORE_PATH
+
+    def setup(self) -> None:
+        if not self.path.exists():
+            self.path.write_text("[]\n", encoding="utf-8")
+
+    def remember(
+        self,
+        *,
+        memory_type: str,
+        title: str,
+        content: str,
+        confidence: float,
+        tags: list[str],
+    ) -> dict[str, Any]:
+        memories = self._load()
+        memory_id = f"local-{len(memories) + 1}"
+        record = {
+            "id": memory_id,
+            "memory_id": memory_id,
+            "type": memory_type,
+            "title": title,
+            "content": content,
+            "confidence": confidence,
+            "tags": tags,
+            "agent_id": self.agent_id,
+        }
+        memories.append(record)
+        self.path.write_text(json.dumps(memories, indent=2) + "\n", encoding="utf-8")
+        return {"memory_id": memory_id, "status": "stored", "agent_id": self.agent_id}
+
+    def recall(
+        self,
+        *,
+        query: str,
+        limit: int = 5,
+        memory_types: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        query_terms = {term.lower() for term in query.split() if len(term) > 2}
+        memories = [
+            memory
+            for memory in self._load()
+            if not memory_types or memory.get("type") in memory_types
+        ]
+
+        def score(memory: dict[str, Any]) -> int:
+            text = f"{memory.get('title', '')} {memory.get('content', '')}".lower()
+            return sum(1 for term in query_terms if term in text)
+
+        ranked = sorted(memories, key=score, reverse=True)
+        return ranked[:limit]
+
+    def close(self) -> None:
+        return None
+
+    def _load(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        return json.loads(self.path.read_text(encoding="utf-8"))
+
+
+def create_memory_backend() -> MemoryBackend:
+    """Create the configured memory backend."""
+    load_dotenv()
+
+    agent_id = os.environ.get("MEMANTO_AGENT_ID", DEFAULT_AGENT_ID)
+    if os.environ.get("MEMANTO_DEMO_BACKEND") == "local":
+        return LocalJsonMemory(agent_id=agent_id)
+
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "MOORCHEH_API_KEY is required. Copy .env.example to .env and add "
+            "your key, or set MEMANTO_DEMO_BACKEND=local for a no-key dry run."
+        )
+
+    return MemantoMemory(api_key=api_key, agent_id=agent_id)

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,3 @@
+langgraph>=0.2.60
+memanto>=0.1.0
+python-dotenv>=1.0.0

--- a/examples/langgraph-memanto/run_day1_store.py
+++ b/examples/langgraph-memanto/run_day1_store.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Session 1: store customer details in Memanto through a LangGraph run."""
+
+from __future__ import annotations
+
+from graph import CUSTOMER_ID, DAY_1_MESSAGE, build_support_graph, print_run_summary
+from memory_adapter import create_memory_backend
+
+
+def main() -> None:
+    memory = create_memory_backend()
+    memory.setup()
+    try:
+        graph = build_support_graph(memory)
+        result = graph.invoke(
+            {
+                "customer_id": CUSTOMER_ID,
+                "message": DAY_1_MESSAGE,
+            }
+        )
+        print_run_summary("Day 1: stored customer context", result)
+    finally:
+        memory.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/run_day2_recall.py
+++ b/examples/langgraph-memanto/run_day2_recall.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Session 2: start with empty LangGraph state and recall yesterday's context.
+
+Run this after `run_day1_store.py` to show that the graph can personalize the
+reply from Memanto, even though no previous messages are passed in state.
+"""
+
+from __future__ import annotations
+
+from graph import CUSTOMER_ID, DAY_2_MESSAGE, build_support_graph, print_run_summary
+from memory_adapter import create_memory_backend
+
+
+def main() -> None:
+    memory = create_memory_backend()
+    memory.setup()
+    try:
+        graph = build_support_graph(memory)
+        result = graph.invoke(
+            {
+                "customer_id": CUSTOMER_ID,
+                "message": DAY_2_MESSAGE,
+                "memories_to_store": [],
+                "stored_memory_ids": [],
+            }
+        )
+        print_run_summary("Day 2: recalled context from a fresh graph run", result)
+    finally:
+        memory.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/run_full_demo.py
+++ b/examples/langgraph-memanto/run_full_demo.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Run the complete two-session LangGraph + Memanto demo."""
+
+from __future__ import annotations
+
+from graph import (
+    CUSTOMER_ID,
+    DAY_1_MESSAGE,
+    DAY_2_MESSAGE,
+    build_support_graph,
+    print_run_summary,
+)
+from memory_adapter import create_memory_backend
+
+
+def run_session(label: str, message: str, store: bool = True) -> None:
+    memory = create_memory_backend()
+    memory.setup()
+    try:
+        graph = build_support_graph(memory)
+        initial_state = {
+            "customer_id": CUSTOMER_ID,
+            "message": message,
+        }
+        if not store:
+            initial_state["memories_to_store"] = []
+            initial_state["stored_memory_ids"] = []
+        result = graph.invoke(initial_state)
+        print_run_summary(label, result)
+    finally:
+        memory.close()
+
+
+def main() -> None:
+    run_session("Day 1: store durable customer context", DAY_1_MESSAGE)
+    run_session(
+        "Day 2: new LangGraph run recalls yesterday's context",
+        DAY_2_MESSAGE,
+        store=False,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a LangGraph + Memanto example under `examples/langgraph-memanto`
- Demonstrate cross-session recall: day 2 starts with fresh LangGraph state and recalls day 1 customer context from Memanto
- Include a deterministic no-LLM support-agent workflow, setup docs, and optional local dry-run backend for reviewers

## Testing
- Compiled all new Python files with `compile(...)`
- Ran `MEMANTO_DEMO_BACKEND=local python run_full_demo.py`
- Verified day 2 recalls Priya, enterprise plan, Pacific time, concise bullet preference, and checkout latency escalation from stored memory

## Bounty Notes
This PR addresses #397 by adding the requested `examples/langgraph-memanto` integration example.

Demo video/GIF: TODO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a LangGraph example demonstrating durable agent memory using Memanto for cross-session persistence across separate process invocations

## Documentation
* Added comprehensive setup guide with prerequisites, environment configuration, and architecture overview
* Added environment configuration example file with optional local testing support

## Chores
* Updated project ignore rules for virtual environment variants and demo artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->