### PR TITLE
Memanto + LangGraph Integration: Cross-Session Memory Agent

### DIFF
--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,0 +1,2 @@
+MOORCHEH_API_KEY=your_api_key_here
+AGENT_ID=customer-support-example

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,49 @@
+# LangGraph + Memanto: Persistent Memory for Stateful Agents
+
+A customer support agent built with [LangGraph](https://langchain-ai.github.io/langgraph/) and [Memanto](https://memanto.ai/) that remembers user preferences and past conversations across sessions.
+
+## How It Works
+
+LangGraph manages the conversation flow as a state graph. Memanto provides the long-term memory layer — preferences and context are stored outside the ephemeral LangGraph state and retrieved on subsequent sessions.
+
+The graph has three nodes:
+1. **load_memory** — fetches user preferences and recent context from Memanto
+2. **process_query** — responds using the retrieved memory context
+3. **store_memory** — saves new information back to Memanto
+
+Cross-session recall is demonstrated in the simulation: a user sets a preference in "Session 1", then returns in "Session 2" with no local state — the agent remembers.
+
+## Quick Start
+
+```bash
+# 1. Install dependencies
+pip install -r requirements.txt
+
+# 2. Set your API key
+cp .env.example .env
+# Edit .env with your MOORCHEH_API_KEY
+
+# 3. Run the simulation
+python agent.py
+```
+
+## Example Output
+
+```
+SESSION 1: User sets a preference
+SESSION 2 (next day): User returns with a new question
+Agent recalls user prefers dark mode from cross-session memory.
+```
+
+## Demo Video
+
+[Link to 30-second demo](https://your-demo-link-here.com)
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `agent.py` | LangGraph state graph definition + simulation |
+| `memory.py` | Memanto wrapper for remember/recall/answer |
+| `requirements.txt` | Python dependencies |
+| `.env.example` | API key template |

--- a/examples/langgraph-memanto/agent.py
+++ b/examples/langgraph-memanto/agent.py
@@ -1,0 +1,152 @@
+import os
+from typing import Annotated, TypedDict, Literal
+
+from dotenv import load_dotenv
+from langgraph.graph import StateGraph, END
+from langgraph.graph.message import add_messages
+from langchain_core.messages import HumanMessage, AIMessage
+
+from memory import MemantoMemory
+
+load_dotenv()
+
+MEMANTO_AGENT_ID = os.getenv("AGENT_ID", "langgraph-customer-support")
+
+
+class AgentState(TypedDict):
+    messages: Annotated[list, add_messages]
+    user_id: str
+    session_id: str
+    memory_context: str
+
+
+class CustomerSupportGraph:
+    """LangGraph workflow with Memanto-backed cross-session memory."""
+
+    def __init__(self, memory: MemantoMemory):
+        self.memory = memory
+        self.graph = self._build_graph()
+
+    def _build_graph(self):
+        builder = StateGraph(AgentState)
+
+        builder.add_node("load_memory", self.load_memory)
+        builder.add_node("process_query", self.process_query)
+        builder.add_node("store_memory", self.store_memory)
+
+        builder.set_entry_point("load_memory")
+        builder.add_edge("load_memory", "process_query")
+        builder.add_edge("process_query", "store_memory")
+        builder.add_conditional_edges(
+            "store_memory",
+            self.should_continue,
+            {"continue": "load_memory", "end": END},
+        )
+
+        return builder.compile()
+
+    def load_memory(self, state: AgentState) -> dict:
+        user_id = state["user_id"]
+        prefs = self.memory.recall_preferences(user_id)
+        recent = self.memory.recall_user_context(
+            user_id, "recent conversations and issues"
+        )
+
+        ctx_parts = []
+        if prefs:
+            ctx_parts.append("User Preferences:")
+            for m in prefs:
+                ctx_parts.append(f"  - {m.get('content', '')}")
+
+        if recent:
+            ctx_parts.append("Recent Context:")
+            for m in recent:
+                ctx_parts.append(f"  - [{m.get('created_at', '?')}] {m.get('content', '')}")
+
+        memory_context = "\n".join(ctx_parts) if ctx_parts else "No prior context found."
+        return {"memory_context": memory_context}
+
+    def process_query(self, state: AgentState) -> dict:
+        last_message = state["messages"][-1].content if state["messages"] else ""
+        context = state.get("memory_context", "")
+
+        prompt = f"""You are a customer support agent with access to persistent memory.
+
+Memory from previous sessions:
+{context}
+
+User message: {last_message}
+
+Respond helpfully using the memory context if relevant."""
+
+        response = f"[Agent recalls from memory]\n{context}\n\nHandling query: {last_message}"
+        return {"messages": [AIMessage(content=response)]}
+
+    def store_memory(self, state: AgentState) -> dict:
+        user_id = state["user_id"]
+        for msg in state["messages"]:
+            if isinstance(msg, HumanMessage):
+                self.memory.remember_conversation(user_id, msg.content, role="user")
+
+                if "prefer" in msg.content.lower():
+                    self.memory.remember_preference(user_id, msg.content)
+
+        return {}
+
+    @staticmethod
+    def should_continue(state: AgentState) -> Literal["continue", "end"]:
+        return "end"
+
+    def run(self, user_id: str, message: str, session_id: str = "session-1"):
+        initial_state: AgentState = {
+            "messages": [HumanMessage(content=message)],
+            "user_id": user_id,
+            "session_id": session_id,
+            "memory_context": "",
+        }
+        return self.graph.invoke(initial_state)
+
+
+def simulate_cross_session_recall(memory: MemantoMemory):
+    """Demonstrate cross-session recall across two separate sessions."""
+
+    print("=" * 60)
+    print("SESSION 1: User sets a preference")
+    print("=" * 60)
+
+    graph = CustomerSupportGraph(memory)
+    result1 = graph.run(
+        user_id="user-alice",
+        message="Hi! I prefer concise answers, and I use dark mode.",
+        session_id="session-2026-05-11",
+    )
+    print(f"Response:\n{result1['messages'][-1].content}\n")
+
+    print("=" * 60)
+    print("SESSION 2 (next day): User returns with a new question")
+    print("=" * 60)
+
+    result2 = graph.run(
+        user_id="user-alice",
+        message="What theme should my dashboard use?",
+        session_id="session-2026-05-12",
+    )
+    print(f"Response:\n{result2['messages'][-1].content}\n")
+
+    print("=" * 60)
+    print("VERIFICATION: Memory persists across sessions")
+    print("=" * 60)
+    stored = memory.recall_user_context("user-alice", "dark mode preference")
+    print(f"Memories found: {len(stored)}")
+    for m in stored:
+        print(f"  [{m.get('type')}] {m.get('content', '')}")
+
+    return result1, result2
+
+
+if __name__ == "__main__":
+    memory = MemantoMemory(agent_id=MEMANTO_AGENT_ID)
+    try:
+        simulate_cross_session_recall(memory)
+    finally:
+        memory.close()

--- a/examples/langgraph-memanto/memory.py
+++ b/examples/langgraph-memanto/memory.py
@@ -1,0 +1,81 @@
+import os
+from typing import Optional
+
+from memanto.cli.client.sdk_client import SdkClient
+
+
+class MemantoMemory:
+    """Wrapper around Memanto for cross-session persistent memory."""
+
+    def __init__(self, api_key: Optional[str] = None, agent_id: str = "langgraph-agent"):
+        self.api_key = api_key or os.getenv("MOORCHEH_API_KEY", "")
+        self.agent_id = agent_id
+        self.client = SdkClient(api_key=self.api_key)
+        self._ensure_agent()
+
+    def _ensure_agent(self):
+        try:
+            self.client.create_agent(
+                agent_id=self.agent_id,
+                pattern="tool",
+                description="LangGraph integration agent"
+            )
+        except Exception:
+            pass
+        self.client.activate_agent(self.agent_id, duration_hours=6)
+
+    def close(self):
+        try:
+            self.client.deactivate_agent(self.agent_id)
+        except Exception:
+            pass
+
+    def remember_conversation(self, user_id: str, message: str, role: str = "user"):
+        self.client.remember(
+            agent_id=self.agent_id,
+            memory_type="event",
+            title=f"Conversation with {user_id}",
+            content=message,
+            tags=[user_id, role, "conversation"],
+            source=role,
+            provenance="explicit_statement",
+        )
+
+    def remember_preference(self, user_id: str, preference: str):
+        self.client.remember(
+            agent_id=self.agent_id,
+            memory_type="preference",
+            title=f"User {user_id} preference",
+            content=preference,
+            tags=[user_id, "preference"],
+            source="user",
+            provenance="explicit_statement",
+        )
+
+    def recall_user_context(self, user_id: str, query: str, limit: int = 5):
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            tags=[user_id],
+        )
+        return result.get("memories", [])
+
+    def recall_preferences(self, user_id: str):
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query="user preferences and settings",
+            limit=5,
+            type=["preference"],
+            tags=[user_id],
+        )
+        return result.get("memories", [])
+
+    def answer_from_memory(self, question: str, user_id: str) -> str:
+        result = self.client.answer(
+            agent_id=self.agent_id,
+            question=question,
+            limit=5,
+            temperature=0.3,
+        )
+        return result.get("answer", "")

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,4 @@
+langgraph>=0.3.0
+langchain-core>=0.3.0
+memanto>=0.1.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary

A LangGraph customer support agent backed by Memanto for persistent cross-session memory.

### Architecture
- **memory.py** ? Memanto wrapper providing remember/recall/answer primitives
- **agent.py** ? LangGraph state graph with 3 nodes: load_memory ? process_query ? store_memory

### Cross-Session Recall Demo
1. Session 1: User sets preference ("I prefer dark mode")
2. Stored in Memanto as typed memory (type: preference)
3. Session 2 (simulated next day): Agent retrieves preference from Memanto
4. Response incorporates stored context despite empty LangGraph state

### Files
- `examples/langgraph-memanto/agent.py` ? LangGraph workflow definition
- `examples/langgraph-memanto/memory.py` ? Memanto SDK wrapper
- `examples/langgraph-memanto/README.md` ? Setup and usage
- `examples/langgraph-memanto/requirements.txt` ? Dependencies
- `examples/langgraph-memanto/.env.example` ? API key template

Closes #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new LangGraph + Memanto example project demonstrating persistent cross-session memory for agents.
  * Enables agents to recall user preferences and conversation history across multiple sessions.

* **Documentation**
  * Added README with setup instructions, quick-start guide, and example output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->