### PR TITLE
Add LangGraph + Memanto support memory demo

### DIFF
--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,0 +1,1 @@
+MOORCHEH_API_KEY=your_moorcheh_api_key

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,86 @@
+# LangGraph + Memanto Support Memory Demo
+
+This example wires Memanto into a LangGraph customer-support workflow. The graph
+recalls long-term customer context before drafting a response, then stores any
+new preference it learns for the next session.
+
+## What It Demonstrates
+
+- A LangGraph `StateGraph` with memory recall, response drafting, and memory
+  persistence nodes.
+- Memanto as the long-term memory layer for customer preferences and support
+  context.
+- Cross-session recall: run one script to store context, then a second script to
+  retrieve it in a fresh session.
+- A deterministic demo path that does not require a separate LLM API key.
+
+## Architecture
+
+```text
+Support ticket
+    |
+    v
+LangGraph recall_memory node
+    |
+    v
+Memanto recall(customer context)
+    |
+    v
+LangGraph draft_reply node
+    |
+    v
+LangGraph persist_preference node
+    |
+    v
+Memanto remember(new preference)
+```
+
+## Setup
+
+```bash
+cd examples/langgraph-memanto
+python -m venv .venv
+.venv\Scripts\activate  # Windows
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Add your `MOORCHEH_API_KEY` to `.env`, or export it in your shell.
+
+## Run The Cross-Session Demo
+
+```bash
+python run_seed_session.py
+python run_recall_session.py
+```
+
+The first command stores this preference for `cust-acme-42`:
+
+```text
+Customer cust-acme-42 prefers concise, action-oriented support replies with
+bullet points.
+```
+
+The second command starts a fresh workflow session and recalls that preference
+before drafting a reply for a new ticket.
+
+## Demo Recording
+
+Use [demo-script.md](demo-script.md) to record a 30-second GIF or video. The
+recording should show the seed command storing a preference and the recall
+command using it in a separate session.
+
+## Files
+
+```text
+examples/langgraph-memanto/
+├── README.md
+├── .env.example
+├── requirements.txt
+├── client_factory.py
+├── memory_adapter.py
+├── workflow.py
+├── run_seed_session.py
+├── run_recall_session.py
+└── demo-script.md
+```

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -74,13 +74,13 @@ command using it in a separate session.
 
 ```text
 examples/langgraph-memanto/
-├── README.md
-├── .env.example
-├── requirements.txt
-├── client_factory.py
-├── memory_adapter.py
-├── workflow.py
-├── run_seed_session.py
-├── run_recall_session.py
-└── demo-script.md
++-- README.md
++-- .env.example
++-- requirements.txt
++-- client_factory.py
++-- memory_adapter.py
++-- workflow.py
++-- run_seed_session.py
++-- run_recall_session.py
++-- demo-script.md
 ```

--- a/examples/langgraph-memanto/client_factory.py
+++ b/examples/langgraph-memanto/client_factory.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from memanto.app.utils.errors import AgentAlreadyExistsError
+from memanto.cli.client.sdk_client import SdkClient
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - python-dotenv is in requirements.txt
+    load_dotenv = None
+
+
+def build_memanto_client(
+    agent_id: str,
+    *,
+    description: str = "LangGraph support workflow memory",
+) -> SdkClient:
+    if load_dotenv:
+        load_dotenv()
+
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "MOORCHEH_API_KEY is required. Create a Moorcheh key, then set it "
+            "before running the LangGraph example."
+        )
+
+    client = SdkClient(api_key)
+    try:
+        client.create_agent(agent_id, pattern="support", description=description)
+    except AgentAlreadyExistsError:
+        pass
+
+    client.activate_agent(agent_id)
+    return client
+
+
+def deactivate_client(client: Any, agent_id: str) -> None:
+    try:
+        client.deactivate_agent(agent_id)
+    except Exception:
+        pass

--- a/examples/langgraph-memanto/demo-script.md
+++ b/examples/langgraph-memanto/demo-script.md
@@ -1,0 +1,15 @@
+# 30-second demo script
+
+```bash
+cd examples/langgraph-memanto
+cp .env.example .env
+# Add MOORCHEH_API_KEY to .env, then:
+python run_seed_session.py
+python run_recall_session.py
+```
+
+Expected story:
+
+1. The seed run stores a customer preference in Memanto from inside a LangGraph node.
+2. The recall run starts a separate session for the same customer.
+3. The reply includes the remembered preference before drafting the response.

--- a/examples/langgraph-memanto/memory_adapter.py
+++ b/examples/langgraph-memanto/memory_adapter.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class MemantoClient(Protocol):
+    def remember(self, **kwargs: Any) -> dict[str, Any]:
+        ...
+
+    def recall(self, **kwargs: Any) -> dict[str, Any]:
+        ...
+
+
+def _memory_content(memory: Any) -> str | None:
+    if isinstance(memory, str):
+        return memory
+
+    if not isinstance(memory, dict):
+        return None
+
+    for key in ("content", "text", "summary"):
+        value = memory.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    nested = memory.get("memory")
+    if isinstance(nested, dict):
+        return _memory_content(nested)
+
+    metadata = memory.get("metadata")
+    if isinstance(metadata, dict):
+        return _memory_content(metadata)
+
+    return None
+
+
+class MemantoMemoryAdapter:
+    def __init__(self, client: MemantoClient, agent_id: str) -> None:
+        self.client = client
+        self.agent_id = agent_id
+
+    def store_customer_preference(
+        self,
+        *,
+        customer_id: str,
+        preference: str,
+        source_ticket: str,
+    ) -> dict[str, Any]:
+        return self.client.remember(
+            agent_id=self.agent_id,
+            memory_type="preference",
+            title=f"Preference for {customer_id}",
+            content=preference,
+            confidence=0.9,
+            tags=["langgraph-demo", f"customer:{customer_id}", f"ticket:{source_ticket}"],
+            source="langgraph-support-demo",
+            provenance="explicit_statement",
+        )
+
+    def recall_customer_context(
+        self,
+        customer_id: str,
+        *,
+        limit: int = 4,
+    ) -> list[str]:
+        response = self.client.recall(
+            agent_id=self.agent_id,
+            query=f"support context and preferences for customer {customer_id}",
+            limit=limit,
+            type=["preference", "fact", "decision", "context", "event"],
+            tags=["langgraph-demo", f"customer:{customer_id}"],
+        )
+
+        raw_memories = response.get("memories", [])
+        normalized: list[str] = []
+        for memory in raw_memories:
+            content = _memory_content(memory)
+            if content:
+                normalized.append(content)
+
+        return normalized
+
+
+def format_context(memories: list[str]) -> str:
+    if not memories:
+        return "No prior Memanto context found for this customer."
+
+    return "\n".join(f"- {memory}" for memory in memories)

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,3 @@
+langgraph>=0.2.70
+python-dotenv>=1.0.0
+memanto

--- a/examples/langgraph-memanto/run_recall_session.py
+++ b/examples/langgraph-memanto/run_recall_session.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from client_factory import build_memanto_client, deactivate_client
+from memory_adapter import MemantoMemoryAdapter
+from workflow import build_support_graph
+
+AGENT_ID = "langgraph-support-memory-demo"
+
+
+def main() -> None:
+    client = build_memanto_client(AGENT_ID)
+    adapter = MemantoMemoryAdapter(client, AGENT_ID)
+    graph = build_support_graph(adapter)
+
+    try:
+        result = graph.invoke(
+            {
+                "customer_id": "cust-acme-42",
+                "ticket_id": "ticket-1002",
+                "current_ticket": "Can you summarize renewal options?",
+            }
+        )
+
+        print(result["reply"])
+    finally:
+        deactivate_client(client, AGENT_ID)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/run_seed_session.py
+++ b/examples/langgraph-memanto/run_seed_session.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from client_factory import build_memanto_client, deactivate_client
+from memory_adapter import MemantoMemoryAdapter
+from workflow import build_support_graph
+
+AGENT_ID = "langgraph-support-memory-demo"
+
+
+def main() -> None:
+    client = build_memanto_client(AGENT_ID)
+    adapter = MemantoMemoryAdapter(client, AGENT_ID)
+    graph = build_support_graph(adapter)
+
+    try:
+        result = graph.invoke(
+            {
+                "customer_id": "cust-acme-42",
+                "ticket_id": "ticket-1001",
+                "current_ticket": "Please keep renewal updates short and actionable.",
+                "new_preference": (
+                    "Customer cust-acme-42 prefers concise, action-oriented "
+                    "support replies with bullet points."
+                ),
+            }
+        )
+
+        print(result["reply"])
+        print(f"\nStored preference memory: {result.get('stored_memory_id', 'n/a')}")
+        print("\nRun `python run_recall_session.py` next to prove persistence.")
+    finally:
+        deactivate_client(client, AGENT_ID)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/workflow.py
+++ b/examples/langgraph-memanto/workflow.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict
+
+from memory_adapter import MemantoMemoryAdapter, format_context
+
+
+class SupportState(TypedDict):
+    customer_id: str
+    ticket_id: str
+    current_ticket: str
+    new_preference: NotRequired[str]
+    remembered_context: NotRequired[list[str]]
+    reply: NotRequired[str]
+    stored_memory_id: NotRequired[str]
+
+
+def recall_memory(adapter: MemantoMemoryAdapter):
+    def node(state: SupportState) -> dict[str, list[str]]:
+        return {
+            "remembered_context": adapter.recall_customer_context(
+                state["customer_id"]
+            )
+        }
+
+    return node
+
+
+def draft_reply(state: SupportState) -> dict[str, str]:
+    context = format_context(state.get("remembered_context", []))
+    reply = (
+        f"Customer: {state['customer_id']}\n"
+        f"Ticket: {state['ticket_id']}\n\n"
+        "Memanto context recalled before drafting:\n"
+        f"{context}\n\n"
+        "Draft response:\n"
+        "Thanks for the update. I checked your previous preferences and will "
+        "keep this concise while answering the current request."
+    )
+    return {"reply": reply}
+
+
+def persist_preference(adapter: MemantoMemoryAdapter):
+    def node(state: SupportState) -> dict[str, str]:
+        preference = state.get("new_preference")
+        if not preference:
+            return {}
+
+        result = adapter.store_customer_preference(
+            customer_id=state["customer_id"],
+            preference=preference,
+            source_ticket=state["ticket_id"],
+        )
+        memory_id = result.get("memory_id") or result.get("id") or "stored"
+        return {"stored_memory_id": str(memory_id)}
+
+    return node
+
+
+def build_support_graph(adapter: MemantoMemoryAdapter):
+    try:
+        from langgraph.graph import END, StateGraph
+    except ImportError as exc:
+        raise RuntimeError(
+            "Install the example requirements first: "
+            "pip install -r examples/langgraph-memanto/requirements.txt"
+        ) from exc
+
+    graph = StateGraph(SupportState)
+    graph.add_node("recall_memory", recall_memory(adapter))
+    graph.add_node("draft_reply", draft_reply)
+    graph.add_node("persist_preference", persist_preference(adapter))
+
+    graph.set_entry_point("recall_memory")
+    graph.add_edge("recall_memory", "draft_reply")
+    graph.add_edge("draft_reply", "persist_preference")
+    graph.add_edge("persist_preference", END)
+
+    return graph.compile()

--- a/tests/test_langgraph_memanto_example.py
+++ b/tests/test_langgraph_memanto_example.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "langgraph-memanto"
 
 

--- a/tests/test_langgraph_memanto_example.py
+++ b/tests/test_langgraph_memanto_example.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "langgraph-memanto"
+
+
+def load_example_module(name: str):
+    module_path = EXAMPLE_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeMemantoClient:
+    def __init__(self) -> None:
+        self.remember_calls: list[dict[str, object]] = []
+        self.recall_response = {
+            "memories": [
+                {"content": "Customer prefers concise replies."},
+                {"memory": {"content": "Customer is on the startup plan."}},
+                {"text": "Escalate billing questions to account owner."},
+            ]
+        }
+
+    def remember(self, **kwargs):
+        self.remember_calls.append(kwargs)
+        return {"memory_id": "mem_123", "status": "stored"}
+
+    def recall(self, **kwargs):
+        return self.recall_response
+
+
+def test_adapter_stores_customer_preference_with_tags():
+    adapter_module = load_example_module("memory_adapter")
+    client = FakeMemantoClient()
+    adapter = adapter_module.MemantoMemoryAdapter(client, "support-agent")
+
+    result = adapter.store_customer_preference(
+        customer_id="cust-42",
+        preference="Customer prefers concise replies.",
+        source_ticket="ticket-1001",
+    )
+
+    assert result["memory_id"] == "mem_123"
+    assert client.remember_calls == [
+        {
+            "agent_id": "support-agent",
+            "memory_type": "preference",
+            "title": "Preference for cust-42",
+            "content": "Customer prefers concise replies.",
+            "confidence": 0.9,
+            "tags": ["langgraph-demo", "customer:cust-42", "ticket:ticket-1001"],
+            "source": "langgraph-support-demo",
+            "provenance": "explicit_statement",
+        }
+    ]
+
+
+def test_adapter_recalls_and_normalizes_context():
+    adapter_module = load_example_module("memory_adapter")
+    adapter = adapter_module.MemantoMemoryAdapter(
+        FakeMemantoClient(), "support-agent"
+    )
+
+    memories = adapter.recall_customer_context("cust-42")
+
+    assert memories == [
+        "Customer prefers concise replies.",
+        "Customer is on the startup plan.",
+        "Escalate billing questions to account owner.",
+    ]


### PR DESCRIPTION
Refs #397

## Summary
- adds a LangGraph + Memanto support-memory example under `examples/langgraph-memanto`
- includes a Memanto adapter for storing customer preferences and recalling support context across sessions
- adds two demo scripts: one seed run that writes memory and one recall run that starts a fresh session and uses the remembered context
- documents setup, architecture, and a 30-second recording script

## Verification
- `python -m pytest tests/test_langgraph_memanto_example.py -q`
- `python -m ruff check examples\langgraph-memanto tests\test_langgraph_memanto_example.py`
- `python -m compileall examples\langgraph-memanto`
- ran the LangGraph workflow with a fake Memanto client and confirmed it recalled context and stored one memory

## Demo Note
The runnable recording script is included in `examples/langgraph-memanto/demo-script.md`. A video/GIF link can be attached after recording the two commands with a real Moorcheh API key.