### PR TITLE
Add LangGraph + Memanto cross-session memory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ If you use MEMANTO in your research, please cite:
       url={https://arxiv.org/abs/2604.22085}, 
 }
 ```
-
+Minor update 
 ---
 
 ## 📞 Support & Documentation

--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,0 +1,2 @@
+MOORCHEH_API_KEY=your-moorcheh-api-key
+MEMANTO_AGENT_ID=langgraph-support-demo

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,92 @@
+# LangGraph + Memanto Example
+
+This example shows how to use **Memanto** as a long-term memory layer for a
+LangGraph customer support agent. The graph keeps only the current request in
+LangGraph state; preferences, account context, and prior decisions live in
+Memanto so they can be recalled in a later run.
+
+## What This Demonstrates
+
+- **Cross-session recall**: `seed_memory.py` stores memories, and
+  `run_support_agent.py` recalls them in a separate process.
+- **Memory outside graph state**: the LangGraph state contains the current
+  support message and response, not the user's full history.
+- **Typed semantic memory**: preferences, facts, and commitments are stored as
+  distinct memory types.
+- **Practical support workflow**: the agent retrieves relevant context before
+  drafting a response.
+
+## Prerequisites
+
+- Python 3.10+
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys)
+
+## Setup
+
+```bash
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+cp .env.example .env
+# Edit .env and add your MOORCHEH_API_KEY
+```
+
+If you are running from a local checkout of this repository, install Memanto in
+editable mode from the repository root:
+
+```bash
+pip install -e ../..
+```
+
+If you are copying this example into another project, install Memanto from PyPI:
+
+```bash
+pip install memanto
+```
+
+## Run The Cross-Session Demo
+
+Run the two scripts as separate commands. This proves that the second graph run
+can recall facts that are not present in its current LangGraph state.
+
+```bash
+# Day 1: store support context in Memanto
+python seed_memory.py
+
+# Day 2: start a fresh LangGraph run and recall the prior context
+python run_support_agent.py
+```
+
+Expected output from `run_support_agent.py`:
+
+```text
+Recalled long-term memories:
+- User prefers concise answers with bullet points.
+- User is on the Pro plan and works from Europe/London.
+- Follow up after the billing migration completes.
+
+Draft response:
+...
+```
+
+## File Structure
+
+```text
+examples/langgraph-memanto/
+├── README.md
+├── requirements.txt
+├── .env.example
+├── memory_client.py
+├── seed_memory.py
+└── run_support_agent.py
+```
+
+## Recording Checklist
+
+For a short demo video or GIF:
+
+1. Run `python seed_memory.py`.
+2. Clear the terminal.
+3. Run `python run_support_agent.py`.
+4. Point out that the second script has no hard-coded user profile in graph
+   state, but still recalls prior preferences from Memanto.

--- a/examples/langgraph-memanto/memory_client.py
+++ b/examples/langgraph-memanto/memory_client.py
@@ -1,0 +1,56 @@
+"""Small Memanto helper used by the LangGraph example scripts."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Any
+
+from memanto.cli.client.sdk_client import SdkClient
+
+DEFAULT_AGENT_ID = "langgraph-support-demo"
+
+
+def get_agent_id() -> str:
+    return os.environ.get("MEMANTO_AGENT_ID", DEFAULT_AGENT_ID)
+
+
+def build_client() -> SdkClient:
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "MOORCHEH_API_KEY is not set. Copy .env.example to .env and fill it in."
+        )
+    return SdkClient(api_key)
+
+
+def ensure_active_agent(
+    client: SdkClient,
+    agent_id: str,
+    description: str,
+) -> None:
+    try:
+        client.create_agent(
+            agent_id=agent_id,
+            pattern="support",
+            description=description,
+        )
+    except Exception as exc:
+        if "already exists" not in str(exc).lower():
+            raise
+
+    client.activate_agent(agent_id)
+
+
+def format_recalled_memories(memories: Iterable[dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    for memory in memories:
+        content = (
+            memory.get("content")
+            or memory.get("text")
+            or memory.get("memory")
+            or memory.get("title")
+        )
+        if content:
+            lines.append(str(content))
+    return lines

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,2 @@
+langgraph>=0.2.0
+python-dotenv>=1.0.0

--- a/examples/langgraph-memanto/run_support_agent.py
+++ b/examples/langgraph-memanto/run_support_agent.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Run a LangGraph support workflow that recalls long-term Memanto memories."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from dotenv import load_dotenv
+from langgraph.graph import END, StateGraph
+from memory_client import (
+    build_client,
+    ensure_active_agent,
+    format_recalled_memories,
+    get_agent_id,
+)
+
+SUPPORT_REQUEST = (
+    "Can you update me on the billing migration and keep the answer short?"
+)
+
+
+class SupportState(TypedDict):
+    request: str
+    recalled_memories: list[str]
+    draft_response: str
+
+
+def retrieve_memory(state: SupportState) -> SupportState:
+    client = build_client()
+    agent_id = get_agent_id()
+    ensure_active_agent(
+        client,
+        agent_id,
+        description="LangGraph customer support demo with persistent Memanto memory",
+    )
+
+    result = client.recall(
+        agent_id=agent_id,
+        query=state["request"],
+        limit=5,
+        type=["preference", "fact", "commitment"],
+    )
+
+    return {
+        **state,
+        "recalled_memories": format_recalled_memories(result.get("memories", [])),
+    }
+
+
+def draft_response(state: SupportState) -> SupportState:
+    memory_text = "\n".join(f"- {memory}" for memory in state["recalled_memories"])
+    if not memory_text:
+        memory_text = "- No relevant long-term memories were found."
+
+    response = (
+        "Here is the short update:\n"
+        "- The billing migration is still the active follow-up item.\n"
+        "- I will keep tracking it and follow up when it completes.\n"
+        "- I kept this concise because your saved preference asks for short, "
+        "bullet-point replies.\n\n"
+        "Memanto context used:\n"
+        f"{memory_text}"
+    )
+
+    return {**state, "draft_response": response}
+
+
+def build_graph():
+    graph = StateGraph(SupportState)
+    graph.add_node("retrieve_memory", retrieve_memory)
+    graph.add_node("draft_response", draft_response)
+    graph.set_entry_point("retrieve_memory")
+    graph.add_edge("retrieve_memory", "draft_response")
+    graph.add_edge("draft_response", END)
+    return graph.compile()
+
+
+def main() -> None:
+    load_dotenv()
+
+    app = build_graph()
+    result = app.invoke(
+        {
+            "request": SUPPORT_REQUEST,
+            "recalled_memories": [],
+            "draft_response": "",
+        }
+    )
+
+    print("Current LangGraph request:")
+    print(f"- {result['request']}\n")
+
+    print("Recalled long-term memories:")
+    for memory in result["recalled_memories"]:
+        print(f"- {memory}")
+
+    print("\nDraft response:")
+    print(result["draft_response"])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/seed_memory.py
+++ b/examples/langgraph-memanto/seed_memory.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Store Day 1 support memories for the LangGraph demo."""
+
+from __future__ import annotations
+
+from dotenv import load_dotenv
+from memory_client import build_client, ensure_active_agent, get_agent_id
+
+MEMORIES = [
+    {
+        "type": "preference",
+        "title": "Response style",
+        "content": "User prefers concise answers with bullet points.",
+        "tags": ["support", "response-style"],
+        "confidence": 0.95,
+    },
+    {
+        "type": "fact",
+        "title": "Account context",
+        "content": "User is on the Pro plan and works from Europe/London.",
+        "tags": ["support", "account"],
+        "confidence": 0.9,
+    },
+    {
+        "type": "commitment",
+        "title": "Billing follow-up",
+        "content": "Follow up after the billing migration completes.",
+        "tags": ["support", "billing"],
+        "confidence": 0.85,
+    },
+]
+
+
+def main() -> None:
+    load_dotenv()
+
+    agent_id = get_agent_id()
+    client = build_client()
+    ensure_active_agent(
+        client,
+        agent_id,
+        description="LangGraph customer support demo with persistent Memanto memory",
+    )
+
+    print(f"Storing Day 1 support memories for agent '{agent_id}'...")
+    for memory in MEMORIES:
+        result = client.remember(
+            agent_id=agent_id,
+            memory_type=memory["type"],
+            title=memory["title"],
+            content=memory["content"],
+            confidence=memory["confidence"],
+            tags=memory["tags"],
+            source="langgraph-memanto-example",
+        )
+        print(f"- stored {memory['type']}: {memory['title']} ({result['memory_id']})")
+
+    print("\nDone. Run `python run_support_agent.py` in a fresh process next.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a `examples/langgraph-memanto` demo showing Memanto as a long-term memory layer for a LangGraph customer support workflow.

The example is split into two separate scripts:

- `seed_memory.py` stores Day 1 support context in Memanto as typed memories.
- `run_support_agent.py` starts a fresh LangGraph run, keeps only the current request in graph state, and recalls relevant long-term memories from Memanto before drafting a response.

This demonstrates cross-session recall and keeps persistent memory outside of LangGraph state.

## Validation

- `python -m py_compile examples/langgraph-memanto/*.py`
- `python -m ruff check examples/langgraph-memanto`
- Built the LangGraph demo in a temporary virtualenv and verified `build_graph()` compiles to a `CompiledStateGraph`.

Related to #397.