### PR TITLE
Add Claude Code skills Memanto memory example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,100 @@
+# Claude Code Skills + Memanto Global Memory
+
+This example shows how Memanto can act as a global memory companion across
+separate developer skill runs, such as `/grill-with-docs`, `/tdd`, and
+`/handoff`.
+
+The example is intentionally reviewable without private credentials:
+
+- `local-preview` mode stores memories in a local JSONL file and uses a
+  deterministic token-overlap recall strategy.
+- `memanto-cli` mode can be enabled when `memanto` is configured with a
+  Moorcheh API key in the developer's environment.
+
+## What It Demonstrates
+
+1. A skill starts and asks the memory hook for relevant prior engineering
+   decisions.
+2. The skill receives a concise context block that can be appended to its
+   prompt.
+3. When the skill finishes, the hook distills durable engineering memories from
+   its transcript.
+4. A later skill in a fresh terminal can recall those decisions without manual
+   context shoving.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `skill_memory.py` | Memory store adapters and the reusable skill lifecycle hook. |
+| `demo.py` | Two-session demo that simulates separate skill executions. |
+| `validate.py` | Credential-free regression check for the demo behavior. |
+| `demo-transcript.md` | Expected demo output for quick review. |
+
+## Quick Start
+
+Run the credential-free preview:
+
+```bash
+cd examples/claudecode-skills-memanto
+python validate.py
+python demo.py
+```
+
+Use a custom local memory path:
+
+```bash
+MEMANTO_SKILLS_MEMORY=.demo-memory/memories.jsonl python demo.py
+```
+
+Use a configured Memanto CLI instead of the local preview:
+
+```bash
+MEMANTO_SKILLS_BACKEND=memanto-cli python demo.py
+```
+
+`memanto-cli` mode expects the repository's normal Memanto CLI setup to already
+be complete, including a Moorcheh API key and active agent/session.
+
+## Integration Pattern
+
+Call `before_skill()` at the start of a skill command:
+
+```python
+from skill_memory import SkillMemoryHook, build_memory_store
+
+hook = SkillMemoryHook(build_memory_store())
+context_block = hook.before_skill(
+    skill_name="/tdd",
+    task="Add tests for invoice retry scheduling",
+    files=["billing/retry.py"],
+)
+```
+
+Append `context_block` to the skill prompt when it is non-empty.
+
+Call `after_skill()` when the skill finishes:
+
+```python
+hook.after_skill(
+    skill_name="/grill-with-docs",
+    task="Review billing retry architecture",
+    transcript=review_transcript,
+    files=["billing/retry.py", "docs/billing.md"],
+)
+```
+
+The hook captures durable memories such as:
+
+- architecture decisions
+- framework preferences
+- file-specific constraints
+- validation commands
+- handoff notes
+
+## Review Notes
+
+The local preview exists so reviewers can validate the workflow without secrets
+or hosted services. The same lifecycle interface can use Memanto through the CLI
+adapter once credentials are configured.
+

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -8,6 +8,8 @@ The example is intentionally reviewable without private credentials:
 
 - `local-preview` mode stores memories in a local JSONL file and uses a
   deterministic token-overlap recall strategy.
+- `memanto-sdk` mode uses Memanto's Python package directly through the
+  repository's `SdkClient` and active agent/session configuration.
 - `memanto-cli` mode can be enabled when `memanto` is configured with a
   Moorcheh API key in the developer's environment.
 
@@ -53,8 +55,20 @@ Use a configured Memanto CLI instead of the local preview:
 MEMANTO_SKILLS_BACKEND=memanto-cli python demo.py
 ```
 
+Use the Memanto Python package directly after configuring an API key and active
+agent/session:
+
+```bash
+memanto
+memanto agent activate <agent-id>
+MEMANTO_SKILLS_BACKEND=memanto-sdk python demo.py
+```
+
 `memanto-cli` mode expects the repository's normal Memanto CLI setup to already
 be complete, including a Moorcheh API key and active agent/session.
+`memanto-sdk` mode uses the same configured API key and session through
+`memanto.cli.client.sdk_client.SdkClient`. If no active agent is configured, set
+`MEMANTO_SKILLS_AGENT_ID=<agent-id>`.
 
 ## Integration Pattern
 
@@ -95,6 +109,5 @@ The hook captures durable memories such as:
 ## Review Notes
 
 The local preview exists so reviewers can validate the workflow without secrets
-or hosted services. The same lifecycle interface can use Memanto through the CLI
-adapter once credentials are configured.
-
+or hosted services. The same lifecycle interface can use Memanto through the SDK
+or CLI adapter once credentials are configured.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -29,6 +29,7 @@ The example is intentionally reviewable without private credentials:
 | File | Purpose |
 | --- | --- |
 | `skill_memory.py` | Memory store adapters and the reusable skill lifecycle hook. |
+| `run_skill_with_memory.py` | CLI wrapper for running a skill command with memory injection/capture. |
 | `demo.py` | Two-session demo that simulates separate skill executions. |
 | `validate.py` | Credential-free regression check for the demo behavior. |
 | `demo-transcript.md` | Expected demo output for quick review. |
@@ -41,6 +42,16 @@ Run the credential-free preview:
 cd examples/claudecode-skills-memanto
 python validate.py
 python demo.py
+```
+
+Wrap a real command with recalled memory:
+
+```bash
+python run_skill_with_memory.py \
+  --skill /tdd \
+  --task "Add tests for invoice retry scheduling" \
+  --file billing/retry.py \
+  -- python -m pytest tests/billing/test_retry.py -q
 ```
 
 Use a custom local memory path:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -32,6 +32,7 @@ The example is intentionally reviewable without private credentials:
 | `run_skill_with_memory.py` | CLI wrapper for running a skill command with memory injection/capture. |
 | `demo.py` | Two-session demo that simulates separate skill executions. |
 | `validate.py` | Credential-free regression check for the demo behavior. |
+| `test_skill_memory.py` | Stdlib tests that avoid repository-level pytest dependencies. |
 | `demo-transcript.md` | Expected demo output for quick review. |
 
 ## Quick Start
@@ -42,6 +43,7 @@ Run the credential-free preview:
 cd examples/claudecode-skills-memanto
 python validate.py
 python demo.py
+python -m unittest test_skill_memory.py
 ```
 
 Wrap a real command with recalled memory:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -30,6 +30,7 @@ The example is intentionally reviewable without private credentials:
 | --- | --- |
 | `skill_memory.py` | Memory store adapters and the reusable skill lifecycle hook. |
 | `run_skill_with_memory.py` | CLI wrapper for running a skill command with memory injection/capture. |
+| `mattpocock_adapter.py` | Generates Memanto-aware command specs for mattpocock-style developer skills. |
 | `demo.py` | Two-session demo that simulates separate skill executions. |
 | `validate.py` | Credential-free regression check for the demo behavior. |
 | `test_skill_memory.py` | Stdlib tests that avoid repository-level pytest dependencies. |
@@ -54,6 +55,14 @@ python run_skill_with_memory.py \
   --task "Add tests for invoice retry scheduling" \
   --file billing/retry.py \
   -- python -m pytest tests/billing/test_retry.py -q
+```
+
+Generate Claude Code command specs for the mattpocock-style skills used in
+the challenge:
+
+```bash
+python mattpocock_adapter.py --json
+python mattpocock_adapter.py --write .claude/commands
 ```
 
 Use a custom local memory path:
@@ -118,6 +127,14 @@ The hook captures durable memories such as:
 - file-specific constraints
 - validation commands
 - handoff notes
+
+## Matt Pocock Skill Wrappers
+
+`mattpocock_adapter.py` maps `/grill-with-docs`, `/tdd`, and `/handoff` to
+Memanto-aware Claude Code command specs. Each generated command keeps the
+underlying skill command separate while wrapping it with `run_skill_with_memory.py`,
+so prior decisions are injected through `MEMANTO_SKILL_CONTEXT` before the
+command runs and the transcript is captured afterward.
 
 ## Review Notes
 

--- a/examples/claudecode-skills-memanto/demo-transcript.md
+++ b/examples/claudecode-skills-memanto/demo-transcript.md
@@ -1,0 +1,20 @@
+# Demo Transcript
+
+```text
+== Session 1: /grill-with-docs ==
+No prior memory yet.
+Stored 4 durable engineering memories.
+
+== Session 2: /tdd in a fresh terminal ==
+Relevant prior engineering memory from Memanto:
+- Run `pytest tests/billing/test_retry.py -q` after touching retry scheduling.
+- Tests should use the local fake clock fixture and avoid sleeping in real time.
+- Keep retry scheduling in billing/retry.py instead of moving it into the API router.
+- Billing retries should use a service-layer function so CLI jobs and HTTP handlers share one path.
+
+Use these as constraints unless the current task explicitly changes them.
+```
+
+The second session does not receive the first transcript directly. It recalls
+the durable decisions through the shared memory store, which is the same
+lifecycle boundary a live Memanto-backed adapter would use.

--- a/examples/claudecode-skills-memanto/demo.py
+++ b/examples/claudecode-skills-memanto/demo.py
@@ -1,0 +1,55 @@
+"""Two-session demo for the Claude Code skills + Memanto memory hook."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from skill_memory import LocalPreviewMemoryStore, SkillMemoryHook
+
+
+DEMO_DIR = Path(".memanto-preview")
+MEMORY_PATH = DEMO_DIR / "demo-memory.jsonl"
+
+
+def main() -> None:
+    if DEMO_DIR.exists():
+        shutil.rmtree(DEMO_DIR)
+
+    hook = SkillMemoryHook(LocalPreviewMemoryStore(MEMORY_PATH))
+
+    print("== Session 1: /grill-with-docs ==")
+    first_context = hook.before_skill(
+        "/grill-with-docs",
+        "Review the billing retry architecture",
+        ["billing/retry.py", "docs/billing.md"],
+    )
+    print(first_context or "No prior memory yet.")
+
+    review_transcript = """
+Decision: Keep retry scheduling in billing/retry.py instead of moving it into the API router.
+Architecture: Billing retries should use a service-layer function so CLI jobs and HTTP handlers share one path.
+Preference: Tests should use the local fake clock fixture and avoid sleeping in real time.
+Validation: Run `pytest tests/billing/test_retry.py -q` after touching retry scheduling.
+"""
+    stored = hook.after_skill(
+        "/grill-with-docs",
+        "Review the billing retry architecture",
+        review_transcript,
+        ["billing/retry.py", "docs/billing.md"],
+    )
+    print(f"Stored {len(stored)} durable engineering memories.")
+
+    print("\n== Session 2: /tdd in a fresh terminal ==")
+    second_hook = SkillMemoryHook(LocalPreviewMemoryStore(MEMORY_PATH))
+    second_context = second_hook.before_skill(
+        "/tdd",
+        "Add tests for billing retry scheduling",
+        ["tests/billing/test_retry.py", "billing/retry.py"],
+    )
+    print(second_context)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -1,0 +1,120 @@
+"""Generate Claude Code command specs for mattpocock-style developer skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SkillCommandSpec:
+    name: str
+    description: str
+    task_template: str
+    default_files: tuple[str, ...] = ()
+
+    @property
+    def command_name(self) -> str:
+        return self.name.strip("/")
+
+
+DEFAULT_SKILLS = (
+    SkillCommandSpec(
+        name="/grill-with-docs",
+        description="Review an implementation against docs and durable project memory.",
+        task_template="Review the current change against the relevant docs.",
+        default_files=("docs/",),
+    ),
+    SkillCommandSpec(
+        name="/tdd",
+        description="Run a test-first implementation loop with recalled constraints.",
+        task_template="Write the next focused test and implementation step.",
+        default_files=("tests/",),
+    ),
+    SkillCommandSpec(
+        name="/handoff",
+        description="Capture decisions and next steps for a future skill run.",
+        task_template="Summarize the current state and durable handoff notes.",
+        default_files=(),
+    ),
+)
+
+
+def command_payload(spec: SkillCommandSpec) -> dict[str, object]:
+    return {
+        "name": spec.command_name,
+        "description": spec.description,
+        "wrapper": "run_skill_with_memory.py",
+        "backend_env": "MEMANTO_SKILLS_BACKEND",
+        "memory_env": "MEMANTO_SKILLS_MEMORY",
+        "task_template": spec.task_template,
+        "default_files": list(spec.default_files),
+    }
+
+
+def render_markdown(spec: SkillCommandSpec) -> str:
+    files = " ".join(f"--file {file}" for file in spec.default_files)
+    file_args = f" {files}" if files else ""
+    return "\n".join(
+        [
+            f"# {spec.name}",
+            "",
+            spec.description,
+            "",
+            "```bash",
+            "python run_skill_with_memory.py "
+            f"--skill {spec.name} "
+            f"--task {json.dumps(spec.task_template)}"
+            f"{file_args} "
+            "-- <underlying skill command>",
+            "```",
+            "",
+        ]
+    )
+
+
+def write_command_specs(output_dir: str | Path) -> list[Path]:
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for spec in DEFAULT_SKILLS:
+        target = output_path / f"{spec.command_name}.md"
+        target.write_text(render_markdown(spec), encoding="utf-8")
+        written.append(target)
+    return written
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate Memanto-aware Claude Code command wrappers."
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print command specs as JSON instead of Markdown.",
+    )
+    parser.add_argument(
+        "--write",
+        metavar="DIR",
+        help="Write Markdown command specs into DIR.",
+    )
+    args = parser.parse_args()
+
+    if args.write:
+        written = write_command_specs(args.write)
+        for path in written:
+            print(path)
+        return
+
+    if args.json:
+        print(json.dumps([command_payload(spec) for spec in DEFAULT_SKILLS], indent=2))
+        return
+
+    for spec in DEFAULT_SKILLS:
+        print(render_markdown(spec))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/run_skill_with_memory.py
+++ b/examples/claudecode-skills-memanto/run_skill_with_memory.py
@@ -1,0 +1,50 @@
+"""Run a skill command with Memanto memory injection and capture."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from skill_memory import SkillMemoryHook, build_memory_store
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Wrap a skill command with Memanto memory recall/capture."
+    )
+    parser.add_argument("--skill", required=True, help="Skill name, e.g. /tdd")
+    parser.add_argument("--task", required=True, help="Current skill task")
+    parser.add_argument(
+        "--file",
+        action="append",
+        default=[],
+        dest="files",
+        help="Relevant file path. May be repeated.",
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Command to run after --, e.g. -- python script.py",
+    )
+    args = parser.parse_args()
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("Provide a command after --")
+
+    hook = SkillMemoryHook(build_memory_store())
+    context_block = hook.before_skill(args.skill, args.task, args.files)
+    if context_block:
+        print(context_block)
+        print()
+
+    result = hook.run_skill_command(args.skill, command, args.task, args.files)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,265 @@
+"""Reusable Memanto memory hooks for developer skill workflows.
+
+The module keeps the integration small on purpose:
+
+- local preview mode is deterministic and credential-free for reviewers
+- Memanto CLI mode can be used when the developer has already configured the
+  standard `memanto` command with Moorcheh credentials
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Protocol
+
+
+MEMORY_ENV = "MEMANTO_SKILLS_MEMORY"
+BACKEND_ENV = "MEMANTO_SKILLS_BACKEND"
+
+
+@dataclass
+class MemoryRecord:
+    text: str
+    skill_name: str
+    task: str
+    files: list[str] = field(default_factory=list)
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+class MemoryStore(Protocol):
+    def remember(self, record: MemoryRecord) -> None:
+        """Persist a durable engineering memory."""
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        """Return memories relevant to the current skill invocation."""
+
+
+class LocalPreviewMemoryStore:
+    """JSONL-backed local memory store used for credential-free review."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        default_path = Path(".memanto-preview") / "skills-memory.jsonl"
+        self.path = Path(path or os.getenv(MEMORY_ENV, default_path))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def remember(self, record: MemoryRecord) -> None:
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        query_terms = _tokens(query)
+        scored: list[tuple[int, MemoryRecord]] = []
+        for record in self._records():
+            haystack = " ".join([record.text, record.task, *record.files])
+            score = len(query_terms & _tokens(haystack))
+            if score:
+                scored.append((score, record))
+
+        scored.sort(key=lambda item: (item[0], item[1].created_at), reverse=True)
+        return [record for _, record in scored[:limit]]
+
+    def _records(self) -> list[MemoryRecord]:
+        if not self.path.exists():
+            return []
+
+        records: list[MemoryRecord] = []
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                payload = json.loads(line)
+                records.append(MemoryRecord(**payload))
+        return records
+
+
+class MemantoCliMemoryStore:
+    """Adapter for an already configured Memanto CLI environment."""
+
+    def remember(self, record: MemoryRecord) -> None:
+        text = _format_record(record)
+        subprocess.run(
+            ["memanto", "remember", text, "--type", "decision"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        result = subprocess.run(
+            ["memanto", "recall", query, "--limit", str(limit)],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        memories = []
+        for line in result.stdout.splitlines():
+            text = line.strip()
+            if text:
+                memories.append(
+                    MemoryRecord(text=text, skill_name="memanto-cli", task=query)
+                )
+        return memories[:limit]
+
+
+class SkillMemoryHook:
+    """Lifecycle hook that bridges skill execution and durable memory."""
+
+    def __init__(self, store: MemoryStore) -> None:
+        self.store = store
+
+    def before_skill(
+        self,
+        skill_name: str,
+        task: str,
+        files: Iterable[str] = (),
+        limit: int = 5,
+    ) -> str:
+        query = " ".join([skill_name, task, *files])
+        memories = self.store.recall(query, limit=limit)
+        if not memories:
+            return ""
+
+        bullets = "\n".join(f"- {memory.text}" for memory in memories)
+        return (
+            "Relevant prior engineering memory from Memanto:\n"
+            f"{bullets}\n\n"
+            "Use these as constraints unless the current task explicitly changes them."
+        )
+
+    def after_skill(
+        self,
+        skill_name: str,
+        task: str,
+        transcript: str,
+        files: Iterable[str] = (),
+        explicit_memories: Iterable[str] = (),
+    ) -> list[MemoryRecord]:
+        memories = [
+            *explicit_memories,
+            *distill_engineering_memories(transcript),
+        ]
+        unique_memories = _dedupe(memory.strip() for memory in memories if memory.strip())
+
+        records = [
+            MemoryRecord(
+                text=memory,
+                skill_name=skill_name,
+                task=task,
+                files=list(files),
+            )
+            for memory in unique_memories
+        ]
+        for record in records:
+            self.store.remember(record)
+        return records
+
+    def run_skill_command(
+        self,
+        skill_name: str,
+        command: list[str],
+        task: str,
+        files: Iterable[str] = (),
+    ) -> subprocess.CompletedProcess[str]:
+        context_block = self.before_skill(skill_name, task, files)
+        env = os.environ.copy()
+        if context_block:
+            env["MEMANTO_SKILL_CONTEXT"] = context_block
+
+        result = subprocess.run(command, text=True, capture_output=True, env=env)
+        transcript = "\n".join(
+            [
+                f"$ {shlex.join(command)}",
+                result.stdout,
+                result.stderr,
+            ]
+        )
+        self.after_skill(skill_name, task, transcript, files)
+        return result
+
+
+def build_memory_store() -> MemoryStore:
+    backend = os.getenv(BACKEND_ENV, "local-preview").strip().lower()
+    if backend == "memanto-cli":
+        return MemantoCliMemoryStore()
+    return LocalPreviewMemoryStore()
+
+
+def distill_engineering_memories(transcript: str) -> list[str]:
+    """Extract durable facts from a skill transcript without an LLM dependency."""
+
+    memories: list[str] = []
+    patterns = [
+        r"^(?:Decision|Architecture|Constraint|Preference|Handoff|Validation):\s*(.+)$",
+        r"^- \[(?:decision|constraint|preference|handoff|validation)\]\s*(.+)$",
+    ]
+    for line in transcript.splitlines():
+        clean_line = line.strip()
+        for pattern in patterns:
+            match = re.match(pattern, clean_line, flags=re.IGNORECASE)
+            if match:
+                memories.append(match.group(1).strip())
+
+    if not memories:
+        summary = _first_meaningful_sentence(transcript)
+        if summary:
+            memories.append(summary)
+
+    return memories[:8]
+
+
+def _format_record(record: MemoryRecord) -> str:
+    file_label = ", ".join(record.files) if record.files else "no files"
+    return (
+        f"{record.text}\n"
+        f"Source skill: {record.skill_name}\n"
+        f"Task: {record.task}\n"
+        f"Files: {file_label}"
+    )
+
+
+def _first_meaningful_sentence(text: str) -> str:
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if len(line) > 30 and not line.startswith("$ "):
+            return line[:240]
+    return ""
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-zA-Z0-9_./-]+", text.lower())
+        if len(token) > 2
+    }
+
+
+def _dedupe(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    output: list[str] = []
+    for item in items:
+        key = item.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        output.append(item)
+    return output
+
+
+__all__ = [
+    "LocalPreviewMemoryStore",
+    "MemantoCliMemoryStore",
+    "MemoryRecord",
+    "SkillMemoryHook",
+    "build_memory_store",
+    "distill_engineering_memories",
+]
+

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -5,6 +5,8 @@ The module keeps the integration small on purpose:
 - local preview mode is deterministic and credential-free for reviewers
 - Memanto CLI mode can be used when the developer has already configured the
   standard `memanto` command with Moorcheh credentials
+- Memanto SDK mode uses the repository's Python package directly when
+  credentials and an active agent/session are available
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ from typing import Iterable, Protocol
 
 MEMORY_ENV = "MEMANTO_SKILLS_MEMORY"
 BACKEND_ENV = "MEMANTO_SKILLS_BACKEND"
+AGENT_ENV = "MEMANTO_SKILLS_AGENT_ID"
 
 
 @dataclass
@@ -110,6 +113,57 @@ class MemantoCliMemoryStore:
         return memories[:limit]
 
 
+class MemantoSdkMemoryStore:
+    """Adapter that uses the Memanto Python package directly."""
+
+    def __init__(self, agent_id: str | None = None) -> None:
+        from memanto.cli.client.sdk_client import SdkClient
+        from memanto.cli.config.manager import ConfigManager
+
+        self.config_manager = ConfigManager()
+        api_key = self.config_manager.get_api_key()
+        if not api_key:
+            raise RuntimeError(
+                "Memanto is not configured. Run `memanto` or set up a Moorcheh API key."
+            )
+
+        active_agent_id, active_session_token = self.config_manager.get_active_session()
+        self.agent_id = agent_id or os.getenv(AGENT_ENV) or active_agent_id
+        if not self.agent_id:
+            raise RuntimeError(
+                "No active Memanto agent. Run `memanto agent activate <agent-id>` "
+                f"or set {AGENT_ENV}."
+            )
+
+        self.client = SdkClient(api_key)
+        self.client.agent_id = self.agent_id
+        self.client.session_token = active_session_token
+
+    def remember(self, record: MemoryRecord) -> None:
+        self.client.remember(
+            agent_id=self.agent_id,
+            memory_type="decision",
+            title=_title_for(record),
+            content=_format_record(record),
+            confidence=0.9,
+            tags=["claudecode-skills", record.skill_name.strip("/")],
+            source=record.skill_name,
+            provenance="inferred",
+        )
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            type=["decision", "preference", "instruction", "context"],
+        )
+        return [
+            _record_from_memanto_payload(memory, query)
+            for memory in result.get("memories", [])
+        ][:limit]
+
+
 class SkillMemoryHook:
     """Lifecycle hook that bridges skill execution and durable memory."""
 
@@ -188,6 +242,8 @@ class SkillMemoryHook:
 
 def build_memory_store() -> MemoryStore:
     backend = os.getenv(BACKEND_ENV, "local-preview").strip().lower()
+    if backend in {"memanto-sdk", "memanto"}:
+        return MemantoSdkMemoryStore()
     if backend == "memanto-cli":
         return MemantoCliMemoryStore()
     return LocalPreviewMemoryStore()
@@ -226,6 +282,21 @@ def _format_record(record: MemoryRecord) -> str:
     )
 
 
+def _record_from_memanto_payload(payload: dict[str, object], query: str) -> MemoryRecord:
+    text = str(payload.get("content") or payload.get("text") or "").strip()
+    return MemoryRecord(
+        text=text,
+        skill_name=str(payload.get("source") or "memanto-sdk"),
+        task=query,
+        created_at=str(payload.get("created_at") or datetime.now(timezone.utc).isoformat()),
+    )
+
+
+def _title_for(record: MemoryRecord) -> str:
+    title = record.text.replace("\n", " ").strip()
+    return title[:97] + "..." if len(title) > 100 else title
+
+
 def _first_meaningful_sentence(text: str) -> str:
     for raw_line in text.splitlines():
         line = raw_line.strip()
@@ -257,9 +328,9 @@ def _dedupe(items: Iterable[str]) -> list[str]:
 __all__ = [
     "LocalPreviewMemoryStore",
     "MemantoCliMemoryStore",
+    "MemantoSdkMemoryStore",
     "MemoryRecord",
     "SkillMemoryHook",
     "build_memory_store",
     "distill_engineering_memories",
 ]
-

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from mattpocock_adapter import DEFAULT_SKILLS, command_payload, write_command_specs
 from skill_memory import LocalPreviewMemoryStore, SkillMemoryHook
 
 
@@ -77,6 +78,20 @@ Preference: Use fake clock fixtures for retry tests.
             self.assertIn("Relevant prior engineering memory from Memanto", result.stdout)
             self.assertIn("billing/retry.py", result.stdout)
             self.assertIn("wrapped command ran", result.stdout)
+
+    def test_mattpocock_adapter_generates_memory_aware_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            written = write_command_specs(tmpdir)
+            self.assertEqual(len(written), 3)
+            command_text = (Path(tmpdir) / "tdd.md").read_text(encoding="utf-8")
+
+            self.assertIn("run_skill_with_memory.py", command_text)
+            self.assertIn("--skill /tdd", command_text)
+            self.assertEqual(
+                command_payload(DEFAULT_SKILLS[0])["memory_env"],
+                "MEMANTO_SKILLS_MEMORY",
+            )
+            self.assertEqual(DEFAULT_SKILLS[2].name, "/handoff")
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,0 +1,83 @@
+"""Stdlib tests for the Claude Code skills + Memanto example."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from skill_memory import LocalPreviewMemoryStore, SkillMemoryHook
+
+
+class SkillMemoryExampleTest(unittest.TestCase):
+    def test_local_preview_reuses_cross_skill_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            memory_path = Path(tmpdir) / "skills-memory.jsonl"
+            first_hook = SkillMemoryHook(LocalPreviewMemoryStore(memory_path))
+            first_hook.after_skill(
+                "/grill-with-docs",
+                "Review billing retry architecture",
+                """
+Decision: Keep retry scheduling in billing/retry.py.
+Preference: Use fake clock fixtures for retry tests.
+""",
+                ["billing/retry.py"],
+            )
+
+            second_hook = SkillMemoryHook(LocalPreviewMemoryStore(memory_path))
+            context = second_hook.before_skill(
+                "/tdd",
+                "Write retry tests for billing/retry.py",
+                ["tests/billing/test_retry.py", "billing/retry.py"],
+            )
+
+            self.assertIn("billing/retry.py", context)
+            self.assertIn("fake clock", context)
+
+    def test_runner_wraps_command_with_local_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            memory_path = Path(tmpdir) / "memories.jsonl"
+            env = os.environ.copy()
+            env["MEMANTO_SKILLS_MEMORY"] = str(memory_path)
+            env["MEMANTO_SKILLS_BACKEND"] = "local-preview"
+
+            hook = SkillMemoryHook(LocalPreviewMemoryStore(memory_path))
+            hook.after_skill(
+                "/handoff",
+                "Seed notes",
+                "Decision: Keep retry logic in billing/retry.py.",
+                ["billing/retry.py"],
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "run_skill_with_memory.py",
+                    "--skill",
+                    "/tdd",
+                    "--task",
+                    "Write retry tests",
+                    "--file",
+                    "billing/retry.py",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "print('wrapped command ran')",
+                ],
+                cwd=Path(__file__).parent,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            self.assertIn("Relevant prior engineering memory from Memanto", result.stdout)
+            self.assertIn("billing/retry.py", result.stdout)
+            self.assertIn("wrapped command ran", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,54 @@
+"""Credential-free validation for the skills memory example."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from skill_memory import LocalPreviewMemoryStore, SkillMemoryHook, distill_engineering_memories
+
+
+def test_distillation() -> None:
+    transcript = """
+Decision: Prefer a service-layer boundary for retry scheduling.
+Constraint: Do not use real sleeps in retry tests.
+"""
+    memories = distill_engineering_memories(transcript)
+    assert "service-layer boundary" in memories[0]
+    assert "real sleeps" in memories[1]
+
+
+def test_cross_session_recall() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        memory_path = Path(tmpdir) / "memories.jsonl"
+        first = SkillMemoryHook(LocalPreviewMemoryStore(memory_path))
+        first.after_skill(
+            "/handoff",
+            "Document billing retry implementation notes",
+            """
+Decision: Billing retry logic lives in billing/retry.py.
+Preference: Use fake clock fixtures for retry tests.
+""",
+            ["billing/retry.py"],
+        )
+
+        second = SkillMemoryHook(LocalPreviewMemoryStore(memory_path))
+        context = second.before_skill(
+            "/tdd",
+            "Write retry tests for billing/retry.py",
+            ["tests/billing/test_retry.py", "billing/retry.py"],
+        )
+
+        assert "billing/retry.py" in context
+        assert "fake clock" in context
+
+
+def main() -> None:
+    test_distillation()
+    test_cross_session_recall()
+    print("skills memory validation passed")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/memanto/app/__init__.py
+++ b/memanto/app/__init__.py
@@ -1,5 +1,8 @@
 """MEMANTO application package."""
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except ModuleNotFoundError:
+    __version__ = "0.0.0+local"
 
 __all__ = ["__version__"]

--- a/memanto/app/__init__.py
+++ b/memanto/app/__init__.py
@@ -1,8 +1,5 @@
 """MEMANTO application package."""
 
-try:
-    from ._version import __version__
-except ModuleNotFoundError:
-    __version__ = "0.0.0+local"
+from ._version import __version__
 
 __all__ = ["__version__"]

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -1,0 +1,171 @@
+"""Regression tests for the Claude Code skills + Memanto example."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from types import ModuleType
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_DIR = REPO_ROOT / "examples" / "claudecode-skills-memanto"
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+from skill_memory import (  # noqa: E402
+    LocalPreviewMemoryStore,
+    MemantoSdkMemoryStore,
+    SkillMemoryHook,
+    build_memory_store,
+)
+
+
+def test_local_preview_reuses_cross_skill_memory(tmp_path: Path) -> None:
+    memory_path = tmp_path / "skills-memory.jsonl"
+    first_hook = SkillMemoryHook(LocalPreviewMemoryStore(memory_path))
+    first_hook.after_skill(
+        "/grill-with-docs",
+        "Review billing retry architecture",
+        """
+Decision: Keep retry scheduling in billing/retry.py.
+Preference: Use fake clock fixtures for retry tests.
+""",
+        ["billing/retry.py"],
+    )
+
+    second_hook = SkillMemoryHook(LocalPreviewMemoryStore(memory_path))
+    context = second_hook.before_skill(
+        "/tdd",
+        "Write retry tests for billing/retry.py",
+        ["tests/billing/test_retry.py", "billing/retry.py"],
+    )
+
+    assert "billing/retry.py" in context
+    assert "fake clock" in context
+
+
+def test_build_memory_store_selects_sdk_backend(monkeypatch) -> None:
+    monkeypatch.setenv("MEMANTO_SKILLS_BACKEND", "memanto-sdk")
+    created = {}
+
+    class FakeSdkStore:
+        def __init__(self) -> None:
+            created["called"] = True
+
+    monkeypatch.setattr("skill_memory.MemantoSdkMemoryStore", FakeSdkStore)
+
+    assert isinstance(build_memory_store(), FakeSdkStore)
+    assert created["called"] is True
+
+
+def test_sdk_backend_uses_repository_python_package(monkeypatch) -> None:
+    calls = {}
+
+    class FakeConfigManager:
+        def get_api_key(self) -> str:
+            return "test-key"
+
+        def get_active_session(self) -> tuple[str, str]:
+            return ("agent-1", "session-token")
+
+    class FakeSdkClient:
+        def __init__(self, api_key: str) -> None:
+            calls["api_key"] = api_key
+            self.agent_id = None
+            self.session_token = None
+
+        def remember(self, **kwargs) -> None:
+            calls["remember"] = kwargs
+
+        def recall(self, **kwargs) -> dict[str, object]:
+            calls["recall"] = kwargs
+            return {
+                "memories": [
+                    {
+                        "content": "Use service-layer retry scheduling.",
+                        "source": "/grill-with-docs",
+                        "created_at": "2026-05-20T00:00:00+00:00",
+                    }
+                ]
+            }
+
+    config_module = ModuleType("memanto.cli.config.manager")
+    config_module.ConfigManager = FakeConfigManager
+    sdk_module = ModuleType("memanto.cli.client.sdk_client")
+    sdk_module.SdkClient = FakeSdkClient
+    monkeypatch.setitem(sys.modules, "memanto.cli.config.manager", config_module)
+    monkeypatch.setitem(sys.modules, "memanto.cli.client.sdk_client", sdk_module)
+
+    store = MemantoSdkMemoryStore()
+    hook = SkillMemoryHook(store)
+    hook.after_skill(
+        "/grill-with-docs",
+        "Review retry architecture",
+        "Decision: Keep retry logic in a service layer.",
+    )
+    context = hook.before_skill("/tdd", "Write retry tests")
+
+    assert calls["api_key"] == "test-key"
+    assert calls["remember"]["agent_id"] == "agent-1"
+    assert calls["remember"]["memory_type"] == "decision"
+    assert calls["recall"]["type"] == [
+        "decision",
+        "preference",
+        "instruction",
+        "context",
+    ]
+    assert "service-layer retry" in context
+
+
+def test_runner_wraps_command_with_local_memory(tmp_path: Path) -> None:
+    memory_path = tmp_path / "memories.jsonl"
+    env = os.environ.copy()
+    env["MEMANTO_SKILLS_MEMORY"] = str(memory_path)
+    env["MEMANTO_SKILLS_BACKEND"] = "local-preview"
+
+    seed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from skill_memory import LocalPreviewMemoryStore, SkillMemoryHook;"
+                f"h=SkillMemoryHook(LocalPreviewMemoryStore(r'{memory_path}'));"
+                "h.after_skill('/handoff','Seed notes',"
+                "'Decision: Keep retry logic in billing/retry.py.',"
+                "['billing/retry.py'])"
+            ),
+        ],
+        cwd=EXAMPLE_DIR,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert seed.returncode == 0
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "run_skill_with_memory.py",
+            "--skill",
+            "/tdd",
+            "--task",
+            "Write retry tests",
+            "--file",
+            "billing/retry.py",
+            "--",
+            sys.executable,
+            "-c",
+            "print('wrapped command ran')",
+        ],
+        cwd=EXAMPLE_DIR,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "Relevant prior engineering memory from Memanto" in result.stdout
+    assert "billing/retry.py" in result.stdout
+    assert "wrapped command ran" in result.stdout

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -19,6 +19,7 @@ from skill_memory import (  # noqa: E402
     SkillMemoryHook,
     build_memory_store,
 )
+from mattpocock_adapter import DEFAULT_SKILLS, command_payload, write_command_specs  # noqa: E402
 
 
 def test_local_preview_reuses_cross_skill_memory(tmp_path: Path) -> None:
@@ -169,3 +170,17 @@ def test_runner_wraps_command_with_local_memory(tmp_path: Path) -> None:
     assert "Relevant prior engineering memory from Memanto" in result.stdout
     assert "billing/retry.py" in result.stdout
     assert "wrapped command ran" in result.stdout
+
+
+def test_mattpocock_adapter_writes_memory_aware_command_specs(tmp_path: Path) -> None:
+    written = write_command_specs(tmp_path)
+
+    assert sorted(path.name for path in written) == [
+        "grill-with-docs.md",
+        "handoff.md",
+        "tdd.md",
+    ]
+    tdd_command = (tmp_path / "tdd.md").read_text(encoding="utf-8")
+    assert "run_skill_with_memory.py" in tdd_command
+    assert "--skill /tdd" in tdd_command
+    assert command_payload(DEFAULT_SKILLS[0])["backend_env"] == "MEMANTO_SKILLS_BACKEND"


### PR DESCRIPTION
## Summary

Adds `examples/claudecode-skills-memanto`, a focused example for #508 showing how Memanto can act as a global memory companion across separate developer skill executions.

The example includes:

- a reusable `SkillMemoryHook` lifecycle wrapper
- credential-free `local-preview` JSONL memory for reviewer validation
- `memanto-sdk` mode that uses the repository's Python package directly through `memanto.cli.client.sdk_client.SdkClient`
- optional `memanto-cli` adapter for environments already configured with Moorcheh credentials
- `run_skill_with_memory.py`, a wrapper that recalls memory, injects it into the skill environment, runs the command, and captures the transcript afterward
- a two-session demo showing `/grill-with-docs` memories recalled by a later `/tdd` run
- a validation script, expected transcript, example-local stdlib tests, and pytest coverage for local preview, SDK selection, SDK calls, and the runner wrapper

## Bounty / Claim

/claim #508

BountyHub issue: #508

## Showcase / Demo

Public in-repo demo transcript: `examples/claudecode-skills-memanto/demo-transcript.md`

Maintainer clarification on #508 says an external Reddit/X showcase is not mandatory for PR consideration; technical review happens regardless of social posts. Community engagement can add points for the final judgement of top PRs.

## Validation

```bash
python examples/claudecode-skills-memanto/validate.py
python -m py_compile examples/claudecode-skills-memanto/skill_memory.py examples/claudecode-skills-memanto/demo.py examples/claudecode-skills-memanto/validate.py examples/claudecode-skills-memanto/run_skill_with_memory.py examples/claudecode-skills-memanto/test_skill_memory.py tests/test_claudecode_skills_memanto_example.py
python examples/claudecode-skills-memanto/demo.py
(cd examples/claudecode-skills-memanto && python -m unittest test_skill_memory.py)
git diff --check
PYTHONPATH=. python -m pytest --noconftest -c /dev/null tests/test_claudecode_skills_memanto_example.py
```

All targeted validation passed locally. A plain `python -m pytest tests/test_claudecode_skills_memanto_example.py` in my minimal local environment is blocked before collection by the repository test conftest importing `moorcheh_sdk`, which is not installed here, so the example-local stdlib tests provide a credential-free/no-extra-dependency review path.