### PR TITLE
feat: MCP server for Memanto

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 <p align="center">
     <a href="https://pypi.org/project/memanto/"><img alt="PyPI - Total Downloads" src="https://img.shields.io/pepy/dt/memanto.svg?color=blue&label=downloads"></a>
+    <a href="https://deepwiki.com/moorcheh-ai/memanto"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
     <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
     <a href="https://pypi.org/project/memanto/"><img alt="PyPI Version" src="https://img.shields.io/pypi/v/memanto.svg?color=%2334D058"></a>
     <a href="https://x.com/moorcheh_ai" target="_blank"><img src="https://img.shields.io/twitter/url/https/twitter.com/langchain.svg?style=social&label=Follow%20%40Moorcheh.ai" alt="Twitter / X"></a>

--- a/integrations/mcp/.env.example
+++ b/integrations/mcp/.env.example
@@ -1,0 +1,36 @@
+# ============================================================================
+# Memanto MCP Server - environment configuration
+# ============================================================================
+# Copy this file to `.env` (or set these vars in your MCP client config).
+
+# REQUIRED: Moorcheh API key (https://console.moorcheh.ai/api-keys)
+MOORCHEH_API_KEY=your_key_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# OPTIONAL: Default agent for memory operations.
+# When set, the `agent_id` argument becomes optional on every tool call.
+# Recommended: set this to a stable per-project or per-user identifier.
+MEMANTO_DEFAULT_AGENT_ID=my-mcp-agent
+
+# OPTIONAL: Agent pattern used when auto-creating the default agent.
+# One of: support | project | tool   (default: tool)
+MEMANTO_AGENT_PATTERN=tool
+
+# OPTIONAL: Auto-create the default agent if it does not exist (default: true).
+MEMANTO_AGENT_AUTO_CREATE=true
+
+# OPTIONAL: Session lifetime in hours (default: server config / 6).
+# MEMANTO_SESSION_DURATION_HOURS=6
+
+# OPTIONAL: Expose agent-management tools (create/list/get/delete).
+# Off by default to keep the MCP tool surface focused on memory operations.
+# MEMANTO_EXPOSE_ADMIN=false
+
+# OPTIONAL: Transport. One of: stdio (default) | sse | streamable-http
+# MEMANTO_MCP_TRANSPORT=stdio
+
+# OPTIONAL: Host/port when using sse or streamable-http transports
+# MEMANTO_MCP_HOST=127.0.0.1
+# MEMANTO_MCP_PORT=8765
+
+# OPTIONAL: Log level (DEBUG | INFO | WARNING | ERROR)
+# MEMANTO_MCP_LOG_LEVEL=INFO

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -1,0 +1,212 @@
+# Memanto MCP Server
+
+**Persistent semantic memory for any MCP-compatible agent.**
+
+This package exposes [Memanto's](https://memanto.ai) memory primitives —
+`remember`, `recall`, `answer`, and friends — as
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) tools so any
+MCP client (Claude Desktop, Cursor, Windsurf, Cline, Continue, Goose,
+custom agents, …) can plug into long-term memory in a single config line.
+
+> One Moorcheh API key → typed semantic memory across every agent that
+> shares the namespace, with sub-90 ms retrieval, conflict detection, and
+> zero ingestion latency.
+
+---
+
+## Install
+
+```bash
+pip install memanto-mcp
+```
+
+Requires Python 3.10+ and a [Moorcheh API key](https://console.moorcheh.ai/api-keys)
+(free tier: 100K ops/month).
+
+## Quick start (Claude Desktop)
+
+1. Get a Moorcheh API key from the [console](https://console.moorcheh.ai/api-keys).
+2. Edit `claude_desktop_config.json` (Settings → Developer → Edit Config):
+
+```json
+{
+  "mcpServers": {
+    "memanto": {
+      "command": "memanto-mcp",
+      "env": {
+        "MOORCHEH_API_KEY": "mch_xxxxxxxxxxxxxxxxxx",
+        "MEMANTO_DEFAULT_AGENT_ID": "my-assistant"
+      }
+    }
+  }
+}
+```
+
+3. Restart Claude Desktop. Ask it to *"remember that I prefer concise
+   answers"* — then in a brand-new chat tomorrow ask *"what do I prefer?"*.
+
+The first call auto-creates the `my-assistant` agent and namespace; every
+subsequent call reuses the same persistent memory.
+
+## Quick start (Cursor / Windsurf / Cline / Continue / Goose)
+
+Most clients consume a config file in the
+[standard MCP shape](https://modelcontextprotocol.io/docs/clients).
+The same JSON snippet works almost verbatim:
+
+```json
+{
+  "mcpServers": {
+    "memanto": {
+      "command": "memanto-mcp",
+      "env": {
+        "MOORCHEH_API_KEY": "mch_xxxxxxxxxxxxxxxxxx",
+        "MEMANTO_DEFAULT_AGENT_ID": "cursor-workspace"
+      }
+    }
+  }
+}
+```
+
+| Client | Config path |
+|---|---|
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) / `%APPDATA%\Claude\claude_desktop_config.json` (Windows) |
+| Cursor | `~/.cursor/mcp.json` (or per-project `.cursor/mcp.json`) |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
+| Cline (VS Code) | `~/.config/Code/User/globalStorage/cline.cline/settings/cline_mcp_settings.json` |
+| Continue | `~/.continue/config.json` → `experimental.modelContextProtocolServers` |
+| Goose | `~/.config/goose/config.yaml` |
+
+## Available tools
+
+The server registers **7 memory tools by default**. Set
+`MEMANTO_EXPOSE_ADMIN=true` to also expose **4 agent-management tools**.
+
+### Memory tools (always on)
+
+| Tool | When the agent should call it |
+|---|---|
+| `remember` | Persist a single new fact/preference/decision/goal/instruction. |
+| `batch_remember` | Persist up to 100 memories in one call (e.g. extracted from a document). |
+| `recall` | Semantic search — *always* check here before asking the user to repeat stable info. |
+| `recall_recent` | "What did we just decide?" — newest-first, no query needed. |
+| `recall_as_of` | Point-in-time recall — "what did we know on 2025-11-01?" |
+| `recall_changed_since` | Differential — "what's new since I last checked?" |
+| `answer` | RAG: grounded LLM answer synthesized over the agent's memories. |
+
+### Agent admin tools (opt-in)
+
+Enabled when `MEMANTO_EXPOSE_ADMIN=true`:
+
+| Tool | Purpose |
+|---|---|
+| `create_agent` | Create a new memory namespace. |
+| `list_agents` | List every agent the API key can see. |
+| `get_agent` | Look up an agent's metadata. |
+| `delete_agent` | Remove an agent's local metadata. |
+
+Memory types accepted by `remember` / `batch_remember`:
+`fact`, `preference`, `goal`, `decision`, `artifact`, `learning`, `event`,
+`instruction`, `relationship`, `context`, `observation`, `commitment`,
+`error`.
+
+Provenance values: `explicit_statement`, `inferred`, `corrected`,
+`validated`, `observed`, `imported`.
+
+## Configuration
+
+All config is via environment variables (load order: process env →
+`.env` file in the working directory).
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `MOORCHEH_API_KEY` | **yes** | — | Moorcheh API key. |
+| `MEMANTO_DEFAULT_AGENT_ID` | recommended | _none_ | Default agent. When set, tool calls may omit `agent_id`. |
+| `MEMANTO_AGENT_PATTERN` | no | `tool` | Pattern (`support`/`project`/`tool`) used when auto-creating the default agent. |
+| `MEMANTO_AGENT_AUTO_CREATE` | no | `true` | Create the default agent on first use if missing. |
+| `MEMANTO_SESSION_DURATION_HOURS` | no | server default (6) | Session lifetime in hours. |
+| `MEMANTO_EXPOSE_ADMIN` | no | `false` | Register the 4 agent-management tools. |
+| `MEMANTO_MCP_TRANSPORT` | no | `stdio` | `stdio`, `sse`, or `streamable-http`. |
+| `MEMANTO_MCP_HOST` | no | `127.0.0.1` | Bind host for sse/http transports. |
+| `MEMANTO_MCP_PORT` | no | `8765` | Bind port for sse/http transports. |
+| `MEMANTO_MCP_LOG_LEVEL` | no | `INFO` | Log level (logs are always sent to stderr). |
+
+CLI flags (`memanto-mcp --transport sse --port 9000`) override env vars.
+
+## Running over HTTP / SSE
+
+For remote clients or multi-process setups, run the server over a network
+transport:
+
+```bash
+# Streamable HTTP (recommended modern transport)
+memanto-mcp --transport streamable-http --host 0.0.0.0 --port 8765
+
+# Server-Sent Events (older, still widely supported)
+memanto-mcp --transport sse --host 0.0.0.0 --port 8765
+```
+
+Then point your client at `http://your-host:8765/mcp` (or whatever path the
+chosen transport advertises). Pair with a reverse proxy + auth for
+production deployments — the server itself authenticates upstream to
+Moorcheh using your API key but does **not** authenticate inbound MCP
+clients.
+
+## How it works
+
+```
+┌──────────────┐    MCP/stdio    ┌──────────────────┐    Moorcheh API    ┌─────────────┐
+│ Claude / IDE │ ──────────────► │  memanto-mcp     │ ────────────────► │   Moorcheh  │
+│   (client)   │ ◄────────────── │  (this package)  │ ◄──────────────── │   Service   │
+└──────────────┘    tool calls   └──────────────────┘    HTTPS+API key   └─────────────┘
+                                          │
+                                          └─ uses memanto.cli.client.SdkClient
+                                             (same client the Memanto CLI uses)
+```
+
+- On startup, settings are validated; the API key is verified lazily on
+  first tool call.
+- On the first memory tool invocation for a given agent, the server
+  ensures the agent exists (auto-creates if needed) and activates a JWT
+  session. Sessions auto-renew before expiry, so long-running MCP
+  connections never hit a session-expired error mid-conversation.
+- The server intentionally keeps the session alive on shutdown: JWT
+  sessions are TTL-bound and other Memanto clients (CLI, REST) may want
+  to share them.
+
+## Programmatic embedding
+
+If you're building a custom MCP host or wiring this server into a larger
+process, you can construct the FastMCP instance yourself:
+
+```python
+from memanto_mcp import MCPServerSettings, build_server
+
+settings = MCPServerSettings()  # reads env / .env
+mcp = build_server(settings)
+
+# Add your own tools alongside Memanto's, then run.
+mcp.run(transport="stdio")
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `configuration error: MOORCHEH_API_KEY is required` | Set the env var in your MCP client config's `env` block. |
+| `Agent '…' does not exist and MEMANTO_AGENT_AUTO_CREATE is disabled` | Either re-enable auto-create or call `create_agent` (admin tools) / `memanto agent create <id>` once. |
+| Tools never appear in the client | Confirm the client supports MCP and the config path matches. Look at the client's MCP log: the server's stderr lines (prefixed `memanto_mcp`) will appear there on startup. |
+| Garbled output in stdio mode | Something on your side is writing to **stdout** — that channel is reserved for JSON-RPC. Move logs to stderr. The server itself only writes to stderr. |
+| Slow first call | Cold-start cost: SDK import + first session activation. Subsequent calls reuse the live session. |
+
+## License
+
+MIT — same as the [Memanto](https://github.com/moorcheh-ai/memanto)
+project. See [LICENSE](../../LICENSE).
+
+## Links
+
+- [Memanto](https://memanto.ai) — the memory agent itself
+- [Moorcheh](https://moorcheh.ai) — the no-indexing semantic DB underneath
+- [Model Context Protocol spec](https://modelcontextprotocol.io)
+- [Anthropic MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)

--- a/integrations/mcp/memanto_mcp/__init__.py
+++ b/integrations/mcp/memanto_mcp/__init__.py
@@ -1,0 +1,14 @@
+"""Memanto MCP Server.
+
+Exposes Memanto's persistent semantic memory as Model Context Protocol tools
+so any MCP-compatible agent (Claude Desktop, Cursor, Windsurf, Cline, etc.)
+can store and retrieve long-term memory.
+"""
+
+from __future__ import annotations
+
+from memanto_mcp.config import MCPServerSettings
+from memanto_mcp.server import build_server, run_server
+
+__all__ = ["MCPServerSettings", "build_server", "run_server", "__version__"]
+__version__ = "0.1.0"

--- a/integrations/mcp/memanto_mcp/__main__.py
+++ b/integrations/mcp/memanto_mcp/__main__.py
@@ -1,0 +1,95 @@
+"""Module entrypoint: ``python -m memanto_mcp``.
+
+Equivalent to the ``memanto-mcp`` console script declared in pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from memanto_mcp.config import MCPServerSettings, TransportType
+from memanto_mcp.server import run_server
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="memanto-mcp",
+        description=(
+            "Memanto MCP server - exposes Memanto's persistent semantic memory "
+            "(remember, recall, answer) as Model Context Protocol tools."
+        ),
+    )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http"),
+        help=(
+            "Transport to use. Defaults to stdio (the standard for desktop "
+            "MCP clients like Claude Desktop / Cursor). Use sse or "
+            "streamable-http for remote/HTTP clients."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        help="Bind host for sse/streamable-http transports (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="Bind port for sse/streamable-http transports (default: 8765).",
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR"),
+        help="Log level (default: INFO). Logs are always written to stderr.",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the package version and exit.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if args.version:
+        from memanto_mcp import __version__
+
+        print(__version__)
+        return 0
+
+    overrides: dict[str, object] = {}
+    if args.transport:
+        overrides["transport"] = TransportType(args.transport)
+    if args.host:
+        overrides["host"] = args.host
+    if args.port is not None:
+        overrides["port"] = args.port
+    if args.log_level:
+        overrides["log_level"] = args.log_level
+
+    try:
+        settings = MCPServerSettings(**overrides)  # type: ignore[arg-type]
+    except Exception as exc:
+        # Print a clear actionable error to stderr - do NOT pollute stdout in
+        # stdio mode (it is reserved for JSON-RPC frames).
+        print(f"memanto-mcp: configuration error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        run_server(settings)
+    except KeyboardInterrupt:
+        logging.getLogger("memanto_mcp").info("Shutting down (KeyboardInterrupt)")
+        return 0
+    except Exception as exc:
+        logging.getLogger("memanto_mcp").exception("Fatal error: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/mcp/memanto_mcp/config.py
+++ b/integrations/mcp/memanto_mcp/config.py
@@ -1,0 +1,154 @@
+"""Configuration for the Memanto MCP server.
+
+Loaded from environment variables (and optionally a ``.env`` file in the
+working directory). Validated via pydantic-settings so misconfiguration
+surfaces immediately at startup rather than on the first tool call.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import Field, SecretStr, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class TransportType(str, Enum):
+    """MCP transport modes supported by this server."""
+
+    STDIO = "stdio"
+    SSE = "sse"
+    STREAMABLE_HTTP = "streamable-http"
+
+
+# Patterns recognized by Memanto's agent service. Kept in sync with
+# `memanto.app.constants.VALID_PATTERNS`.
+_VALID_AGENT_PATTERNS = {"support", "project", "tool"}
+
+
+class MCPServerSettings(BaseSettings):
+    """Server settings loaded from env / ``.env``.
+
+    Required:
+        moorcheh_api_key: Moorcheh API key.
+
+    Optional:
+        default_agent_id: When set, callers may omit ``agent_id`` from tool
+            calls and this value is used. Strongly recommended in MCP setups
+            since most clients invoke a tool per turn with no shared state.
+        agent_pattern: Pattern used when auto-creating the default agent
+            (``support``, ``project``, or ``tool``).
+        agent_auto_create: If True (default), the default agent is created
+            on first use when missing.
+        session_duration_hours: Override session lifetime (defaults to the
+            value baked into the Memanto core config).
+        expose_admin_tools: If True, register ``create_agent``, ``list_agents``,
+            ``get_agent``, and ``delete_agent`` tools. Off by default to keep
+            the surface focused on memory operations.
+        transport / host / port: How the server is reached.
+        log_level: Logging verbosity (logs go to stderr).
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_prefix="",
+        extra="ignore",
+        case_sensitive=False,
+    )
+
+    # ---- Memanto credentials & agent ----
+    moorcheh_api_key: SecretStr = Field(
+        ...,
+        validation_alias="MOORCHEH_API_KEY",
+        description="Moorcheh API key. Create one at https://console.moorcheh.ai/api-keys",
+    )
+    default_agent_id: str | None = Field(
+        default=None,
+        validation_alias="MEMANTO_DEFAULT_AGENT_ID",
+        description=(
+            "Default agent used when a tool call omits agent_id. "
+            "Set this to a stable per-project identifier."
+        ),
+    )
+    agent_pattern: str = Field(
+        default="tool",
+        validation_alias="MEMANTO_AGENT_PATTERN",
+        description="Memanto pattern used when auto-creating the default agent.",
+    )
+    agent_auto_create: bool = Field(
+        default=True,
+        validation_alias="MEMANTO_AGENT_AUTO_CREATE",
+        description="Auto-create the default agent if it does not exist.",
+    )
+    session_duration_hours: int | None = Field(
+        default=None,
+        validation_alias="MEMANTO_SESSION_DURATION_HOURS",
+        ge=1,
+        le=24 * 30,
+        description="Override session lifetime in hours.",
+    )
+    expose_admin_tools: bool = Field(
+        default=False,
+        validation_alias="MEMANTO_EXPOSE_ADMIN",
+        description="Register agent-management tools (create/list/get/delete).",
+    )
+
+    # ---- Transport ----
+    transport: TransportType = Field(
+        default=TransportType.STDIO,
+        validation_alias="MEMANTO_MCP_TRANSPORT",
+        description="MCP transport mode.",
+    )
+    host: str = Field(
+        default="127.0.0.1",
+        validation_alias="MEMANTO_MCP_HOST",
+        description="Bind host for sse / streamable-http.",
+    )
+    port: int = Field(
+        default=8765,
+        ge=1,
+        le=65535,
+        validation_alias="MEMANTO_MCP_PORT",
+        description="Bind port for sse / streamable-http.",
+    )
+
+    # ---- Logging ----
+    log_level: str = Field(
+        default="INFO",
+        validation_alias="MEMANTO_MCP_LOG_LEVEL",
+        description="Log level (DEBUG / INFO / WARNING / ERROR).",
+    )
+
+    @field_validator("agent_pattern")
+    @classmethod
+    def _validate_pattern(cls, v: str) -> str:
+        if v not in _VALID_AGENT_PATTERNS:
+            allowed = ", ".join(sorted(_VALID_AGENT_PATTERNS))
+            raise ValueError(f"agent_pattern must be one of: {allowed} (got {v!r})")
+        return v
+
+    @field_validator("log_level")
+    @classmethod
+    def _validate_log_level(cls, v: str) -> str:
+        upper = v.upper()
+        if upper not in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}:
+            raise ValueError(
+                "log_level must be one of: DEBUG, INFO, WARNING, ERROR, CRITICAL"
+            )
+        return upper
+
+    @field_validator("moorcheh_api_key")
+    @classmethod
+    def _validate_api_key(cls, v: SecretStr) -> SecretStr:
+        if not v.get_secret_value().strip():
+            raise ValueError(
+                "MOORCHEH_API_KEY is required. Create one at "
+                "https://console.moorcheh.ai/api-keys and set it in your "
+                "environment or MCP client config."
+            )
+        return v
+
+    # Convenience accessor — never logged.
+    def api_key_value(self) -> str:
+        return self.moorcheh_api_key.get_secret_value()

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -1,0 +1,151 @@
+"""Agent + session lifecycle management for the MCP server.
+
+MCP tool calls are stateless from the model's perspective — the agent decides
+to call ``recall`` and expects it to "just work". This module owns:
+
+* Resolving which Memanto agent_id a given tool call targets (explicit arg
+  wins; otherwise the configured default).
+* Lazily creating the default agent on first use (if enabled).
+* Lazily activating a session and keeping it valid across calls. The underlying
+  ``SdkClient._get_validated_session_for_agent`` already auto-renews tokens
+  nearing expiry, so we only have to activate once per agent.
+
+All operations are guarded by a lock so concurrent tool invocations don't race
+to create the same agent twice.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+from memanto.app.utils.errors import (
+    AgentAlreadyExistsError,
+    AgentNotFoundError,
+    SessionError,
+)
+from memanto.cli.client.sdk_client import SdkClient
+
+if TYPE_CHECKING:
+    from memanto_mcp.config import MCPServerSettings
+
+logger = logging.getLogger(__name__)
+
+
+class NoAgentConfiguredError(ValueError):
+    """Raised when a tool call omits agent_id and no default is configured."""
+
+
+class MemantoLifecycle:
+    """Owns the long-lived SdkClient and per-agent session bookkeeping."""
+
+    def __init__(self, settings: MCPServerSettings) -> None:
+        self._settings = settings
+        self._client = SdkClient(api_key=settings.api_key_value())
+        self._activated_agents: set[str] = set()
+        self._ensured_agents: set[str] = set()
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------ #
+    # Public API used by tools
+    # ------------------------------------------------------------------ #
+
+    @property
+    def client(self) -> SdkClient:
+        """The shared Memanto SDK client."""
+        return self._client
+
+    @property
+    def settings(self) -> MCPServerSettings:
+        """The server settings driving this lifecycle."""
+        return self._settings
+
+    def resolve_agent_id(self, agent_id: str | None) -> str:
+        """Pick the explicit ``agent_id`` if given, else fall back to default.
+
+        Raises:
+            NoAgentConfiguredError: If neither was provided.
+        """
+        if agent_id and agent_id.strip():
+            return agent_id.strip()
+        if self._settings.default_agent_id:
+            return self._settings.default_agent_id
+        raise NoAgentConfiguredError(
+            "No agent_id was supplied and no MEMANTO_DEFAULT_AGENT_ID is "
+            "configured. Either pass agent_id explicitly or set the env var."
+        )
+
+    def ensure_ready(self, agent_id: str) -> str:
+        """Make sure the agent exists and a session is active for it.
+
+        Returns the resolved agent_id (mostly a convenience so callers can
+        chain ``ensure_ready(resolve_agent_id(...))``).
+        """
+        with self._lock:
+            if agent_id not in self._ensured_agents:
+                self._ensure_agent_exists_locked(agent_id)
+                self._ensured_agents.add(agent_id)
+
+            if (
+                agent_id not in self._activated_agents
+                or self._client.agent_id != agent_id
+            ):
+                self._activate_locked(agent_id)
+                self._activated_agents.add(agent_id)
+
+        return agent_id
+
+    def shutdown(self) -> None:
+        """Best-effort cleanup. Sessions can outlive the process safely."""
+        # We deliberately do NOT deactivate sessions on shutdown: they are
+        # JWT-backed with a TTL and other Memanto clients (CLI, REST) may
+        # still want to use them after the MCP server exits.
+        logger.debug("MemantoLifecycle shutting down (no-op cleanup).")
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+
+    def _ensure_agent_exists_locked(self, agent_id: str) -> None:
+        try:
+            self._client.get_agent(agent_id)
+            logger.debug("Agent '%s' exists.", agent_id)
+            return
+        except AgentNotFoundError:
+            pass
+
+        if not self._settings.agent_auto_create:
+            raise AgentNotFoundError(
+                f"Agent '{agent_id}' does not exist and MEMANTO_AGENT_AUTO_CREATE "
+                f"is disabled. Create it first with `memanto agent create "
+                f"{agent_id}` or via the create_agent tool."
+            )
+
+        logger.info(
+            "Auto-creating agent '%s' with pattern '%s'.",
+            agent_id,
+            self._settings.agent_pattern,
+        )
+        try:
+            self._client.create_agent(
+                agent_id=agent_id,
+                pattern=self._settings.agent_pattern,
+                description="Auto-created by memanto-mcp",
+            )
+        except AgentAlreadyExistsError:
+            # Race: another caller created it between our get_agent and create.
+            logger.debug("Agent '%s' was created concurrently.", agent_id)
+
+    def _activate_locked(self, agent_id: str) -> None:
+        try:
+            self._client.activate_agent(
+                agent_id=agent_id,
+                duration_hours=self._settings.session_duration_hours,
+            )
+            logger.info("Activated Memanto session for agent '%s'.", agent_id)
+        except Exception as exc:
+            # Wrap so tools surface a uniform error type.
+            raise SessionError(
+                f"Failed to activate Memanto session for '{agent_id}': {exc}"
+            ) from exc

--- a/integrations/mcp/memanto_mcp/server.py
+++ b/integrations/mcp/memanto_mcp/server.py
@@ -1,0 +1,112 @@
+"""FastMCP server assembly and transport runner.
+
+Builds a fully configured ``FastMCP`` instance with every Memanto tool
+registered, then dispatches to the requested transport.
+
+Logging is routed to **stderr only** because stdio MCP clients use stdout
+exclusively for JSON-RPC frames - anything written there breaks the protocol.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError as exc:  # pragma: no cover - install-time message
+    raise ImportError(
+        "memanto-mcp requires the `mcp` package. Install with: pip install 'mcp[cli]>=1.2'"
+    ) from exc
+
+from memanto_mcp.config import MCPServerSettings, TransportType
+from memanto_mcp.lifecycle import MemantoLifecycle
+from memanto_mcp.tools import register_tools
+
+logger = logging.getLogger("memanto_mcp")
+
+
+def _configure_logging(level: str) -> None:
+    """Send every log line to stderr - stdout is reserved for MCP frames."""
+    root = logging.getLogger()
+    # Drop any handlers another importer may have attached to root (e.g.
+    # a parent CLI). They might point at stdout, which would corrupt JSON-RPC.
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s [%(name)s] %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+    )
+    root.addHandler(handler)
+    root.setLevel(level)
+
+    # Quiet a few noisy third-party loggers that don't add value at INFO.
+    for noisy in ("httpx", "httpcore", "urllib3"):
+        logging.getLogger(noisy).setLevel(max(logging.WARNING, root.level))
+
+
+def build_server(settings: MCPServerSettings | None = None) -> FastMCP:
+    """Construct a FastMCP server with all Memanto tools wired up.
+
+    Returned without being run, so callers (tests, custom hosts) can mount
+    additional tools or inspect the schema before serving.
+    """
+    settings = settings or MCPServerSettings()  # type: ignore[call-arg]
+    _configure_logging(settings.log_level)
+
+    instructions = (
+        "Memanto provides persistent semantic memory for AI agents. Use "
+        "`recall` (or `answer` for RAG) BEFORE asking the user to repeat "
+        "stable facts, preferences, or prior decisions - the answer may "
+        "already be in memory. After learning something new and durable, "
+        "use `remember` (or `batch_remember`) to persist it for future "
+        "sessions. Pass a fresh, well-phrased natural-language query to "
+        "`recall`; do not pass keyword fragments."
+    )
+
+    mcp = FastMCP(
+        name="memanto",
+        instructions=instructions,
+        host=settings.host,
+        port=settings.port,
+    )
+
+    lifecycle = MemantoLifecycle(settings)
+    register_tools(mcp, lifecycle)
+
+    # Stash on the server object so transport runners / tests can reach it.
+    mcp._memanto_lifecycle = lifecycle  # type: ignore[attr-defined]
+    mcp._memanto_settings = settings  # type: ignore[attr-defined]
+
+    logger.info(
+        "Memanto MCP server ready (transport=%s, default_agent=%s, admin_tools=%s)",
+        settings.transport.value,
+        settings.default_agent_id or "<none>",
+        settings.expose_admin_tools,
+    )
+    return mcp
+
+
+def run_server(settings: MCPServerSettings | None = None) -> None:
+    """Build the server and serve over the configured transport."""
+    mcp = build_server(settings)
+    settings = mcp._memanto_settings  # type: ignore[attr-defined]
+    lifecycle: MemantoLifecycle = mcp._memanto_lifecycle  # type: ignore[attr-defined]
+
+    transport = settings.transport
+    try:
+        if transport is TransportType.STDIO:
+            # FastMCP.run() defaults to stdio when called with no transport.
+            mcp.run(transport="stdio")
+        elif transport is TransportType.SSE:
+            mcp.run(transport="sse")
+        elif transport is TransportType.STREAMABLE_HTTP:
+            mcp.run(transport="streamable-http")
+        else:  # pragma: no cover - exhausted by enum
+            raise ValueError(f"Unsupported transport: {transport}")
+    finally:
+        lifecycle.shutdown()

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -14,7 +14,7 @@ at tool-registration time, and we use closure-scoped type aliases (e.g.
 """
 
 import logging
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, TypeVar
 
 from memanto.app.constants import (
     VALID_MEMORY_TYPES,
@@ -107,7 +107,9 @@ class RecallResult(BaseModel):
     status: str
     agent_id: str
     query: str | None = None
-    mode: str = Field(default="semantic", description="semantic | recent | as_of | changed_since")
+    mode: str = Field(
+        default="semantic", description="semantic | recent | as_of | changed_since"
+    )
     count: int = 0
     memories: list[MemoryHit] = Field(default_factory=list)
     message: str | None = None
@@ -164,7 +166,12 @@ class AgentListResult(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _error_payload(model_cls: type[BaseModel], message: str, **defaults: Any) -> Any:
+T = TypeVar("T", bound=BaseModel)
+# NOTE: we cannot use 'from __future__ import annotations' here (see module docstring)
+# so we use traditional type hints.
+
+
+def _error_payload(model_cls: type[T], message: str, **defaults: Any) -> T:
     """Build a uniform error response of the given result model type."""
     return model_cls(status="error", message=message, **defaults)
 
@@ -361,9 +368,13 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             # Validate before round-trip so we fail fast with a clear error.
             for i, item in enumerate(memories):
                 if not isinstance(item, dict):
-                    raise ValueError(f"memories[{i}] must be an object, got {type(item).__name__}")
+                    raise ValueError(
+                        f"memories[{i}] must be an object, got {type(item).__name__}"
+                    )
                 if "content" not in item or not str(item["content"]).strip():
-                    raise ValueError(f"memories[{i}] is missing required field 'content'")
+                    raise ValueError(
+                        f"memories[{i}] is missing required field 'content'"
+                    )
                 m_type = item.get("type", "fact")
                 if m_type not in VALID_MEMORY_TYPES:
                     raise ValueError(
@@ -399,7 +410,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 results=sub_results,
             )
         except NoAgentConfiguredError as exc:
-            return _error_payload(BatchRememberResult, str(exc), agent_id=agent_id or "")
+            return _error_payload(
+                BatchRememberResult, str(exc), agent_id=agent_id or ""
+            )
         except Exception as exc:
             logger.exception("batch_remember failed")
             return _error_payload(
@@ -479,7 +492,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 memories=hits,
             )
         except NoAgentConfiguredError as exc:
-            return _error_payload(RecallResult, str(exc), agent_id=agent_id or "", query=query)
+            return _error_payload(
+                RecallResult, str(exc), agent_id=agent_id or "", query=query
+            )
         except Exception as exc:
             logger.exception("recall failed")
             return _error_payload(
@@ -773,7 +788,9 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 namespace=agent.get("namespace"),
                 pattern=agent.get("pattern"),
                 description=agent.get("description"),
-                created_at=str(agent.get("created_at")) if agent.get("created_at") else None,
+                created_at=str(agent.get("created_at"))
+                if agent.get("created_at")
+                else None,
             )
         except AgentAlreadyExistsError as exc:
             return AgentInfoResult(
@@ -783,7 +800,9 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             )
         except Exception as exc:
             logger.exception("create_agent failed")
-            return _error_payload(AgentInfoResult, _format_exception(exc), agent_id=agent_id)
+            return _error_payload(
+                AgentInfoResult, _format_exception(exc), agent_id=agent_id
+            )
 
     @mcp.tool(
         name="list_agents",
@@ -802,7 +821,9 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         description="Look up an agent's metadata by id.",
     )
     def get_agent(
-        agent_id: Annotated[str, Field(description="Agent id to look up.", min_length=1)],
+        agent_id: Annotated[
+            str, Field(description="Agent id to look up.", min_length=1)
+        ],
     ) -> AgentInfoResult:
         try:
             agent = lifecycle.client.get_agent(agent_id)
@@ -812,7 +833,9 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 namespace=agent.get("namespace"),
                 pattern=agent.get("pattern"),
                 description=agent.get("description"),
-                created_at=str(agent.get("created_at")) if agent.get("created_at") else None,
+                created_at=str(agent.get("created_at"))
+                if agent.get("created_at")
+                else None,
             )
         except AgentNotFoundError as exc:
             return AgentInfoResult(
@@ -820,7 +843,9 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             )
         except Exception as exc:
             logger.exception("get_agent failed")
-            return _error_payload(AgentInfoResult, _format_exception(exc), agent_id=agent_id)
+            return _error_payload(
+                AgentInfoResult, _format_exception(exc), agent_id=agent_id
+            )
 
     @mcp.tool(
         name="delete_agent",
@@ -831,7 +856,9 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ),
     )
     def delete_agent(
-        agent_id: Annotated[str, Field(description="Agent id to delete.", min_length=1)],
+        agent_id: Annotated[
+            str, Field(description="Agent id to delete.", min_length=1)
+        ],
     ) -> AgentInfoResult:
         try:
             lifecycle.client.delete_agent(agent_id)
@@ -842,7 +869,9 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             )
         except Exception as exc:
             logger.exception("delete_agent failed")
-            return _error_payload(AgentInfoResult, _format_exception(exc), agent_id=agent_id)
+            return _error_payload(
+                AgentInfoResult, _format_exception(exc), agent_id=agent_id
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -1,0 +1,873 @@
+"""Memanto MCP tools.
+
+Each tool is a thin, well-documented wrapper around the Memanto ``SdkClient``.
+Tool descriptions are tuned for LLM tool-selection: they start with a verb,
+explain *when* to use the tool, and list its non-obvious constraints.
+
+Tools never raise raw Python exceptions back through the MCP transport - they
+catch and re-format them so the calling model gets actionable feedback.
+
+Note: this module deliberately does NOT use ``from __future__ import
+annotations``. FastMCP evaluates parameter annotations with ``eval_str=True``
+at tool-registration time, and we use closure-scoped type aliases (e.g.
+``AgentIdField``) that won't resolve once they have been deferred to strings.
+"""
+
+import logging
+from typing import Annotated, Any, Literal
+
+from memanto.app.constants import (
+    VALID_MEMORY_TYPES,
+    VALID_PROVENANCE_TYPES,
+)
+from memanto.app.utils.errors import (
+    AgentAlreadyExistsError,
+    AgentNotFoundError,
+    MemantoError,
+)
+from memanto.app.utils.validation import InputLimits
+from pydantic import BaseModel, Field
+
+from memanto_mcp.lifecycle import MemantoLifecycle, NoAgentConfiguredError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Type aliases pulled from Memanto core so the JSON schema we expose matches
+# what the server validates internally. Keeping these as Literals gives the
+# calling model a hard enum to pick from.
+# ---------------------------------------------------------------------------
+
+MemoryTypeLiteral = Literal[
+    "fact",
+    "preference",
+    "goal",
+    "decision",
+    "artifact",
+    "learning",
+    "event",
+    "instruction",
+    "relationship",
+    "context",
+    "observation",
+    "commitment",
+    "error",
+]
+
+ProvenanceLiteral = Literal[
+    "explicit_statement",
+    "inferred",
+    "corrected",
+    "validated",
+    "observed",
+    "imported",
+]
+
+# Hard caps mirroring the Memanto core service (see SdkClient).
+_MAX_CONTENT_LENGTH = InputLimits.MAX_TEXT_LENGTH
+_MAX_TITLE_LENGTH = 100
+_MAX_BATCH_SIZE = 100
+
+
+# ---------------------------------------------------------------------------
+# Structured output models. FastMCP serializes return values to text content,
+# but using BaseModel keeps the schema self-documenting and stable.
+# ---------------------------------------------------------------------------
+
+
+class RememberResult(BaseModel):
+    """Outcome of storing a single memory."""
+
+    status: str = Field(description="'ok' on success, 'error' otherwise.")
+    memory_id: str | None = Field(default=None, description="Memanto-assigned ID.")
+    agent_id: str = Field(description="Agent the memory belongs to.")
+    namespace: str | None = Field(default=None, description="Underlying namespace.")
+    confidence: float | None = Field(default=None, description="Confidence stored.")
+    message: str | None = Field(default=None, description="Human-readable detail.")
+
+
+class MemoryHit(BaseModel):
+    """A single retrieved memory."""
+
+    id: str | None = None
+    type: str | None = None
+    title: str | None = None
+    content: str | None = None
+    confidence: float | None = None
+    tags: list[str] = Field(default_factory=list)
+    created_at: str | None = None
+    score: float | None = Field(
+        default=None, description="Similarity score when available."
+    )
+
+
+class RecallResult(BaseModel):
+    """Outcome of a recall query."""
+
+    status: str
+    agent_id: str
+    query: str | None = None
+    mode: str = Field(default="semantic", description="semantic | recent | as_of | changed_since")
+    count: int = 0
+    memories: list[MemoryHit] = Field(default_factory=list)
+    message: str | None = None
+
+
+class AnswerResult(BaseModel):
+    """Outcome of a RAG ``answer`` call."""
+
+    status: str
+    agent_id: str
+    question: str
+    answer: str | None = None
+    sources: list[Any] = Field(default_factory=list)
+    namespace: str | None = None
+    message: str | None = None
+
+
+class BatchRememberItemResult(BaseModel):
+    id: str | None = None
+    status: str
+    error: str | None = None
+
+
+class BatchRememberResult(BaseModel):
+    status: str
+    agent_id: str
+    namespace: str | None = None
+    total_submitted: int = 0
+    successful: int = 0
+    failed: int = 0
+    results: list[BatchRememberItemResult] = Field(default_factory=list)
+    message: str | None = None
+
+
+class AgentInfoResult(BaseModel):
+    status: str
+    agent_id: str | None = None
+    namespace: str | None = None
+    pattern: str | None = None
+    description: str | None = None
+    created_at: str | None = None
+    message: str | None = None
+
+
+class AgentListResult(BaseModel):
+    status: str
+    count: int = 0
+    agents: list[dict[str, Any]] = Field(default_factory=list)
+    message: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Error shaping
+# ---------------------------------------------------------------------------
+
+
+def _error_payload(model_cls: type[BaseModel], message: str, **defaults: Any) -> Any:
+    """Build a uniform error response of the given result model type."""
+    return model_cls(status="error", message=message, **defaults)
+
+
+def _format_exception(exc: Exception) -> str:
+    """Render an exception as a short human-readable string."""
+    if isinstance(exc, MemantoError):
+        return exc.message
+    return f"{type(exc).__name__}: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+
+def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
+    """Register every Memanto MCP tool against the given FastMCP instance.
+
+    Imported lazily so tests can swap out the lifecycle implementation.
+    """
+
+    settings = lifecycle.settings
+    default_hint = (
+        f" (defaults to '{settings.default_agent_id}')"
+        if settings.default_agent_id
+        else " (required: no MEMANTO_DEFAULT_AGENT_ID is configured)"
+    )
+
+    AgentIdField = Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Memanto agent identifier the memory belongs to" + default_hint + "."
+            ),
+        ),
+    ]
+
+    # ============================================================ #
+    # remember
+    # ============================================================ #
+    @mcp.tool(
+        name="remember",
+        description=(
+            "Store a single piece of information in the agent's long-term "
+            "memory. Use this whenever the user shares a stable fact, "
+            "preference, decision, goal, or instruction you should recall "
+            "in a future conversation. Memory is typed (13 categories) and "
+            "carries confidence + provenance so later retrievals can rank "
+            f"and filter intelligently. Content is capped at "
+            f"{_MAX_CONTENT_LENGTH} chars - store atomic, self-contained "
+            "statements."
+        ),
+    )
+    def remember(
+        content: Annotated[
+            str,
+            Field(
+                description=(
+                    "The memory itself - one atomic statement. "
+                    f"Max {_MAX_CONTENT_LENGTH} characters."
+                ),
+                min_length=1,
+                max_length=_MAX_CONTENT_LENGTH,
+            ),
+        ],
+        type: Annotated[
+            MemoryTypeLiteral,
+            Field(
+                description=(
+                    "Semantic memory type. Use 'preference' for likes/styles, "
+                    "'fact' for stable factual claims, 'decision' for choices "
+                    "the user has made, 'goal' for objectives, 'instruction' "
+                    "for explicit how-to directives, 'event' for things that "
+                    "happened, 'observation' for inferred behavior."
+                ),
+            ),
+        ] = "fact",
+        title: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description=(
+                    "Short label (<= 100 chars). If omitted, derived from content."
+                ),
+                max_length=_MAX_TITLE_LENGTH,
+            ),
+        ] = None,
+        confidence: Annotated[
+            float,
+            Field(
+                description=(
+                    "How sure you are this is true (0.0-1.0). Use 1.0 only "
+                    "for things the user stated explicitly. 0.6-0.8 is a "
+                    "sensible default for inferred information."
+                ),
+                ge=0.0,
+                le=1.0,
+            ),
+        ] = 0.85,
+        tags: Annotated[
+            list[str] | None,
+            Field(
+                default=None,
+                description="Optional lowercase tag list for later filtering.",
+            ),
+        ] = None,
+        provenance: Annotated[
+            ProvenanceLiteral,
+            Field(
+                description=(
+                    "How this memory was obtained. 'explicit_statement' means "
+                    "the user said it; 'inferred' means you deduced it; "
+                    "'observed' means you saw it during a tool call; "
+                    "'corrected' means it overrides an earlier wrong memory."
+                ),
+            ),
+        ] = "explicit_statement",
+        source: Annotated[
+            str,
+            Field(
+                description=(
+                    "Free-form label for the source of this memory "
+                    "(e.g. 'user', 'web', 'tool-call', or your agent name)."
+                ),
+            ),
+        ] = "mcp-agent",
+        agent_id: AgentIdField = None,
+    ) -> RememberResult:
+        try:
+            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved_title = title or (
+                content[: _MAX_TITLE_LENGTH - 3] + "..."
+                if len(content) > _MAX_TITLE_LENGTH
+                else content
+            )
+            result = lifecycle.client.remember(
+                agent_id=resolved,
+                memory_type=type,
+                title=resolved_title,
+                content=content,
+                confidence=confidence,
+                tags=tags or [],
+                source=source,
+                provenance=provenance,
+            )
+            return RememberResult(
+                status="ok",
+                memory_id=result.get("memory_id"),
+                agent_id=resolved,
+                namespace=result.get("namespace"),
+                confidence=result.get("confidence", confidence),
+            )
+        except NoAgentConfiguredError as exc:
+            return _error_payload(RememberResult, str(exc), agent_id=agent_id or "")
+        except Exception as exc:
+            logger.exception("remember failed")
+            return _error_payload(
+                RememberResult,
+                _format_exception(exc),
+                agent_id=agent_id or settings.default_agent_id or "",
+            )
+
+    # ============================================================ #
+    # batch_remember
+    # ============================================================ #
+    @mcp.tool(
+        name="batch_remember",
+        description=(
+            "Store many memories at once (up to 100). Use this when you have "
+            "a list of independent facts to persist - e.g. extracting "
+            "structured data from a document. For a single item, prefer "
+            "`remember`."
+        ),
+    )
+    def batch_remember(
+        memories: Annotated[
+            list[dict[str, Any]],
+            Field(
+                description=(
+                    "List of memory dicts. Each item supports the same fields "
+                    "as `remember` (content [required], type, title, "
+                    "confidence, tags, source, provenance). Max 100 items."
+                ),
+                min_length=1,
+                max_length=_MAX_BATCH_SIZE,
+            ),
+        ],
+        agent_id: AgentIdField = None,
+    ) -> BatchRememberResult:
+        try:
+            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            # Validate before round-trip so we fail fast with a clear error.
+            for i, item in enumerate(memories):
+                if not isinstance(item, dict):
+                    raise ValueError(f"memories[{i}] must be an object, got {type(item).__name__}")
+                if "content" not in item or not str(item["content"]).strip():
+                    raise ValueError(f"memories[{i}] is missing required field 'content'")
+                m_type = item.get("type", "fact")
+                if m_type not in VALID_MEMORY_TYPES:
+                    raise ValueError(
+                        f"memories[{i}].type={m_type!r} is not a valid memory type. "
+                        f"Choose one of: {sorted(VALID_MEMORY_TYPES)}"
+                    )
+                prov = item.get("provenance", "explicit_statement")
+                if prov not in VALID_PROVENANCE_TYPES:
+                    raise ValueError(
+                        f"memories[{i}].provenance={prov!r} is not valid. "
+                        f"Choose one of: {sorted(VALID_PROVENANCE_TYPES)}"
+                    )
+
+            result = lifecycle.client.batch_remember(
+                agent_id=resolved,
+                memories=memories,
+            )
+            sub_results = [
+                BatchRememberItemResult(
+                    id=r.get("id"),
+                    status=r.get("status", "queued"),
+                    error=r.get("error"),
+                )
+                for r in result.get("results", [])
+            ]
+            return BatchRememberResult(
+                status="ok",
+                agent_id=resolved,
+                namespace=result.get("namespace"),
+                total_submitted=result.get("total_submitted", len(memories)),
+                successful=result.get("successful", 0),
+                failed=result.get("failed", 0),
+                results=sub_results,
+            )
+        except NoAgentConfiguredError as exc:
+            return _error_payload(BatchRememberResult, str(exc), agent_id=agent_id or "")
+        except Exception as exc:
+            logger.exception("batch_remember failed")
+            return _error_payload(
+                BatchRememberResult,
+                _format_exception(exc),
+                agent_id=agent_id or settings.default_agent_id or "",
+            )
+
+    # ============================================================ #
+    # recall
+    # ============================================================ #
+    @mcp.tool(
+        name="recall",
+        description=(
+            "Search the agent's memories by semantic similarity. Returns the "
+            "top-N most relevant items. Use this FIRST before asking the user "
+            "to repeat information - the agent may already remember it. The "
+            "query should be natural language ('what does the user prefer for "
+            "code style?'), not keywords."
+        ),
+    )
+    def recall(
+        query: Annotated[
+            str,
+            Field(
+                description="Natural-language search query.",
+                min_length=1,
+                max_length=2000,
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Field(
+                description="Max number of memories to return (1-100).",
+                ge=1,
+                le=100,
+            ),
+        ] = 10,
+        type: Annotated[
+            list[MemoryTypeLiteral] | None,
+            Field(
+                default=None,
+                description=(
+                    "Optional type filter - e.g. ['preference'] to only "
+                    "retrieve user preferences."
+                ),
+            ),
+        ] = None,
+        min_similarity: Annotated[
+            float | None,
+            Field(
+                default=None,
+                ge=0.0,
+                le=1.0,
+                description="Minimum similarity score 0-1.",
+            ),
+        ] = None,
+        agent_id: AgentIdField = None,
+    ) -> RecallResult:
+        try:
+            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            result = lifecycle.client.recall(
+                agent_id=resolved,
+                query=query,
+                limit=limit,
+                type=list(type) if type else None,
+            )
+            hits = [_to_memory_hit(m) for m in result.get("memories", [])]
+            if min_similarity is not None:
+                hits = [h for h in hits if (h.score or 0.0) >= min_similarity]
+            return RecallResult(
+                status="ok",
+                agent_id=resolved,
+                query=query,
+                mode="semantic",
+                count=len(hits),
+                memories=hits,
+            )
+        except NoAgentConfiguredError as exc:
+            return _error_payload(RecallResult, str(exc), agent_id=agent_id or "", query=query)
+        except Exception as exc:
+            logger.exception("recall failed")
+            return _error_payload(
+                RecallResult,
+                _format_exception(exc),
+                agent_id=agent_id or settings.default_agent_id or "",
+                query=query,
+            )
+
+    # ============================================================ #
+    # recall_recent
+    # ============================================================ #
+    @mcp.tool(
+        name="recall_recent",
+        description=(
+            "Return the most recently stored memories (newest first). Use "
+            "this to surface fresh context - e.g. 'what did we just decide?' "
+            "- when you don't have a specific search query."
+        ),
+    )
+    def recall_recent(
+        limit: Annotated[
+            int,
+            Field(description="Max number of memories to return.", ge=1, le=100),
+        ] = 10,
+        type: Annotated[
+            list[MemoryTypeLiteral] | None,
+            Field(default=None, description="Optional type filter."),
+        ] = None,
+        agent_id: AgentIdField = None,
+    ) -> RecallResult:
+        try:
+            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            result = lifecycle.client.recall_recent(
+                agent_id=resolved,
+                limit=limit,
+                type=list(type) if type else None,
+            )
+            hits = [_to_memory_hit(m) for m in result.get("memories", [])]
+            return RecallResult(
+                status="ok",
+                agent_id=resolved,
+                mode="recent",
+                count=len(hits),
+                memories=hits,
+            )
+        except NoAgentConfiguredError as exc:
+            return _error_payload(RecallResult, str(exc), agent_id=agent_id or "")
+        except Exception as exc:
+            logger.exception("recall_recent failed")
+            return _error_payload(
+                RecallResult,
+                _format_exception(exc),
+                agent_id=agent_id or settings.default_agent_id or "",
+            )
+
+    # ============================================================ #
+    # recall_as_of
+    # ============================================================ #
+    @mcp.tool(
+        name="recall_as_of",
+        description=(
+            "Point-in-time recall: return only memories that were known "
+            "before the given timestamp. Use this when the user asks "
+            "historical questions like 'what did we know on 2025-11-01?' or "
+            "to reconstruct context at a previous moment."
+        ),
+    )
+    def recall_as_of(
+        as_of: Annotated[
+            str,
+            Field(
+                description=(
+                    "Cutoff timestamp. Accepts YYYY-MM-DD (interpreted as end "
+                    "of that day) or full ISO 8601 e.g. 2025-11-01T14:30:00Z."
+                ),
+                min_length=1,
+            ),
+        ],
+        limit: Annotated[int, Field(ge=1, le=100)] = 10,
+        type: Annotated[
+            list[MemoryTypeLiteral] | None,
+            Field(default=None, description="Optional type filter."),
+        ] = None,
+        agent_id: AgentIdField = None,
+    ) -> RecallResult:
+        try:
+            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            result = lifecycle.client.recall_as_of(
+                agent_id=resolved,
+                as_of=as_of,
+                limit=limit,
+                type=list(type) if type else None,
+            )
+            hits = [_to_memory_hit(m) for m in result.get("memories", [])]
+            return RecallResult(
+                status="ok",
+                agent_id=resolved,
+                mode="as_of",
+                count=len(hits),
+                memories=hits,
+                message=f"as_of={as_of}",
+            )
+        except NoAgentConfiguredError as exc:
+            return _error_payload(RecallResult, str(exc), agent_id=agent_id or "")
+        except Exception as exc:
+            logger.exception("recall_as_of failed")
+            return _error_payload(
+                RecallResult,
+                _format_exception(exc),
+                agent_id=agent_id or settings.default_agent_id or "",
+            )
+
+    # ============================================================ #
+    # recall_changed_since
+    # ============================================================ #
+    @mcp.tool(
+        name="recall_changed_since",
+        description=(
+            "Differential retrieval: return memories created or updated "
+            "after the given timestamp. Use this for 'what's new since X?' "
+            "or to catch up on activity between sessions."
+        ),
+    )
+    def recall_changed_since(
+        since: Annotated[
+            str,
+            Field(
+                description=(
+                    "Lower-bound timestamp. Accepts YYYY-MM-DD (start of day) "
+                    "or full ISO 8601 e.g. 2025-11-01T00:00:00Z."
+                ),
+                min_length=1,
+            ),
+        ],
+        limit: Annotated[int, Field(ge=1, le=100)] = 10,
+        type: Annotated[
+            list[MemoryTypeLiteral] | None,
+            Field(default=None, description="Optional type filter."),
+        ] = None,
+        agent_id: AgentIdField = None,
+    ) -> RecallResult:
+        try:
+            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            result = lifecycle.client.recall_changed_since(
+                agent_id=resolved,
+                since=since,
+                limit=limit,
+                type=list(type) if type else None,
+            )
+            hits = [_to_memory_hit(m) for m in result.get("memories", [])]
+            return RecallResult(
+                status="ok",
+                agent_id=resolved,
+                mode="changed_since",
+                count=len(hits),
+                memories=hits,
+                message=f"since={since}",
+            )
+        except NoAgentConfiguredError as exc:
+            return _error_payload(RecallResult, str(exc), agent_id=agent_id or "")
+        except Exception as exc:
+            logger.exception("recall_changed_since failed")
+            return _error_payload(
+                RecallResult,
+                _format_exception(exc),
+                agent_id=agent_id or settings.default_agent_id or "",
+            )
+
+    # ============================================================ #
+    # answer (RAG)
+    # ============================================================ #
+    @mcp.tool(
+        name="answer",
+        description=(
+            "Ask a natural-language question and get an LLM-generated answer "
+            "grounded ONLY in the agent's stored memories (RAG). Prefer this "
+            "over `recall` when you need a synthesized answer rather than a "
+            "ranked list. Returns the answer text plus the supporting memory "
+            "sources."
+        ),
+    )
+    def answer(
+        question: Annotated[
+            str,
+            Field(description="The question to answer.", min_length=1, max_length=2000),
+        ],
+        limit: Annotated[
+            int | None,
+            Field(
+                default=None,
+                ge=1,
+                le=100,
+                description="Number of context memories to retrieve. Defaults to server config.",
+            ),
+        ] = None,
+        temperature: Annotated[
+            float | None,
+            Field(
+                default=None,
+                ge=0.0,
+                le=2.0,
+                description="LLM temperature. Defaults to server config.",
+            ),
+        ] = None,
+        kiosk_mode: Annotated[
+            bool,
+            Field(
+                description=(
+                    "If true, refuses to answer when no memory clears the "
+                    "similarity threshold (useful for strictly grounded "
+                    "applications)."
+                ),
+            ),
+        ] = False,
+        agent_id: AgentIdField = None,
+    ) -> AnswerResult:
+        try:
+            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            result = lifecycle.client.answer(
+                agent_id=resolved,
+                question=question,
+                limit=limit,
+                temperature=temperature,
+                kiosk_mode=kiosk_mode,
+            )
+            return AnswerResult(
+                status="ok",
+                agent_id=resolved,
+                question=question,
+                answer=result.get("answer"),
+                sources=result.get("sources", []),
+                namespace=result.get("namespace"),
+            )
+        except NoAgentConfiguredError as exc:
+            return _error_payload(
+                AnswerResult, str(exc), agent_id=agent_id or "", question=question
+            )
+        except Exception as exc:
+            logger.exception("answer failed")
+            return _error_payload(
+                AnswerResult,
+                _format_exception(exc),
+                agent_id=agent_id or settings.default_agent_id or "",
+                question=question,
+            )
+
+    # ============================================================ #
+    # Optional agent administration tools
+    # ============================================================ #
+    if settings.expose_admin_tools:
+        _register_admin_tools(mcp, lifecycle)
+
+
+def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
+    """Optional agent lifecycle tools, gated by MEMANTO_EXPOSE_ADMIN."""
+
+    @mcp.tool(
+        name="create_agent",
+        description=(
+            "Create a new Memanto agent (memory namespace). Most users only "
+            "need one agent per project - it is fine to leave this disabled "
+            "and rely on auto-create."
+        ),
+    )
+    def create_agent(
+        agent_id: Annotated[
+            str,
+            Field(
+                description="Unique agent id (letters, numbers, '-', '_').",
+                min_length=1,
+                max_length=64,
+            ),
+        ],
+        pattern: Annotated[
+            Literal["support", "project", "tool"],
+            Field(description="Agent pattern - affects default behaviors."),
+        ] = "tool",
+        description: Annotated[
+            str | None,
+            Field(default=None, description="Optional human-readable description."),
+        ] = None,
+    ) -> AgentInfoResult:
+        try:
+            agent = lifecycle.client.create_agent(
+                agent_id=agent_id, pattern=pattern, description=description
+            )
+            return AgentInfoResult(
+                status="ok",
+                agent_id=agent.get("agent_id"),
+                namespace=agent.get("namespace"),
+                pattern=agent.get("pattern"),
+                description=agent.get("description"),
+                created_at=str(agent.get("created_at")) if agent.get("created_at") else None,
+            )
+        except AgentAlreadyExistsError as exc:
+            return AgentInfoResult(
+                status="exists",
+                agent_id=agent_id,
+                message=exc.message,
+            )
+        except Exception as exc:
+            logger.exception("create_agent failed")
+            return _error_payload(AgentInfoResult, _format_exception(exc), agent_id=agent_id)
+
+    @mcp.tool(
+        name="list_agents",
+        description="List every Memanto agent visible to the current API key.",
+    )
+    def list_agents() -> AgentListResult:
+        try:
+            agents = lifecycle.client.list_agents()
+            return AgentListResult(status="ok", count=len(agents), agents=agents)
+        except Exception as exc:
+            logger.exception("list_agents failed")
+            return _error_payload(AgentListResult, _format_exception(exc))
+
+    @mcp.tool(
+        name="get_agent",
+        description="Look up an agent's metadata by id.",
+    )
+    def get_agent(
+        agent_id: Annotated[str, Field(description="Agent id to look up.", min_length=1)],
+    ) -> AgentInfoResult:
+        try:
+            agent = lifecycle.client.get_agent(agent_id)
+            return AgentInfoResult(
+                status="ok",
+                agent_id=agent.get("agent_id"),
+                namespace=agent.get("namespace"),
+                pattern=agent.get("pattern"),
+                description=agent.get("description"),
+                created_at=str(agent.get("created_at")) if agent.get("created_at") else None,
+            )
+        except AgentNotFoundError as exc:
+            return AgentInfoResult(
+                status="not_found", agent_id=agent_id, message=exc.message
+            )
+        except Exception as exc:
+            logger.exception("get_agent failed")
+            return _error_payload(AgentInfoResult, _format_exception(exc), agent_id=agent_id)
+
+    @mcp.tool(
+        name="delete_agent",
+        description=(
+            "Delete an agent's local metadata. Note: by default this does NOT "
+            "delete the remote Moorcheh namespace - memories are retained "
+            "until explicitly purged via the Memanto CLI/REST API."
+        ),
+    )
+    def delete_agent(
+        agent_id: Annotated[str, Field(description="Agent id to delete.", min_length=1)],
+    ) -> AgentInfoResult:
+        try:
+            lifecycle.client.delete_agent(agent_id)
+            return AgentInfoResult(status="ok", agent_id=agent_id, message="deleted")
+        except AgentNotFoundError as exc:
+            return AgentInfoResult(
+                status="not_found", agent_id=agent_id, message=exc.message
+            )
+        except Exception as exc:
+            logger.exception("delete_agent failed")
+            return _error_payload(AgentInfoResult, _format_exception(exc), agent_id=agent_id)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_memory_hit(raw: dict[str, Any]) -> MemoryHit:
+    """Map a Memanto recall result row into the MCP MemoryHit shape.
+
+    Memanto returns slightly different keys across endpoints (e.g. ``score``
+    vs ``similarity_score``). We coalesce them here so tool consumers see a
+    stable schema.
+    """
+    return MemoryHit(
+        id=str(raw.get("id")) if raw.get("id") is not None else None,
+        type=raw.get("type"),
+        title=raw.get("title"),
+        content=raw.get("content"),
+        confidence=raw.get("confidence"),
+        tags=list(raw.get("tags") or []),
+        created_at=str(raw.get("created_at")) if raw.get("created_at") else None,
+        score=(
+            raw.get("score")
+            if raw.get("score") is not None
+            else raw.get("similarity_score")
+        ),
+    )

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -1,0 +1,74 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "memanto-mcp"
+version = "0.1.0"
+description = "Model Context Protocol (MCP) server for Memanto - persistent semantic memory for any MCP-compatible agent"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10,<4"
+authors = [
+    { name = "Memanto", email = "info@memanto.ai" }
+]
+keywords = [
+    "memanto",
+    "moorcheh",
+    "mcp",
+    "model-context-protocol",
+    "agent memory",
+    "semantic memory",
+    "claude",
+    "cursor",
+    "anthropic",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "mcp[cli]>=1.2.0",
+    "memanto>=0.1.0",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2.0,<9",
+    "pytest-asyncio>=0.21.0",
+    "pytest-mock>=3.12.0,<4",
+    "ruff>=0.14.6,<0.15",
+    "mypy>=1.10.0,<2",
+]
+
+[project.scripts]
+memanto-mcp = "memanto_mcp.__main__:main"
+
+[project.urls]
+Homepage = "https://www.memanto.ai"
+Documentation = "https://docs.memanto.ai"
+Repository = "https://github.com/moorcheh-ai/memanto"
+"Bug Tracker" = "https://github.com/moorcheh-ai/memanto/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["memanto_mcp"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+ignore = ["B904", "E501", "B008", "C901"]


### PR DESCRIPTION
- MCP server for memanto
- exposed tools `remember` `recall` `answer` `recall_recent` `recall_as_of` `recall_changed_since` `batch_remember` `create_agent` `list_agents` `get_agent` `delete_agent`
