### PR TITLE
feat: add LangGraph + Memanto cross-session memory example

### DIFF
--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,201 @@
+# LangGraph + Memanto: Give Your Graph a Permanent Brain
+
+A minimal LangGraph example that uses **Memanto** as a long-term,
+cross-session memory layer — sitting *outside* of LangGraph's
+thread-scoped `StateGraph` state.
+
+> 30-second demo: _<add link to GIF / video here>_ — record your terminal
+> running `python run_ingest.py` then `python run_recall.py` and drop the
+> link in.
+
+## What this demonstrates
+
+- **Cross-session recall** — `run_ingest.py` stores a fact today.
+  `run_recall.py`, started in a fresh process with **no LangGraph
+  checkpoint and no shared thread state**, answers a question that
+  can only come from yesterday's run. The only thing that crossed
+  the boundary is the Memanto agent namespace.
+- **Memory outside the graph state** — LangGraph's `StateGraph`
+  state is ephemeral per thread. Memanto holds the persistent
+  knowledge; the graph just calls `remember` / `recall` / `answer`
+  tools.
+- **Plain LangChain tools** — Memanto is exposed via
+  `StructuredTool` instances, so the same wrappers also work with
+  `create_react_agent`, custom routers, or `ToolNode`.
+
+## Architecture
+
+```
+                 ┌─────────────────────────────────────────────┐
+                 │              LangGraph StateGraph            │
+                 │                                              │
+   user turn ──► intake ─► recall ─► reason ─► remember ─► respond
+                 │           │                    │             │
+                 └───────────┼────────────────────┼─────────────┘
+                             ▼                    ▼
+                       memanto_recall      memanto_remember
+                       memanto_answer
+                             │                    │
+                             └─────────┬──────────┘
+                                       ▼
+                          ┌────────────────────────┐
+                          │   Memanto (Moorcheh)   │
+                          │   agent_id namespace   │
+                          │   - survives process   │
+                          │   - survives threads   │
+                          └────────────────────────┘
+```
+
+The `recall` and `remember` nodes are the only edges that leave the
+graph. Everything else they do — checkpointing, semantic search,
+type-aware storage — happens inside Memanto.
+
+## Prerequisites
+
+- Python 3.10+
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys)
+  (free tier: 100K ops/month)
+
+No LLM key is required to run the example as-is. The `reason` node
+is rule-based on purpose so the demo is deterministic and
+zero-cost. Swap in any LangChain chat model when you want an
+agentic loop.
+
+## Setup
+
+```bash
+# 1. Clone the repo (if you haven't already)
+git clone https://github.com/moorcheh-ai/memanto.git
+cd memanto/examples/langgraph-memanto
+
+# 2. Create a virtual environment
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+
+# 3. Install dependencies
+pip install -r requirements.txt
+
+# 4. Configure your API key
+cp .env.example .env
+# Edit .env and add your MOORCHEH_API_KEY
+```
+
+## Cross-session demo (the bounty acceptance criterion)
+
+This is the recommended flow to record for your video / GIF:
+
+```bash
+# Step 1 ("yesterday"): write a fact through LangGraph into Memanto.
+python run_ingest.py
+
+# Step 2 ("today"): start a brand-new process. LangGraph has zero
+# thread state from step 1 — the only thing that survived is the
+# Memanto namespace.
+python run_recall.py
+```
+
+`run_recall.py` answers *"Who runs the support desk and what's the
+response SLA?"* by pulling the fact through `memanto_recall` and
+`memanto_answer`. The graph never sees yesterday's `StateGraph`
+state — yet it still knows the answer.
+
+You can also run both halves back-to-back in a single process:
+
+```bash
+python run_full_pipeline.py
+```
+
+Each `graph.invoke(...)` call gets its own fresh `GraphState`
+(there's no checkpointer wired up), so even within one process
+the second invocation only knows what Memanto told it.
+
+## How LangGraph's thread state vs. Memanto compare
+
+| Concern | LangGraph `StateGraph` | Memanto |
+|---------|------------------------|---------|
+| Lifetime | One thread / one run (or checkpoint TTL) | Permanent |
+| Cross-process | No (unless a checkpointer is configured) | Yes |
+| Cross-graph | No | Yes — any graph with the same `agent_id` |
+| Search | Whatever you write into `state` | Semantic recall + RAG answer |
+| Typing | TypedDict you define | 13 built-in semantic types + confidence |
+| Cost at idle | N/A | Zero (serverless) |
+
+Use both. LangGraph state is great for the current turn's working
+memory; Memanto is great for everything you want the agent to know
+tomorrow.
+
+## How to plug Memanto into an existing LangGraph
+
+### Before: an ephemeral graph
+
+```python
+from langgraph.graph import StateGraph
+
+graph = StateGraph(MyState)
+graph.add_node("reason", reason_node)
+# ... edges ...
+app = graph.compile()
+# State dies when the thread ends.
+```
+
+### After: graph with a permanent brain
+
+```python
+from memanto.cli.client.sdk_client import SdkClient
+from memanto_tools import MemantoSetup, create_memanto_tools
+
+# 1. Boot Memanto (once per process)
+setup = MemantoSetup(api_key="your-moorcheh-key")
+client = setup.setup(agent_id="my-graph")
+
+# 2. Build LangChain-compatible tools
+tools = create_memanto_tools(client, agent_id="my-graph")
+
+# 3. Use them inside nodes — they're just StructuredTools
+def recall_node(state):
+    found = tools["recall"].invoke({"query": state["user_input"], "limit": 5})
+    return {"recalled": found}
+
+def remember_node(state):
+    tools["remember"].invoke({
+        "memory_type": "fact",
+        "title": "User goal",
+        "content": state["user_input"],
+    })
+    return {}
+```
+
+The tools also work unchanged inside a LangGraph `ToolNode` or a
+prebuilt `create_react_agent` if you'd rather have the LLM pick
+when to remember.
+
+## File structure
+
+```
+examples/langgraph-memanto/
+├── README.md              # This file
+├── requirements.txt       # Python dependencies
+├── .env.example           # API key template
+├── memanto_tools.py       # LangChain StructuredTool wrappers + MemantoSetup
+├── graph.py               # StateGraph: intake → recall → reason → remember → respond
+├── run_ingest.py          # Run 1: write a fact ("yesterday")
+├── run_recall.py          # Run 2: prove cross-session recall ("today")
+└── run_full_pipeline.py   # Both halves back-to-back in one process
+```
+
+## Troubleshooting
+
+- **"MOORCHEH_API_KEY not set"** — copy `.env.example` to `.env`
+  and fill in your key from
+  [console.moorcheh.ai/api-keys](https://console.moorcheh.ai/api-keys).
+- **"No memories found for query"** on the recall run — make sure
+  `run_ingest.py` finished without errors. Memanto writes are
+  durable, but the activation step has to succeed.
+- **Want to start over?** Just change `MEMANTO_AGENT_ID` in
+  `.env` to a new value; you'll get a fresh namespace.
+
+## Learn more
+
+- [Memanto Documentation](https://docs.memanto.ai)
+- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+- [Moorcheh API Keys](https://console.moorcheh.ai/api-keys)

--- a/examples/langgraph-memanto/graph.py
+++ b/examples/langgraph-memanto/graph.py
@@ -1,0 +1,168 @@
+"""
+LangGraph StateGraph wired to Memanto as a long-term memory layer.
+
+The graph models a tiny support-assistant pipeline:
+
+    intake -> recall -> reason -> remember -> respond
+
+Only `intake`, `reason`, and `respond` write to LangGraph's thread
+state. The `recall` and `remember` nodes call Memanto tools — those
+operations persist *outside* the thread state, which is what gives
+the graph cross-session memory.
+
+We deliberately do not bind an LLM here so the example stays free
+to run with just a Moorcheh API key. The "reason" step is a simple
+rule-based summarizer that consumes recalled memories and the new
+user turn. Swap it for an LLM call (any LangChain chat model) if
+you want richer behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from langchain_core.tools import StructuredTool
+from langgraph.graph import END, START, StateGraph
+
+from memanto.cli.client.sdk_client import SdkClient
+
+from memanto_tools import create_memanto_tools
+
+
+class GraphState(TypedDict, total=False):
+    """
+    Per-thread state for the LangGraph run.
+
+    Note: this state is ephemeral — it does NOT carry memory between
+    threads or runs. Anything that needs to survive across sessions
+    must go through Memanto via the `remember` / `recall` tools.
+    """
+
+    user_input: str
+    mode: str  # "ingest" or "recall"
+    fact_type: str
+    fact_title: str
+    fact_content: str
+    fact_tags: str
+    recalled: str
+    answer: str
+    response: str
+
+
+def _intake_node(state: GraphState) -> dict[str, Any]:
+    """Normalize the incoming turn. Pure function on thread state."""
+    mode = state.get("mode", "recall")
+    return {"mode": mode, "user_input": state.get("user_input", "")}
+
+
+def _make_recall_node(recall_tool: StructuredTool, answer_tool: StructuredTool):
+    """
+    Build a node that pulls long-term memory for the current turn.
+
+    This is where Memanto replaces LangGraph's thread state as the
+    source of truth for "what does the assistant already know".
+    """
+
+    def _recall_node(state: GraphState) -> dict[str, Any]:
+        query = state.get("user_input", "") or "user context"
+        recalled = recall_tool.invoke({"query": query, "limit": 5})
+        answer = answer_tool.invoke({"question": query})
+        return {"recalled": recalled, "answer": answer}
+
+    return _recall_node
+
+
+def _reason_node(state: GraphState) -> dict[str, Any]:
+    """
+    Plan the response using recalled memories + the current turn.
+
+    Rule-based by design so the example runs without an LLM key.
+    Replace this with a `ChatModel.invoke(...)` call to make it agentic.
+    """
+    user_input = state.get("user_input", "")
+    recalled = state.get("recalled", "")
+    answer = state.get("answer", "")
+
+    if state.get("mode") == "ingest":
+        plan = (
+            "Storing the user's latest statement as a long-term memory in Memanto "
+            "so a future LangGraph run (different thread, different process) can "
+            "recall it without any LangGraph checkpoint."
+        )
+    else:
+        plan = (
+            "Composing a reply that cites long-term memory pulled from Memanto, "
+            "not from LangGraph's thread state. The recalled block below was "
+            "fetched via memanto_recall; the answer block via memanto_answer."
+        )
+
+    response = (
+        f"[plan]\n{plan}\n\n"
+        f"[user turn]\n{user_input}\n\n"
+        f"[memanto.recall]\n{recalled}\n\n"
+        f"[memanto.answer]\n{answer}\n"
+    )
+    return {"response": response}
+
+
+def _make_remember_node(remember_tool: StructuredTool):
+    """
+    Build a node that writes the current turn's takeaway to Memanto.
+
+    Only fires when `mode == "ingest"`. The fact fields come from the
+    caller (typically the `run_ingest.py` script) so the example is
+    deterministic and easy to verify.
+    """
+
+    def _remember_node(state: GraphState) -> dict[str, Any]:
+        if state.get("mode") != "ingest":
+            return {}
+
+        result = remember_tool.invoke(
+            {
+                "memory_type": state.get("fact_type", "fact"),
+                "title": state.get("fact_title", "Untitled fact"),
+                "content": state.get("fact_content", state.get("user_input", "")),
+                "confidence": 0.95,
+                "tags": state.get("fact_tags", ""),
+            }
+        )
+        previous = state.get("response", "")
+        return {"response": f"{previous}\n[memanto.remember]\n{result}\n"}
+
+    return _remember_node
+
+
+def _respond_node(state: GraphState) -> dict[str, Any]:
+    """Final node — just passes the composed response through."""
+    return {"response": state.get("response", "")}
+
+
+def build_graph(
+    client: SdkClient,
+    agent_id: str,
+):
+    """
+    Wire the StateGraph: intake -> recall -> reason -> remember -> respond.
+
+    The compiled graph is returned without a checkpointer on purpose:
+    we want to prove that memory persists *without* any LangGraph
+    checkpoint. All cross-session state lives in Memanto.
+    """
+    tools = create_memanto_tools(client, agent_id)
+
+    graph = StateGraph(GraphState)
+    graph.add_node("intake", _intake_node)
+    graph.add_node("recall", _make_recall_node(tools["recall"], tools["answer"]))
+    graph.add_node("reason", _reason_node)
+    graph.add_node("remember", _make_remember_node(tools["remember"]))
+    graph.add_node("respond", _respond_node)
+
+    graph.add_edge(START, "intake")
+    graph.add_edge("intake", "recall")
+    graph.add_edge("recall", "reason")
+    graph.add_edge("reason", "remember")
+    graph.add_edge("remember", "respond")
+    graph.add_edge("respond", END)
+
+    return graph.compile()

--- a/examples/langgraph-memanto/memanto_tools.py
+++ b/examples/langgraph-memanto/memanto_tools.py
@@ -1,0 +1,282 @@
+"""
+Memanto tools for LangGraph.
+
+LangChain-compatible tool wrappers around Memanto's SdkClient. These
+tools let LangGraph nodes store and retrieve memories that live
+*outside* of LangGraph's thread-scoped state, giving the graph a
+permanent, cross-session brain.
+
+Why these aren't bound to LangGraph state:
+LangGraph's StateGraph passes a `state` dict between nodes within a
+single thread. That state is ephemeral — start a new thread (or a
+different process) and the state is gone. Memanto stores memories in
+its own namespace (keyed by `agent_id`), so any LangGraph node in any
+thread, on any machine, can read memories another node wrote earlier.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from memanto.cli.client.sdk_client import SdkClient
+
+logger = logging.getLogger(__name__)
+
+VALID_MEMORY_TYPES = (
+    "fact, preference, goal, decision, artifact, learning, event, "
+    "instruction, relationship, context, observation, commitment, error"
+)
+
+
+class MemantoSetup:
+    """
+    Manage Memanto agent lifecycle for a LangGraph integration.
+
+    Handles agent creation, session activation, and teardown so the
+    graph scripts can focus on graph orchestration.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self.client = SdkClient(api_key=api_key)
+
+    def setup(
+        self,
+        agent_id: str,
+        pattern: str = "tool",
+        description: str | None = None,
+        duration_hours: int = 6,
+    ) -> SdkClient:
+        """Create the agent (if needed) and activate a session."""
+        try:
+            self.client.create_agent(
+                agent_id=agent_id,
+                pattern=pattern,
+                description=description,
+            )
+            logger.info("Created Memanto agent '%s'", agent_id)
+        except Exception:
+            logger.info("Memanto agent '%s' already exists, reusing", agent_id)
+
+        self.client.activate_agent(agent_id, duration_hours=duration_hours)
+        logger.info("Activated session for agent '%s'", agent_id)
+        return self.client
+
+    def teardown(self, agent_id: str) -> None:
+        """Deactivate the agent session."""
+        try:
+            self.client.deactivate_agent(agent_id)
+            logger.info("Deactivated session for agent '%s'", agent_id)
+        except Exception as e:
+            logger.warning("Failed to deactivate agent '%s': %s", agent_id, e)
+
+
+# ---------------------------------------------------------------------------
+# Tool input schemas
+# ---------------------------------------------------------------------------
+
+
+class RememberInput(BaseModel):
+    """Input schema for the Memanto remember tool."""
+
+    memory_type: str = Field(
+        ...,
+        description=(
+            f"The semantic type of memory to store. Must be one of: {VALID_MEMORY_TYPES}"
+        ),
+    )
+    title: str = Field(
+        ...,
+        description="Short title for the memory (max 100 characters).",
+    )
+    content: str = Field(
+        ...,
+        description="The memory content to store (max 500 characters). Be concise and atomic.",
+    )
+    confidence: float = Field(
+        default=0.85,
+        description=(
+            "Confidence score from 0.0 to 1.0. Use 1.0 for explicit facts, "
+            "0.7-0.85 for observations."
+        ),
+    )
+    tags: str = Field(
+        default="",
+        description="Comma-separated tags for categorization (e.g. 'market,ai,trend'). Use lowercase.",
+    )
+
+
+class RecallInput(BaseModel):
+    """Input schema for the Memanto recall tool."""
+
+    query: str = Field(
+        ...,
+        description="Natural language search query to find relevant memories.",
+    )
+    limit: int = Field(
+        default=5,
+        description="Maximum number of memories to retrieve (1-20).",
+    )
+    memory_types: str = Field(
+        default="",
+        description=(
+            "Comma-separated memory types to filter by "
+            "(e.g. 'fact,observation'). Leave empty for all types."
+        ),
+    )
+
+
+class AnswerInput(BaseModel):
+    """Input schema for the Memanto answer tool."""
+
+    question: str = Field(
+        ...,
+        description="A question to answer using RAG over the agent's stored memories.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool factories
+# ---------------------------------------------------------------------------
+
+
+def _format_remember_result(
+    memory_type: str,
+    title: str,
+    confidence: float,
+    result: dict[str, Any],
+) -> str:
+    return (
+        f"Memory stored successfully.\n"
+        f"  ID: {result.get('memory_id')}\n"
+        f"  Type: {memory_type}\n"
+        f"  Title: {title}\n"
+        f"  Confidence: {confidence}"
+    )
+
+
+def _format_recall_result(query: str, memories: list[dict[str, Any]]) -> str:
+    if not memories:
+        return f"No memories found for query: '{query}'"
+
+    lines = [f"Found {len(memories)} memories for '{query}':\n"]
+    for i, mem in enumerate(memories, 1):
+        title = mem.get("title", "Untitled")
+        content = mem.get("content", "")
+        mem_type = mem.get("type", "unknown")
+        confidence = mem.get("confidence", "N/A")
+        tags = mem.get("tags", [])
+        tag_str = f" [tags: {', '.join(tags)}]" if tags else ""
+
+        lines.append(
+            f"  {i}. [{mem_type}] {title} (confidence: {confidence}){tag_str}\n"
+            f"     {content}\n"
+        )
+    return "\n".join(lines)
+
+
+def _make_remember_tool(client: SdkClient, agent_id: str) -> StructuredTool:
+    def _remember(
+        memory_type: str,
+        title: str,
+        content: str,
+        confidence: float = 0.85,
+        tags: str = "",
+    ) -> str:
+        tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
+        result = client.remember(
+            agent_id=agent_id,
+            memory_type=memory_type,
+            title=title,
+            content=content,
+            confidence=confidence,
+            tags=tag_list,
+            source="langgraph-node",
+            provenance="explicit_statement",
+        )
+        return _format_remember_result(memory_type, title, confidence, result)
+
+    return StructuredTool.from_function(
+        func=_remember,
+        name="memanto_remember",
+        description=(
+            "Store a structured memory in Memanto for long-term persistence. "
+            "Use this to save facts, observations, decisions, preferences, or any "
+            "information that should be available to future LangGraph runs or other "
+            "agents. Each memory has a type, title (max 100 chars), content (max 500 "
+            "chars), confidence score, and optional tags."
+        ),
+        args_schema=RememberInput,
+    )
+
+
+def _make_recall_tool(client: SdkClient, agent_id: str) -> StructuredTool:
+    def _recall(query: str, limit: int = 5, memory_types: str = "") -> str:
+        type_list = (
+            [t.strip() for t in memory_types.split(",") if t.strip()]
+            if memory_types
+            else None
+        )
+        result = client.recall(
+            agent_id=agent_id,
+            query=query,
+            limit=min(limit, 20),
+            type=type_list,
+        )
+        return _format_recall_result(query, result.get("memories", []))
+
+    return StructuredTool.from_function(
+        func=_recall,
+        name="memanto_recall",
+        description=(
+            "Search Memanto's persistent memory database using natural language. "
+            "Returns stored memories ranked by semantic relevance. Use this to "
+            "retrieve facts, prior conversation context, or any previously stored "
+            "information from earlier LangGraph runs."
+        ),
+        args_schema=RecallInput,
+    )
+
+
+def _make_answer_tool(client: SdkClient, agent_id: str) -> StructuredTool:
+    def _answer(question: str) -> str:
+        result = client.answer(agent_id=agent_id, question=question)
+        answer = result.get("answer", "No answer could be generated.")
+        sources = result.get("sources", [])
+        output = f"Answer: {answer}"
+        if sources:
+            output += f"\n\nBased on {len(sources)} memory source(s)."
+        return output
+
+    return StructuredTool.from_function(
+        func=_answer,
+        name="memanto_answer",
+        description=(
+            "Ask a question and get an AI-generated answer grounded in the agent's "
+            "stored memories using Retrieval-Augmented Generation (RAG). Useful for "
+            "synthesizing insights from multiple stored memories into a coherent answer."
+        ),
+        args_schema=AnswerInput,
+    )
+
+
+def create_memanto_tools(
+    client: SdkClient,
+    agent_id: str,
+) -> dict[str, StructuredTool]:
+    """
+    Create all Memanto tools bound to a specific client and agent.
+
+    Returns:
+        Dict with keys 'remember', 'recall', 'answer' mapping to
+        LangChain `StructuredTool` instances usable from any LangGraph
+        node.
+    """
+    return {
+        "remember": _make_remember_tool(client, agent_id),
+        "recall": _make_recall_tool(client, agent_id),
+        "answer": _make_answer_tool(client, agent_id),
+    }

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,4 @@
+langgraph>=0.2.0
+langchain-core>=0.3.0
+memanto>=0.1.0
+python-dotenv>=1.0.0

--- a/examples/langgraph-memanto/run_full_pipeline.py
+++ b/examples/langgraph-memanto/run_full_pipeline.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Full pipeline: ingest then recall in a single process, but across
+two SEPARATE LangGraph invocations.
+
+Even within one process the two `graph.invoke(...)` calls do not
+share thread state — LangGraph state is per-invocation when no
+checkpointer is configured. So the second call's ability to answer
+the question still proves that memory crossed the boundary via
+Memanto, not via LangGraph.
+
+Usage:
+    python run_full_pipeline.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from graph import build_graph
+from memanto_tools import MemantoSetup
+
+DEFAULT_AGENT_ID = "langgraph-support-bot"
+
+
+def main() -> None:
+    load_dotenv()
+
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        print(
+            "Error: MOORCHEH_API_KEY not set. Copy .env.example to .env and fill it in."
+        )
+        sys.exit(1)
+
+    agent_id = os.environ.get("MEMANTO_AGENT_ID", DEFAULT_AGENT_ID)
+
+    setup = MemantoSetup(api_key)
+    client = setup.setup(
+        agent_id=agent_id,
+        description="Long-term memory for the LangGraph support bot example",
+    )
+
+    print(f"\n{'=' * 60}")
+    print("  LangGraph + Memanto - Full pipeline")
+    print(f"  Agent ID: {agent_id}")
+    print(f"{'=' * 60}\n")
+
+    try:
+        graph = build_graph(client, agent_id)
+
+        print("--- Invocation 1: ingest ---\n")
+        ingest_result = graph.invoke(
+            {
+                "user_input": (
+                    "Hi, my name is Dana and I run the Memanto support desk. "
+                    "Our preferred response language is English and our SLA is 4 hours."
+                ),
+                "mode": "ingest",
+                "fact_type": "fact",
+                "fact_title": "Support contact: Dana (Memanto support desk)",
+                "fact_content": (
+                    "User Dana runs the Memanto support desk. Preferred language: "
+                    "English. Response SLA: 4 hours."
+                ),
+                "fact_tags": "user,support,sla",
+            }
+        )
+        print(ingest_result.get("response", ""))
+
+        print("\n--- Invocation 2: recall (separate thread state) ---\n")
+        recall_result = graph.invoke(
+            {
+                "user_input": (
+                    "Who runs the support desk and what's the response SLA?"
+                ),
+                "mode": "recall",
+            }
+        )
+        print(recall_result.get("response", ""))
+
+        print(f"\n{'=' * 60}")
+        print("  Pipeline complete — memory crossed the invocation boundary via Memanto.")
+        print(f"{'=' * 60}")
+    finally:
+        setup.teardown(agent_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/run_ingest.py
+++ b/examples/langgraph-memanto/run_ingest.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Run 1 ("yesterday"): ingest a user fact into Memanto via LangGraph.
+
+This script kicks off a LangGraph run whose `remember` node calls
+Memanto's `remember` tool. The fact is stored in Memanto's namespace
+for `agent_id`, NOT in any LangGraph checkpoint.
+
+Run `python run_recall.py` afterwards (in a brand-new process — a
+different "session") to see the graph pull the fact back from
+Memanto with zero LangGraph thread state carried over.
+
+Usage:
+    python run_ingest.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from graph import build_graph
+from memanto_tools import MemantoSetup
+
+DEFAULT_AGENT_ID = "langgraph-support-bot"
+
+
+def main() -> None:
+    load_dotenv()
+
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        print(
+            "Error: MOORCHEH_API_KEY not set. Copy .env.example to .env and fill it in."
+        )
+        sys.exit(1)
+
+    agent_id = os.environ.get("MEMANTO_AGENT_ID", DEFAULT_AGENT_ID)
+
+    setup = MemantoSetup(api_key)
+    client = setup.setup(
+        agent_id=agent_id,
+        description="Long-term memory for the LangGraph support bot example",
+    )
+
+    print(f"\n{'=' * 60}")
+    print("  LangGraph + Memanto - Ingest run ('yesterday')")
+    print(f"  Agent ID: {agent_id}")
+    print(f"{'=' * 60}\n")
+
+    try:
+        graph = build_graph(client, agent_id)
+        result = graph.invoke(
+            {
+                "user_input": (
+                    "Hi, my name is Dana and I run the Memanto support desk. "
+                    "Our preferred response language is English and our SLA is 4 hours."
+                ),
+                "mode": "ingest",
+                "fact_type": "fact",
+                "fact_title": "Support contact: Dana (Memanto support desk)",
+                "fact_content": (
+                    "User Dana runs the Memanto support desk. Preferred language: "
+                    "English. Response SLA: 4 hours."
+                ),
+                "fact_tags": "user,support,sla",
+            }
+        )
+
+        print(result.get("response", ""))
+        print(
+            "\nFact written to Memanto. Now run `python run_recall.py` in a fresh "
+            "process to prove cross-session recall without a LangGraph checkpoint."
+        )
+    finally:
+        setup.teardown(agent_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/run_recall.py
+++ b/examples/langgraph-memanto/run_recall.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Run 2 ("today"): recall the fact stored by run_ingest.py.
+
+This script builds a *fresh* LangGraph (no checkpointer, no shared
+state with run_ingest.py) and asks a question that can only be
+answered by reading the memory written in the previous run. Because
+the graph holds zero prior thread state, a correct answer proves
+that the memory lives in Memanto, not in LangGraph.
+
+Usage:
+    python run_recall.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from graph import build_graph
+from memanto_tools import MemantoSetup
+
+DEFAULT_AGENT_ID = "langgraph-support-bot"
+
+
+def main() -> None:
+    load_dotenv()
+
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        print(
+            "Error: MOORCHEH_API_KEY not set. Copy .env.example to .env and fill it in."
+        )
+        sys.exit(1)
+
+    agent_id = os.environ.get("MEMANTO_AGENT_ID", DEFAULT_AGENT_ID)
+
+    setup = MemantoSetup(api_key)
+    client = setup.setup(
+        agent_id=agent_id,
+        description="Long-term memory for the LangGraph support bot example",
+    )
+
+    print(f"\n{'=' * 60}")
+    print("  LangGraph + Memanto - Recall run ('today')")
+    print(f"  Agent ID: {agent_id}")
+    print(f"{'=' * 60}")
+    print("  (Fresh graph, no checkpoint — answers must come from Memanto)")
+    print()
+
+    try:
+        graph = build_graph(client, agent_id)
+        result = graph.invoke(
+            {
+                "user_input": (
+                    "Who runs the support desk and what's the response SLA?"
+                ),
+                "mode": "recall",
+            }
+        )
+
+        print(result.get("response", ""))
+    finally:
+        setup.teardown(agent_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a new `examples/langgraph-memanto/` example showing how a LangGraph `StateGraph` can use Memanto as a long-term memory layer that lives outside of LangGraph's thread-scoped state. The example proves cross-session recall: one process writes a fact through the graph, a second process — with no shared LangGraph checkpoint or thread state — answers a question that can only come from the first run, with the Memanto agent namespace as the only thing crossing the boundary.

## Changes
- Add `examples/langgraph-memanto/README.md` documenting setup, the cross-session demo flow, an architecture diagram, a comparison table for LangGraph thread state vs. Memanto, a before/after snippet for plugging Memanto into an existing graph, and a placeholder for the 30-second video/GIF link.
- Add `examples/langgraph-memanto/memanto_tools.py` wrapping `SdkClient` `remember` / `recall` / `answer` operations as LangChain `StructuredTool` instances, plus a `MemantoSetup` helper that handles agent activation.
- Add `examples/langgraph-memanto/graph.py` defining a `GraphState` TypedDict and a `intake → recall → reason → remember → respond` `StateGraph`. The `recall` and `remember` nodes are the only ones that touch external state; `reason` is intentionally rule-based so the example runs without an LLM key.
- Add `examples/langgraph-memanto/run_ingest.py` (writes a fact via the graph) and `examples/langgraph-memanto/run_recall.py` (fresh-process recall) to demonstrate cross-session memory across separate processes.
- Add `examples/langgraph-memanto/run_full_pipeline.py` running both halves back-to-back in one process, relying on the absence of a checkpointer to prove the second `invoke` only knows what Memanto told it.
- Add `examples/langgraph-memanto/requirements.txt` and `examples/langgraph-memanto/.env.example` for setup.

## Testing
Verified with `python -m compileall examples/langgraph-memanto` — all modules compile cleanly. End-to-end execution against the live Moorcheh API was not run here because it requires a real `MOORCHEH_API_KEY`; the README documents the exact two-command flow (`run_ingest.py` then `run_recall.py`) for the maintainer to record the demo.

## Notes
- Pure additive change confined to a new `examples/` subdirectory. No production code, tests, dependencies, lockfiles, or CI files are touched.
- The `reason` node is deliberately rule-based so the example is deterministic and zero-cost to run. Swapping in any LangChain chat model is a one-line change documented in the README.
- The bounty's social-traction items (X / LinkedIn / Reddit posts and the 30-second video/GIF) are out of scope for code; the README leaves a clearly marked placeholder for the media link.
- Assumes the existing `SdkClient` surface (`remember` / `recall` / `answer` with `type=...`) used by the CrewAI example is the canonical one to wrap.

Closes #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new LangGraph example demonstrating integration with Memanto for cross-session memory management
  * Included comprehensive documentation, setup instructions, and three executable demo scripts
  * Added helper tools for seamless Memanto integration within LangGraph workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->