### PR TITLE
feat(examples): add LangGraph + Memanto cross-session memory example (#397)

### DIFF
--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,0 +1,10 @@
+# Moorcheh API Key (required) - https://console.moorcheh.ai/api-keys
+MOORCHEH_API_KEY=your_moorcheh_api_key_here
+
+# OpenRouter API key (required for the LangGraph agent's LLM)
+# Get yours at: https://openrouter.ai/keys
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+# Optional overrides
+# LANGGRAPH_LLM_MODEL=openai/gpt-4o-mini
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,121 @@
+# LangGraph + Memanto Example
+
+A minimal, production-shaped [LangGraph](https://github.com/langchain-ai/langgraph)
+support-concierge agent that uses **Memanto** as its long-term memory layer.
+
+LangGraph already gives you stateful, multi-step agent workflows. The piece it
+intentionally does *not* solve is **durable memory across sessions** — the
+graph's `MessagesState` is per-run. This example demonstrates a clean pattern
+for snapping Memanto in as the cross-session memory layer so the agent
+*genuinely* remembers the user between disjointed runs of the program.
+
+> Closes the technical criterion from [issue #397](https://github.com/moorcheh-ai/memanto/issues/397):
+> *"Must demonstrate Cross-Session Recall (The agent remembers something from
+> 'yesterday' that isn't in the current thread's state)."*
+
+## Demo Video
+
+> **TODO (PR author):** Replace this line with a 30-second screencast GIF or
+> Loom / YouTube link showing `run_session_1.py` followed by
+> `run_session_2.py` from a fresh process.
+
+## What This Demonstrates
+
+- **Cross-session recall** — `run_session_1.py` stores facts; `run_session_2.py`
+  is a separate process with an empty LangGraph state and the agent still
+  answers correctly by recalling from Memanto.
+- **Drop-in memory layer** — `memanto_memory.py` exposes a tiny
+  `MemantoMemory` facade that any LangGraph node can call.
+- **Memory extraction, not just storage** — the graph has a dedicated
+  `extract` node that uses the LLM in JSON mode to pull *durable* facts out
+  of each user turn before writing them to Memanto. The assistant's own
+  output is never stored as ground truth.
+- **Typed memory** — preferences, facts, decisions, and goals are stored
+  with the right Memanto memory type so retrieval is clean.
+
+## Graph Shape
+
+```
+       +--------+     +---------+     +---------+
+USER ->| recall |  -> | respond |  -> | extract | -> END
+       +--------+     +---------+     +---------+
+            |              |                |
+            v              v                v
+       Memanto.recall   LLM.invoke     Memanto.remember
+```
+
+- `recall` — semantic-search Memanto with the latest user message; stash
+  results in the graph state.
+- `respond` — call the LLM with system prompt + recalled memories + the
+  current turn.
+- `extract` — JSON-mode LLM call that returns atomic memories to write to
+  Memanto. Only the user's input is mined; the assistant's reply is treated
+  as ephemeral.
+
+## Prerequisites
+
+- Python 3.10+
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys) — free tier is plenty.
+- An [OpenRouter API key](https://openrouter.ai/keys) — `openai/gpt-4o-mini`
+  is the default; any tool-capable chat model works.
+
+## Setup
+
+```bash
+python -m venv venv
+source venv/bin/activate          # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+cp .env.example .env              # then edit and fill in the two API keys
+```
+
+## Run the cross-session demo
+
+The two scripts are designed to be run in **two separate processes** with
+nothing shared but Memanto:
+
+```bash
+# Step 1: Capture context (preferences, region, migration plans, ...)
+python run_session_1.py
+
+# Step 2: Brand-new process, empty LangGraph state.
+# The agent answers correctly only because Memanto remembers.
+python run_session_2.py
+```
+
+`run_session_2.py` exits non-zero if the assistant's replies fail to
+reference at least two of the facts captured in session 1 — so it doubles
+as a smoke test.
+
+### Interactive mode
+
+```bash
+python run_chat.py
+```
+
+Drop into a REPL with the same memory namespace. Useful for recording the
+30-second screencast the bounty asks for.
+
+## Files
+
+| File | What it does |
+|------|--------------|
+| `memanto_memory.py` | `SdkClient` lifecycle + `remember` / `recall` / `answer` facade + a context manager that handles agent create/activate/deactivate. |
+| `graph.py` | `recall -> respond -> extract` LangGraph workflow plus tiny helpers (`initial_state`, `assistant_reply`). |
+| `run_session_1.py` | Run 1 — user shares context. |
+| `run_session_2.py` | Run 2 — fresh process; agent recalls. |
+| `run_chat.py` | Interactive REPL for demos. |
+| `requirements.txt` | `memanto`, `langgraph`, `langchain-openai`, `python-dotenv`. |
+| `.env.example` | `MOORCHEH_API_KEY` + `OPENROUTER_API_KEY` template. |
+
+## Notes on memory hygiene
+
+- We only feed the **latest user turn** into the extractor; the assistant's
+  reply is never written to memory. This is the difference between *what
+  the user told us* (durable) and *what the bot said back* (ephemeral).
+- The extractor returns strict JSON and is validated against Memanto's
+  13 allowed memory types before writing. Malformed candidates are dropped.
+- `recall` uses semantic similarity; we cap to 6 memories per turn to keep
+  the prompt tight. Tune with `memory.recall(..., limit=N)`.
+- The Memanto agent id is shared across all three scripts
+  (`langgraph-support-concierge`); changing it gives you a clean namespace
+  for a different demo.

--- a/examples/langgraph-memanto/graph.py
+++ b/examples/langgraph-memanto/graph.py
@@ -1,0 +1,234 @@
+"""
+LangGraph workflow with Memanto as the long-term memory layer.
+
+The graph is intentionally small so the wiring is obvious:
+
+    recall  -->  respond  -->  extract  -->  END
+
+* ``recall``  reads the latest user message, queries Memanto, and stashes
+  the rendered memories in the graph state.
+* ``respond`` calls the LLM with system prompt + recalled memories + the
+  conversation so far.
+* ``extract`` asks the LLM (in JSON mode) to pull any *durable* facts /
+  preferences out of the new user turn and writes them back to Memanto.
+
+Only the user's turn is mined for memories -- the assistant's answer is
+ephemeral. This keeps storage tight and prevents the LLM from
+hallucinating "facts" into long-term memory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Annotated, Any, TypedDict
+
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, StateGraph
+from langgraph.graph.message import add_messages
+
+from memanto_memory import MemantoMemory, Memory
+
+logger = logging.getLogger(__name__)
+
+VALID_MEMORY_TYPES = {
+    "fact",
+    "preference",
+    "goal",
+    "decision",
+    "commitment",
+    "relationship",
+    "context",
+    "event",
+    "observation",
+    "instruction",
+    "artifact",
+    "learning",
+    "error",
+}
+
+SYSTEM_PROMPT = """You are a helpful customer support concierge with persistent long-term memory.
+
+You have access to memories carried over from previous sessions with this user. \
+When relevant memories appear under "Relevant memories", treat them as known \
+facts about the user and reference them naturally -- do NOT say "I don't \
+remember" if the answer is in the memory block. If a memory is missing, ask a \
+short clarifying question rather than guessing.
+
+Keep responses concise (3-5 sentences). Be warm but direct.
+"""
+
+EXTRACTION_PROMPT = """You are a memory extraction module. Read the user's latest message and \
+extract any DURABLE facts about the user that should be remembered across \
+sessions (preferences, goals, decisions, commitments, biographical facts, \
+relationships).
+
+Rules:
+- Skip ephemeral things ("I'm running late today", "thanks!", "ok").
+- One memory per atomic fact. Do NOT merge unrelated facts.
+- Title <= 80 chars. Content <= 400 chars. Phrase content as a third-person \
+  statement about the user ("User prefers X").
+- Confidence: 0.95 for explicit statements, 0.75 for clear implications.
+- Return STRICT JSON: {{"memories": [{{"type": ..., "title": ..., "content": ..., "confidence": ..., "tags": [...]}}, ...]}}
+- type MUST be one of: fact, preference, goal, decision, commitment, \
+  relationship, context, event, observation, instruction, artifact, learning, error.
+- If nothing is worth remembering, return {{"memories": []}}.
+
+User message:
+\"\"\"{user_text}\"\"\"
+"""
+
+
+class GraphState(TypedDict):
+    """State threaded through the graph."""
+
+    messages: Annotated[list[BaseMessage], add_messages]
+    user_id: str
+    recalled: list[Memory]
+    stored_ids: list[str]
+
+
+def _build_llm(model: str | None = None, temperature: float = 0.2) -> ChatOpenAI:
+    """Build a ChatOpenAI client pointed at OpenRouter by default."""
+    api_key = os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "OPENROUTER_API_KEY (or OPENAI_API_KEY) is not set. "
+            "Copy .env.example to .env and fill it in."
+        )
+    base_url = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+    resolved_model = (
+        model
+        or os.environ.get("LANGGRAPH_LLM_MODEL")
+        or "openai/gpt-4o-mini"
+    )
+    return ChatOpenAI(
+        model=resolved_model,
+        api_key=api_key,
+        base_url=base_url,
+        temperature=temperature,
+    )
+
+
+def _latest_user_text(messages: list[BaseMessage]) -> str:
+    for msg in reversed(messages):
+        if isinstance(msg, HumanMessage):
+            content = msg.content
+            return content if isinstance(content, str) else str(content)
+    return ""
+
+
+def build_graph(memory: MemantoMemory, model: str | None = None) -> Any:
+    """Compile a LangGraph workflow bound to a Memanto memory instance."""
+
+    llm = _build_llm(model=model)
+    extractor_llm = _build_llm(model=model, temperature=0.0)
+
+    def recall_node(state: GraphState) -> dict[str, Any]:
+        user_text = _latest_user_text(state["messages"])
+        if not user_text:
+            return {"recalled": []}
+        recalled = memory.recall(user_text, limit=6)
+        logger.info("Recalled %d memories for query=%r", len(recalled), user_text)
+        return {"recalled": recalled}
+
+    def respond_node(state: GraphState) -> dict[str, Any]:
+        rendered = MemantoMemory.render_memories(state.get("recalled", []))
+        system = SystemMessage(
+            content=(
+                f"{SYSTEM_PROMPT}\n\n"
+                f"User id: {state['user_id']}\n\n"
+                f"Relevant memories from prior sessions:\n{rendered}"
+            )
+        )
+        reply = llm.invoke([system, *state["messages"]])
+        return {"messages": [reply]}
+
+    def extract_node(state: GraphState) -> dict[str, Any]:
+        user_text = _latest_user_text(state["messages"])
+        if not user_text:
+            return {"stored_ids": []}
+
+        prompt = EXTRACTION_PROMPT.format(user_text=user_text.replace('"""', "'''"))
+        raw = extractor_llm.invoke([HumanMessage(content=prompt)]).content
+        text = raw if isinstance(raw, str) else str(raw)
+
+        try:
+            payload = json.loads(_strip_json_fence(text))
+            candidates = payload.get("memories", [])
+            if not isinstance(candidates, list):
+                candidates = []
+        except json.JSONDecodeError as exc:
+            logger.warning("Memory extraction returned non-JSON: %s (%s)", text, exc)
+            candidates = []
+
+        stored: list[str] = []
+        for cand in candidates:
+            if not isinstance(cand, dict):
+                continue
+            mem_type = str(cand.get("type", "")).strip().lower()
+            title = str(cand.get("title", "")).strip()
+            content = str(cand.get("content", "")).strip()
+            confidence = float(cand.get("confidence", 0.85) or 0.85)
+            tags = [str(t).strip() for t in cand.get("tags", []) if str(t).strip()]
+            if mem_type not in VALID_MEMORY_TYPES or not title or not content:
+                logger.debug("Skipping malformed memory candidate: %r", cand)
+                continue
+            mem_id = memory.remember(
+                memory_type=mem_type,
+                title=title,
+                content=content,
+                confidence=max(0.0, min(1.0, confidence)),
+                tags=tags,
+            )
+            stored.append(mem_id)
+
+        return {"stored_ids": stored}
+
+    builder = StateGraph(GraphState)
+    builder.add_node("recall", recall_node)
+    builder.add_node("respond", respond_node)
+    builder.add_node("extract", extract_node)
+
+    builder.set_entry_point("recall")
+    builder.add_edge("recall", "respond")
+    builder.add_edge("respond", "extract")
+    builder.add_edge("extract", END)
+
+    return builder.compile()
+
+
+def _strip_json_fence(text: str) -> str:
+    """Strip ```json ... ``` fences if the model wrapped its reply."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = stripped.split("\n", 1)[1] if "\n" in stripped else stripped[3:]
+        if stripped.rstrip().endswith("```"):
+            stripped = stripped.rstrip()[:-3]
+    return stripped.strip()
+
+
+def initial_state(user_id: str, user_text: str) -> GraphState:
+    """Convenience constructor for a single-turn graph invocation."""
+    return GraphState(
+        messages=[HumanMessage(content=user_text)],
+        user_id=user_id,
+        recalled=[],
+        stored_ids=[],
+    )
+
+
+def assistant_reply(state: GraphState) -> str:
+    """Extract the last assistant reply from a finished graph state."""
+    for msg in reversed(state.get("messages", [])):
+        if isinstance(msg, AIMessage):
+            content = msg.content
+            return content if isinstance(content, str) else str(content)
+    return ""

--- a/examples/langgraph-memanto/memanto_memory.py
+++ b/examples/langgraph-memanto/memanto_memory.py
@@ -1,0 +1,170 @@
+"""
+Memanto memory layer for the LangGraph example.
+
+A thin facade around ``memanto.cli.client.sdk_client.SdkClient`` that:
+
+* Creates / activates a single shared agent namespace.
+* Exposes ``remember`` / ``recall`` / ``answer`` with the small surface this
+  example actually uses.
+* Renders recalled memories as a compact context block ready to drop into a
+  LangGraph state's prompt.
+
+The point of this module is to keep ``graph.py`` focused on the LangGraph
+wiring -- all the Memanto bookkeeping lives here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+from memanto.cli.client.sdk_client import SdkClient
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_AGENT_ID = "langgraph-support-concierge"
+DEFAULT_SESSION_HOURS = 6
+
+
+@dataclass(frozen=True)
+class Memory:
+    """A retrieved memory rendered for prompt consumption."""
+
+    title: str
+    content: str
+    type: str
+    confidence: float
+    tags: tuple[str, ...]
+
+    @classmethod
+    def from_raw(cls, raw: dict[str, Any]) -> "Memory":
+        return cls(
+            title=raw.get("title", "Untitled"),
+            content=raw.get("content", ""),
+            type=raw.get("type", "unknown"),
+            confidence=float(raw.get("confidence", 0.0) or 0.0),
+            tags=tuple(raw.get("tags", []) or []),
+        )
+
+    def render(self) -> str:
+        tag_str = f" [{', '.join(self.tags)}]" if self.tags else ""
+        return f"- ({self.type}, c={self.confidence:.2f}){tag_str} {self.title}: {self.content}"
+
+
+class MemantoMemory:
+    """High-level memory operations bound to a single agent namespace."""
+
+    def __init__(
+        self,
+        client: SdkClient,
+        agent_id: str = DEFAULT_AGENT_ID,
+    ) -> None:
+        self._client = client
+        self.agent_id = agent_id
+
+    @property
+    def client(self) -> SdkClient:
+        return self._client
+
+    def remember(
+        self,
+        memory_type: str,
+        title: str,
+        content: str,
+        *,
+        confidence: float = 0.85,
+        tags: list[str] | None = None,
+    ) -> str:
+        """Store a single memory; returns the new memory id."""
+        result = self._client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory_type,
+            title=title[:100],
+            content=content[:500],
+            confidence=confidence,
+            tags=tags or [],
+            source="langgraph-agent",
+            provenance="explicit_statement",
+        )
+        memory_id = result.get("memory_id", "")
+        logger.info(
+            "Stored memory %s (type=%s, title=%r)", memory_id, memory_type, title
+        )
+        return memory_id
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int = 6,
+        memory_types: list[str] | None = None,
+    ) -> list[Memory]:
+        """Semantic search; returns rendered memories sorted by relevance."""
+        result = self._client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            type=memory_types,
+        )
+        return [Memory.from_raw(m) for m in result.get("memories", [])]
+
+    def answer(self, question: str) -> str:
+        """RAG-grounded answer over the agent's memories."""
+        result = self._client.answer(
+            agent_id=self.agent_id,
+            question=question,
+        )
+        return result.get("answer", "")
+
+    @staticmethod
+    def render_memories(memories: list[Memory]) -> str:
+        if not memories:
+            return "(no relevant memories)"
+        return "\n".join(m.render() for m in memories)
+
+
+@contextmanager
+def memanto_session(
+    api_key: str | None = None,
+    agent_id: str = DEFAULT_AGENT_ID,
+    description: str = "LangGraph + Memanto cross-session memory example",
+    duration_hours: int = DEFAULT_SESSION_HOURS,
+) -> Iterator[MemantoMemory]:
+    """
+    Context manager that creates (idempotently), activates, and tears down a
+    Memanto agent session.
+
+    Reads ``MOORCHEH_API_KEY`` from the environment if *api_key* is not given.
+    """
+    resolved_key = api_key or os.environ.get("MOORCHEH_API_KEY")
+    if not resolved_key:
+        raise RuntimeError(
+            "MOORCHEH_API_KEY is not set. Copy .env.example to .env and fill it in."
+        )
+
+    client = SdkClient(api_key=resolved_key)
+
+    try:
+        client.create_agent(
+            agent_id=agent_id,
+            pattern="tool",
+            description=description,
+        )
+        logger.info("Created Memanto agent %r", agent_id)
+    except Exception:
+        logger.info("Memanto agent %r already exists; reusing", agent_id)
+
+    client.activate_agent(agent_id, duration_hours=duration_hours)
+    logger.info("Activated session for agent %r", agent_id)
+
+    try:
+        yield MemantoMemory(client=client, agent_id=agent_id)
+    finally:
+        try:
+            client.deactivate_agent(agent_id)
+            logger.info("Deactivated session for agent %r", agent_id)
+        except Exception as exc:
+            logger.warning("Failed to deactivate agent %r: %s", agent_id, exc)

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,5 @@
+memanto>=0.1.0
+langgraph>=0.2.50
+langchain-core>=0.3.20
+langchain-openai>=0.2.10
+python-dotenv>=1.0.0

--- a/examples/langgraph-memanto/run_chat.py
+++ b/examples/langgraph-memanto/run_chat.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Interactive REPL for the LangGraph + Memanto support concierge.
+
+Useful for recording demo videos. Every user turn flows through:
+
+    recall -> respond -> extract
+
+so the agent learns about you on the fly and remembers across restarts.
+
+Usage:
+    python run_chat.py [--user-id <id>]
+    (type 'exit' or Ctrl-C to quit)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from graph import assistant_reply, build_graph, initial_state
+from memanto_memory import memanto_session
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user-id", default="demo-user-001")
+    args = parser.parse_args()
+
+    load_dotenv()
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "WARNING"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    print("\n" + "=" * 72)
+    print("  LangGraph + Memanto Support Concierge -- interactive REPL")
+    print(f"  user_id: {args.user_id}")
+    print("  (type 'exit' to quit)")
+    print("=" * 72 + "\n")
+
+    with memanto_session() as memory:
+        graph = build_graph(memory)
+
+        while True:
+            try:
+                user_text = input("you> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                break
+            if not user_text:
+                continue
+            if user_text.lower() in {"exit", "quit", ":q"}:
+                break
+
+            result = graph.invoke(initial_state(args.user_id, user_text))
+            print(f"\nassistant> {assistant_reply(result)}")
+            stored = result.get("stored_ids", [])
+            recalled = result.get("recalled", [])
+            print(
+                f"  (recalled {len(recalled)} memories, "
+                f"stored {len(stored)} new memories)\n"
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/langgraph-memanto/run_session_1.py
+++ b/examples/langgraph-memanto/run_session_1.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Session 1 -- User shares context with the support concierge.
+
+Run this first. The LangGraph workflow will:
+1. Recall prior memories (none yet on a fresh agent).
+2. Respond conversationally.
+3. Extract durable facts/preferences from the user's turn and write them
+   to Memanto.
+
+After this script exits the Python process is gone, but every fact the user
+shared lives on in Memanto's vector store. Run ``run_session_2.py`` in a
+fresh process to prove the agent recalls them.
+
+Usage:
+    python run_session_1.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from graph import assistant_reply, build_graph, initial_state
+from memanto_memory import memanto_session
+
+USER_ID = "demo-user-001"
+
+SESSION_1_TURNS = [
+    "Hi! Quick intro: I'm Priya, a senior data engineer at Vertex Robotics. "
+    "We run our entire platform on AWS in us-west-2 and I'm the on-call "
+    "lead for the data ingestion stack.",
+    "Heads up for future tickets -- I always prefer reply emails over phone "
+    "calls, and please send any urgent comms through Slack rather than SMS. "
+    "Also, our team's procurement budget for new tooling is locked at $2k "
+    "per quarter so anything above that needs CFO approval.",
+    "One more thing: we're planning to migrate from Kinesis to MSK by end "
+    "of Q3 next year, so any recommendations you give us going forward "
+    "should bias toward Kafka-compatible tooling.",
+]
+
+
+def main() -> int:
+    load_dotenv()
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    print("\n" + "=" * 72)
+    print("  Session 1 -- Capturing context into Memanto")
+    print(f"  user_id: {USER_ID}")
+    print("=" * 72 + "\n")
+
+    with memanto_session() as memory:
+        graph = build_graph(memory)
+        total_stored = 0
+
+        for i, user_text in enumerate(SESSION_1_TURNS, start=1):
+            print(f"[Turn {i}] USER:\n  {user_text}\n")
+            result = graph.invoke(initial_state(USER_ID, user_text))
+            print(f"[Turn {i}] ASSISTANT:\n  {assistant_reply(result)}\n")
+            stored = result.get("stored_ids", [])
+            total_stored += len(stored)
+            print(f"  -> stored {len(stored)} memory(ies) in Memanto\n")
+
+        print("=" * 72)
+        print(f"  Session 1 complete. Stored {total_stored} total memories.")
+        print("  Run `python run_session_2.py` next to prove cross-session recall.")
+        print("=" * 72 + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/langgraph-memanto/run_session_2.py
+++ b/examples/langgraph-memanto/run_session_2.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Session 2 -- Fresh process, new LangGraph state. Memanto remembers.
+
+Run this AFTER ``run_session_1.py`` finishes. The LangGraph state object is
+brand new (zero messages carried over), so the only way the assistant can
+answer the questions below is by pulling memories from Memanto.
+
+This is the core "cross-session recall" demonstration the bounty asks for.
+
+Usage:
+    python run_session_2.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from graph import assistant_reply, build_graph, initial_state
+from memanto_memory import memanto_session
+
+USER_ID = "demo-user-001"
+
+PROBE_QUESTIONS = [
+    "Remind me -- which cloud region do we run our platform in?",
+    "Should I page you on your phone or send a Slack message for an urgent "
+    "P1 incident?",
+    "We're evaluating a new streaming tool that costs $3,200/quarter. Any "
+    "blockers given what you've told me before?",
+    "Looking at the Q3 roadmap -- does our planned platform migration affect "
+    "the tools I should be recommending?",
+]
+
+
+def _heuristic_recall_check(replies: list[str]) -> bool:
+    """Lightweight smoke check that the answers reference stored memories."""
+    blob = " ".join(replies).lower()
+    expected_hits = ["us-west-2", "slack", "cfo", "kafka"]
+    return sum(token in blob for token in expected_hits) >= 2
+
+
+def main() -> int:
+    load_dotenv()
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    print("\n" + "=" * 72)
+    print("  Session 2 -- Cross-session recall via Memanto")
+    print(f"  user_id: {USER_ID}")
+    print("  (Note: this is a fresh process; LangGraph state is empty.)")
+    print("=" * 72 + "\n")
+
+    with memanto_session() as memory:
+        graph = build_graph(memory)
+        replies: list[str] = []
+
+        for i, question in enumerate(PROBE_QUESTIONS, start=1):
+            print(f"[Probe {i}] USER:\n  {question}\n")
+            result = graph.invoke(initial_state(USER_ID, question))
+            reply = assistant_reply(result)
+            replies.append(reply)
+            recalled = result.get("recalled", [])
+            print(f"[Probe {i}] ASSISTANT (recalled {len(recalled)} memories):\n  {reply}\n")
+
+        recall_ok = _heuristic_recall_check(replies)
+        print("=" * 72)
+        print(
+            "  Cross-session recall heuristic: "
+            f"{'PASS' if recall_ok else 'FAIL -- review run_session_1 output'}"
+        )
+        print("=" * 72 + "\n")
+        return 0 if recall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `examples/langgraph-memanto/` — a minimal, production-shaped LangGraph
support concierge that uses Memanto as its long-term memory layer.

LangGraph already gives you stateful, multi-step agent workflows. The piece
it intentionally does *not* solve is **durable memory across sessions** —
the graph's `MessagesState` is per-run. This example shows a clean pattern
for snapping Memanto in as the cross-session memory layer.

Closes the technical criterion from #397: *"Must demonstrate Cross-Session
Recall (The agent remembers something from 'yesterday' that isn't in the
current thread's state)."*

## Graph shape

```
USER -> [recall] -> [respond] -> [extract] -> END
            |           |             |
            v           v             v
   Memanto.recall   LLM.invoke   Memanto.remember
```

- **recall** — semantic-search Memanto with the latest user message; stash
  results in the graph state.
- **respond** — call the LLM with system prompt + recalled memories + the
  current turn.
- **extract** — JSON-mode LLM call that returns atomic memories to write
  to Memanto. Only the user's input is mined; the assistant's reply is
  treated as ephemeral so the model can't hallucinate "facts" into
  long-term memory.

## Cross-session recall demo

Two scripts designed to be run in **two separate processes** with nothing
shared but Memanto:

```bash
# Process 1 — captures context (region, preferences, migration plans, ...)
python run_session_1.py

# Process 2 — fresh interpreter, empty LangGraph state. The agent answers
# correctly only because Memanto remembers.
python run_session_2.py
```

`run_session_2.py` exits non-zero unless the agent's replies reference at
least two of the facts stored in session 1, so it doubles as a smoke test
for cross-session recall.

`run_chat.py` is an interactive REPL on the same memory namespace, useful
for recording the 30-second screencast the bounty asks for.

## Files

| File | Purpose |
|------|---------|
| `memanto_memory.py` | `SdkClient` lifecycle + `remember`/`recall`/`answer` facade + context manager for agent create/activate/deactivate. |
| `graph.py` | `recall -> respond -> extract` LangGraph workflow plus helpers. |
| `run_session_1.py` | Captures user context. |
| `run_session_2.py` | Fresh process; proves cross-session recall. |
| `run_chat.py` | Interactive REPL. |
| `requirements.txt`, `.env.example`, `README.md` | Setup. |

## Test plan

- [x] All Python modules pass `ast.parse` syntax check.
- [x] `import memanto_memory; import graph` succeeds against released `memanto` package.
- [x] `SdkClient` method signatures match the calls in `memanto_memory.py` (verified via `inspect.signature`).
- [x] Graph compiles end-to-end with a mocked `SdkClient`; nodes resolve to `['__start__', 'recall', 'respond', 'extract', '__end__']`.
- [x] `MemantoMemory.recall` round-trips raw API dicts through the `Memory` dataclass and renders cleanly.
- [x] `_strip_json_fence` strips ` ```json ... ``` ` wrappers correctly.
- [ ] **Manual run** (requires `MOORCHEH_API_KEY` + `OPENROUTER_API_KEY`):
      `python run_session_1.py && python run_session_2.py` exits 0 and
      session 2's replies cite session 1 facts.
- [ ] **Demo asset** (PR author follow-up): add 30-second GIF / Loom link
      to the `## Demo Video` section of the README.

## Notes

- I did not run the repo's pytest suite as part of validation because
  collection already fails on `main` with
  `ModuleNotFoundError: No module named 'memanto.app._version'` (the
  `_version.py` is generated by `hatch-vcs` at package build time, not
  checked in). This is a pre-existing condition unrelated to this PR — my
  changes are confined to `examples/langgraph-memanto/`.
- The example imports `memanto.cli.client.sdk_client.SdkClient`, matching
  the pattern already established by `integrations/crewai`.

## Bounty entry (#397)

- Build: ✅ this PR
- Star: ⭐ (added)
- Amplify (X / LinkedIn / Reddit): PR author follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a complete example demonstrating cross-session memory integration, allowing an agent to recall information across separate program runs using persistent storage.

* **Documentation**
  * Included comprehensive setup guide with required API key configuration, usage instructions, and a two-session smoke test workflow for verifying memory persistence and recall.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->