### PR TITLE
Add LangGraph + Memanto integration example

### DIFF
--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,57 @@
+# 🐜 Memanto + LangGraph Integration
+
+This example demonstrates how to give your LangGraph agents a **Permanent Brain** using Memanto as the long-term memory layer. 
+
+By default, LangGraph is the gold standard for stateful agents, but its state is bound to the current thread/session. Memanto solves this by acting as a persistent semantic memory layer that survives across disjointed sessions.
+
+## 🌟 Key Features
+- **Cross-Session Recall**: The agent remembers facts and preferences from completely independent threads.
+- **Tool-Based Integration**: Memanto is natively integrated as LangChain `tool` nodes (`remember` and `recall`), allowing the LLM to decide when to store and when to retrieve memories.
+- **Zero-Latency Ingestion**: Memories are instantly available for recall without waiting for expensive graph reconstructions.
+
+## 📺 Demonstration
+The `agent.py` script runs a demo containing two completely separate LangGraph sessions:
+1. **Session 1**: The user states a preference ("My favorite color is crimson red and I prefer very short answers"). The agent uses the `remember` tool to store this in Memanto.
+2. **Session 2**: The LangGraph state is completely wiped. The user asks "What is my favorite color?". The agent uses the `recall` tool, retrieves the memory from Memanto, and answers correctly in a concise format!
+
+## 🚀 How to Run
+
+### 1. Install Dependencies
+```bash
+pip install memanto langgraph langchain-openai
+```
+
+### 2. Configure Memanto
+You need a Moorcheh API key to use Memanto.
+```bash
+memanto
+```
+Follow the prompts to configure your environment.
+
+### 3. Create and Activate an Agent Namespace
+Create a dedicated agent namespace for this demo:
+```bash
+memanto agent create langgraph-demo-agent
+memanto activate langgraph-demo-agent
+```
+
+### 4. Run the Agent
+Make sure your OpenAI API key is set, then run the script!
+```bash
+export OPENAI_API_KEY="sk-your-key-here"
+python agent.py
+```
+
+## 🏗️ Code Architecture
+```python
+# The agent is equipped with two straightforward tools:
+
+@tool
+def remember(memory_type: str, content: str) -> str:
+    # Uses Memanto to permanently store facts, preferences, or goals.
+    
+@tool
+def recall(query: str) -> str:
+    # Uses Memanto's exact semantic search to pull relevant memories before answering.
+```
+The LLM dynamically reasons about when to call these tools based on the user's input, creating a seamless, persistent conversational experience.

--- a/examples/langgraph-memanto/agent.py
+++ b/examples/langgraph-memanto/agent.py
@@ -1,0 +1,129 @@
+import os
+import subprocess
+from typing import Annotated, Sequence, TypedDict
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import tool
+from langgraph.graph import StateGraph, START, END
+from langgraph.prebuilt import ToolNode
+
+# ==========================================
+# Memanto Tools for Long-Term Memory
+# ==========================================
+
+@tool
+def remember(memory_type: str, content: str) -> str:
+    """
+    Store a piece of information into the agent's long-term memory.
+    Use this when the user tells you a fact, preference, or goal that should be remembered for future sessions.
+    Valid memory types: fact, preference, goal, instruction.
+    """
+    try:
+        # We use the CLI to seamlessly integrate with the configured Memanto session
+        result = subprocess.run(
+            ["memanto", "remember", content, "--type", memory_type],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return f"Successfully remembered: {content}"
+    except subprocess.CalledProcessError as e:
+        return f"Failed to remember. Error: {e.stderr}"
+
+@tool
+def recall(query: str) -> str:
+    """
+    Search the agent's long-term memory for information relevant to the user's query.
+    Use this to retrieve past context, preferences, or facts from previous sessions before answering.
+    """
+    try:
+        result = subprocess.run(
+            ["memanto", "recall", query],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        return f"Failed to recall. Error: {e.stderr}"
+
+tools = [remember, recall]
+tool_node = ToolNode(tools)
+
+# ==========================================
+# LangGraph Agent Setup
+# ==========================================
+
+class AgentState(TypedDict):
+    messages: Annotated[Sequence[BaseMessage], lambda a, b: a + b]
+
+# Initialize the LLM with tools
+# Ensure OPENAI_API_KEY is set in your environment
+llm = ChatOpenAI(model="gpt-4o", temperature=0)
+llm_with_tools = llm.bind_tools(tools)
+
+def agent_node(state: AgentState):
+    """The main reasoning node of the agent."""
+    messages = state["messages"]
+    
+    # Inject a system prompt if it's the start of the conversation
+    if not any(isinstance(m, SystemMessage) for m in messages):
+        sys_msg = SystemMessage(content=(
+            "You are a helpful AI assistant equipped with a permanent memory (Memanto). "
+            "If the user asks you something about their past or preferences, use the `recall` tool. "
+            "If the user shares new facts, preferences, or instructions, use the `remember` tool to store it permanently."
+        ))
+        messages = [sys_msg] + list(messages)
+        
+    response = llm_with_tools.invoke(messages)
+    return {"messages": [response]}
+
+def should_continue(state: AgentState) -> str:
+    """Determine if we need to call tools or finish."""
+    last_message = state["messages"][-1]
+    if last_message.tool_calls:
+        return "tools"
+    return END
+
+# Build the graph
+workflow = StateGraph(AgentState)
+workflow.add_node("agent", agent_node)
+workflow.add_node("tools", tool_node)
+
+workflow.add_edge(START, "agent")
+workflow.add_conditional_edges("agent", should_continue, {"tools": "tools", END: END})
+workflow.add_edge("tools", "agent")
+
+app = workflow.compile()
+
+# ==========================================
+# Demonstration: Cross-Session Recall
+# ==========================================
+
+if __name__ == "__main__":
+    print("\n=== Memanto + LangGraph Integration Demo ===\n")
+    print("Initializing agent... (Make sure you have run `memanto agent create demo-agent` and activated it)")
+    
+    # Session 1: The user tells the agent a preference
+    print("\n--- Session 1: Storing a Memory ---")
+    session1_input = "Hi! I just wanted to let you know that my favorite color is crimson red and I prefer very short answers."
+    print(f"User: {session1_input}")
+    
+    state1 = {"messages": [HumanMessage(content=session1_input)]}
+    for event in app.stream(state1):
+        for key, value in event.items():
+            if key == "agent" and not value["messages"][-1].tool_calls:
+                print(f"Agent: {value['messages'][-1].content}")
+                
+    # Simulate a completely new session (LangGraph state is reset)
+    print("\n--- Session 2: Cross-Session Recall ---")
+    print("(LangGraph state has been completely cleared)")
+    session2_input = "What is my favorite color? And please answer according to my preferences."
+    print(f"User: {session2_input}")
+    
+    state2 = {"messages": [HumanMessage(content=session2_input)]}
+    for event in app.stream(state2):
+        for key, value in event.items():
+            if key == "agent" and not value["messages"][-1].tool_calls:
+                print(f"Agent: {value['messages'][-1].content}")


### PR DESCRIPTION
## Description\nThis PR adds a complete integration example demonstrating how to use Memanto as the long-term memory layer for a LangGraph agent. \n\n### Implementation\n- Includes `agent.py` showing cross-session recall.\n- Wraps Memanto CLI as LangChain tools (`remember` and `recall`) so the LLM can dynamically decide when to read/write.\n- Includes a comprehensive `README.md`.\n\nCloses #397 (Memanto + LangGraph Integration Challenge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README explaining how to integrate Memanto as a "Permanent Brain" for LangGraph agents, including setup, API configuration, and system architecture overview

* **Examples**
  * Added complete working agent example demonstrating cross-session memory persistence through tool-based remember/recall integration with support for agent namespace management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->