### PR TITLE
feat: add LangGraph Memanto cross-session memory example

### DIFF
--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -75,6 +75,10 @@ Expected behavior:
 
 ## Record a 30-Second Demo
 
+Demo video: https://github.com/user-attachments/assets/97e73bca-e491-4d3c-a31f-87f99d165515
+
+Social post: https://x.com/al_faturachman/status/2055406413346992281?s=46
+
 Suggested flow:
 
 1. Show `python demo_day1.py` storing the memories.
@@ -82,8 +86,6 @@ Suggested flow:
 3. Run `python demo_day2.py`.
 4. Highlight that day 2 recalls the Enterprise plan, Europe/London timezone,
    dark dashboard preference, and Tuesday follow-up.
-
-Add the video or GIF link to your PR description for bounty review.
 
 ## Files
 

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,105 @@
+# LangGraph + Memanto Example
+
+This example shows how to use Memanto as a persistent long-term memory layer
+for a LangGraph customer-support agent.
+
+The demo is intentionally split into two runs:
+
+1. `demo_day1.py` stores facts from a first customer conversation.
+2. `demo_day2.py` starts a fresh process and recalls the earlier memories.
+
+That split demonstrates cross-session recall: the LangGraph state is new on
+day 2, but Memanto still remembers what the customer said on day 1.
+
+## What This Demonstrates
+
+- A LangGraph workflow that reads from and writes to Memanto.
+- Cross-session recall outside of LangGraph's in-thread state.
+- Typed memories for preferences, facts, events, and commitments.
+- A deterministic fallback store for local dry-runs and unit tests.
+- A small support-agent scenario that is easy to record as a 30-second demo.
+
+## Architecture
+
+```text
+User message
+    |
+    v
+LangGraph StateGraph
+    |
+    +--> recall_memories node -----> Memanto recall
+    |
+    +--> draft_response node ------> response grounded in recalled memories
+    |
+    +--> write_memory node --------> Memanto remember
+```
+
+Memanto is the durable memory system. LangGraph manages the per-run workflow
+state. The two systems remain separate: restarting the graph clears transient
+state, but the stored memories remain available.
+
+## Setup
+
+```bash
+cd examples/langgraph-memanto
+python -m venv .venv
+.venv\Scripts\activate  # Windows
+pip install -r requirements.txt
+```
+
+For a live Memanto run, set a Moorcheh API key:
+
+```bash
+set MOORCHEH_API_KEY=your_key_here
+```
+
+Without `MOORCHEH_API_KEY`, the demo uses `.memanto_local_store.json` as a
+deterministic local fallback. The fallback is useful for reviewing the
+LangGraph flow without external services, but the bounty demo should be
+recorded with a real Memanto key.
+
+## Run the Demo
+
+```bash
+python demo_day1.py
+python demo_day2.py
+```
+
+Expected behavior:
+
+- Day 1 stores the customer's timezone, plan, dashboard preference, and follow-up
+  commitment.
+- Day 2 asks a new question in a fresh process.
+- The agent recalls day-1 memories and answers with the saved preference and
+  follow-up details.
+
+## Record a 30-Second Demo
+
+Suggested flow:
+
+1. Show `python demo_day1.py` storing the memories.
+2. Close or clear the terminal.
+3. Run `python demo_day2.py`.
+4. Highlight that day 2 recalls the Enterprise plan, Europe/London timezone,
+   dark dashboard preference, and Tuesday follow-up.
+
+Add the video or GIF link to your PR description for bounty review.
+
+## Files
+
+```text
+examples/langgraph-memanto/
+├── README.md
+├── demo_day1.py
+├── demo_day2.py
+├── memory_store.py
+├── requirements.txt
+└── support_agent.py
+```
+
+## Notes
+
+- The live adapter uses `memanto.cli.client.sdk_client.SdkClient`.
+- The fallback adapter is not a replacement for Memanto; it only keeps the
+  example testable without external credentials.
+- Keep support facts short and atomic so retrieval stays easy to inspect.

--- a/examples/langgraph-memanto/demo_day1.py
+++ b/examples/langgraph-memanto/demo_day1.py
@@ -1,0 +1,33 @@
+"""Day 1 demo: store customer facts in Memanto through LangGraph."""
+
+from __future__ import annotations
+
+from memory_store import create_memory_store, reset_local_store
+from support_agent import format_memories, run_support_turn
+
+
+CUSTOMER_ID = "acme-ops"
+MESSAGE = (
+    "ACME Ops is on the Enterprise plan. Their admin works in Europe/London, "
+    "prefers a dark analytics dashboard, and asked for a Tuesday follow-up "
+    "about CSV export limits."
+)
+
+
+def main() -> None:
+    reset_local_store()
+    store = create_memory_store()
+    try:
+        state = run_support_turn(store, CUSTOMER_ID, MESSAGE)
+        print("Day 1 saved memory ids:")
+        for memory_id in state["saved_memory_ids"]:
+            print(f"- {memory_id}")
+
+        print("\nDay 1 recalled before saving:")
+        print(format_memories(state["recalled_memories"]))
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/demo_day2.py
+++ b/examples/langgraph-memanto/demo_day2.py
@@ -1,0 +1,30 @@
+"""Day 2 demo: recall day-1 customer memories in a fresh graph run."""
+
+from __future__ import annotations
+
+from memory_store import create_memory_store
+from support_agent import format_memories, run_support_turn
+
+
+CUSTOMER_ID = "acme-ops"
+MESSAGE = (
+    "Before I reply to ACME Ops, what dashboard style and follow-up timing "
+    "should I remember?"
+)
+
+
+def main() -> None:
+    store = create_memory_store()
+    try:
+        state = run_support_turn(store, CUSTOMER_ID, MESSAGE)
+        print("Day 2 recalled memories:")
+        print(format_memories(state["recalled_memories"]))
+
+        print("\nAgent response:")
+        print(state["response"])
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/memory_store.py
+++ b/examples/langgraph-memanto/memory_store.py
@@ -1,0 +1,164 @@
+"""Memory adapters for the LangGraph + Memanto example."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Protocol
+
+from dotenv import load_dotenv
+
+
+AGENT_ID = "langgraph-support-agent"
+LOCAL_STORE_PATH = Path(__file__).with_name(".memanto_local_store.json")
+
+
+@dataclass(frozen=True)
+class MemoryItem:
+    """Small normalized memory shape used by the example graph."""
+
+    title: str
+    content: str
+    memory_type: str = "fact"
+    confidence: float = 0.9
+    tags: tuple[str, ...] = ()
+
+
+class MemoryStore(Protocol):
+    """Protocol shared by the live Memanto and local fallback adapters."""
+
+    def remember(self, item: MemoryItem) -> str:
+        """Store a memory and return its identifier."""
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryItem]:
+        """Recall memories relevant to the query."""
+
+    def close(self) -> None:
+        """Release any active session resources."""
+
+
+class LocalJsonMemoryStore:
+    """Deterministic local fallback for tests and no-key demos."""
+
+    def __init__(self, path: Path = LOCAL_STORE_PATH) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def remember(self, item: MemoryItem) -> str:
+        rows = self._load()
+        memory_id = f"local-{len(rows) + 1}"
+        rows.append({"id": memory_id, **asdict(item), "tags": list(item.tags)})
+        self.path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+        return memory_id
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryItem]:
+        query_terms = _terms(query)
+        ranked = []
+        for row in self._load():
+            text = " ".join(
+                [
+                    row.get("title", ""),
+                    row.get("content", ""),
+                    " ".join(row.get("tags", [])),
+                ]
+            )
+            score = len(query_terms.intersection(_terms(text)))
+            if score:
+                ranked.append((score, row))
+
+        ranked.sort(key=lambda item: item[0], reverse=True)
+        return [
+            MemoryItem(
+                title=row["title"],
+                content=row["content"],
+                memory_type=row.get("memory_type", "fact"),
+                confidence=float(row.get("confidence", 0.9)),
+                tags=tuple(row.get("tags", [])),
+            )
+            for _, row in ranked[:limit]
+        ]
+
+    def close(self) -> None:
+        return None
+
+    def _load(self) -> list[dict]:
+        if not self.path.exists():
+            return []
+        return json.loads(self.path.read_text(encoding="utf-8"))
+
+
+class MemantoSdkMemoryStore:
+    """Live Memanto adapter used when MOORCHEH_API_KEY is available."""
+
+    def __init__(self, api_key: str, agent_id: str = AGENT_ID) -> None:
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self.agent_id = agent_id
+        self.client = SdkClient(api_key=api_key)
+        try:
+            self.client.create_agent(
+                agent_id=agent_id,
+                pattern="support",
+                description="LangGraph support agent with persistent Memanto memory",
+            )
+        except Exception:
+            pass
+        self.client.activate_agent(agent_id)
+
+    def remember(self, item: MemoryItem) -> str:
+        result = self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=item.memory_type,
+            title=item.title,
+            content=item.content,
+            confidence=item.confidence,
+            tags=list(item.tags),
+            source="langgraph-example",
+            provenance="explicit_statement",
+        )
+        return str(result["memory_id"])
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryItem]:
+        result = self.client.recall(agent_id=self.agent_id, query=query, limit=limit)
+        memories = []
+        for row in result.get("memories", []):
+            memories.append(
+                MemoryItem(
+                    title=str(row.get("title", "Untitled")),
+                    content=str(row.get("content", "")),
+                    memory_type=str(row.get("type", row.get("memory_type", "fact"))),
+                    confidence=float(row.get("confidence", 0.9)),
+                    tags=tuple(row.get("tags", []) or []),
+                )
+            )
+        return memories
+
+    def close(self) -> None:
+        try:
+            self.client.deactivate_agent(self.agent_id)
+        except Exception:
+            pass
+
+
+def create_memory_store(force_local: bool = False) -> MemoryStore:
+    """Create a live Memanto store when configured, otherwise local fallback."""
+
+    load_dotenv()
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if api_key and not force_local:
+        return MemantoSdkMemoryStore(api_key)
+    return LocalJsonMemoryStore()
+
+
+def reset_local_store(path: Path = LOCAL_STORE_PATH) -> None:
+    """Remove local fallback memories so the demo starts clean."""
+
+    if path.exists():
+        path.unlink()
+
+
+def _terms(text: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+", text.lower()))

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,4 @@
+langgraph>=0.2.60
+langchain-core>=0.3.0
+python-dotenv>=1.0.0
+memanto>=0.1.0

--- a/examples/langgraph-memanto/support_agent.py
+++ b/examples/langgraph-memanto/support_agent.py
@@ -1,0 +1,150 @@
+"""LangGraph support agent that uses Memanto for durable memory."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from memory_store import MemoryItem, MemoryStore
+
+
+class SupportState(TypedDict):
+    """State passed between LangGraph nodes."""
+
+    customer_id: str
+    message: str
+    recalled_memories: list[MemoryItem]
+    response: str
+    saved_memory_ids: list[str]
+
+
+def build_support_graph(store: MemoryStore):
+    """Build the LangGraph workflow."""
+
+    from langgraph.graph import END, StateGraph
+
+    graph = StateGraph(SupportState)
+
+    def recall_memories(state: SupportState) -> SupportState:
+        query = f"{state['customer_id']} {state['message']}"
+        state["recalled_memories"] = store.recall(query, limit=6)
+        return state
+
+    def draft_response(state: SupportState) -> SupportState:
+        memories = state.get("recalled_memories", [])
+        if not memories:
+            state["response"] = (
+                "I do not have stored context for this customer yet. "
+                "I will ask one clarifying question and save the answer."
+            )
+            return state
+
+        bullets = "; ".join(memory.content for memory in memories[:4])
+        state["response"] = (
+            "I found prior context before replying: "
+            f"{bullets}. I will use that context for the next support action."
+        )
+        return state
+
+    def write_memory(state: SupportState) -> SupportState:
+        new_memories = extract_memories(state["customer_id"], state["message"])
+        saved_ids = [store.remember(item) for item in new_memories]
+        state["saved_memory_ids"] = saved_ids
+        return state
+
+    graph.add_node("recall_memories", recall_memories)
+    graph.add_node("draft_response", draft_response)
+    graph.add_node("write_memory", write_memory)
+    graph.set_entry_point("recall_memories")
+    graph.add_edge("recall_memories", "draft_response")
+    graph.add_edge("draft_response", "write_memory")
+    graph.add_edge("write_memory", END)
+    return graph.compile()
+
+
+def run_support_turn(
+    store: MemoryStore,
+    customer_id: str,
+    message: str,
+) -> SupportState:
+    """Run one support turn through the graph."""
+
+    graph = build_support_graph(store)
+    return graph.invoke(
+        {
+            "customer_id": customer_id,
+            "message": message,
+            "recalled_memories": [],
+            "response": "",
+            "saved_memory_ids": [],
+        }
+    )
+
+
+def extract_memories(customer_id: str, message: str) -> list[MemoryItem]:
+    """Extract deterministic support memories from the demo message."""
+
+    lower = message.lower()
+    memories: list[MemoryItem] = []
+
+    if "enterprise" in lower:
+        memories.append(
+            MemoryItem(
+                title=f"{customer_id} plan",
+                content=f"{customer_id} is on the Enterprise plan.",
+                memory_type="fact",
+                tags=("customer", "plan", customer_id),
+            )
+        )
+
+    if "europe/london" in lower or "london" in lower:
+        memories.append(
+            MemoryItem(
+                title=f"{customer_id} timezone",
+                content=f"{customer_id} works in the Europe/London timezone.",
+                memory_type="preference",
+                tags=("customer", "timezone", customer_id),
+            )
+        )
+
+    if "dark" in lower and "dashboard" in lower:
+        memories.append(
+            MemoryItem(
+                title=f"{customer_id} dashboard preference",
+                content=f"{customer_id} prefers a dark analytics dashboard.",
+                memory_type="preference",
+                tags=("customer", "dashboard", customer_id),
+            )
+        )
+
+    if "tuesday" in lower:
+        memories.append(
+            MemoryItem(
+                title=f"{customer_id} follow-up commitment",
+                content=f"Follow up with {customer_id} on Tuesday about export limits.",
+                memory_type="commitment",
+                tags=("customer", "follow-up", customer_id),
+            )
+        )
+
+    if not memories:
+        memories.append(
+            MemoryItem(
+                title=f"{customer_id} support note",
+                content=f"{customer_id} asked: {message[:420]}",
+                memory_type="observation",
+                confidence=0.8,
+                tags=("customer", "support", customer_id),
+            )
+        )
+
+    return memories
+
+
+def format_memories(memories: list[MemoryItem]) -> str:
+    """Render memories for terminal demos."""
+
+    if not memories:
+        return "No memories recalled."
+    return "\n".join(
+        f"- [{item.memory_type}] {item.title}: {item.content}" for item in memories
+    )

--- a/tests/test_langgraph_memanto_example.py
+++ b/tests/test_langgraph_memanto_example.py
@@ -1,0 +1,66 @@
+"""Tests for the LangGraph + Memanto example helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "langgraph-memanto"
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+memory_store_spec = importlib.util.spec_from_file_location(
+    "langgraph_memanto_memory_store", EXAMPLE_DIR / "memory_store.py"
+)
+support_agent_spec = importlib.util.spec_from_file_location(
+    "langgraph_memanto_support_agent", EXAMPLE_DIR / "support_agent.py"
+)
+assert memory_store_spec and memory_store_spec.loader
+assert support_agent_spec and support_agent_spec.loader
+
+memory_store = importlib.util.module_from_spec(memory_store_spec)
+sys.modules["memory_store"] = memory_store
+sys.modules[memory_store_spec.name] = memory_store
+memory_store_spec.loader.exec_module(memory_store)
+
+support_agent = importlib.util.module_from_spec(support_agent_spec)
+sys.modules[support_agent_spec.name] = support_agent
+support_agent_spec.loader.exec_module(support_agent)
+
+
+def test_extract_memories_creates_typed_customer_facts():
+    memories = support_agent.extract_memories(
+        "acme-ops",
+        (
+            "Enterprise customer in Europe/London prefers a dark dashboard "
+            "and wants Tuesday follow-up."
+        ),
+    )
+
+    memory_types = {memory.memory_type for memory in memories}
+    titles = {memory.title for memory in memories}
+
+    assert {"fact", "preference", "commitment"}.issubset(memory_types)
+    assert "acme-ops plan" in titles
+    assert "acme-ops dashboard preference" in titles
+
+
+def test_local_store_recalls_memories_across_instances(tmp_path):
+    store_path = tmp_path / "memories.json"
+    day1 = memory_store.LocalJsonMemoryStore(store_path)
+    day1.remember(
+        memory_store.MemoryItem(
+            title="acme-ops dashboard preference",
+            content="acme-ops prefers a dark analytics dashboard.",
+            memory_type="preference",
+            tags=("acme-ops", "dashboard"),
+        )
+    )
+
+    day2 = memory_store.LocalJsonMemoryStore(store_path)
+    results = day2.recall("what dashboard preference does acme-ops have?")
+
+    assert len(results) == 1
+    assert results[0].title == "acme-ops dashboard preference"
+    assert "dark analytics dashboard" in results[0].content


### PR DESCRIPTION
## Summary
- Adds a LangGraph + Memanto example under `examples/langgraph-memanto`
- Demonstrates cross-session recall with separate day-1/day-2 support-agent runs
- Includes a live Memanto SDK adapter, deterministic local fallback, and unit tests for helper behavior

## Bounty
Closes #397

## What changed
- `examples/langgraph-memanto/support_agent.py`: LangGraph support workflow with recall, response drafting, and memory-write nodes
- `examples/langgraph-memanto/memory_store.py`: Memanto SDK adapter plus local JSON fallback for deterministic review/test runs
- `examples/langgraph-memanto/demo_day1.py`: stores customer plan, timezone, dashboard preference, and follow-up commitment
- `examples/langgraph-memanto/demo_day2.py`: starts a fresh run and recalls day-1 memories
- `examples/langgraph-memanto/README.md`: setup, architecture, demo steps, and video-recording guidance
- `tests/test_langgraph_memanto_example.py`: tests typed memory extraction and cross-instance local recall

## Demo / social link
- 30-second demo video: https://github.com/user-attachments/assets/97e73bca-e491-4d3c-a31f-87f99d165515
- Social post: https://x.com/al_faturachman/status/2055406413346992281?s=46

The demo shows Day 1 storing customer support memories through LangGraph + Memanto, then Day 2 starting a fresh graph run and recalling those memories across sessions.

## Testing
Not run locally because this Windows environment does not currently have `python` or `uv` available in PATH.

Suggested commands once Python is available:

```bash
python -m pytest tests/test_langgraph_memanto_example.py -q
cd examples/langgraph-memanto
python -m venv .venv
.venv\Scripts\activate
pip install -r requirements.txt
python demo_day1.py
python demo_day2.py
```


