### PR TITLE
feat: Add Memanto + LangGraph integration example ( Bounty)

### DIFF
--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -45,7 +45,7 @@ python demo.py
 
 ### Expected Output
 
-```
+```text
 --------------------------------------------------
  🌙 SESSION 1: The User Provides Information
 --------------------------------------------------

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -4,11 +4,15 @@ This example demonstrates how to use **Memanto** to give your **LangGraph** agen
 
 While LangGraph's native `State` is fantastic for maintaining context during a single workflow run, it is ephemeral once the graph execution completes. Memanto acts as the long-term semantic database for your agent, allowing it to remember user preferences, facts, and past instructions forever.
 
-## 📺 Demo & Social Traction
+## 📺 Demo
 
-Check out the 30-second Demo Video of this agent in action:
+Watch the 30-second demo of the agent recalling Alice's preferences across two completely isolated sessions:
+
+https://github.com/user-attachments/assets/b9e63b79-19cd-43e8-b33c-157d5f82baf0
+
+**Discussion & traction:**
 - [▶️ Watch on X (Twitter)](https://x.com/Johan2aa/status/2054277719697903695)
-- [▶️ Join the discussion on Reddit (r/LangChain)](https://www.reddit.com/r/LangChain/comments/1tbb3nx/i_solved_the_langgraph_crosssession_memory/)
+- [💬 Reddit r/LangChain thread](https://www.reddit.com/r/LangChain/comments/1tbb3nx/i_solved_the_langgraph_crosssession_memory/)
 
 ## 🛠️ How it works
 

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,60 @@
+# Memanto + LangGraph Integration
+
+This example demonstrates how to use **Memanto** to give your **LangGraph** agents a persistent, long-term memory across completely disjointed sessions.
+
+While LangGraph's native `State` is fantastic for maintaining context during a single workflow run, it is ephemeral once the graph execution completes. Memanto acts as the long-term semantic database for your agent, allowing it to remember user preferences, facts, and past instructions forever.
+
+## 📺 Demo & Social Traction
+
+Check out the 30-second Demo Video of this agent in action:
+- [▶️ Watch on X (Twitter)](https://x.com/Johan2aa/status/2054277719697903695)
+- [▶️ Join the discussion on Reddit (r/LangChain)](https://www.reddit.com/r/LangChain/comments/1tbb3nx/i_solved_the_langgraph_crosssession_memory/)
+
+## 🛠️ How it works
+
+1. **Tools:** We wrap `SdkClient.remember()` and `SdkClient.recall()` into Langchain `@tool` functions (`memanto_langchain_tools.py`).
+2. **Graph:** The tools are bound to the `ChatOpenAI` LLM inside the LangGraph `StateGraph`. The LLM's system prompt instructs it to actively save new facts and query memory when past context is needed (`agent.py`).
+3. **Cross-Session:** In `demo.py`, we run the graph twice with two completely isolated states. The agent successfully retrieves what the user said in Session 1 to answer the query in Session 2.
+
+## 🚀 Setup & Run
+
+### 1. Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Configure API Keys
+
+Create a `.env` file in this directory with your keys:
+
+```env
+MOORCHEH_API_KEY=your_moorcheh_api_key
+OPENAI_API_KEY=your_openai_api_key
+```
+
+### 3. Run the Demo
+
+```bash
+python demo.py
+```
+
+### Expected Output
+
+```
+--------------------------------------------------
+ 🌙 SESSION 1: The User Provides Information
+--------------------------------------------------
+User: Hi! I'm Alice. I'm a big fan of cyberpunk aesthetics and my favorite framework is LangGraph.
+
+🤖 Agent (Session 1): Nice to meet you, Alice! I've made a note of your love for cyberpunk aesthetics and your preference for LangGraph. How can I help you with LangGraph today?
+
+[The LangGraph state is completely cleared. Simulating a new day...]
+
+--------------------------------------------------
+ ☀️ SESSION 2: Cross-Session Recall
+--------------------------------------------------
+User: Hi again! What is my name and what kind of UI theme should you build for me?
+
+🤖 Agent (Session 2): Your name is Alice, and based on your preferences, I should build a cyberpunk-themed UI for you!
+```

--- a/examples/langgraph-memanto/agent.py
+++ b/examples/langgraph-memanto/agent.py
@@ -1,0 +1,44 @@
+from typing import Annotated, List
+from typing_extensions import TypedDict
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode, tools_condition
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import SystemMessage
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+def build_graph(tools: List[callable]):
+    """
+    Builds the LangGraph state graph for the agent.
+    """
+    # Using a fast and capable model
+    llm = ChatOpenAI(model="gpt-4o", temperature=0)
+    llm_with_tools = llm.bind_tools(tools)
+    
+    def chatbot(state: State):
+        sys_msg = SystemMessage(
+            content=(
+                "You are an intelligent personal assistant equipped with a persistent memory. "
+                "You have two special tools: memanto_remember and memanto_recall. "
+                "1. When the user tells you personal facts, preferences, or important instructions, ALWAYS use 'memanto_remember' to save them. "
+                "2. When the user asks you a question that might require past context, ALWAYS use 'memanto_recall' to search your memory first. "
+                "Do not hallucinate facts about the user. Rely on your long-term memory."
+            )
+        )
+        messages = [sys_msg] + state["messages"]
+        response = llm_with_tools.invoke(messages)
+        return {"messages": [response]}
+        
+    graph_builder = StateGraph(State)
+    graph_builder.add_node("chatbot", chatbot)
+    
+    tool_node = ToolNode(tools=tools)
+    graph_builder.add_node("tools", tool_node)
+    
+    graph_builder.add_conditional_edges("chatbot", tools_condition)
+    graph_builder.add_edge("tools", "chatbot")
+    graph_builder.add_edge(START, "chatbot")
+    
+    return graph_builder.compile()

--- a/examples/langgraph-memanto/demo.py
+++ b/examples/langgraph-memanto/demo.py
@@ -37,8 +37,8 @@ def main():
         client.create_agent(agent_id=agent_id, description="LangGraph cross-session memory agent")
         client.activate_agent(agent_id=agent_id)
     except Exception as e:
-        print(f"Error creating agent: {e}")
-        pass
+        print(f"❌ Error creating or activating agent '{agent_id}': {e}")
+        sys.exit(1)
 
     tools = create_memanto_tools(client, agent_id)
     graph = build_graph(tools)

--- a/examples/langgraph-memanto/demo.py
+++ b/examples/langgraph-memanto/demo.py
@@ -1,0 +1,94 @@
+import os
+import sys
+import uuid
+import time
+from memanto.cli.client.sdk_client import SdkClient
+from langchain_core.messages import HumanMessage
+from agent import build_graph
+from memanto_langchain_tools import create_memanto_tools
+from dotenv import load_dotenv
+
+def main():
+    load_dotenv()
+    
+    print("\n" + "="*60)
+    print("🚀 Initializing Memanto + LangGraph Integration Demo...")
+    print("="*60 + "\n")
+    
+    if not os.getenv("MOORCHEH_API_KEY"):
+        print("❌ Error: MOORCHEH_API_KEY environment variable is missing.")
+        print("Please set it: export MOORCHEH_API_KEY='your_key'")
+        sys.exit(1)
+        
+    if not os.getenv("OPENAI_API_KEY"):
+        print("❌ Error: OPENAI_API_KEY environment variable is missing.")
+        print("Please set it: export OPENAI_API_KEY='your_key'")
+        sys.exit(1)
+
+    # Initialize Memanto Client
+    # Since SdkClient uses API key from the environment/init, we'll pass it if needed,
+    # but SdkClient(api_key=...) is the signature in SDK.
+    client = SdkClient(api_key=os.environ["MOORCHEH_API_KEY"])
+    agent_id = f"langgraph-demo-{uuid.uuid4().hex[:6]}"
+    
+    # Try to create an agent
+    print(f"[*] Creating Memanto agent: {agent_id}...")
+    try:
+        client.create_agent(agent_id=agent_id, description="LangGraph cross-session memory agent")
+        client.activate_agent(agent_id=agent_id)
+    except Exception as e:
+        print(f"Error creating agent: {e}")
+        pass
+
+    tools = create_memanto_tools(client, agent_id)
+    graph = build_graph(tools)
+    
+    # ---------------------------------------------------------
+    # SESSION 1
+    # ---------------------------------------------------------
+    print("\n" + "-"*50)
+    print(" 🌙 SESSION 1: The User Provides Information")
+    print("-"*50)
+    
+    session1_input = "Hi! I'm Alice. I'm a big fan of cyberpunk aesthetics and my favorite framework is LangGraph."
+    print(f"User: {session1_input}\n")
+    
+    state1 = {"messages": [HumanMessage(content=session1_input)]}
+    for event in graph.stream(state1, stream_mode="values"):
+        message = event["messages"][-1]
+        if message.type == "ai" and message.content:
+            print(f"🤖 Agent (Session 1): {message.content}")
+            
+    print("\n[The LangGraph state is completely cleared. Simulating a new day...]")
+    time.sleep(2)
+    
+    # ---------------------------------------------------------
+    # SESSION 2
+    # ---------------------------------------------------------
+    print("\n" + "-"*50)
+    print(" ☀️ SESSION 2: Cross-Session Recall")
+    print("-"*50)
+    
+    session2_input = "Hi again! What is my name and what kind of UI theme should you build for me?"
+    print(f"User: {session2_input}\n")
+    
+    # Completely new state! No memory in LangGraph messages.
+    state2 = {"messages": [HumanMessage(content=session2_input)]}
+    for event in graph.stream(state2, stream_mode="values"):
+        message = event["messages"][-1]
+        if message.type == "ai" and message.content:
+            print(f"🤖 Agent (Session 2): {message.content}")
+
+    print("\n" + "="*60)
+    print("✅ Demo complete. The agent successfully recalled cross-session memory using Memanto!")
+    print("="*60 + "\n")
+
+    # Cleanup
+    try:
+        client.delete_agent(agent_id=agent_id)
+        print("[*] Cleaned up temporary agent.")
+    except:
+        pass
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/memanto_langchain_tools.py
+++ b/examples/langgraph-memanto/memanto_langchain_tools.py
@@ -1,0 +1,59 @@
+from typing import List
+from langchain_core.tools import tool
+from memanto.cli.client.sdk_client import SdkClient
+
+def create_memanto_tools(client: SdkClient, agent_id: str) -> List[callable]:
+    """
+    Creates LangChain tools bound to a specific Memanto client and agent_id.
+    """
+    
+    @tool
+    def memanto_remember(content: str, memory_type: str = "fact") -> str:
+        """
+        Store a new memory into the agent's long-term semantic database.
+        Use this tool to save facts, preferences, or important instructions that you must remember for future sessions.
+        
+        Args:
+            content: The text of the memory to store (e.g. "User prefers dark mode").
+            memory_type: The category of the memory. Valid types: 'fact', 'preference', 'decision', 'instruction', 'goal'.
+        """
+        try:
+            # We must use a short title for the memory
+            title = content[:47] + "..." if len(content) > 50 else content
+            result = client.remember(
+                agent_id=agent_id,
+                memory_type=memory_type,
+                title=title,
+                content=content
+            )
+            return f"Successfully remembered: '{content}' (Type: {memory_type})"
+        except Exception as e:
+            return f"Error storing memory: {str(e)}"
+
+    @tool
+    def memanto_recall(query: str) -> str:
+        """
+        Run a semantic search against the agent's long-term memories.
+        Use this tool whenever you need context about the user's past preferences or facts from previous conversations.
+        
+        Args:
+            query: The search query to retrieve relevant memories.
+        """
+        try:
+            result = client.recall(agent_id=agent_id, query=query)
+            memories = result.get("memories", [])
+            
+            if not memories:
+                return "No relevant memories found."
+            
+            formatted = []
+            for mem in memories:
+                # mem is likely a dict
+                content = mem.get("content", str(mem))
+                formatted.append(f"- {content}")
+                
+            return "Retrieved Memories:\n" + "\n".join(formatted)
+        except Exception as e:
+            return f"Error recalling memory: {str(e)}"
+            
+    return [memanto_remember, memanto_recall]

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,5 @@
+langgraph>=0.0.60
+langchain>=0.2.0
+langchain-openai>=0.1.7
+memanto>=0.1.0
+python-dotenv>=1.0.1


### PR DESCRIPTION
Fixes #397

This PR introduces a complete, standalone example of a LangGraph agent equipped with Memanto long-term memory.

### Features
- Wraps \SdkClient.remember\ and \SdkClient.recall\ into native Langchain \@tool\s.
- Instructs the \ChatOpenAI\ node to actively capture user context and recall it automatically in future sessions.
- Demonstrates cross-session context persistence without inflating the LangGraph State.

### Demo & Social Traction
- Watch the demo on X (Twitter): https://x.com/Johan2aa/status/2054277719697903695
- Join the discussion on Reddit: https://www.reddit.com/r/LangChain/comments/1tbb3nx/i_solved_the_langgraph_crosssession_memory/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runnable example demonstrating Memanto-backed persistent cross-session memory for LangGraph agents, with tool-backed remember/recall and a two-session streamed demo showcasing recall.

* **Documentation**
  * Step-by-step setup and run instructions plus an expected-output demo transcript illustrating Session 2 recalling Session 1.

* **Chores**
  * Added example dependency pins to reproduce the demo environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->