### PR TITLE
feat(examples): LangGraph + Memanto persistent cross-session memory

### DIFF
--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,0 +1,3 @@
+# Moorcheh API Key (free tier: 100K ops/month)
+# Get yours at https://console.moorcheh.ai/api-keys
+MOORCHEH_API_KEY=

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,197 @@
+# LangGraph + Memanto: Persistent Cross-Session Memory
+
+> **Bounty Entry** — [BOUNTY $100] 🐜 The Memanto + LangGraph Integration Challenge
+>
+> This example shows how to give a [LangGraph](https://langchain-ai.github.io/langgraph/) workflow permanent memory using [Memanto](https://memanto.ai) — so an agent remembers across sessions, across restarts, and across process boundaries.
+
+https://github.com/user-attachments/assets/9855599c-1496-45c8-a8db-0b93a3dedac1
+
+## What This Demonstrates
+
+| Capability | How it's shown |
+|-----------|----------------|
+| **Cross-session recall** | Run the demo, then run it again — the second run loads memories stored by the first |
+| **Typed semantic memory** | Memories are stored with types (`fact`, `preference`, `decision`) and confidence scores |
+| **RAG from memory** | The `answer_from_memory` tool synthesizes answers from multiple stored memories |
+| **LangGraph integration** | Memanto tools are used inside standard LangGraph `StateGraph` nodes |
+| **Zero overhead on existing state** | Memanto supplements LangGraph's built-in `State`, not replaces it — your graph keeps working as-is |
+
+## Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │     LangGraph Graph      │
+                    │  ┌─────────────────────┐ │
+  START ──────────▶ │  │ load_context node   │ │ ──▶ recall_memory tool ──▶ Memanto
+                    │  └─────────────────────┘ │
+                    │  ┌─────────────────────┐ │
+                    │  │ store_memories node │ │ ──▶ remember_memory tool ──▶ Memanto
+                    │  └─────────────────────┘ │
+                    │  ┌─────────────────────┐ │
+                    │  │ answer_question node│ │ ──▶ answer_from_memory tool ──▶ Memanto
+                    │  └─────────────────────┘ │
+                    │  ┌─────────────────────┐ │
+                    │  │ summarize node      │ │
+                    │  └─────────────────────┘ │
+                    └──────────┬──────────────┘
+                               │
+                    ╔══════════╧══════════╗
+                    ║     Memanto SDK     ║
+                    ║  remember / recall  ║
+                    ║  / answer           ║
+                    ╚═════════════════════╝
+                               │
+                    ┌──────────┴──────────┐
+                    │  Moorcheh API       │
+                    │  (serverless,       │
+                    │   zero idle cost)   │
+                    └─────────────────────┘
+```
+
+### Why tools, not a storage backend override?
+
+LangGraph stores conversation state in its own `State` — this is good for single-session, in-progress state. But that state is gone when the process exits.
+
+Memanto fills the gap: **permanent, queryable, cross-session memory**. We expose it as *tools* that the LangGraph graph calls at specific nodes:
+
+- At **startup**: `recall_memory` retrieves what the agent knows about the user
+- During **processing**: `remember_memory` stores new facts and preferences
+- On **demand**: `answer_from_memory` synthesizes answers from stored memories
+
+This keeps Memanto's memory system **independent** of the LangGraph state lifecycle. Your graph keeps its existing state handling; Memanto adds persistence on top.
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.10+
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys) (free tier: 100K ops/month)
+
+### Setup
+
+```bash
+# 1. Navigate to the example
+cd examples/langgraph-memanto
+
+# 2. Create a virtual environment
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+
+# 3. Install dependencies
+pip install -r requirements.txt
+
+# 4. Configure your API key
+cp .env.example .env
+# Edit .env and add your MOORCHEH_API_KEY
+```
+
+### Run
+
+```bash
+export MOORCHEH_API_KEY="sk-..."  # or set in .env
+python run_cross_session.py
+```
+
+**First run:** Creates a Memanto agent, stores preferences and decisions, then exits.
+
+**Second run** (proves cross-session recall!):
+```bash
+python run_cross_session.py
+```
+The startup node automatically loads the memories stored by the first run. You'll see the agent say:
+```
+Context loaded: Existing memories for this user:
+  [preference, conf=0.8] Dark mode preference: The user prefers dark mode...
+  [fact, conf=0.8] Timezone: The user's timezone is Asia/Shanghai...
+```
+
+## File Structure
+
+```
+examples/langgraph-memanto/
+├── README.md               # This file
+├── requirements.txt        # Python dependencies
+├── .env.example            # API key template
+├── memanto_tools.py        # Memanto → LangChain Tool wrappers
+│                            #   - MemantoSetup: bootstrap helper
+│                            #   - create_memanto_tools(): returns remember/recall/answer tools
+└── run_cross_session.py    # Main demo: LangGraph StateGraph with Memanto memory
+```
+
+## Memanto Tools Reference
+
+| Tool | SDK Method | Description |
+|------|-----------|-------------|
+| `remember_memory` | `SdkClient.remember()` | Store a memory with type, confidence, tags |
+| `recall_memory` | `SdkClient.recall()` | Semantic search of stored memories |
+| `answer_from_memory` | `SdkClient.answer()` | RAG-based answer from memory context |
+
+### Using the Tools in Your Own Graph
+
+```python
+from memanto_tools import MemantoSetup, create_memanto_tools
+
+# 1. Setup
+setup = MemantoSetup(api_key="sk-...")
+client = setup.setup(agent_id="my-custom-agent")
+tools = create_memanto_tools(client, agent_id="my-custom-agent")
+
+# 2. Use inside any LangGraph node
+def my_node(state):
+    # Store something
+    tools["remember"].invoke({
+        "input": '{"content": "Learned X", "memory_type": "fact"}'
+    })
+    # Recall later
+    memories = tools["recall"].invoke(
+        {"query": "What did I learn about X?"}
+    )
+    return {"messages": [("assistant", memories)]}
+
+# 3. Cleanup
+setup.teardown()
+```
+
+## How to Win the Social Traction Bonus
+
+The bounty uses a "Social Traction Formula" to rank entries. Here's how to max your score:
+
+| Action | Platform | Points |
+|--------|----------|--------|
+| Post your demo + link to PR | X/Twitter, tag @moorcheh_ai + #Memanto | 1pt per like, 3pt per RT/bookmark |
+| Share in a relevant Reddit community | r/LangGraph, r/LocalLLaMA, r/MachineLearning | 5pt base + 2pt per upvote |
+| Add a 🚀 reaction on the PR | GitHub | 2pt each |
+
+### Suggested Posts
+
+**X/Twitter:**
+> 🧠 Gave my LangGraph agent permanent memory using @moorcheh_ai's Memanto.
+>
+> It remembers across sessions — preferences, facts, decisions — even after the process exits.
+>
+> 🔗 [link to your PR]
+> #Memanto #LangGraph #AIAgents
+
+**Reddit (r/LangGraph):**
+> Title: I gave my LangGraph agent permanent cross-session memory with Memanto
+>
+> Body: LangGraph's built-in State is great for single sessions, but what about long-term memory? Here's a clean integration where Memanto handles persistence while LangGraph handles orchestration. Full code in the PR linked below.
+
+## Comparison: Memanto vs. LangGraph Built-in Memory
+
+| Feature | LangGraph State | Memanto (via this integration) |
+|---------|----------------|--------------------------------|
+| Scope | Single session | Cross-session, cross-process |
+| Persistence | Lost on exit | Permanent (serverless) |
+| Search | Key-based access only | Semantic / natural-language query |
+| Memory types | Untyped | 13 semantic types (fact, preference, decision, goal, …) |
+| Confidence | N/A | 0.0–1.0 scoring |
+| Conflict detection | N/A | Automatic contradiction detection |
+| RAG | N/A | Built-in `answer()` with source citations |
+| Cost at idle | N/A | Zero (serverless) |
+
+## Learn More
+
+- [Memanto Documentation](https://docs.memanto.ai)
+- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+- [Moorcheh API Keys](https://console.moorcheh.ai/api-keys)

--- a/examples/langgraph-memanto/memanto_tools.py
+++ b/examples/langgraph-memanto/memanto_tools.py
@@ -1,0 +1,226 @@
+"""
+Memanto Tools for LangGraph — Persistent, Cross-Session Memory.
+
+This module wraps Memanto's SdkClient (remember / recall / answer) as
+LangChain-compatible Tool objects, so they can be used inside LangGraph
+StateGraph nodes, LangChain agents, or any tool-calling LLM.
+
+Usage:
+    from memanto_tools import create_memanto_tools, MemantoSetup
+
+    setup = MemantoSetup(api_key="your-moorcheh-key")
+    client = setup.setup(agent_id="my-agent")
+    tools = create_memanto_tools(client, agent_id="my-agent")
+
+    # In a LangGraph node:
+    result = tools["recall"].invoke({"query": "What does the user prefer?"})
+"""
+
+import os
+from typing import Any
+
+from langchain_core.tools import Tool
+
+
+# ---------------------------------------------------------------------------
+# MemantoSetup — one-call bootstrap for LangGraph examples
+# ---------------------------------------------------------------------------
+
+class MemantoSetup:
+    """Bootstrap helper: creates/activates a Memanto agent from an API key.
+
+    Usage:
+        setup = MemantoSetup(api_key="sk-...")
+        client = setup.setup(agent_id="my-langgraph-agent")
+
+    The resulting *client* is a fully authenticated ``SdkClient`` with an
+    active session.  Call ``setup.teardown()`` when done to release resources.
+    """
+
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.environ.get("MOORCHEH_API_KEY", "")
+        if not self.api_key:
+            raise ValueError(
+                "MOORCHEH_API_KEY is required. "
+                "Get one free at https://console.moorcheh.ai/api-keys"
+            )
+        self._client: Any = None
+        self._agent_id: str | None = None
+
+    def setup(self, agent_id: str = "langgraph-agent") -> Any:
+        """Create (or reuse) an agent and start a session.
+
+        Returns an ``SdkClient`` with an active session.
+        """
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self._agent_id = agent_id
+        self._client = SdkClient(api_key=self.api_key)
+
+        # Create agent if it doesn't exist yet (idempotent — reuses existing)
+        try:
+            self._client.get_agent(agent_id)
+        except Exception:
+            self._client.create_agent(
+                agent_id=agent_id,
+                pattern="tool",
+                description="LangGraph agent with Memanto persistent memory",
+            )
+
+        # Activate session
+        self._client.activate_agent(agent_id)
+        return self._client
+
+    def teardown(self) -> None:
+        """End the current session."""
+        if self._client and self._agent_id:
+            try:
+                self._client.deactivate_agent(self._agent_id)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Tool factory
+# ---------------------------------------------------------------------------
+
+def create_memanto_tools(client: Any, agent_id: str) -> dict[str, Tool]:
+    """Create LangChain Tool objects wrapping Memanto SDK operations.
+
+    Returns a dict with three keys: ``remember``, ``recall``, ``answer``.
+    Pass these tools to your LangGraph agent or tool-executing node.
+
+    Parameters
+    ----------
+    client : SdkClient
+        An authenticated Memanto SDK client (from ``MemantoSetup.setup()``).
+    agent_id : str
+        The agent namespace to read/write memories from.
+    """
+    return {
+        "remember": Tool(
+            name="remember_memory",
+            description=(
+                "Store a new memory for the current agent. "
+                "Input should be a JSON string with keys: "
+                "content (str, required), "
+                "memory_type (str, optional: fact|instruction|decision|goal|preference|event|commitment), "
+                "title (str, optional), "
+                "confidence (float, optional, 0-1). "
+                "Use this whenever the agent learns something worth remembering across sessions."
+            ),
+            func=lambda input_str: _remember(client, agent_id, input_str),
+        ),
+        "recall": Tool(
+            name="recall_memory",
+            description=(
+                "Search the agent's persistent memory using a natural-language query. "
+                "Input is a plain-text search string (e.g. 'What does the user prefer?'). "
+                "Returns relevant memories ranked by semantic relevance. "
+                "Use this at the start of every session to restore context."
+            ),
+            func=lambda query: _recall(client, agent_id, query),
+        ),
+        "answer": Tool(
+            name="answer_from_memory",
+            description=(
+                "Answer a question using Retrieval-Augmented Generation over the "
+                "agent's persistent memory. Input is a plain-text question. "
+                "Returns a natural-language answer with source citations. "
+                "Use this when you need a synthesized answer from multiple memories."
+            ),
+            func=lambda question: _answer(client, agent_id, question),
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal dispatch helpers
+# ---------------------------------------------------------------------------
+
+def _remember(client: Any, agent_id: str, input_str: str) -> str:
+    import json
+
+    try:
+        params = json.loads(input_str)
+    except json.JSONDecodeError:
+        params = {"content": input_str}
+
+    content = params.get("content", input_str)
+    title = params.get("title", content[:47] + "..." if len(content) > 50 else content)
+    memory_type = params.get("memory_type", "fact")
+    confidence = params.get("confidence", 0.8)
+
+    try:
+        result = client.remember(
+            agent_id=agent_id,
+            memory_type=memory_type,
+            title=title,
+            content=content,
+            confidence=confidence,
+        )
+        return json.dumps(
+            {
+                "status": "stored",
+                "memory_id": result.get("memory_id", "unknown"),
+                "type": memory_type,
+            }
+        )
+    except Exception as e:
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+def _recall(client: Any, agent_id: str, query: str) -> str:
+    import json
+
+    if not query or not query.strip():
+        return json.dumps({"status": "error", "message": "Query cannot be empty"})
+
+    try:
+        result = client.recall(agent_id=agent_id, query=query, limit=10)
+        memories = result.get("memories", [])
+        if not memories:
+            return json.dumps(
+                {"status": "success", "memories": [], "count": 0}
+            )
+
+        formatted = []
+        for m in memories:
+            formatted.append(
+                {
+                    "id": m.get("id", ""),
+                    "type": m.get("type", "unknown"),
+                    "title": m.get("title", ""),
+                    "content": m.get("content", ""),
+                    "confidence": m.get("confidence", 0.0),
+                    "created_at": str(m.get("created_at", "")),
+                }
+            )
+        return json.dumps(
+            {
+                "status": "success",
+                "memories": formatted,
+                "count": len(formatted),
+            }
+        )
+    except Exception as e:
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+def _answer(client: Any, agent_id: str, question: str) -> str:
+    import json
+
+    if not question or not question.strip():
+        return json.dumps({"status": "error", "message": "Question cannot be empty"})
+
+    try:
+        result = client.answer(agent_id=agent_id, question=question)
+        return json.dumps(
+            {
+                "status": "success",
+                "answer": result.get("answer", ""),
+                "sources": result.get("sources", []),
+            }
+        )
+    except Exception as e:
+        return json.dumps({"status": "error", "message": str(e)})

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,3 @@
+langgraph>=1.0.0
+langchain-core>=0.3.0
+memanto>=0.1.0

--- a/examples/langgraph-memanto/run_cross_session.py
+++ b/examples/langgraph-memanto/run_cross_session.py
@@ -1,0 +1,289 @@
+"""
+LangGraph + Memanto: Cross-Session Persistent Memory Demo
+=========================================================
+
+This example demonstrates a LangGraph workflow that uses Memanto
+as its persistent memory layer.  The key feature is **cross-session
+recall**: information stored in one session is available in a
+completely new session — even after the first program exits.
+
+Scenario
+--------
+A customer-support agent that interacts with a user across
+multiple sessions.  In Session 1 the user states preferences;
+in Session 2 the agent recalls them automatically without
+being told again.
+
+How to run
+----------
+    export MOORCHEH_API_KEY="sk-..."
+    python run_cross_session.py
+
+The script exits 0 on success.  It requires no interactive input.
+"""
+
+import json
+import os
+import sys
+import time
+import textwrap
+from typing import Any, Literal
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from typing_extensions import TypedDict, Annotated
+
+
+# ---------------------------------------------------------------------------
+# LangGraph State
+# ---------------------------------------------------------------------------
+
+class AgentState(TypedDict):
+    """State passed between graph nodes."""
+    messages: Annotated[list, add_messages]
+    memanto_context: str  # Context loaded from Memanto at the start of a session
+    session_phase: str    # "startup", "processing", "shutdown"
+
+
+# ---------------------------------------------------------------------------
+# Graph nodes
+# ---------------------------------------------------------------------------
+
+def build_graph(tools: dict) -> StateGraph:
+    """Construct and return a compiled LangGraph StateGraph.
+
+    Parameters
+    ----------
+    tools : dict
+        Dict with keys ``remember``, ``recall``, ``answer`` — the output
+        of ``create_memanto_tools()``.
+    """
+
+    # ---- Node: load session context from Memanto ---------------------------
+
+    def load_context(state: AgentState) -> dict:
+        """At session start, recall any existing memories."""
+        recall_tool = tools["recall"]
+        result = recall_tool.invoke(
+            {"query": "What does the agent already know about this user?"}
+        )
+        data = json.loads(result)
+        if data.get("status") == "success" and data.get("count", 0) > 0:
+            memories = data["memories"]
+            lines = []
+            for m in memories:
+                lines.append(
+                    f"  [{m['type']}, conf={m['confidence']}] "
+                    f"{m['title']}: {m['content']}"
+                )
+            context = f"Existing memories for this user:\n" + "\n".join(lines)
+        else:
+            context = "No existing memories found. This appears to be a new user."
+        return {"memanto_context": context, "session_phase": "processing"}
+
+    # ---- Node: demonstrate recall of specific facts ------------------------
+
+    def demonstrate_recall(state: AgentState) -> dict:
+        """Demonstrate recalling specific memories."""
+        recall_tool = tools["recall"]
+
+        # 1. Recall user preferences
+        pref_result = recall_tool.invoke(
+            {"query": "User preferences and settings"}
+        )
+        # 2. Recall any decisions made
+        decision_result = recall_tool.invoke(
+            {"query": "What decisions has the user made?"}
+        )
+
+        combined = f"[RECALL RESULT]\n"
+        combined += f"--- Preferences ---\n{pref_result}\n\n"
+        combined += f"--- Decisions ---\n{decision_result}\n"
+
+        return {"messages": [("assistant", combined)]}
+
+    # ---- Node: store new information ---------------------------------------
+
+    def store_memories(state: AgentState) -> dict:
+        """Store sample memories that will persist across sessions."""
+        remember_tool = tools["remember"]
+
+        memories_to_store = [
+            {
+                "content": "The user prefers dark mode for all interfaces.",
+                "memory_type": "preference",
+                "title": "Dark mode preference",
+            },
+            {
+                "content": "The user's timezone is Asia/Shanghai (UTC+8).",
+                "memory_type": "fact",
+                "title": "Timezone",
+            },
+            {
+                "content": "The user decided to use Memanto as their memory backend for LangGraph.",
+                "memory_type": "decision",
+                "title": "Memory backend decision",
+            },
+        ]
+
+        results = []
+        for mem in memories_to_store:
+            r = remember_tool.invoke({"input": json.dumps(mem)})
+            results.append(json.loads(r))
+
+        status_line = f"Stored {len(memories_to_store)} memories: "
+        status_line += ", ".join(
+            f"{mem['memory_type']} ({r.get('status', '?')})"
+            for mem, r in zip(memories_to_store, results)
+        )
+        return {"messages": [("assistant", status_line)]}
+
+    # ---- Node: answer from memory ------------------------------------------
+
+    def answer_question(state: AgentState) -> dict:
+        """Use Memanto's ``answer`` (RAG) to answer a question from memory."""
+        answer_tool = tools["answer"]
+        question = "What do I know about my user, and how should I interact with them?"
+        result = answer_tool.invoke({"input": question})
+        return {"messages": [("assistant", f"[ANSWER]\n{result}")]}
+
+    # ---- Node: session summary ---------------------------------------------
+
+    def summarize(state: AgentState) -> dict:
+        """Provide a final summary of what was accomplished in this session."""
+        context = state.get("memanto_context", "No context")
+        summary = (
+            f"## Session Summary\n\n"
+            f"**Startup context loaded from Memanto:**\n{context}\n\n"
+            f"**Session complete.** All memories are persisted in Memanto "
+            f"and will be available in future sessions.\n"
+            f"To verify cross-session recall, run this script again — "
+            f"the second run will load memories stored by the first run."
+        )
+        return {
+            "messages": [("assistant", summary)],
+            "session_phase": "shutdown",
+        }
+
+    # ---- Build graph -------------------------------------------------------
+
+    builder = StateGraph(AgentState)
+
+    builder.add_node("load_context", load_context)
+    builder.add_node("demonstrate_recall", demonstrate_recall)
+    builder.add_node("store_memories", store_memories)
+    builder.add_node("answer_question", answer_question)
+    builder.add_node("summarize", summarize)
+
+    builder.add_edge(START, "load_context")
+    builder.add_edge("load_context", "demonstrate_recall")
+    builder.add_edge("demonstrate_recall", "store_memories")
+    builder.add_edge("store_memories", "answer_question")
+    builder.add_edge("answer_question", "summarize")
+    builder.add_edge("summarize", END)
+
+    return builder.compile()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+# Width for print formatting
+W = 72
+
+
+def _box(title: str, body: str) -> None:
+    """Print a labelled box to stdout."""
+    print("┌" + "─" * (W - 2) + "┐")
+    for line in textwrap.wrap(title, width=W - 6):
+        print(f"│  {line: <{W - 5}}│")
+    print("│" + "─" * (W - 2) + "│")
+    for line in body.strip().splitlines():
+        for chunk in textwrap.wrap(line, width=W - 4):
+            print(f"│  {chunk: <{W - 5}}│")
+    print("└" + "─" * (W - 2) + "┘")
+    print()
+
+
+def main():
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        print("ERROR: MOORCHEH_API_KEY environment variable is not set.")
+        print("Get a free key at https://console.moorcheh.ai/api-keys")
+        sys.exit(1)
+
+    agent_id = "langgraph-support-agent"
+
+    # ---- Setup Memanto -----------------------------------------------------
+    _box("⏳ Setup", "Initializing Memanto agent and session...")
+    from memanto_tools import MemantoSetup, create_memanto_tools
+
+    setup = MemantoSetup(api_key=api_key)
+    client = setup.setup(agent_id=agent_id)
+    tools = create_memanto_tools(client, agent_id=agent_id)
+    print("  ✓ Memanto agent ready:", agent_id)
+
+    # ---- Build and run the LangGraph ---------------------------------------
+    graph = build_graph(tools)
+
+    # Print the graph structure for visual verification
+    try:
+        # LangGraph 1.x uses get_graph() with print()
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            graph.get_graph().print_ascii()
+        _box("🧠 LangGraph Structure", f.getvalue())
+    except Exception:
+        pass  # Older versions may not support print_ascii
+
+    _box("🚀 Running Session", "Executing the LangGraph workflow...")
+
+    # Initial state — no prior messages, the graph loads context from Memanto
+    initial = {
+        "messages": [],
+        "memanto_context": "",
+        "session_phase": "startup",
+    }
+
+    output = None
+    for event in graph.stream(initial):
+        for node_name, values in event.items():
+            msgs = values.get("messages", [])
+            if msgs:
+                for msg in msgs:
+                    if hasattr(msg, "content"):
+                        print(f"  [{node_name}] {msg.content}")
+                    elif isinstance(msg, tuple):
+                        print(f"  [{node_name}] {msg[1]}")
+                    elif isinstance(msg, str):
+                        print(f"  [{node_name}] {msg}")
+            if values.get("memanto_context"):
+                ctx = values["memanto_context"]
+                preview = ctx[:120] + "..." if len(ctx) > 120 else ctx
+                print(f"  [{node_name}] Context loaded: {preview}")
+            output = values
+
+    # ---- Summary -----------------------------------------------------------
+    print()
+    _box(
+        "✅ Session Complete",
+        (
+            "All memories have been stored in Memanto.\n\n"
+            "To verify CROSS-SESSION RECALL, run this script again.\n"
+            "The second run will automatically find the memories\n"
+            "stored by this run — proving persistence beyond the\n"
+            "LangGraph state lifecycle.\n\n"
+            f"  python {__file__}\n"
+        ),
+    )
+
+    # ---- Teardown ----------------------------------------------------------
+    setup.teardown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a complete LangGraph integration example demonstrating persistent, cross-session memory using Memanto.

## What's Included

| File | Purpose |
|------|---------|
| `memanto_tools.py` | LangChain Tool wrappers for Memanto SDK (remember / recall / answer) + MemantoSetup bootstrap helper |
| `run_cross_session.py` | Fully-functional LangGraph StateGraph demo with 5 nodes showing cross-session recall |
| `README.md` | Full documentation with architecture, quick-start, social traction guide |
| `requirements.txt` | Python dependencies |
| `.env.example` | API key template |

## Key Features

- **Cross-session recall**: Memories stored in one session are available in a completely new session — even after the process exits
- **Typed semantic memory**: Memories use Memanto's 13 built-in types (fact, preference, decision, goal, etc.) with confidence scoring
- **RAG from memory**: The `answer_from_memory` tool synthesizes answers from stored memories with source citations
- **Tool-based integration**: Memanto supplements LangGraph's built-in State rather than replacing it — your existing graph logic stays intact
- **Zero overhead on existing state**: The graph keeps its standard state handling; Memanto adds persistence on top

## How to Verify Cross-Session Persistence

```bash
# Run once — stores preferences and facts
python run_cross_session.py

# Run again — automatically loads memories from the first run
python run_cross_session.py
```

The second run's `load_context` node will show:
> Existing memories for this user: [preference] Dark mode preference...

## Social Traction

This PR is amplified with:
- 🐦 X/Twitter: https://x.com/Johnson483454/status/2054065992146514362
- 📬 Reddit: https://www.reddit.com/r/LangGraph/comments/1taruxn/langgraph_memanto_permanent_crosssession_memory/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for LangGraph with persistent memory, including setup instructions, architecture overview, tools reference, and comparison with built-in alternatives.

* **New Features**
  * Added working example demonstrating cross-session persistent memory with Memanto integration in a LangGraph workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->