### PR TITLE
feat: LangGraph + Memanto integration example

### DIFF
--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,0 +1,5 @@
+# Memanto API key — create one at https://console.moorcheh.ai/api-keys
+MOORCHEH_API_KEY=your_moorcheh_api_key_here
+
+# OpenRouter API key — free tier available at https://openrouter.ai/keys
+OPENROUTER_API_KEY=your_openrouter_api_key_here

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,123 @@
+# Memanto + LangGraph Integration Example
+
+> **Give your LangGraph agents a permanent brain.**
+
+This example shows how to use **Memanto** as the long-term memory layer for a **LangGraph** agent. Memories survive across sessions, agents, and even reboots — so your graph never starts from a blank slate.
+
+## 🎯 What This Demonstrates
+
+| Challenge | How Memanto Solves It |
+|-----------|----------------------|
+| LangGraph state is ephemeral — lost on restart | Memanto persists memories in a semantic database |
+| Multiple agents can't share context | All agents read/write the same `agent_id` namespace |
+| No built-in memory retrieval | `recall` searches by meaning, not just keyword |
+| Flat context window | `answer` uses RAG to synthesize insights from many memories |
+
+## 🏠 Architecture
+
+```
+User Message
+     |
+     v
++------------------+
+| classify_intent  |  --> technical_issue | billing_question | feature_request | general_chat
++------------------+
+     |
+     v
++------------------+
+|  fetch_context   |  --> memanto_recall(user_id + intent)
++------------------+
+     |
+     v
++------------------+
+| generate_response|  --> LLM drafts reply using retrieved memories
++------------------+
+     |
+     v
++------------------+
+| persist_memory   |  --> memanto_remember(extracted facts)
++------------------+
+```
+
+## 🚀 Quick Start
+
+### 1. Install dependencies
+
+```bash
+cd examples/langgraph-memanto
+pip install -r requirements.txt
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+# Edit .env and add your keys
+```
+
+| Variable | Where to get it |
+|----------|-----------------|
+| `MOORCHEH_API_KEY` | https://console.moorcheh.ai/api-keys |
+| `OPENROUTER_API_KEY` | https://openrouter.ai/keys (free tier works) |
+
+### 3. Run the customer-support agent
+
+```bash
+python run_customer_support.py
+```
+
+Type messages and watch the agent recall previous context even after you restart the script.
+
+## 📚 Memory Types Used
+
+The agent stores memories with rich metadata:
+
+- **preference** — user likes/dislikes (e.g. "prefers email over chat")
+- **fact** — verified information (e.g. "on Pro plan since 2024")
+- **decision** — agreed resolution (e.g. "refund approved")
+- **issue** — reported problems (e.g. "login fails on Safari")
+
+Each memory includes confidence scores, tags, and provenance for clean retrieval.
+
+## 🔧 Customisation
+
+### Swap the LLM
+
+The graph accepts any LangChain-compatible chat model:
+
+```python
+from langchain_anthropic import ChatAnthropic
+
+llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+```
+
+### Change the agent namespace
+
+```python
+AGENT_ID = "my-company-support-agent"
+```
+
+All memories are scoped to this ID, so you can run multiple agents without collision.
+
+### Add more graph nodes
+
+`build_customer_support_graph()` returns a compiled `StateGraph`. You can extend it with additional nodes (escalation, sentiment analysis, etc.) before calling `.compile()`.
+
+## 📝 Files
+
+| File | Purpose |
+|------|---------|
+| `langgraph_memanto/client.py` | Memanto lifecycle manager (setup/teardown) |
+| `langgraph_memanto/tools.py` | Raw `remember` / `recall` / `answer` functions |
+| `langgraph_memanto/graph.py` | Re-usable `build_customer_support_graph()` builder |
+| `run_customer_support.py` | Interactive CLI demo |
+| `requirements.txt` | Python dependencies |
+| `.env.example` | Environment template |
+
+## 📱 Social Traction
+
+If you build something cool with this, post it and tag **#Memanto** + **@moorcheh-ai** on X / LinkedIn / Reddit. The bounty is awarded to the PR with the highest engagement by **June 1st 2026**.
+
+---
+
+Built with ❤️ by the open-source community.

--- a/examples/langgraph-memanto/langgraph_memanto/__init__.py
+++ b/examples/langgraph-memanto/langgraph_memanto/__init__.py
@@ -1,0 +1,8 @@
+"""LangGraph + Memanto integration utilities."""
+
+from __future__ import annotations
+
+from langgraph_memanto.client import MemantoSetup
+from langgraph_memanto.tools import create_memanto_tools
+
+__all__ = ["MemantoSetup", "create_memanto_tools"]

--- a/examples/langgraph-memanto/langgraph_memanto/client.py
+++ b/examples/langgraph-memanto/langgraph_memanto/client.py
@@ -1,0 +1,50 @@
+"""Memanto client lifecycle manager for LangGraph."""
+
+from __future__ import annotations
+
+import logging
+
+from memanto.cli.client.sdk_client import SdkClient
+
+logger = logging.getLogger(__name__)
+
+
+class MemantoSetup:
+    """Manages Memanto agent lifecycle for LangGraph integration."""
+
+    def __init__(self, api_key: str) -> None:
+        self._client = SdkClient(api_key=api_key)
+
+    @property
+    def client(self) -> SdkClient:
+        return self._client
+
+    def setup(
+        self,
+        agent_id: str,
+        pattern: str = "tool",
+        description: str | None = None,
+        duration_hours: int = 6,
+    ) -> SdkClient:
+        """Create agent (if needed) and activate a session."""
+        try:
+            self._client.create_agent(
+                agent_id=agent_id,
+                pattern=pattern,
+                description=description,
+            )
+            logger.info("Created Memanto agent '%s'", agent_id)
+        except Exception:
+            logger.info("Memanto agent '%s' already exists, reusing", agent_id)
+
+        self._client.activate_agent(agent_id, duration_hours=duration_hours)
+        logger.info("Activated session for agent '%s'", agent_id)
+        return self._client
+
+    def teardown(self, agent_id: str) -> None:
+        """Deactivate the agent session."""
+        try:
+            self._client.deactivate_agent(agent_id)
+            logger.info("Deactivated session for agent '%s'", agent_id)
+        except Exception as e:
+            logger.warning("Failed to deactivate agent '%s': %s", agent_id, e)

--- a/examples/langgraph-memanto/langgraph_memanto/graph.py
+++ b/examples/langgraph-memanto/langgraph_memanto/graph.py
@@ -1,0 +1,203 @@
+"""Re-usable LangGraph graph builder for Memanto-backed agents."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langgraph.graph import END, StateGraph
+from langgraph.graph.message import add_messages
+from pydantic import BaseModel, Field
+
+from langgraph_memanto.tools import memanto_recall, memanto_remember
+from memanto.cli.client.sdk_client import SdkClient
+
+
+class MemantoState(BaseModel):
+    """Shared state for a Memanto-backed LangGraph agent."""
+
+    messages: Annotated[list[BaseMessage], add_messages] = Field(
+        default_factory=list,
+        description="Conversation history.",
+    )
+    user_id: str = Field(default="", description="Identifier for the end-user.")
+    intent: str = Field(default="", description="Classified intent of the last user message.")
+    retrieved_memories: str = Field(
+        default="",
+        description="Raw text of memories recalled from Memanto.",
+    )
+    done: bool = Field(default=False, description="Set to True when the workflow should end.")
+
+
+def build_customer_support_graph(
+    llm: BaseChatModel,
+    client: SdkClient,
+    agent_id: str,
+) -> StateGraph:
+    """Build a StateGraph for a customer-support agent with long-term memory.
+
+    The graph follows a 4-step pipeline:
+
+    1. **classify_intent** — LLM decides whether the user is reporting a
+       *technical_issue*, asking a *billing_question*, making a
+       *feature_request*, or just *general_chat*.
+    2. **fetch_context** — Recalls previous memories for this ``user_id``
+       that match the classified intent.
+    3. **generate_response** — LLM drafts a reply that explicitly references
+       retrieved memories (if any).
+    4. **persist_memory** — Stores salient facts from the latest exchange so
+       they survive across sessions.
+
+    Args:
+        llm: Any LangChain-compatible chat model (e.g. ChatOpenAI,
+            ChatAnthropic, ChatOpenRouter).
+        client: Active Memanto :class:`SdkClient`.
+        agent_id: Memanto namespace for this agent.
+
+    Returns:
+        A compiled LangGraph state graph ready for ``graph.invoke(state)``.
+    """
+
+    def classify_intent(state: MemantoState) -> dict:
+        """Node 1 — classify the user's intent."""
+        if not state.messages:
+            return {"intent": "general_chat", "done": True}
+
+        last_msg = state.messages[-1]
+        if not isinstance(last_msg, HumanMessage):
+            return {"intent": state.intent}
+
+        system = SystemMessage(
+            content=(
+                "You are an intent-classifier for a customer-support system.\n"
+                "Reply with EXACTLY ONE word from this list:\n"
+                "  technical_issue, billing_question, feature_request, general_chat\n"
+                "No punctuation, no explanation."
+            )
+        )
+        response = llm.invoke([system, HumanMessage(content=last_msg.content)])
+        intent = response.content.strip().lower().split()[0]
+        valid = {"technical_issue", "billing_question", "feature_request", "general_chat"}
+        if intent not in valid:
+            intent = "general_chat"
+        return {"intent": intent}
+
+    def fetch_context(state: MemantoState) -> dict:
+        """Node 2 — recall memories for this user + intent."""
+        query = f"{state.intent} for user {state.user_id}"
+        memories = memanto_recall(
+            client=client,
+            agent_id=agent_id,
+            query=query,
+            limit=5,
+        )
+        return {"retrieved_memories": memories}
+
+    def generate_response(state: MemantoState) -> dict:
+        """Node 3 — draft a response using retrieved memories."""
+        system_parts = [
+            "You are a helpful customer-support agent.\n",
+            "You have access to the user's conversation history and past memories.\n",
+        ]
+        if state.retrieved_memories and "No memories found" not in state.retrieved_memories:
+            system_parts.append(
+                "The following memories were retrieved for this user:\n"
+                f"{state.retrieved_memories}\n"
+            )
+        else:
+            system_parts.append("No prior memories found for this user.\n")
+
+        system_parts.append(
+            "Instructions:\n"
+            "- Be concise (3-5 sentences).\n"
+            "- If a memory directly answers the question, cite it.\n"
+            "- If you need more info, ask a clarifying question.\n"
+            "- Never make up facts that aren't in the memories or current message."
+        )
+
+        system = SystemMessage(content="".join(system_parts))
+        response = llm.invoke([system, *state.messages])
+        return {"messages": [response]}
+
+    def persist_memory(state: MemantoState) -> dict:
+        """Node 4 — extract and store facts that should survive across sessions."""
+        if not state.messages or len(state.messages) < 2:
+            return {}
+
+        last_human = None
+        last_ai = None
+        for msg in reversed(state.messages):
+            if isinstance(msg, HumanMessage) and last_human is None:
+                last_human = msg
+            elif isinstance(msg, AIMessage) and last_ai is None:
+                last_ai = msg
+            if last_human and last_ai:
+                break
+
+        if not last_human:
+            return {}
+
+        extraction_prompt = SystemMessage(
+            content=(
+                "You are a memory-extraction engine.\n"
+                "Given the latest user message and your reply, produce 0-3 atomic facts\n"
+                "that should be stored as long-term memory.\n\n"
+                "Rules:\n"
+                "- Only extract explicit facts, preferences, or decisions.\n"
+                "- Do NOT store greetings, pleasantries, or transient info.\n"
+                "- Format: 'memory_type | title | content' (one per line).\n"
+                "- Valid memory_types: preference, fact, goal, decision, issue.\n"
+                "- If nothing worth storing, reply 'NONE'."
+            )
+        )
+        extraction_input = HumanMessage(
+            content=f"User: {last_human.content}\nAgent: {last_ai.content if last_ai else 'N/A'}"
+        )
+        extraction = llm.invoke([extraction_prompt, extraction_input])
+        raw = extraction.content.strip()
+
+        if raw.upper() == "NONE" or not raw:
+            return {}
+
+        stored = 0
+        for line in raw.splitlines():
+            line = line.strip()
+            if "|" not in line:
+                continue
+            parts = [p.strip() for p in line.split("|", 2)]
+            if len(parts) != 3:
+                continue
+            mem_type, title, content = parts
+            try:
+                memanto_remember(
+                    client=client,
+                    agent_id=agent_id,
+                    memory_type=mem_type,
+                    title=title[:100],
+                    content=content[:500],
+                    confidence=0.85,
+                    tags=["customer_support", state.intent, f"user:{state.user_id}"],
+                )
+                stored += 1
+            except Exception:
+                pass  # best-effort; don't crash the chat flow
+
+        return {}
+
+    # ------------------------------------------------------------------
+    # Assemble graph
+    # ------------------------------------------------------------------
+    builder = StateGraph(MemantoState)
+    builder.add_node("classify_intent", classify_intent)
+    builder.add_node("fetch_context", fetch_context)
+    builder.add_node("generate_response", generate_response)
+    builder.add_node("persist_memory", persist_memory)
+
+    builder.set_entry_point("classify_intent")
+    builder.add_edge("classify_intent", "fetch_context")
+    builder.add_edge("fetch_context", "generate_response")
+    builder.add_edge("generate_response", "persist_memory")
+    builder.add_edge("persist_memory", END)
+
+    return builder.compile()

--- a/examples/langgraph-memanto/langgraph_memanto/tools.py
+++ b/examples/langgraph-memanto/langgraph_memanto/tools.py
@@ -1,0 +1,207 @@
+"""Memanto tool functions for LangGraph agents.
+
+These are plain Python functions that wrap SdkClient operations.
+They can be used directly in LangGraph nodes or bound to an LLM via
+`bind_tools` for tool-calling agents.
+"""
+
+from __future__ import annotations
+
+from memanto.cli.client.sdk_client import SdkClient
+
+VALID_MEMORY_TYPES = frozenset(
+    {
+        "fact",
+        "preference",
+        "goal",
+        "decision",
+        "artifact",
+        "learning",
+        "event",
+        "instruction",
+        "relationship",
+        "context",
+        "observation",
+        "commitment",
+        "error",
+    }
+)
+
+
+def memanto_remember(
+    client: SdkClient,
+    agent_id: str,
+    memory_type: str,
+    title: str,
+    content: str,
+    confidence: float = 0.85,
+    tags: list[str] | None = None,
+) -> str:
+    """Store a structured memory in Memanto.
+
+    Args:
+        client: Active SdkClient instance.
+        agent_id: Namespace / agent identifier.
+        memory_type: One of the VALID_MEMORY_TYPES.
+        title: Short title (max 100 characters).
+        content: Atomic memory content (max 500 characters).
+        confidence: 0.0-1.0 confidence score.
+        tags: Optional list of categorization tags.
+
+    Returns:
+        Confirmation string with memory id and type.
+    """
+    if memory_type not in VALID_MEMORY_TYPES:
+        valid = ", ".join(sorted(VALID_MEMORY_TYPES))
+        return f"Error: invalid memory_type '{memory_type}'. Must be one of: {valid}"
+
+    result = client.remember(
+        agent_id=agent_id,
+        memory_type=memory_type,
+        title=title,
+        content=content,
+        confidence=confidence,
+        tags=tags or [],
+        source="langgraph-agent",
+        provenance="explicit_statement",
+    )
+
+    mem_id = result.get("memory_id", "unknown")
+    return (
+        f"Memory stored successfully.\n"
+        f"  ID: {mem_id}\n"
+        f"  Type: {memory_type}\n"
+        f"  Title: {title}"
+    )
+
+
+def memanto_recall(
+    client: SdkClient,
+    agent_id: str,
+    query: str,
+    limit: int = 5,
+    memory_types: list[str] | None = None,
+) -> str:
+    """Search Memanto memories with natural language.
+
+    Args:
+        client: Active SdkClient instance.
+        agent_id: Namespace / agent identifier.
+        query: Natural language search query.
+        limit: Max memories to retrieve (1-20).
+        memory_types: Optional filter by memory type(s).
+
+    Returns:
+        Formatted string with retrieved memories.
+    """
+    result = client.recall(
+        agent_id=agent_id,
+        query=query,
+        limit=min(limit, 20),
+        type=memory_types,
+    )
+
+    memories = result.get("memories", [])
+    if not memories:
+        return f"No memories found for query: '{query}'"
+
+    lines = [f"Found {len(memories)} memories for '{query}':\n"]
+    for i, mem in enumerate(memories, 1):
+        title = mem.get("title", "Untitled")
+        content = mem.get("content", "")
+        mem_type = mem.get("type", "unknown")
+        confidence = mem.get("confidence", "N/A")
+        tags = mem.get("tags", [])
+        tag_str = f" [tags: {', '.join(tags)}]" if tags else ""
+        lines.append(
+            f"  {i}. [{mem_type}] {title} (confidence: {confidence}){tag_str}\n"
+            f"     {content}"
+        )
+
+    return "\n".join(lines)
+
+
+def memanto_answer(
+    client: SdkClient,
+    agent_id: str,
+    question: str,
+) -> str:
+    """Get an AI-generated answer grounded in stored memories (RAG).
+
+    Args:
+        client: Active SdkClient instance.
+        agent_id: Namespace / agent identifier.
+        question: Question to answer from memory.
+
+    Returns:
+        Answer string with optional source count.
+    """
+    result = client.answer(
+        agent_id=agent_id,
+        question=question,
+    )
+
+    answer = result.get("answer", "No answer could be generated.")
+    sources = result.get("sources", [])
+    output = f"Answer: {answer}"
+    if sources:
+        output += f"\n\nBased on {len(sources)} memory source(s)."
+    return output
+
+
+def create_memanto_tools(
+    client: SdkClient,
+    agent_id: str,
+) -> dict[str, object]:
+    """Return a dict of Memanto tool functions bound to *client* and *agent_id*.
+
+    Because LangGraph tool-calling expects functions that receive only the
+    arguments defined in the schema, this factory returns thin wrappers that
+    close over *client* and *agent_id*.
+
+    Returns:
+        Dict with keys ``remember``, ``recall``, ``answer``.
+    """
+
+    def _remember(
+        memory_type: str,
+        title: str,
+        content: str,
+        confidence: float = 0.85,
+        tags: list[str] | None = None,
+    ) -> str:
+        return memanto_remember(
+            client=client,
+            agent_id=agent_id,
+            memory_type=memory_type,
+            title=title,
+            content=content,
+            confidence=confidence,
+            tags=tags,
+        )
+
+    def _recall(
+        query: str,
+        limit: int = 5,
+        memory_types: list[str] | None = None,
+    ) -> str:
+        return memanto_recall(
+            client=client,
+            agent_id=agent_id,
+            query=query,
+            limit=limit,
+            memory_types=memory_types,
+        )
+
+    def _answer(question: str) -> str:
+        return memanto_answer(
+            client=client,
+            agent_id=agent_id,
+            question=question,
+        )
+
+    return {
+        "remember": _remember,
+        "recall": _recall,
+        "answer": _answer,
+    }

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,5 @@
+langgraph>=0.3.0
+langchain-core>=0.3.0
+langchain-openai>=0.3.0
+python-dotenv>=1.0.0
+memanto>=0.1.0

--- a/examples/langgraph-memanto/run_customer_support.py
+++ b/examples/langgraph-memanto/run_customer_support.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Customer Support Agent with Memanto Long-Term Memory
+
+This example demonstrates a LangGraph agent that:
+  1. Classifies the user's intent (technical, billing, feature, chat)
+  2. Recalls previous memories for that user from Memanto
+  3. Generates a context-aware response
+  4. Stores new facts back into Memanto so they survive across sessions
+
+Usage:
+    export MOORCHEH_API_KEY="your-key"
+    export OPENROUTER_API_KEY="your-key"   # free models available
+    python run_customer_support.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from dotenv import load_dotenv
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_openai import ChatOpenAI
+from langgraph_memanto.client import MemantoSetup
+from langgraph_memanto.graph import MemantoState, build_customer_support_graph
+
+AGENT_ID = "langgraph-customer-support"
+USER_ID = "demo-user-42"
+
+
+def main() -> None:
+    load_dotenv()
+
+    moorcheh_key = os.environ.get("MOORCHEH_API_KEY")
+    if not moorcheh_key:
+        print("Error: MOORCHEH_API_KEY not set. Copy .env.example to .env and fill it in.")
+        sys.exit(1)
+
+    openrouter_key = os.environ.get("OPENROUTER_API_KEY")
+    if not openrouter_key:
+        print("Error: OPENROUTER_API_KEY not set. Get a free key at https://openrouter.ai/keys")
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # 1. Set up Memanto
+    # ------------------------------------------------------------------
+    setup = MemantoSetup(api_key=moorcheh_key)
+    client = setup.setup(
+        agent_id=AGENT_ID,
+        description="Customer support agent with persistent user memory",
+    )
+
+    # ------------------------------------------------------------------
+    # 2. Configure LLM (OpenRouter free tier)
+    # ------------------------------------------------------------------
+    llm = ChatOpenAI(
+        model="openrouter/tencent/hy3-preview:free",
+        openai_api_base="https://openrouter.ai/api/v1",
+        api_key=openrouter_key,
+        temperature=0.3,
+    )
+
+    # ------------------------------------------------------------------
+    # 3. Build the graph
+    # ------------------------------------------------------------------
+    graph = build_customer_support_graph(
+        llm=llm,
+        client=client,
+        agent_id=AGENT_ID,
+    )
+
+    # ------------------------------------------------------------------
+    # 4. Interactive demo loop
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("  Memanto + LangGraph — Customer Support Agent")
+    print("=" * 60)
+    print("  Type your message and press Enter.")
+    print("  Type 'quit' or 'exit' to finish.\n")
+
+    state = MemantoState(user_id=USER_ID)
+
+    try:
+        while True:
+            user_input = input("You: ").strip()
+            if user_input.lower() in {"quit", "exit", "q"}:
+                break
+
+            state.messages.append(HumanMessage(content=user_input))
+            result = graph.invoke(state)
+
+            # Update state for the next turn
+            state = MemantoState(**result)
+
+            # Print the latest AI message
+            for msg in reversed(state.messages):
+                if isinstance(msg, AIMessage):
+                    print(f"Agent: {msg.content}\n")
+                    break
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+    finally:
+        setup.teardown(AGENT_ID)
+        print("\nSession ended. Memories persisted in Memanto.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #397

## What
A complete customer-support agent built with **LangGraph** that uses **Memanto** as its long-term memory layer.

## Architecture (4-step pipeline)
1. **classify_intent** — categorises user message (technical / billing / feature / chat)
2. **fetch_context** — recalls previous memories from Memanto via 
3. **generate_response** — drafts a reply grounded in retrieved context
4. **persist_memory** — stores new facts back into Memanto so they survive across sessions

## Files added
-  — Memanto lifecycle wrapper
-  —  /  /  functions
-  — reusable  builder
-  — interactive CLI demo
-  — setup guide + architecture diagram
-  + 

## Why this approach
- **No DOM restructuring** — purely additive example under 
- **Re-usable** —  accepts any LangChain chat model
- **Persistent** — memories survive script restarts via Memanto semantic DB

/claim #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete LangGraph example project demonstrating Memanto integration for agents. Features a customer support agent with persistent long-term memory, semantic memory recall from conversations, and automatic memory updates. Includes setup documentation with quick-start instructions, API key configuration, and an interactive command-line demo for testing how agents interact with and leverage persistent memory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->