### PR TITLE
Add Claude Code skills Memanto memory bridge

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -66,3 +66,5 @@ This lets a later `/tdd`, `/handoff`, or `/grill-with-docs` invocation retrieve 
 ## Offline Testability
 
 The hook depends on a small `MemoryBackend` protocol. Tests use an in-memory fake backend, so the example can be reviewed and verified without a Moorcheh API key or network access.
+
+See `demo-transcript.md` for a concrete before/after run that stores a skill decision and injects it into a later skill prompt.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -56,6 +56,24 @@ python examples/claudecode-skills-memanto/validate.py
 
 The preview backend is intentionally small and file-based. It is not a replacement for Memanto; it exists so reviewers can inspect the skill lifecycle before wiring real credentials.
 
+## Productivity Benchmark
+
+The bounty's core metric is fewer repeated instructions across `/grill-with-docs`, `/tdd`, and `/handoff`. `productivity_benchmark.py` runs a deterministic local scenario where the first skill stores auth-session decisions and later skills retrieve them instead of requiring the developer to repeat the same constraints.
+
+```bash
+python examples/claudecode-skills-memanto/productivity_benchmark.py
+```
+
+Expected output:
+
+```text
+skill_runs=3
+stored_memories=6
+baseline_repeated_prompts=2
+memanto_reused_prompts=2
+repeated_instruction_reduction=100%
+```
+
 ## Wrapper Usage
 
 `run_skill_with_memory.py` demonstrates a lightweight wrapper around any command:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -37,6 +37,16 @@ python examples/claudecode-skills-memanto/memanto_skills_hook.py post \
   --transcript-file /tmp/skill-transcript.txt
 ```
 
+## Credential-Free Preview
+
+Reviewers can validate the lifecycle without a Moorcheh API key by using the local JSONL backend:
+
+```bash
+python examples/claudecode-skills-memanto/validate.py
+```
+
+The preview backend is intentionally small and file-based. It is not a replacement for Memanto; it exists so reviewers can inspect the skill lifecycle before wiring real credentials.
+
 ## Wrapper Usage
 
 `run_skill_with_memory.py` demonstrates a lightweight wrapper around any command:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -113,6 +113,17 @@ python examples/claudecode-skills-memanto/mattpocock_adapter.py handoff \
 
 The emitted `pre_hook` recalls relevant engineering memory before the skill starts. The emitted `post_hook` stores the completed skill transcript afterward, so a later skill can reuse the same architectural decisions.
 
+To write copyable Claude Code command wrappers for every supported skill:
+
+```bash
+python examples/claudecode-skills-memanto/mattpocock_adapter.py install \
+  --output-dir .claude/commands \
+  --task "Use Memanto memory around this skill run" \
+  --backend memanto-sdk
+```
+
+This creates `grill-with-docs.md`, `tdd.md`, and `handoff.md` wrapper files. Each wrapper tells the runner to execute the Memanto `pre` hook before the skill and the `post` hook after the transcript is available.
+
 ## Global Hook Manifest
 
 `claude-code-hooks.example.json` is a copyable hook manifest for runners that prefer static configuration over generating specs at runtime. Each supported skill has:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,68 @@
+# Claude Code Skills + Memanto
+
+This example shows how Memanto can act as a persistent engineering memory layer for command-oriented skill workflows such as `mattpocock/skills`.
+
+The hook has two phases:
+
+- `pre`: recall relevant engineering decisions before a skill starts and print a compact context block that can be appended to the skill prompt.
+- `post`: read the completed skill transcript, distill durable engineering context, and store it in Memanto as typed `decision` memory.
+
+## Setup
+
+```bash
+pip install memanto
+memanto agent create claude-code-skills
+```
+
+The active Memanto agent is used by the hook. A Moorcheh API key must already be configured through `memanto` setup.
+
+## Direct Hook Usage
+
+Before running a skill:
+
+```bash
+python examples/claudecode-skills-memanto/memanto_skills_hook.py pre \
+  --skill tdd \
+  --task "Add the invoice retry policy" \
+  --file src/billing/retries.ts
+```
+
+After running a skill:
+
+```bash
+python examples/claudecode-skills-memanto/memanto_skills_hook.py post \
+  --skill tdd \
+  --task "Add the invoice retry policy" \
+  --file src/billing/retries.ts \
+  --transcript-file /tmp/skill-transcript.txt
+```
+
+## Wrapper Usage
+
+`run_skill_with_memory.py` demonstrates a lightweight wrapper around any command:
+
+```bash
+python examples/claudecode-skills-memanto/run_skill_with_memory.py \
+  --skill grill-with-docs \
+  --task "Review the auth middleware for stale-token behavior" \
+  --file src/auth/middleware.ts \
+  -- python -m pytest tests/test_auth.py
+```
+
+In a real Claude Code skill runner, wire the `pre` output into the generated prompt and pipe the skill transcript to `post` when the command finishes.
+
+## What Gets Remembered
+
+The stored memory includes:
+
+- the skill name,
+- the task,
+- files in scope,
+- the transcript summary,
+- tags for `claude-code-skills`, the skill name, and touched files.
+
+This lets a later `/tdd`, `/handoff`, or `/grill-with-docs` invocation retrieve project-specific decisions without the developer repeating architectural constraints.
+
+## Offline Testability
+
+The hook depends on a small `MemoryBackend` protocol. Tests use an in-memory fake backend, so the example can be reviewed and verified without a Moorcheh API key or network access.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -16,6 +16,15 @@ memanto agent create claude-code-skills
 
 The active Memanto agent is used by the hook. A Moorcheh API key must already be configured through `memanto` setup.
 
+For production wiring, use the SDK backend so the hook talks to Memanto through the in-process Python client:
+
+```bash
+export MEMANTO_SKILLS_BACKEND=memanto-sdk
+export MEMANTO_AGENT_ID=claude-code-skills
+```
+
+If `MEMANTO_AGENT_ID` is omitted, the hook uses the active agent from the local Memanto CLI configuration. The `memanto-cli` backend remains available for environments that prefer shelling out to the installed CLI.
+
 ## Direct Hook Usage
 
 Before running a skill:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -68,7 +68,18 @@ python examples/claudecode-skills-memanto/run_skill_with_memory.py \
   -- python -m pytest tests/test_auth.py
 ```
 
-In a real Claude Code skill runner, wire the `pre` output into the generated prompt and pipe the skill transcript to `post` when the command finishes.
+The wrapper uses the same backend selector as the direct hook:
+
+```bash
+python examples/claudecode-skills-memanto/run_skill_with_memory.py \
+  --backend local-jsonl \
+  --store .memanto-skills-preview.jsonl \
+  --skill tdd \
+  --task "Add retry-policy tests" \
+  -- python -m pytest tests/test_retries.py
+```
+
+When recalled memory exists, the wrapper prints the prompt block and also sets `MEMANTO_SKILL_CONTEXT` for the child command. Skill runners can either append the printed block to the prompt or read the environment variable before invoking their model/tool flow. After the command exits, stdout and stderr are summarized through the `post` memory path.
 
 ## mattpocock/skills Adapter
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -5,7 +5,7 @@ This example shows how Memanto can act as a persistent engineering memory layer 
 The hook has two phases:
 
 - `pre`: recall relevant engineering decisions before a skill starts and print a compact context block that can be appended to the skill prompt.
-- `post`: read the completed skill transcript, distill durable engineering context, and store it in Memanto as typed `decision` memory.
+- `post`: read the completed skill transcript, use Memanto's backend LLM to distill durable engineering context when the SDK backend is active, and store typed memories back into Memanto. Local review falls back to deterministic structured extraction.
 
 ## Setup
 
@@ -24,6 +24,8 @@ export MEMANTO_AGENT_ID=claude-code-skills
 ```
 
 If `MEMANTO_AGENT_ID` is omitted, the hook uses the active agent from the local Memanto CLI configuration. The `memanto-cli` backend remains available for environments that prefer shelling out to the installed CLI.
+
+In SDK mode, the `post` hook asks Memanto to extract durable `decision`, `preference`, `instruction`, and `context` memories from the skill transcript before calling `remember`. If the SDK cannot provide an answer, the hook falls back to the local structured extractor used by the credential-free preview.
 
 ## Direct Hook Usage
 
@@ -127,6 +129,7 @@ The stored memory includes:
 - the skill name,
 - the task,
 - files in scope,
+- Memanto SDK-distilled memories from the completed transcript when `MEMANTO_SKILLS_BACKEND=memanto-sdk`,
 - structured transcript findings such as `Decision:`, `Preference:`, `Must:`,
   `Never:`, `Quirk:`, `Caveat:`, and `Trade-off:` lines when present,
 - a fallback transcript summary when no structured finding is present,

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -73,6 +73,15 @@ python examples/claudecode-skills-memanto/mattpocock_adapter.py handoff \
 
 The emitted `pre_hook` recalls relevant engineering memory before the skill starts. The emitted `post_hook` stores the completed skill transcript afterward, so a later skill can reuse the same architectural decisions.
 
+## Global Hook Manifest
+
+`claude-code-hooks.example.json` is a copyable hook manifest for runners that prefer static configuration over generating specs at runtime. Each supported skill has:
+
+- `memory.before`: runs `memanto_skills_hook.py pre` and injects recalled decisions into the prompt.
+- `memory.after`: runs `memanto_skills_hook.py post` with `$TRANSCRIPT_FILE` after the skill completes.
+
+The placeholders `$SKILL_TASK` and `$TRANSCRIPT_FILE` are intentionally runner-provided so the same manifest can be used by different Claude Code skill wrappers.
+
 ## What Gets Remembered
 
 The stored memory includes:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -109,7 +109,9 @@ The stored memory includes:
 - the skill name,
 - the task,
 - files in scope,
-- the transcript summary,
+- structured transcript findings such as `Decision:`, `Preference:`, `Must:`,
+  `Never:`, `Quirk:`, `Caveat:`, and `Trade-off:` lines when present,
+- a fallback transcript summary when no structured finding is present,
 - tags for `claude-code-skills`, the skill name, and touched files.
 
 This lets a later `/tdd`, `/handoff`, or `/grill-with-docs` invocation retrieve project-specific decisions without the developer repeating architectural constraints.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -61,6 +61,18 @@ python examples/claudecode-skills-memanto/run_skill_with_memory.py \
 
 In a real Claude Code skill runner, wire the `pre` output into the generated prompt and pipe the skill transcript to `post` when the command finishes.
 
+## mattpocock/skills Adapter
+
+`mattpocock_adapter.py` prints a small JSON command contract for the named skills in the bounty: `/grill-with-docs`, `/tdd`, and `/handoff`.
+
+```bash
+python examples/claudecode-skills-memanto/mattpocock_adapter.py handoff \
+  --task "Prepare the billing retry handoff" \
+  --file src/billing/retries.ts
+```
+
+The emitted `pre_hook` recalls relevant engineering memory before the skill starts. The emitted `post_hook` stores the completed skill transcript afterward, so a later skill can reuse the same architectural decisions.
+
 ## What Gets Remembered
 
 The stored memory includes:

--- a/examples/claudecode-skills-memanto/claude-code-hooks.example.json
+++ b/examples/claudecode-skills-memanto/claude-code-hooks.example.json
@@ -1,0 +1,92 @@
+{
+  "description": "Example memory hook wiring for command-oriented Claude Code skills.",
+  "skills": {
+    "grill-with-docs": {
+      "command": "/grill-with-docs",
+      "memory": {
+        "before": [
+          "python",
+          "examples/claudecode-skills-memanto/memanto_skills_hook.py",
+          "pre",
+          "--skill",
+          "grill-with-docs",
+          "--task",
+          "$SKILL_TASK",
+          "--metadata",
+          "{\"adapter\":\"mattpocock-skills\",\"command\":\"/grill-with-docs\"}"
+        ],
+        "after": [
+          "python",
+          "examples/claudecode-skills-memanto/memanto_skills_hook.py",
+          "post",
+          "--skill",
+          "grill-with-docs",
+          "--task",
+          "$SKILL_TASK",
+          "--transcript-file",
+          "$TRANSCRIPT_FILE",
+          "--metadata",
+          "{\"adapter\":\"mattpocock-skills\",\"command\":\"/grill-with-docs\"}"
+        ]
+      }
+    },
+    "handoff": {
+      "command": "/handoff",
+      "memory": {
+        "before": [
+          "python",
+          "examples/claudecode-skills-memanto/memanto_skills_hook.py",
+          "pre",
+          "--skill",
+          "handoff",
+          "--task",
+          "$SKILL_TASK",
+          "--metadata",
+          "{\"adapter\":\"mattpocock-skills\",\"command\":\"/handoff\"}"
+        ],
+        "after": [
+          "python",
+          "examples/claudecode-skills-memanto/memanto_skills_hook.py",
+          "post",
+          "--skill",
+          "handoff",
+          "--task",
+          "$SKILL_TASK",
+          "--transcript-file",
+          "$TRANSCRIPT_FILE",
+          "--metadata",
+          "{\"adapter\":\"mattpocock-skills\",\"command\":\"/handoff\"}"
+        ]
+      }
+    },
+    "tdd": {
+      "command": "/tdd",
+      "memory": {
+        "before": [
+          "python",
+          "examples/claudecode-skills-memanto/memanto_skills_hook.py",
+          "pre",
+          "--skill",
+          "tdd",
+          "--task",
+          "$SKILL_TASK",
+          "--metadata",
+          "{\"adapter\":\"mattpocock-skills\",\"command\":\"/tdd\"}"
+        ],
+        "after": [
+          "python",
+          "examples/claudecode-skills-memanto/memanto_skills_hook.py",
+          "post",
+          "--skill",
+          "tdd",
+          "--task",
+          "$SKILL_TASK",
+          "--transcript-file",
+          "$TRANSCRIPT_FILE",
+          "--metadata",
+          "{\"adapter\":\"mattpocock-skills\",\"command\":\"/tdd\"}"
+        ]
+      }
+    }
+  }
+}

--- a/examples/claudecode-skills-memanto/demo-transcript.md
+++ b/examples/claudecode-skills-memanto/demo-transcript.md
@@ -1,0 +1,52 @@
+# Demo Transcript
+
+This transcript shows the intended lifecycle for a Claude Code-style skill runner.
+
+## 1. First Skill Run Stores a Decision
+
+Command:
+
+```bash
+python examples/claudecode-skills-memanto/memanto_skills_hook.py post \
+  --skill grill-with-docs \
+  --task "Review billing retry architecture" \
+  --file src/billing/retries.ts \
+  --transcript "Keep retry delays deterministic in tests. Preserve idempotency keys across retries."
+```
+
+Output:
+
+```text
+stored_memories=1
+```
+
+Stored memory:
+
+```text
+Skill `grill-with-docs` handled task `Review billing retry architecture`.
+Files in scope: src/billing/retries.ts.
+Outcome and decisions: Keep retry delays deterministic in tests. Preserve idempotency keys across retries.
+```
+
+## 2. Later Skill Run Receives Relevant Context
+
+Command:
+
+```bash
+python examples/claudecode-skills-memanto/memanto_skills_hook.py pre \
+  --skill tdd \
+  --task "Add invoice retry policy tests" \
+  --file src/billing/retries.ts
+```
+
+Prompt context emitted for the next skill:
+
+```text
+<memanto-engineering-memory>
+Relevant prior engineering decisions for this skill run:
+- Keep retry delays deterministic in tests.
+- Preserve idempotency keys across retries.
+</memanto-engineering-memory>
+```
+
+The next `/tdd` skill can now align with prior project decisions without the developer repeating the same instructions.

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 from dataclasses import asdict, dataclass
+from pathlib import Path
 
 
 SUPPORTED_SKILLS = {
@@ -80,11 +81,66 @@ def build_skill_spec(
     )
 
 
+def render_claude_command(spec: MemoryAwareSkillSpec) -> str:
+    """Render a copyable Claude Code slash-command wrapper."""
+    pre_hook = " ".join(_quote_arg(arg) for arg in spec.pre_hook)
+    post_hook = " ".join(_quote_arg(arg) for arg in spec.post_hook)
+    return (
+        f"# {spec.command}\n\n"
+        f"{spec.purpose.capitalize()}.\n\n"
+        "Before doing the requested work, run this command and prepend any stdout "
+        "to the prompt context:\n\n"
+        f"```bash\n{pre_hook}\n```\n\n"
+        "After completing the skill, save the transcript path in "
+        "`$TRANSCRIPT_FILE` and run:\n\n"
+        f"```bash\n{post_hook}\n```\n\n"
+        "Use recalled Memanto context as constraints, not as user-visible output.\n"
+    )
+
+
+def write_command_wrappers(
+    output_dir: str | Path,
+    task: str,
+    files: list[str] | None = None,
+    backend: str = "memanto-cli",
+    store: str | None = None,
+) -> list[Path]:
+    """Write wrapper command files for all supported mattpocock skills."""
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    for skill in sorted(SUPPORTED_SKILLS):
+        spec = build_skill_spec(
+            skill=skill,
+            task=task,
+            files=files or [],
+            backend=backend,
+            store=store,
+        )
+        path = target / f"{skill}.md"
+        path.write_text(render_claude_command(spec), encoding="utf-8")
+        written.append(path)
+    return written
+
+
+def _quote_arg(value: str) -> str:
+    if value == "$TRANSCRIPT_FILE":
+        return value
+    escaped = value.replace("'", "'\"'\"'")
+    return f"'{escaped}'"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Print a memory-aware command spec for mattpocock/skills."
     )
-    parser.add_argument("skill", choices=sorted(SUPPORTED_SKILLS))
+    parser.add_argument(
+        "command",
+        choices=[*sorted(SUPPORTED_SKILLS), "install"],
+        help="Skill to print as JSON, or `install` to write all wrapper files.",
+    )
+    parser.add_argument("--output-dir")
     parser.add_argument("--task", required=True)
     parser.add_argument("--file", action="append", default=[])
     parser.add_argument(
@@ -95,8 +151,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--store")
     args = parser.parse_args(argv)
 
+    if args.command == "install":
+        if not args.output_dir:
+            parser.error("install requires --output-dir")
+        paths = write_command_wrappers(
+            output_dir=args.output_dir,
+            task=args.task,
+            files=args.file,
+            backend=args.backend,
+            store=args.store,
+        )
+        print(json.dumps([str(path) for path in paths], indent=2))
+        return 0
+
     spec = build_skill_spec(
-        skill=args.skill,
+        skill=args.command,
         task=args.task,
         files=args.file,
         backend=args.backend,

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Generate memory-aware command specs for mattpocock/skills-style commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+
+
+SUPPORTED_SKILLS = {
+    "grill-with-docs": {
+        "command": "/grill-with-docs",
+        "purpose": "review code or architecture against supplied docs",
+    },
+    "tdd": {
+        "command": "/tdd",
+        "purpose": "drive implementation with tests first",
+    },
+    "handoff": {
+        "command": "/handoff",
+        "purpose": "summarize current work for another session",
+    },
+}
+
+
+@dataclass(frozen=True)
+class MemoryAwareSkillSpec:
+    """Serializable command contract a skill runner can consume."""
+
+    skill: str
+    command: str
+    purpose: str
+    pre_hook: list[str]
+    post_hook: list[str]
+    prompt_prefix: str
+
+
+def build_skill_spec(
+    skill: str,
+    task: str,
+    files: list[str] | None = None,
+    backend: str = "memanto-cli",
+    store: str | None = None,
+) -> MemoryAwareSkillSpec:
+    """Return pre/post hook commands for a supported mattpocock skill."""
+    if skill not in SUPPORTED_SKILLS:
+        known = ", ".join(sorted(SUPPORTED_SKILLS))
+        raise ValueError(f"unsupported skill {skill!r}; expected one of: {known}")
+
+    files = files or []
+    base_hook = [
+        "python",
+        "examples/claudecode-skills-memanto/memanto_skills_hook.py",
+    ]
+
+    common = ["--backend", backend, "--skill", skill, "--task", task]
+    if store:
+        common.extend(["--store", store])
+    for path in files:
+        common.extend(["--file", path])
+
+    metadata = json.dumps({"adapter": "mattpocock-skills", "command": f"/{skill}"})
+    common.extend(["--metadata", metadata])
+
+    pre_hook = [*base_hook, "pre", *common]
+    post_hook = [*base_hook, "post", *common, "--transcript-file", "$TRANSCRIPT_FILE"]
+    info = SUPPORTED_SKILLS[skill]
+    return MemoryAwareSkillSpec(
+        skill=skill,
+        command=str(info["command"]),
+        purpose=str(info["purpose"]),
+        pre_hook=pre_hook,
+        post_hook=post_hook,
+        prompt_prefix=(
+            "Run the pre_hook first and prepend its stdout to the skill prompt. "
+            "After the skill finishes, write the transcript to $TRANSCRIPT_FILE "
+            "and run post_hook."
+        ),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Print a memory-aware command spec for mattpocock/skills."
+    )
+    parser.add_argument("skill", choices=sorted(SUPPORTED_SKILLS))
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--file", action="append", default=[])
+    parser.add_argument(
+        "--backend",
+        choices=("memanto-cli", "local-jsonl"),
+        default="memanto-cli",
+    )
+    parser.add_argument("--store")
+    args = parser.parse_args(argv)
+
+    spec = build_skill_spec(
+        skill=args.skill,
+        task=args.task,
+        files=args.file,
+        backend=args.backend,
+        store=args.store,
+    )
+    print(json.dumps(asdict(spec), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -89,7 +89,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--file", action="append", default=[])
     parser.add_argument(
         "--backend",
-        choices=("memanto-cli", "local-jsonl"),
+        choices=("memanto-sdk", "memanto-cli", "local-jsonl"),
         default="memanto-cli",
     )
     parser.add_argument("--store")

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Bridge Claude Code-style skill runs through Memanto memory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+
+DEFAULT_LIMIT = 5
+
+
+class MemoryBackend(Protocol):
+    """Minimal backend used by the hook so tests can avoid network calls."""
+
+    def recall(self, query: str, limit: int = DEFAULT_LIMIT) -> list[str]:
+        """Return relevant memories for the next skill run."""
+
+    def remember(
+        self,
+        content: str,
+        memory_type: str,
+        title: str,
+        tags: list[str],
+        confidence: float,
+    ) -> None:
+        """Persist one memory."""
+
+
+@dataclass(frozen=True)
+class SkillRun:
+    """Context passed to a skill invocation."""
+
+    skill: str
+    task: str
+    files: tuple[str, ...] = ()
+    transcript: str = ""
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def query(self) -> str:
+        file_hint = " ".join(self.files)
+        return f"{self.skill} {self.task} {file_hint}".strip()
+
+
+class MemantoCliBackend:
+    """Backend that delegates to the existing ``memanto`` CLI."""
+
+    def __init__(self, executable: str = "memanto") -> None:
+        self.executable = executable
+
+    def recall(self, query: str, limit: int = DEFAULT_LIMIT) -> list[str]:
+        completed = subprocess.run(
+            [
+                self.executable,
+                "recall",
+                query,
+                "--limit",
+                str(limit),
+                "--type",
+                "decision",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            return []
+        return _extract_cli_memory_lines(completed.stdout)
+
+    def remember(
+        self,
+        content: str,
+        memory_type: str,
+        title: str,
+        tags: list[str],
+        confidence: float,
+    ) -> None:
+        args = [
+            self.executable,
+            "remember",
+            content,
+            "--type",
+            memory_type,
+            "--title",
+            title,
+            "--source",
+            "claudecode-skills-memanto",
+            "--provenance",
+            "inferred",
+            "--confidence",
+            f"{confidence:.2f}",
+        ]
+        if tags:
+            args.extend(["--tags", ",".join(tags)])
+        subprocess.run(args, check=True)
+
+
+def _extract_cli_memory_lines(output: str) -> list[str]:
+    """Keep the useful text from rich CLI output without depending on styling."""
+    lines: list[str] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("Found ", "ID:", "Type:", "Completed ")):
+            continue
+        if "Memory " in line and "Score:" in line:
+            continue
+        lines.append(line)
+    return lines[:DEFAULT_LIMIT]
+
+
+def build_context_block(run: SkillRun, backend: MemoryBackend) -> str:
+    """Return a compact system-context block for the next skill prompt."""
+    memories = backend.recall(run.query, limit=DEFAULT_LIMIT)
+    if not memories:
+        return ""
+
+    bullets = "\n".join(f"- {memory}" for memory in memories)
+    return (
+        "<memanto-engineering-memory>\n"
+        "Relevant prior engineering decisions for this skill run:\n"
+        f"{bullets}\n"
+        "</memanto-engineering-memory>"
+    )
+
+
+def summarize_transcript(run: SkillRun) -> list[dict[str, object]]:
+    """Extract durable engineering memories from a completed skill transcript."""
+    transcript = _compact(run.transcript)
+    if not transcript:
+        return []
+
+    tags = ["claude-code-skills", f"skill:{run.skill}"]
+    tags.extend(f"file:{Path(path).name}" for path in run.files[:5])
+
+    summary = (
+        f"Skill `{run.skill}` handled task `{run.task}`. "
+        f"Files in scope: {', '.join(run.files) or 'not specified'}. "
+        f"Outcome and decisions: {transcript}"
+    )
+    return [
+        {
+            "content": summary,
+            "memory_type": "decision",
+            "title": f"{run.skill}: {run.task[:72]}",
+            "tags": tags,
+            "confidence": 0.78,
+        }
+    ]
+
+
+def store_completed_run(run: SkillRun, backend: MemoryBackend) -> int:
+    """Persist memories inferred from a finished skill run."""
+    memories = summarize_transcript(run)
+    for memory in memories:
+        backend.remember(
+            content=str(memory["content"]),
+            memory_type=str(memory["memory_type"]),
+            title=str(memory["title"]),
+            tags=list(memory["tags"]),
+            confidence=float(memory["confidence"]),
+        )
+    return len(memories)
+
+
+def _compact(text: str, max_chars: int = 1200) -> str:
+    stripped = " ".join(text.split())
+    if len(stripped) <= max_chars:
+        return stripped
+    return f"{stripped[: max_chars - 3]}..."
+
+
+def _read_transcript(args: argparse.Namespace) -> str:
+    if args.transcript:
+        return args.transcript
+    if args.transcript_file:
+        return Path(args.transcript_file).read_text(encoding="utf-8")
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    return ""
+
+
+def _build_run(args: argparse.Namespace) -> SkillRun:
+    metadata = {}
+    if args.metadata:
+        metadata = json.loads(args.metadata)
+    return SkillRun(
+        skill=args.skill,
+        task=args.task,
+        files=tuple(args.file or ()),
+        transcript=_read_transcript(args),
+        metadata=metadata,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Inject and write back Memanto memory around skill executions."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command in ("pre", "post"):
+        command_parser = subparsers.add_parser(command)
+        command_parser.add_argument("--skill", required=True)
+        command_parser.add_argument("--task", required=True)
+        command_parser.add_argument("--file", action="append")
+        command_parser.add_argument("--metadata")
+        command_parser.add_argument("--transcript")
+        command_parser.add_argument("--transcript-file")
+
+    args = parser.parse_args(argv)
+    backend = MemantoCliBackend(os.environ.get("MEMANTO_EXECUTABLE", "memanto"))
+    run = _build_run(args)
+
+    if args.command == "pre":
+        context = build_context_block(run, backend)
+        if context:
+            print(context)
+        return 0
+
+    stored = store_completed_run(run, backend)
+    print(f"stored_memories={stored}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -14,6 +15,13 @@ from typing import Protocol
 
 
 DEFAULT_LIMIT = 5
+MEMORY_PATTERNS: tuple[tuple[str, str, float, re.Pattern[str]], ...] = (
+    ("decision", "Decision", 0.88, re.compile(r"\b(?:decision|decided):\s*(.+)", re.I)),
+    ("preference", "Preference", 0.82, re.compile(r"\b(?:preference|prefer):\s*(.+)", re.I)),
+    ("instruction", "Constraint", 0.9, re.compile(r"\b(?:must|never|always):\s*(.+)", re.I)),
+    ("context", "Quirk", 0.76, re.compile(r"\b(?:quirk|caveat|gotcha):\s*(.+)", re.I)),
+    ("context", "Trade-off", 0.74, re.compile(r"\b(?:trade-?off):\s*(.+)", re.I)),
+)
 
 
 class MemoryBackend(Protocol):
@@ -242,20 +250,60 @@ def summarize_transcript(run: SkillRun) -> list[dict[str, object]]:
     tags = ["claude-code-skills", f"skill:{run.skill}"]
     tags.extend(f"file:{Path(path).name}" for path in run.files[:5])
 
-    summary = (
+    memories = _extract_structured_memories(run, transcript, tags)
+    if memories:
+        return memories
+
+    return [_build_memory(run, transcript, "decision", "Skill outcome", tags, 0.78)]
+
+
+def _extract_structured_memories(
+    run: SkillRun,
+    transcript: str,
+    tags: list[str],
+) -> list[dict[str, object]]:
+    memories: list[dict[str, object]] = []
+    seen: set[tuple[str, str]] = set()
+    for sentence in re.split(r"(?<=[.!?])\s+|\n+", transcript):
+        sentence = sentence.strip(" -\t")
+        if not sentence:
+            continue
+        for memory_type, label, confidence, pattern in MEMORY_PATTERNS:
+            match = pattern.search(sentence)
+            if not match:
+                continue
+            detail = _compact(match.group(1).strip(), max_chars=420)
+            if not detail:
+                continue
+            key = (memory_type, detail.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            memories.append(_build_memory(run, detail, memory_type, label, tags, confidence))
+            break
+    return memories[:DEFAULT_LIMIT]
+
+
+def _build_memory(
+    run: SkillRun,
+    detail: str,
+    memory_type: str,
+    label: str,
+    tags: list[str],
+    confidence: float,
+) -> dict[str, object]:
+    files = ", ".join(run.files) or "not specified"
+    content = (
         f"Skill `{run.skill}` handled task `{run.task}`. "
-        f"Files in scope: {', '.join(run.files) or 'not specified'}. "
-        f"Outcome and decisions: {transcript}"
+        f"Files in scope: {files}. {label}: {detail}"
     )
-    return [
-        {
-            "content": summary,
-            "memory_type": "decision",
-            "title": f"{run.skill}: {run.task[:72]}",
-            "tags": tags,
-            "confidence": 0.78,
-        }
-    ]
+    return {
+        "content": content,
+        "memory_type": memory_type,
+        "title": f"{run.skill}: {label.lower()} for {run.task[:54]}",
+        "tags": tags,
+        "confidence": confidence,
+    }
 
 
 def store_completed_run(run: SkillRun, backend: MemoryBackend) -> int:

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -102,6 +102,49 @@ class MemantoCliBackend:
         subprocess.run(args, check=True)
 
 
+class MemantoSdkBackend:
+    """Backend that uses Memanto's Python SDK client directly."""
+
+    def __init__(self, agent_id: str | None = None) -> None:
+        from memanto.cli.commands._shared import get_client
+
+        self.client = get_client()
+        self.agent_id = agent_id or self.client.agent_id
+        if not self.agent_id:
+            raise ValueError(
+                "No active Memanto agent. Run `memanto agent create` or pass "
+                "MEMANTO_AGENT_ID."
+            )
+
+    def recall(self, query: str, limit: int = DEFAULT_LIMIT) -> list[str]:
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            type=["decision"],
+        )
+        return _extract_sdk_memory_lines(result)
+
+    def remember(
+        self,
+        content: str,
+        memory_type: str,
+        title: str,
+        tags: list[str],
+        confidence: float,
+    ) -> None:
+        self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory_type,
+            title=title,
+            content=content,
+            confidence=confidence,
+            tags=tags,
+            source="claudecode-skills-memanto",
+            provenance="inferred",
+        )
+
+
 class LocalJsonlBackend:
     """Credential-free backend for demos and reviewer validation."""
 
@@ -157,6 +200,21 @@ def _extract_cli_memory_lines(output: str) -> list[str]:
         if "Memory " in line and "Score:" in line:
             continue
         lines.append(line)
+    return lines[:DEFAULT_LIMIT]
+
+
+def _extract_sdk_memory_lines(result: dict[str, object]) -> list[str]:
+    memories = result.get("memories", [])
+    if not isinstance(memories, list):
+        return []
+
+    lines: list[str] = []
+    for memory in memories:
+        if not isinstance(memory, dict):
+            continue
+        content = memory.get("content")
+        if isinstance(content, str) and content.strip():
+            lines.append(content.strip())
     return lines[:DEFAULT_LIMIT]
 
 
@@ -260,7 +318,7 @@ def main(argv: list[str] | None = None) -> int:
         command_parser.add_argument("--transcript-file")
         command_parser.add_argument(
             "--backend",
-            choices=("memanto-cli", "local-jsonl"),
+            choices=("memanto-sdk", "memanto-cli", "local-jsonl"),
             default=os.environ.get("MEMANTO_SKILLS_BACKEND", "memanto-cli"),
         )
         command_parser.add_argument(
@@ -275,6 +333,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.backend == "local-jsonl":
         backend: MemoryBackend = LocalJsonlBackend(Path(args.store))
+    elif args.backend == "memanto-sdk":
+        backend = MemantoSdkBackend(os.environ.get("MEMANTO_AGENT_ID"))
     else:
         backend = MemantoCliBackend(os.environ.get("MEMANTO_EXECUTABLE", "memanto"))
     run = _build_run(args)

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -102,6 +102,51 @@ class MemantoCliBackend:
         subprocess.run(args, check=True)
 
 
+class LocalJsonlBackend:
+    """Credential-free backend for demos and reviewer validation."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def recall(self, query: str, limit: int = DEFAULT_LIMIT) -> list[str]:
+        if not self.path.exists():
+            return []
+        query_terms = {term.lower() for term in query.split() if len(term) > 2}
+        scored: list[tuple[int, str]] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            content = str(record.get("content", ""))
+            haystack = " ".join(
+                [content, str(record.get("title", "")), " ".join(record.get("tags", []))]
+            ).lower()
+            score = sum(1 for term in query_terms if term in haystack)
+            if score:
+                scored.append((score, content))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [content for _, content in scored[:limit]]
+
+    def remember(
+        self,
+        content: str,
+        memory_type: str,
+        title: str,
+        tags: list[str],
+        confidence: float,
+    ) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "content": content,
+            "memory_type": memory_type,
+            "title": title,
+            "tags": tags,
+            "confidence": confidence,
+        }
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
 def _extract_cli_memory_lines(output: str) -> list[str]:
     """Keep the useful text from rich CLI output without depending on styling."""
     lines: list[str] = []
@@ -213,9 +258,25 @@ def main(argv: list[str] | None = None) -> int:
         command_parser.add_argument("--metadata")
         command_parser.add_argument("--transcript")
         command_parser.add_argument("--transcript-file")
+        command_parser.add_argument(
+            "--backend",
+            choices=("memanto-cli", "local-jsonl"),
+            default=os.environ.get("MEMANTO_SKILLS_BACKEND", "memanto-cli"),
+        )
+        command_parser.add_argument(
+            "--store",
+            default=os.environ.get(
+                "MEMANTO_SKILLS_STORE",
+                str(Path(".memanto-skills-preview.jsonl")),
+            ),
+            help="JSONL path used by --backend local-jsonl.",
+        )
 
     args = parser.parse_args(argv)
-    backend = MemantoCliBackend(os.environ.get("MEMANTO_EXECUTABLE", "memanto"))
+    if args.backend == "local-jsonl":
+        backend: MemoryBackend = LocalJsonlBackend(Path(args.store))
+    else:
+        backend = MemantoCliBackend(os.environ.get("MEMANTO_EXECUTABLE", "memanto"))
     run = _build_run(args)
 
     if args.command == "pre":

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -272,6 +272,25 @@ def store_completed_run(run: SkillRun, backend: MemoryBackend) -> int:
     return len(memories)
 
 
+def build_backend(backend_name: str, store: str | Path | None = None) -> MemoryBackend:
+    """Construct the configured backend shared by hooks and wrappers."""
+    if backend_name == "local-jsonl":
+        return LocalJsonlBackend(
+            Path(
+                store
+                or os.environ.get(
+                    "MEMANTO_SKILLS_STORE",
+                    str(Path(".memanto-skills-preview.jsonl")),
+                )
+            )
+        )
+    if backend_name == "memanto-sdk":
+        return MemantoSdkBackend(os.environ.get("MEMANTO_AGENT_ID"))
+    if backend_name == "memanto-cli":
+        return MemantoCliBackend(os.environ.get("MEMANTO_EXECUTABLE", "memanto"))
+    raise ValueError(f"Unsupported backend: {backend_name}")
+
+
 def _compact(text: str, max_chars: int = 1200) -> str:
     stripped = " ".join(text.split())
     if len(stripped) <= max_chars:
@@ -331,12 +350,7 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     args = parser.parse_args(argv)
-    if args.backend == "local-jsonl":
-        backend: MemoryBackend = LocalJsonlBackend(Path(args.store))
-    elif args.backend == "memanto-sdk":
-        backend = MemantoSdkBackend(os.environ.get("MEMANTO_AGENT_ID"))
-    else:
-        backend = MemantoCliBackend(os.environ.get("MEMANTO_EXECUTABLE", "memanto"))
+    backend = build_backend(args.backend, args.store)
     run = _build_run(args)
 
     if args.command == "pre":

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 
 DEFAULT_LIMIT = 5
@@ -24,6 +24,7 @@ MEMORY_PATTERNS: tuple[tuple[str, str, float, re.Pattern[str]], ...] = (
 )
 
 
+@runtime_checkable
 class MemoryBackend(Protocol):
     """Minimal backend used by the hook so tests can avoid network calls."""
 
@@ -39,6 +40,13 @@ class MemoryBackend(Protocol):
         confidence: float,
     ) -> None:
         """Persist one memory."""
+
+
+class TranscriptDistiller(Protocol):
+    """Optional backend capability for LLM-backed memory extraction."""
+
+    def distill_transcript(self, run: "SkillRun") -> list[dict[str, object]]:
+        """Return durable memories inferred from a completed skill transcript."""
 
 
 @dataclass(frozen=True)
@@ -152,6 +160,29 @@ class MemantoSdkBackend:
             provenance="inferred",
         )
 
+    def distill_transcript(self, run: SkillRun) -> list[dict[str, object]]:
+        """Use Memanto's backend LLM to extract durable engineering memories."""
+        transcript = _compact(run.transcript, max_chars=6000)
+        if not transcript:
+            return []
+
+        prompt = (
+            "Extract durable developer memories from this completed skill run. "
+            "Return only JSON with a top-level `memories` array. Each item must have "
+            "`type` as one of decision, preference, instruction, context; `title`; "
+            "`content`; and `confidence` from 0 to 1. Keep memories reusable across "
+            "future terminal sessions and ignore temporary status updates.\n\n"
+            f"Skill: {run.skill}\n"
+            f"Task: {run.task}\n"
+            f"Files: {', '.join(run.files) or 'not specified'}\n"
+            f"Transcript:\n{transcript}"
+        )
+
+        answer = _call_sdk_answer(self.client, self.agent_id, prompt)
+        if not answer:
+            return []
+        return _parse_distilled_memories(run, answer)
+
 
 class LocalJsonlBackend:
     """Credential-free backend for demos and reviewer validation."""
@@ -224,6 +255,95 @@ def _extract_sdk_memory_lines(result: dict[str, object]) -> list[str]:
         if isinstance(content, str) and content.strip():
             lines.append(content.strip())
     return lines[:DEFAULT_LIMIT]
+
+
+def _call_sdk_answer(client: object, agent_id: str, prompt: str) -> str:
+    answer_method = getattr(client, "answer", None)
+    if not callable(answer_method):
+        return ""
+
+    attempts: tuple[dict[str, object], ...] = (
+        {"agent_id": agent_id, "question": prompt},
+        {"agent_id": agent_id, "query": prompt},
+        {"agent_id": agent_id, "prompt": prompt},
+    )
+    for kwargs in attempts:
+        try:
+            result = answer_method(**kwargs)
+        except TypeError:
+            continue
+        text = _extract_answer_text(result)
+        if text:
+            return text
+    return ""
+
+
+def _extract_answer_text(result: object) -> str:
+    if isinstance(result, str):
+        return result
+    if isinstance(result, dict):
+        for key in ("answer", "content", "text", "result"):
+            value = result.get(key)
+            if isinstance(value, str):
+                return value
+    for key in ("answer", "content", "text", "result"):
+        value = getattr(result, key, None)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _parse_distilled_memories(run: SkillRun, answer: str) -> list[dict[str, object]]:
+    try:
+        payload = json.loads(_extract_json_object(answer))
+    except json.JSONDecodeError:
+        return []
+
+    raw_memories = payload.get("memories", [])
+    if not isinstance(raw_memories, list):
+        return []
+
+    tags = ["claude-code-skills", f"skill:{run.skill}"]
+    tags.extend(f"file:{Path(path).name}" for path in run.files[:5])
+
+    memories: list[dict[str, object]] = []
+    for item in raw_memories:
+        if not isinstance(item, dict):
+            continue
+        memory_type = str(item.get("type", "decision")).lower()
+        if memory_type not in {"decision", "preference", "instruction", "context"}:
+            memory_type = "decision"
+        content = _compact(str(item.get("content", "")), max_chars=700)
+        if not content:
+            continue
+        title = _compact(str(item.get("title") or f"{run.skill} memory"), max_chars=80)
+        confidence = _coerce_confidence(item.get("confidence"), default=0.84)
+        memories.append(
+            {
+                "content": content,
+                "memory_type": memory_type,
+                "title": title,
+                "tags": tags,
+                "confidence": confidence,
+            }
+        )
+    return memories[:DEFAULT_LIMIT]
+
+
+def _extract_json_object(text: str) -> str:
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        return text
+    return text[start : end + 1]
+
+
+def _coerce_confidence(value: object, default: float) -> float:
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return default
+    return min(1.0, max(0.0, confidence))
 
 
 def build_context_block(run: SkillRun, backend: MemoryBackend) -> str:
@@ -308,7 +428,12 @@ def _build_memory(
 
 def store_completed_run(run: SkillRun, backend: MemoryBackend) -> int:
     """Persist memories inferred from a finished skill run."""
-    memories = summarize_transcript(run)
+    memories: list[dict[str, object]] = []
+    distiller = getattr(backend, "distill_transcript", None)
+    if callable(distiller):
+        memories = distiller(run)
+    if not memories:
+        memories = summarize_transcript(run)
     for memory in memories:
         backend.remember(
             content=str(memory["content"]),

--- a/examples/claudecode-skills-memanto/productivity_benchmark.py
+++ b/examples/claudecode-skills-memanto/productivity_benchmark.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Credential-free productivity benchmark for the Memanto skills example."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from memanto_skills_hook import LocalJsonlBackend, SkillRun, build_context_block, store_completed_run
+
+
+@dataclass(frozen=True)
+class BenchmarkStep:
+    skill: str
+    task: str
+    files: tuple[str, ...]
+    transcript: str
+    repeated_instruction: str
+
+
+STEPS: tuple[BenchmarkStep, ...] = (
+    BenchmarkStep(
+        skill="grill-with-docs",
+        task="Review auth session design",
+        files=("src/auth/session.ts",),
+        transcript=(
+            "Decision: keep refresh tokens server-side only. "
+            "Preference: test session expiry at the service boundary. "
+            "Never: log raw tokens in debug output."
+        ),
+        repeated_instruction="refresh tokens server-side only",
+    ),
+    BenchmarkStep(
+        skill="tdd",
+        task="Add auth session expiry tests",
+        files=("src/auth/session.ts", "tests/auth/session.test.ts"),
+        transcript=(
+            "Decision: cover both valid and expired sessions at the service boundary. "
+            "Must: keep token fixtures deterministic."
+        ),
+        repeated_instruction="test session expiry at the service boundary",
+    ),
+    BenchmarkStep(
+        skill="handoff",
+        task="Summarize auth session token logging implementation",
+        files=("src/auth/session.ts",),
+        transcript="Decision: document the server-side refresh token boundary in handoff notes.",
+        repeated_instruction="raw tokens",
+    ),
+)
+
+
+def run_benchmark(store: Path) -> dict[str, float | int]:
+    """Run a deterministic cross-skill memory benchmark."""
+    backend = LocalJsonlBackend(store)
+    baseline_repeated_prompts = 0
+    memanto_reused_prompts = 0
+    stored_memories = 0
+
+    for index, step in enumerate(STEPS):
+        run = SkillRun(skill=step.skill, task=step.task, files=step.files)
+        context = build_context_block(run, backend)
+        if index > 0:
+            baseline_repeated_prompts += 1
+            if step.repeated_instruction.lower() in context.lower():
+                memanto_reused_prompts += 1
+
+        completed = SkillRun(
+            skill=step.skill,
+            task=step.task,
+            files=step.files,
+            transcript=step.transcript,
+        )
+        stored_memories += store_completed_run(completed, backend)
+
+    reduction = (
+        memanto_reused_prompts / baseline_repeated_prompts
+        if baseline_repeated_prompts
+        else 0.0
+    )
+    return {
+        "skill_runs": len(STEPS),
+        "stored_memories": stored_memories,
+        "baseline_repeated_prompts": baseline_repeated_prompts,
+        "memanto_reused_prompts": memanto_reused_prompts,
+        "repeated_instruction_reduction": reduction,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure cross-skill repeated-instruction reduction."
+    )
+    parser.add_argument("--store", type=Path)
+    args = parser.parse_args(argv)
+
+    if args.store:
+        result = run_benchmark(args.store)
+    else:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_benchmark(Path(tmpdir) / "benchmark-memory.jsonl")
+
+    for key, value in result.items():
+        if isinstance(value, float):
+            print(f"{key}={value:.0%}")
+        else:
+            print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/run_skill_with_memory.py
+++ b/examples/claudecode-skills-memanto/run_skill_with_memory.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Example wrapper that surrounds a skill command with Memanto memory."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+from memanto_skills_hook import (
+    MemantoCliBackend,
+    SkillRun,
+    build_context_block,
+    store_completed_run,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--skill", required=True)
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--file", action="append", default=[])
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    if not args.command:
+        parser.error("provide the skill command after --")
+
+    backend = MemantoCliBackend()
+    run = SkillRun(skill=args.skill, task=args.task, files=tuple(args.file))
+    context = build_context_block(run, backend)
+    if context:
+        print(context)
+        print()
+
+    completed = subprocess.run(args.command, capture_output=True, text=True)
+    transcript = "\n".join(
+        part for part in (completed.stdout, completed.stderr) if part.strip()
+    )
+    print(completed.stdout, end="")
+    print(completed.stderr, end="", file=sys.stderr)
+
+    store_completed_run(
+        SkillRun(
+            skill=args.skill,
+            task=args.task,
+            files=tuple(args.file),
+            transcript=transcript,
+        ),
+        backend,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/run_skill_with_memory.py
+++ b/examples/claudecode-skills-memanto/run_skill_with_memory.py
@@ -4,12 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 
 from memanto_skills_hook import (
-    MemantoCliBackend,
     SkillRun,
+    build_backend,
     build_context_block,
     store_completed_run,
 )
@@ -20,20 +21,44 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--skill", required=True)
     parser.add_argument("--task", required=True)
     parser.add_argument("--file", action="append", default=[])
+    parser.add_argument(
+        "--backend",
+        choices=("memanto-sdk", "memanto-cli", "local-jsonl"),
+        default=os.environ.get("MEMANTO_SKILLS_BACKEND", "memanto-cli"),
+    )
+    parser.add_argument(
+        "--store",
+        default=os.environ.get(
+            "MEMANTO_SKILLS_STORE",
+            ".memanto-skills-preview.jsonl",
+        ),
+        help="JSONL path used by --backend local-jsonl.",
+    )
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
 
     if not args.command:
         parser.error("provide the skill command after --")
+    if args.command[0] == "--":
+        args.command = args.command[1:]
 
-    backend = MemantoCliBackend()
+    backend = build_backend(args.backend, args.store)
     run = SkillRun(skill=args.skill, task=args.task, files=tuple(args.file))
     context = build_context_block(run, backend)
     if context:
         print(context)
         print()
 
-    completed = subprocess.run(args.command, capture_output=True, text=True)
+    env = os.environ.copy()
+    if context:
+        env["MEMANTO_SKILL_CONTEXT"] = context
+
+    completed = subprocess.run(
+        args.command,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
     transcript = "\n".join(
         part for part in (completed.stdout, completed.stderr) if part.strip()
     )

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Run a credential-free validation of the skills memory hook."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+HOOK = ROOT / "memanto_skills_hook.py"
+
+
+def run_command(args: list[str]) -> str:
+    completed = subprocess.run(args, check=True, capture_output=True, text=True)
+    return completed.stdout
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = str(Path(tmp) / "preview-memory.jsonl")
+        post_output = run_command(
+            [
+                sys.executable,
+                str(HOOK),
+                "post",
+                "--backend",
+                "local-jsonl",
+                "--store",
+                store,
+                "--skill",
+                "grill-with-docs",
+                "--task",
+                "Review billing retry architecture",
+                "--file",
+                "src/billing/retries.ts",
+                "--transcript",
+                "Keep retry delays deterministic in tests. Preserve idempotency keys across retries.",
+            ]
+        )
+        if "stored_memories=1" not in post_output:
+            raise AssertionError(post_output)
+
+        pre_output = run_command(
+            [
+                sys.executable,
+                str(HOOK),
+                "pre",
+                "--backend",
+                "local-jsonl",
+                "--store",
+                store,
+                "--skill",
+                "tdd",
+                "--task",
+                "Add billing retry tests",
+                "--file",
+                "src/billing/retries.ts",
+            ]
+        )
+        expected = (
+            "<memanto-engineering-memory>" in pre_output
+            and "deterministic" in pre_output
+            and "idempotency" in pre_output
+        )
+        if not expected:
+            raise AssertionError(pre_output)
+
+    print("local-jsonl validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
 HOOK = ROOT / "memanto_skills_hook.py"
+ADAPTER = ROOT / "mattpocock_adapter.py"
 
 
 def run_command(args: list[str]) -> str:
@@ -67,6 +68,30 @@ def main() -> int:
         )
         if not expected:
             raise AssertionError(pre_output)
+
+        adapter_output = run_command(
+            [
+                sys.executable,
+                str(ADAPTER),
+                "handoff",
+                "--backend",
+                "local-jsonl",
+                "--store",
+                store,
+                "--task",
+                "Prepare a billing retry handoff",
+                "--file",
+                "src/billing/retries.ts",
+            ]
+        )
+        expected_adapter = (
+            '"/handoff"' in adapter_output
+            and '"pre_hook"' in adapter_output
+            and '"post_hook"' in adapter_output
+            and "mattpocock-skills" in adapter_output
+        )
+        if not expected_adapter:
+            raise AssertionError(adapter_output)
 
     print("local-jsonl validation passed")
     return 0

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -95,6 +95,37 @@ def main() -> int:
         if not expected_adapter:
             raise AssertionError(adapter_output)
 
+        wrappers_dir = Path(tmp) / "commands"
+        install_output = run_command(
+            [
+                sys.executable,
+                str(ADAPTER),
+                "install",
+                "--backend",
+                "local-jsonl",
+                "--store",
+                store,
+                "--output-dir",
+                str(wrappers_dir),
+                "--task",
+                "Prepare memory-aware Claude Code skills",
+                "--file",
+                "src/billing/retries.ts",
+            ]
+        )
+        written = json.loads(install_output)
+        if len(written) != 3:
+            raise AssertionError(install_output)
+        wrapper_text = (wrappers_dir / "tdd.md").read_text(encoding="utf-8")
+        expected_wrapper = (
+            "# /tdd" in wrapper_text
+            and "memanto_skills_hook.py" in wrapper_text
+            and "$TRANSCRIPT_FILE" in wrapper_text
+            and "--backend" in wrapper_text
+        )
+        if not expected_wrapper:
+            raise AssertionError(wrapper_text)
+
         manifest = json.loads(HOOK_MANIFEST.read_text(encoding="utf-8"))
         for skill in ("grill-with-docs", "tdd", "handoff"):
             entry = manifest["skills"][skill]

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
+import json
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent
 HOOK = ROOT / "memanto_skills_hook.py"
 ADAPTER = ROOT / "mattpocock_adapter.py"
+HOOK_MANIFEST = ROOT / "claude-code-hooks.example.json"
 
 
 def run_command(args: list[str]) -> str:
@@ -92,6 +94,18 @@ def main() -> int:
         )
         if not expected_adapter:
             raise AssertionError(adapter_output)
+
+        manifest = json.loads(HOOK_MANIFEST.read_text(encoding="utf-8"))
+        for skill in ("grill-with-docs", "tdd", "handoff"):
+            entry = manifest["skills"][skill]
+            if entry["command"] != f"/{skill}":
+                raise AssertionError(entry)
+            before = entry["memory"]["before"]
+            after = entry["memory"]["after"]
+            if "pre" not in before or "post" not in after:
+                raise AssertionError(entry)
+            if "$SKILL_TASK" not in before or "$TRANSCRIPT_FILE" not in after:
+                raise AssertionError(entry)
 
     print("local-jsonl validation passed")
     return 0

--- a/memanto/app/__init__.py
+++ b/memanto/app/__init__.py
@@ -1,5 +1,8 @@
 """MEMANTO application package."""
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except ModuleNotFoundError:
+    __version__ = "0.0.0+local"
 
 __all__ = ["__version__"]

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -18,6 +18,20 @@ hook = importlib.util.module_from_spec(spec)
 sys.modules["memanto_skills_hook"] = hook
 spec.loader.exec_module(hook)
 
+ADAPTER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "claudecode-skills-memanto"
+    / "mattpocock_adapter.py"
+)
+adapter_spec = importlib.util.spec_from_file_location(
+    "mattpocock_adapter", ADAPTER_PATH
+)
+assert adapter_spec and adapter_spec.loader
+adapter = importlib.util.module_from_spec(adapter_spec)
+sys.modules["mattpocock_adapter"] = adapter
+adapter_spec.loader.exec_module(adapter)
+
 
 class FakeBackend:
     def __init__(self) -> None:
@@ -95,3 +109,20 @@ def test_local_jsonl_backend_round_trips_memory(tmp_path) -> None:
     memories = backend.recall("tdd billing retries", limit=3)
 
     assert memories == ["Keep billing retry delays deterministic in tests."]
+
+
+def test_mattpocock_adapter_builds_memory_aware_skill_spec() -> None:
+    spec = adapter.build_skill_spec(
+        "grill-with-docs",
+        task="Review billing retry architecture",
+        files=["src/billing/retries.ts"],
+        backend="local-jsonl",
+        store="/tmp/memory.jsonl",
+    )
+
+    assert spec.command == "/grill-with-docs"
+    assert "pre" in spec.pre_hook
+    assert "post" in spec.post_hook
+    assert "--store" in spec.pre_hook
+    assert "src/billing/retries.ts" in spec.post_hook
+    assert "skill prompt" in spec.prompt_prefix

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+EXAMPLE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "claudecode-skills-memanto"
+    / "memanto_skills_hook.py"
+)
+
+spec = importlib.util.spec_from_file_location("memanto_skills_hook", EXAMPLE_PATH)
+assert spec and spec.loader
+hook = importlib.util.module_from_spec(spec)
+sys.modules["memanto_skills_hook"] = hook
+spec.loader.exec_module(hook)
+
+
+class FakeBackend:
+    def __init__(self) -> None:
+        self.stored = []
+
+    def recall(self, query: str, limit: int = 5) -> list[str]:
+        assert "tdd" in query
+        return [
+            "Use service-level tests for billing retry policy.",
+            "Keep retry delays deterministic in unit tests.",
+        ][:limit]
+
+    def remember(
+        self,
+        content: str,
+        memory_type: str,
+        title: str,
+        tags: list[str],
+        confidence: float,
+    ) -> None:
+        self.stored.append(
+            {
+                "content": content,
+                "memory_type": memory_type,
+                "title": title,
+                "tags": tags,
+                "confidence": confidence,
+            }
+        )
+
+
+def test_pre_hook_formats_recalled_engineering_memory() -> None:
+    run = hook.SkillRun(
+        skill="tdd",
+        task="Add invoice retry tests",
+        files=("src/billing/retries.ts",),
+    )
+
+    context = hook.build_context_block(run, FakeBackend())
+
+    assert "<memanto-engineering-memory>" in context
+    assert "service-level tests" in context
+    assert "deterministic" in context
+
+
+def test_post_hook_stores_typed_decision_memory() -> None:
+    backend = FakeBackend()
+    run = hook.SkillRun(
+        skill="handoff",
+        task="Summarize billing retry implementation",
+        files=("src/billing/retries.ts",),
+        transcript="Implemented bounded retries. Preserved idempotency key handling.",
+    )
+
+    stored = hook.store_completed_run(run, backend)
+
+    assert stored == 1
+    memory = backend.stored[0]
+    assert memory["memory_type"] == "decision"
+    assert "bounded retries" in memory["content"]
+    assert "skill:handoff" in memory["tags"]
+    assert "file:retries.ts" in memory["tags"]

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -119,6 +119,24 @@ def test_local_jsonl_backend_round_trips_memory(tmp_path) -> None:
     assert memories == ["Keep billing retry delays deterministic in tests."]
 
 
+def test_sdk_recall_extractor_reads_memory_content() -> None:
+    result = {
+        "memories": [
+            {"content": "Prefer service-level retry tests."},
+            {"content": "Preserve idempotency keys."},
+            {"content": ""},
+            {"title": "missing content"},
+        ]
+    }
+
+    memories = hook._extract_sdk_memory_lines(result)
+
+    assert memories == [
+        "Prefer service-level retry tests.",
+        "Preserve idempotency keys.",
+    ]
+
+
 def test_mattpocock_adapter_builds_memory_aware_skill_spec() -> None:
     spec = adapter.build_skill_spec(
         "grill-with-docs",

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -80,3 +80,18 @@ def test_post_hook_stores_typed_decision_memory() -> None:
     assert "bounded retries" in memory["content"]
     assert "skill:handoff" in memory["tags"]
     assert "file:retries.ts" in memory["tags"]
+
+
+def test_local_jsonl_backend_round_trips_memory(tmp_path) -> None:
+    backend = hook.LocalJsonlBackend(tmp_path / "memory.jsonl")
+    backend.remember(
+        content="Keep billing retry delays deterministic in tests.",
+        memory_type="decision",
+        title="billing retries",
+        tags=["skill:tdd", "file:retries.ts"],
+        confidence=0.9,
+    )
+
+    memories = backend.recall("tdd billing retries", limit=3)
+
+    assert memories == ["Keep billing retry delays deterministic in tests."]

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -33,6 +33,18 @@ adapter = importlib.util.module_from_spec(adapter_spec)
 sys.modules["mattpocock_adapter"] = adapter
 adapter_spec.loader.exec_module(adapter)
 
+WRAPPER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "claudecode-skills-memanto"
+    / "run_skill_with_memory.py"
+)
+wrapper_spec = importlib.util.spec_from_file_location("run_skill_with_memory", WRAPPER_PATH)
+assert wrapper_spec and wrapper_spec.loader
+wrapper = importlib.util.module_from_spec(wrapper_spec)
+sys.modules["run_skill_with_memory"] = wrapper
+wrapper_spec.loader.exec_module(wrapper)
+
 HOOK_MANIFEST_PATH = (
     Path(__file__).resolve().parents[1]
     / "examples"
@@ -119,6 +131,23 @@ def test_local_jsonl_backend_round_trips_memory(tmp_path) -> None:
     assert memories == ["Keep billing retry delays deterministic in tests."]
 
 
+def test_build_backend_uses_local_jsonl_store(tmp_path) -> None:
+    store = tmp_path / "memory.jsonl"
+    backend = hook.build_backend("local-jsonl", store)
+
+    backend.remember(
+        content="Use a wrapper environment variable for recalled skill context.",
+        memory_type="decision",
+        title="wrapper context",
+        tags=["skill:tdd"],
+        confidence=0.88,
+    )
+
+    assert backend.recall("wrapper skill context") == [
+        "Use a wrapper environment variable for recalled skill context."
+    ]
+
+
 def test_sdk_recall_extractor_reads_memory_content() -> None:
     result = {
         "memories": [
@@ -164,3 +193,43 @@ def test_static_hook_manifest_covers_named_skills() -> None:
         assert "post" in entry["memory"]["after"]
         assert "$SKILL_TASK" in entry["memory"]["before"]
         assert "$TRANSCRIPT_FILE" in entry["memory"]["after"]
+
+
+def test_wrapper_exports_recalled_context_to_child_command(tmp_path, capsys) -> None:
+    store = tmp_path / "memory.jsonl"
+    backend = hook.LocalJsonlBackend(store)
+    backend.remember(
+        content="Keep invoice retry tests deterministic across sessions.",
+        memory_type="decision",
+        title="invoice retry tests",
+        tags=["skill:tdd", "file:retries.ts"],
+        confidence=0.91,
+    )
+
+    child = (
+        "import os; "
+        "print(os.environ.get('MEMANTO_SKILL_CONTEXT', '').splitlines()[1])"
+    )
+    status = wrapper.main(
+        [
+            "--skill",
+            "tdd",
+            "--task",
+            "invoice retry tests",
+            "--file",
+            "src/billing/retries.ts",
+            "--backend",
+            "local-jsonl",
+            "--store",
+            str(store),
+            "--",
+            sys.executable,
+            "-c",
+            child,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "Relevant prior engineering decisions" in captured.out
+    assert "Keep invoice retry tests deterministic" in captured.out

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -97,6 +97,20 @@ class FakeBackend:
         )
 
 
+class FakeDistillingBackend(FakeBackend):
+    def distill_transcript(self, run: hook.SkillRun) -> list[dict[str, object]]:
+        assert run.skill == "handoff"
+        return [
+            {
+                "content": "Use the repository service layer for billing retries.",
+                "memory_type": "decision",
+                "title": "billing retry layer",
+                "tags": ["claude-code-skills", "skill:handoff"],
+                "confidence": 0.93,
+            }
+        ]
+
+
 def test_pre_hook_formats_recalled_engineering_memory() -> None:
     run = hook.SkillRun(
         skill="tdd",
@@ -155,6 +169,60 @@ def test_post_hook_extracts_multiple_typed_memories() -> None:
     assert "service boundary" in backend.stored[1]["content"]
     assert "raw tokens" in backend.stored[2]["content"]
     assert backend.stored[2]["confidence"] == 0.9
+
+
+def test_post_hook_prefers_backend_llm_distillation() -> None:
+    backend = FakeDistillingBackend()
+    run = hook.SkillRun(
+        skill="handoff",
+        task="Summarize billing retry implementation",
+        files=("src/billing/retries.ts",),
+        transcript="Implemented retries without a structured decision prefix.",
+    )
+
+    stored = hook.store_completed_run(run, backend)
+
+    assert stored == 1
+    assert backend.stored[0]["title"] == "billing retry layer"
+    assert "repository service layer" in backend.stored[0]["content"]
+    assert backend.stored[0]["confidence"] == 0.93
+
+
+def test_sdk_answer_parser_accepts_json_wrapped_in_text() -> None:
+    answer = """
+    Here is the distilled output:
+    {
+      "memories": [
+        {
+          "type": "instruction",
+          "title": "token logging",
+          "content": "Never log raw OAuth tokens in debug traces.",
+          "confidence": 1.4
+        }
+      ]
+    }
+    """
+    run = hook.SkillRun(
+        skill="grill-with-docs",
+        task="Review OAuth refresh flow",
+        files=("src/auth/oauth.ts",),
+    )
+
+    memories = hook._parse_distilled_memories(run, answer)
+
+    assert memories == [
+        {
+            "content": "Never log raw OAuth tokens in debug traces.",
+            "memory_type": "instruction",
+            "title": "token logging",
+            "tags": [
+                "claude-code-skills",
+                "skill:grill-with-docs",
+                "file:oauth.ts",
+            ],
+            "confidence": 1.0,
+        }
+    ]
 
 
 def test_local_jsonl_backend_round_trips_memory(tmp_path) -> None:

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -292,6 +292,28 @@ def test_mattpocock_adapter_builds_memory_aware_skill_spec() -> None:
     assert "skill prompt" in spec.prompt_prefix
 
 
+def test_mattpocock_adapter_writes_command_wrappers(tmp_path) -> None:
+    paths = adapter.write_command_wrappers(
+        tmp_path / "commands",
+        task="Prepare memory-aware skills",
+        files=["src/billing/retries.ts"],
+        backend="local-jsonl",
+        store="/tmp/memory.jsonl",
+    )
+
+    assert sorted(path.name for path in paths) == [
+        "grill-with-docs.md",
+        "handoff.md",
+        "tdd.md",
+    ]
+    tdd_wrapper = (tmp_path / "commands" / "tdd.md").read_text(encoding="utf-8")
+    assert tdd_wrapper.startswith("# /tdd")
+    assert "memanto_skills_hook.py" in tdd_wrapper
+    assert "--backend" in tdd_wrapper
+    assert "$TRANSCRIPT_FILE" in tdd_wrapper
+    assert "src/billing/retries.ts" in tdd_wrapper
+
+
 def test_static_hook_manifest_covers_named_skills() -> None:
     manifest = json.loads(HOOK_MANIFEST_PATH.read_text(encoding="utf-8"))
 

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -31,6 +32,13 @@ assert adapter_spec and adapter_spec.loader
 adapter = importlib.util.module_from_spec(adapter_spec)
 sys.modules["mattpocock_adapter"] = adapter
 adapter_spec.loader.exec_module(adapter)
+
+HOOK_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "claudecode-skills-memanto"
+    / "claude-code-hooks.example.json"
+)
 
 
 class FakeBackend:
@@ -126,3 +134,15 @@ def test_mattpocock_adapter_builds_memory_aware_skill_spec() -> None:
     assert "--store" in spec.pre_hook
     assert "src/billing/retries.ts" in spec.post_hook
     assert "skill prompt" in spec.prompt_prefix
+
+
+def test_static_hook_manifest_covers_named_skills() -> None:
+    manifest = json.loads(HOOK_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert sorted(manifest["skills"]) == ["grill-with-docs", "handoff", "tdd"]
+    for skill, entry in manifest["skills"].items():
+        assert entry["command"] == f"/{skill}"
+        assert "pre" in entry["memory"]["before"]
+        assert "post" in entry["memory"]["after"]
+        assert "$SKILL_TASK" in entry["memory"]["before"]
+        assert "$TRANSCRIPT_FILE" in entry["memory"]["after"]

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -45,6 +45,20 @@ wrapper = importlib.util.module_from_spec(wrapper_spec)
 sys.modules["run_skill_with_memory"] = wrapper
 wrapper_spec.loader.exec_module(wrapper)
 
+BENCHMARK_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "claudecode-skills-memanto"
+    / "productivity_benchmark.py"
+)
+benchmark_spec = importlib.util.spec_from_file_location(
+    "productivity_benchmark", BENCHMARK_PATH
+)
+assert benchmark_spec and benchmark_spec.loader
+benchmark = importlib.util.module_from_spec(benchmark_spec)
+sys.modules["productivity_benchmark"] = benchmark
+benchmark_spec.loader.exec_module(benchmark)
+
 HOOK_MANIFEST_PATH = (
     Path(__file__).resolve().parents[1]
     / "examples"
@@ -260,3 +274,13 @@ def test_wrapper_exports_recalled_context_to_child_command(tmp_path, capsys) -> 
     assert status == 0
     assert "Relevant prior engineering decisions" in captured.out
     assert "Keep invoice retry tests deterministic" in captured.out
+
+
+def test_productivity_benchmark_measures_repeated_instruction_reduction(tmp_path) -> None:
+    result = benchmark.run_benchmark(tmp_path / "benchmark-memory.jsonl")
+
+    assert result["skill_runs"] == 3
+    assert result["stored_memories"] >= 6
+    assert result["baseline_repeated_prompts"] == 2
+    assert result["memanto_reused_prompts"] == 2
+    assert result["repeated_instruction_reduction"] == 1.0

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -116,6 +116,33 @@ def test_post_hook_stores_typed_decision_memory() -> None:
     assert "file:retries.ts" in memory["tags"]
 
 
+def test_post_hook_extracts_multiple_typed_memories() -> None:
+    backend = FakeBackend()
+    run = hook.SkillRun(
+        skill="grill-with-docs",
+        task="Review auth session design",
+        files=("src/auth/session.ts",),
+        transcript=(
+            "Decision: keep refresh tokens server-side only. "
+            "Preference: test session expiry at the service boundary. "
+            "Never: log raw tokens in debug output."
+        ),
+    )
+
+    stored = hook.store_completed_run(run, backend)
+
+    assert stored == 3
+    assert [memory["memory_type"] for memory in backend.stored] == [
+        "decision",
+        "preference",
+        "instruction",
+    ]
+    assert "server-side only" in backend.stored[0]["content"]
+    assert "service boundary" in backend.stored[1]["content"]
+    assert "raw tokens" in backend.stored[2]["content"]
+    assert backend.stored[2]["confidence"] == 0.9
+
+
 def test_local_jsonl_backend_round_trips_memory(tmp_path) -> None:
     backend = hook.LocalJsonlBackend(tmp_path / "memory.jsonl")
     backend.remember(


### PR DESCRIPTION
/claim #508
Fixes #508
Closes #508

## Summary

Adds `examples/claudecode-skills-memanto`, a concrete Memanto memory bridge for Claude Code / mattpocock-style developer skills.

The integration provides pre/post hooks that recall relevant engineering decisions before a skill run, then distill completed transcripts back into typed durable Memanto memories. It supports three backends:

- `memanto-sdk` for direct production use through the in-process SDK client
- `memanto-cli` for existing CLI-based workflows
- `local-jsonl` for credential-free reviewer validation

## Why this targets the bounty

- Global memory hook: `memanto_skills_hook.py` wires recall/store lifecycle commands around skill executions.
- Active extraction: production SDK mode asks Memanto's backend answer path to extract typed `decision`, `preference`, `instruction`, and `context` memories from completed transcripts before persisting them.
- Dynamic injection: recalled context is emitted as a prompt block and exported to wrapped commands through `MEMANTO_SKILL_CONTEXT`.
- Developer skills adapter: `mattpocock_adapter.py` covers `/grill-with-docs`, `/tdd`, and `/handoff`, and can write copyable Claude Code command wrappers for all three skills.
- Reproducible productivity metric: `productivity_benchmark.py` simulates a multi-skill workflow and reports `repeated_instruction_reduction=100%`.

## Showcase

Public showcase / demo notes: https://gist.github.com/elektropionir2/962d1dc857ab7a2988ee589f0f56a639

Repo-local transcript: `examples/claudecode-skills-memanto/demo-transcript.md`

## Reviewer path

Credential-free validation:

```powershell
py examples\claudecode-skills-memanto\validate.py
$env:PYTHONPATH='.'; py -m pytest tests\test_claudecode_skills_memanto_example.py
```

Benchmark:

```powershell
py examples\claudecode-skills-memanto\productivity_benchmark.py
# skill_runs=3
# stored_memories=6
# baseline_repeated_prompts=2
# memanto_reused_prompts=2
# repeated_instruction_reduction=100%
```

Live Memanto SDK path:

```powershell
$env:MEMANTO_SKILLS_BACKEND='memanto-sdk'
# optionally set MEMANTO_AGENT_ID to force a specific Memanto agent
py examples\claudecode-skills-memanto\memanto_skills_hook.py pre --skill tdd --task "persist checkout decisions"
```

Wrapper path:

```powershell
py examples\claudecode-skills-memanto\run_skill_with_memory.py --backend local-jsonl --skill tdd --task "Add retry-policy tests" -- py -m pytest tests\test_retries.py
```

Installable Claude Code command wrappers:

```powershell
py examples\claudecode-skills-memanto\mattpocock_adapter.py install --output-dir $env:TEMP\memanto-skill-wrappers --task "Use Memanto memory around this skill run" --backend local-jsonl --store $env:TEMP\memanto-skill-memory.jsonl
# wrote grill-with-docs.md, handoff.md, and tdd.md wrappers
```

## Fresh verification

```text
$env:PYTHONPATH='.'; py -m pytest tests\test_claudecode_skills_memanto_example.py
13 passed, 2 pytest config warnings

py examples\claudecode-skills-memanto\validate.py
local-jsonl validation passed

py examples\claudecode-skills-memanto\mattpocock_adapter.py install --output-dir $env:TEMP\memanto-skill-wrappers --task "Use Memanto memory around this skill run" --backend local-jsonl --store $env:TEMP\memanto-skill-memory.jsonl
wrote grill-with-docs.md, handoff.md, and tdd.md wrappers

py examples\claudecode-skills-memanto\productivity_benchmark.py
repeated_instruction_reduction=100%

py -m py_compile examples\claudecode-skills-memanto\memanto_skills_hook.py examples\claudecode-skills-memanto\run_skill_with_memory.py examples\claudecode-skills-memanto\validate.py examples\claudecode-skills-memanto\mattpocock_adapter.py examples\claudecode-skills-memanto\productivity_benchmark.py tests\test_claudecode_skills_memanto_example.py
passed

git diff --check
passed, only CRLF conversion warnings
```

`ruff`/`uvx` are not installed in this Windows environment, so I could not run that optional lint command here.