### PR TITLE
Add developer skills memory bridge for Memanto

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,121 @@
+# Claude Code Skills + Memanto
+
+This example adds a small lifecycle layer for command-style developer skills:
+
+- `pre`: recall relevant engineering decisions and emit a compact prompt block.
+- `post`: distill a completed skill transcript and store it as typed memory.
+- `wrap`: run any skill command between `pre` and `post`, passing recalled memory in `MEMANTO_SKILL_CONTEXT`.
+
+It targets the context-fragmentation problem from issue #508: a decision learned
+by one skill, such as `/grill-with-docs`, becomes available to later skills,
+such as `/tdd` or `/handoff`, without repeating the same instructions.
+
+## Credential-free preview
+
+Run the full lifecycle locally with no Moorcheh API key:
+
+```bash
+python examples/claudecode-skills-memanto/validate.py
+```
+
+Manual local run:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py \
+  --backend local \
+  --store /tmp/memanto-skills.jsonl \
+  post \
+  --skill grill-with-docs \
+  --task "Review billing retry architecture" \
+  --file src/billing/retries.ts \
+  --transcript "Decision: keep retry delays deterministic in tests. Preserve idempotency keys across retries."
+
+python examples/claudecode-skills-memanto/skill_memory.py \
+  --backend local \
+  --store /tmp/memanto-skills.jsonl \
+  pre \
+  --skill tdd \
+  --task "Add billing retry tests" \
+  --file src/billing/retries.ts
+```
+
+The local backend is deliberately simple JSONL. It exists for review, demos, and
+tests; it is not a replacement for Memanto.
+
+## Optional live Memanto mode
+
+Live mode uses the repository's existing `memanto` CLI and whatever active agent
+the developer has configured locally. No credentials are stored in this example.
+
+```bash
+export MOORCHEH_API_KEY=...
+memanto agent create claude-code-skills --description "Cross-skill engineering memory"
+
+python examples/claudecode-skills-memanto/skill_memory.py \
+  --backend memanto \
+  post \
+  --skill grill-with-docs \
+  --task "Review billing retry architecture" \
+  --file src/billing/retries.ts \
+  --transcript-file /tmp/skill-transcript.txt
+
+python examples/claudecode-skills-memanto/skill_memory.py \
+  --backend memanto \
+  pre \
+  --skill tdd \
+  --task "Add billing retry tests" \
+  --file src/billing/retries.ts
+```
+
+You can also select live mode with:
+
+```bash
+export MEMANTO_SKILLS_BACKEND=memanto
+```
+
+## Wrapper mode
+
+`wrap` is the integration shape for a skill runner. It prints the recalled block,
+sets `MEMANTO_SKILL_CONTEXT` for the child process, captures the child output,
+then stores the completed transcript.
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py \
+  --backend local \
+  --store /tmp/memanto-skills.jsonl \
+  wrap \
+  --skill handoff \
+  --task "Summarize billing retry test constraints" \
+  --file src/billing/retries.ts \
+  -- python -m pytest tests/test_billing_retries.py
+```
+
+## What gets remembered
+
+Each stored memory includes:
+
+- memory type `decision`
+- source skill
+- task
+- files and project path tags
+- distilled engineering decisions from the transcript
+- confidence and timestamp
+
+The distiller is intentionally narrow: `RuleBasedDistiller` is used for
+credential-free preview and tests. The live backend stores the same structured
+decision into Memanto via `memanto remember`, then later retrieves it via
+`memanto recall`.
+
+## Validation
+
+```bash
+python -m py_compile examples/claudecode-skills-memanto/skill_memory.py \
+  examples/claudecode-skills-memanto/validate.py \
+  examples/claudecode-skills-memanto/test_skill_memory.py
+
+python examples/claudecode-skills-memanto/validate.py
+
+python -m unittest examples/claudecode-skills-memanto/test_skill_memory.py
+```
+
+See `demo-transcript.md` for a concrete before-and-after run.

--- a/examples/claudecode-skills-memanto/demo-transcript.md
+++ b/examples/claudecode-skills-memanto/demo-transcript.md
@@ -1,0 +1,80 @@
+# Demo transcript
+
+This transcript uses the local preview backend, so it is safe to run without
+Moorcheh credentials. Live mode uses the same lifecycle with
+`--backend memanto` after `memanto agent create` or `memanto agent activate`.
+
+## 1. A review skill stores a durable decision
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py \
+  --backend local \
+  --store /tmp/memanto-skills.jsonl \
+  post \
+  --skill grill-with-docs \
+  --task "Review billing retry architecture" \
+  --file src/billing/retries.ts \
+  --cwd /repo/payments \
+  --transcript "Decision: keep retry delays deterministic in tests. Preserve idempotency keys across retries."
+```
+
+Output:
+
+```text
+stored_memories=1
+```
+
+Stored JSONL memory:
+
+```json
+{
+  "memory_type": "decision",
+  "source_skill": "grill-with-docs",
+  "tags": [
+    "claudecode-skills-memanto",
+    "skill:grill-with-docs",
+    "file:retries.ts",
+    "path:src/billing",
+    "project:payments"
+  ],
+  "content": "Skill `grill-with-docs` completed task `Review billing retry architecture`. Files in scope: src/billing/retries.ts. Durable engineering memory: Decision: keep retry delays deterministic in tests. Preserve idempotency keys across retries."
+}
+```
+
+## 2. A later test-writing skill receives that memory
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py \
+  --backend local \
+  --store /tmp/memanto-skills.jsonl \
+  pre \
+  --skill tdd \
+  --task "Add billing retry tests" \
+  --file src/billing/retries.ts \
+  --cwd /repo/payments
+```
+
+Output:
+
+```text
+<memanto-engineering-memory>
+Apply these prior engineering decisions during this skill run:
+- Skill `grill-with-docs` completed task `Review billing retry architecture`. Files in scope: src/billing/retries.ts. Durable engineering memory: Decision: keep retry delays deterministic in tests. Preserve idempotency keys across retries.
+</memanto-engineering-memory>
+```
+
+## 3. Wrapper mode passes the memory into the command
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py \
+  --backend local \
+  --store /tmp/memanto-skills.jsonl \
+  wrap \
+  --skill handoff \
+  --task "Summarize billing retry test constraints" \
+  --file src/billing/retries.ts \
+  -- python -c "import os; print(os.environ['MEMANTO_SKILL_CONTEXT'])"
+```
+
+The wrapped command sees `MEMANTO_SKILL_CONTEXT`, while the wrapper also captures
+the command output and stores the completed run back into memory.

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Memory lifecycle hooks for Claude Code-style developer skills.
+
+The module is intentionally dependency-light so the example can be reviewed in
+three modes:
+
+* local preview: JSONL store, no credentials, deterministic distillation
+* live Memanto CLI: uses the existing ``memanto remember`` / ``memanto recall``
+* wrapper mode: runs any skill command between pre and post lifecycle hooks
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+
+
+DEFAULT_LIMIT = 5
+DEFAULT_STORE = ".memanto-skills-preview/memories.jsonl"
+SOURCE = "claudecode-skills-memanto"
+
+
+@dataclass(frozen=True)
+class SkillRun:
+    skill: str
+    task: str
+    files: tuple[str, ...] = ()
+    transcript: str = ""
+    cwd: str = ""
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def query(self) -> str:
+        parts = [self.skill, self.task, *self.files, self.cwd]
+        return " ".join(part for part in parts if part).strip()
+
+
+@dataclass(frozen=True)
+class EngineeringMemory:
+    title: str
+    content: str
+    memory_type: str = "decision"
+    tags: tuple[str, ...] = ()
+    confidence: float = 0.82
+    source_skill: str = ""
+    created_at: str = ""
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+
+class MemoryBackend(Protocol):
+    def recall(self, run: SkillRun, limit: int = DEFAULT_LIMIT) -> list[EngineeringMemory]:
+        """Return memories relevant to a skill run."""
+
+    def store(self, memory: EngineeringMemory) -> None:
+        """Persist one engineering memory."""
+
+
+class RuleBasedDistiller:
+    """Credential-free distiller used by local preview and tests.
+
+    The live path stores these distilled decisions in Memanto. If a team wants
+    fully LLM-generated summaries, this class is the narrow replacement point.
+    """
+
+    DECISION_PATTERNS = (
+        r"\b(?:decided|decision|choose|chosen|use|prefer|keep|preserve|avoid|must|should)\b[^.!\n]*(?:[.!\n]|$)",
+        r"\b(?:implemented|fixed|changed|refactored|validated)\b[^.!\n]*(?:[.!\n]|$)",
+    )
+
+    def distill(self, run: SkillRun) -> list[EngineeringMemory]:
+        transcript = _compact(run.transcript)
+        if not transcript:
+            return []
+
+        snippets = self._extract_decision_snippets(transcript)
+        content = self._build_content(run, snippets or [transcript])
+        return [
+            EngineeringMemory(
+                title=_title_for(run),
+                content=content,
+                tags=_tags_for(run),
+                confidence=0.86 if snippets else 0.72,
+                source_skill=run.skill,
+                created_at=_now(),
+            )
+        ]
+
+    def _extract_decision_snippets(self, transcript: str) -> list[str]:
+        snippets: list[str] = []
+        for pattern in self.DECISION_PATTERNS:
+            for match in re.finditer(pattern, transcript, flags=re.IGNORECASE):
+                snippet = _compact(match.group(0), max_chars=280)
+                if snippet and snippet not in snippets:
+                    snippets.append(snippet)
+        return snippets[:4]
+
+    def _build_content(self, run: SkillRun, snippets: list[str]) -> str:
+        files = ", ".join(run.files) if run.files else "not specified"
+        decisions = " ".join(snippets)
+        return (
+            f"Skill `{run.skill}` completed task `{run.task}`. "
+            f"Files in scope: {files}. "
+            f"Durable engineering memory: {decisions}"
+        )
+
+
+class LocalJsonlBackend:
+    """Credential-free backend for reviewer preview and tests."""
+
+    def __init__(self, store_path: Path) -> None:
+        self.store_path = store_path
+
+    def recall(self, run: SkillRun, limit: int = DEFAULT_LIMIT) -> list[EngineeringMemory]:
+        query_terms = _terms(run.query)
+        scored: list[tuple[int, EngineeringMemory]] = []
+        for memory in self._read_all():
+            haystack = " ".join(
+                [
+                    memory.title,
+                    memory.content,
+                    " ".join(memory.tags),
+                    memory.source_skill,
+                ]
+            )
+            score = _score(query_terms, haystack)
+            if score > 0:
+                scored.append((score, memory))
+
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+    def store(self, memory: EngineeringMemory) -> None:
+        self.store_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.store_path.open("a", encoding="utf-8") as handle:
+            handle.write(memory.to_json() + "\n")
+
+    def _read_all(self) -> list[EngineeringMemory]:
+        if not self.store_path.exists():
+            return []
+
+        memories: list[EngineeringMemory] = []
+        for line in self.store_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            memories.append(
+                EngineeringMemory(
+                    title=str(record.get("title", "")),
+                    content=str(record.get("content", "")),
+                    memory_type=str(record.get("memory_type", "decision")),
+                    tags=tuple(record.get("tags", ())),
+                    confidence=float(record.get("confidence", 0.0)),
+                    source_skill=str(record.get("source_skill", "")),
+                    created_at=str(record.get("created_at", "")),
+                )
+            )
+        return memories
+
+
+class MemantoCliBackend:
+    """Live backend using the installed Memanto CLI and active agent session."""
+
+    def __init__(self, executable: str = "memanto") -> None:
+        self.executable = executable
+
+    def recall(self, run: SkillRun, limit: int = DEFAULT_LIMIT) -> list[EngineeringMemory]:
+        completed = subprocess.run(
+            [
+                self.executable,
+                "recall",
+                run.query,
+                "--type",
+                "decision",
+                "--tags",
+                SOURCE,
+                "--limit",
+                str(limit),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            return []
+        return _parse_memanto_recall(completed.stdout)
+
+    def store(self, memory: EngineeringMemory) -> None:
+        tags = ",".join(memory.tags)
+        args = [
+            self.executable,
+            "remember",
+            memory.content,
+            "--type",
+            memory.memory_type,
+            "--title",
+            memory.title,
+            "--source",
+            SOURCE,
+            "--provenance",
+            "inferred",
+            "--confidence",
+            f"{memory.confidence:.2f}",
+        ]
+        if tags:
+            args.extend(["--tags", tags])
+        subprocess.run(args, check=True)
+
+
+def build_injection_block(run: SkillRun, backend: MemoryBackend, limit: int) -> str:
+    memories = backend.recall(run, limit=limit)
+    if not memories:
+        return ""
+
+    lines = [
+        "<memanto-engineering-memory>",
+        "Apply these prior engineering decisions during this skill run:",
+    ]
+    for memory in memories:
+        lines.append(f"- {memory.content}")
+    lines.append("</memanto-engineering-memory>")
+    return "\n".join(lines)
+
+
+def store_completed_run(
+    run: SkillRun,
+    backend: MemoryBackend,
+    distiller: RuleBasedDistiller | None = None,
+) -> int:
+    distiller = distiller or RuleBasedDistiller()
+    memories = distiller.distill(run)
+    for memory in memories:
+        backend.store(memory)
+    return len(memories)
+
+
+def run_wrapped_command(
+    run: SkillRun,
+    command: list[str],
+    backend: MemoryBackend,
+    limit: int,
+) -> int:
+    injection = build_injection_block(run, backend, limit)
+    if injection:
+        print(injection)
+        print()
+
+    env = os.environ.copy()
+    if injection:
+        env["MEMANTO_SKILL_CONTEXT"] = injection
+
+    completed = subprocess.run(command, capture_output=True, text=True, env=env)
+    print(completed.stdout, end="")
+    print(completed.stderr, end="", file=sys.stderr)
+
+    transcript = "\n".join(
+        part for part in (injection, completed.stdout, completed.stderr) if part.strip()
+    )
+    store_completed_run(
+        SkillRun(
+            skill=run.skill,
+            task=run.task,
+            files=run.files,
+            transcript=transcript,
+            cwd=run.cwd,
+            metadata=run.metadata,
+        ),
+        backend,
+    )
+    return completed.returncode
+
+
+def backend_from_args(args: argparse.Namespace) -> MemoryBackend:
+    if args.backend == "local":
+        return LocalJsonlBackend(Path(args.store))
+    return MemantoCliBackend(os.environ.get("MEMANTO_EXECUTABLE", "memanto"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inject and store Memanto engineering memory around skill runs."
+    )
+    parser.add_argument(
+        "--backend",
+        choices=("local", "memanto"),
+        default=os.environ.get("MEMANTO_SKILLS_BACKEND", "local"),
+        help="Use local JSONL preview or live Memanto CLI mode.",
+    )
+    parser.add_argument(
+        "--store",
+        default=os.environ.get("MEMANTO_SKILLS_STORE", DEFAULT_STORE),
+        help="JSONL store path for --backend local.",
+    )
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for name in ("pre", "post"):
+        command = subparsers.add_parser(name)
+        _add_run_args(command)
+        command.add_argument("--transcript")
+        command.add_argument("--transcript-file")
+
+    wrapped = subparsers.add_parser("wrap")
+    _add_run_args(wrapped)
+    wrapped.add_argument("wrapped_command", nargs=argparse.REMAINDER)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    backend = backend_from_args(args)
+
+    if args.command == "wrap":
+        if not args.wrapped_command:
+            parser.error("provide the command to run after --")
+        run = _run_from_args(args)
+        command = args.wrapped_command
+        if command and command[0] == "--":
+            command = command[1:]
+        return run_wrapped_command(run, command, backend, args.limit)
+
+    run = _run_from_args(args)
+    if args.command == "pre":
+        injection = build_injection_block(run, backend, args.limit)
+        if injection:
+            print(injection)
+        return 0
+
+    stored = store_completed_run(run, backend)
+    print(f"stored_memories={stored}")
+    return 0
+
+
+def _add_run_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--skill", required=True)
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--file", action="append", default=[])
+    parser.add_argument("--cwd", default=os.getcwd())
+    parser.add_argument("--metadata", default="{}")
+
+
+def _run_from_args(args: argparse.Namespace) -> SkillRun:
+    return SkillRun(
+        skill=args.skill,
+        task=args.task,
+        files=tuple(args.file),
+        transcript=_read_transcript(args),
+        cwd=args.cwd,
+        metadata=_metadata(args.metadata),
+    )
+
+
+def _read_transcript(args: argparse.Namespace) -> str:
+    transcript = getattr(args, "transcript", None)
+    transcript_file = getattr(args, "transcript_file", None)
+    if transcript:
+        return transcript
+    if transcript_file:
+        return Path(transcript_file).read_text(encoding="utf-8")
+    if not sys.stdin.isatty() and getattr(args, "command", "") == "post":
+        return sys.stdin.read()
+    return ""
+
+
+def _metadata(raw: str) -> dict[str, str]:
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("--metadata must be a JSON object")
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def _parse_memanto_recall(output: str) -> list[EngineeringMemory]:
+    memories: list[EngineeringMemory] = []
+    current_title = ""
+    current_content: list[str] = []
+
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("Found ") or line.startswith("Completed in"):
+            continue
+        if line.startswith("ID:") or line.startswith("Type:") or line.startswith("Created:"):
+            continue
+        if line.startswith("Memory ") or " · memory " in line:
+            if current_content:
+                memories.append(
+                    EngineeringMemory(
+                        title=current_title,
+                        content=_compact(" ".join(current_content), 600),
+                    )
+                )
+                current_content = []
+            continue
+        if not current_title:
+            current_title = line
+            continue
+        current_content.append(line)
+
+    if current_content:
+        memories.append(
+            EngineeringMemory(title=current_title, content=_compact(" ".join(current_content), 600))
+        )
+    return memories[:DEFAULT_LIMIT]
+
+
+def _tags_for(run: SkillRun) -> tuple[str, ...]:
+    tags = [SOURCE, f"skill:{run.skill}"]
+    for file_path in run.files[:8]:
+        path = Path(file_path)
+        tags.append(f"file:{path.name}")
+        if path.parent != Path("."):
+            tags.append(f"path:{path.parent.as_posix()}")
+    if run.cwd:
+        tags.append(f"project:{Path(run.cwd).name}")
+    return tuple(dict.fromkeys(tags))
+
+
+def _title_for(run: SkillRun) -> str:
+    compact_task = _compact(run.task, 72)
+    return f"{run.skill}: {compact_task}"
+
+
+def _compact(text: str, max_chars: int = 1200) -> str:
+    value = " ".join(text.split())
+    if len(value) <= max_chars:
+        return value
+    return f"{value[: max_chars - 3]}..."
+
+
+def _terms(value: str) -> set[str]:
+    return {
+        term.lower()
+        for term in re.findall(r"[a-zA-Z0-9_./:-]+", value)
+        if len(term) > 2
+    }
+
+
+def _score(query_terms: set[str], haystack: str) -> int:
+    haystack_lower = haystack.lower()
+    score = 0
+    for term in query_terms:
+        if term in haystack_lower:
+            score += 3 if "/" in term or ":" in term else 1
+    return score
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _self_check() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = Path(tmp) / "memory.jsonl"
+        backend = LocalJsonlBackend(store)
+        first = SkillRun(
+            skill="grill-with-docs",
+            task="Review billing retry architecture",
+            files=("src/billing/retries.ts",),
+            transcript=(
+                "Decision: keep retry delays deterministic in tests. "
+                "Preserve idempotency keys across retries."
+            ),
+            cwd="/repo/payments",
+        )
+        assert store_completed_run(first, backend) == 1
+        second = SkillRun(
+            skill="tdd",
+            task="Add billing retry tests",
+            files=("src/billing/retries.ts",),
+            cwd="/repo/payments",
+        )
+        block = build_injection_block(second, backend, DEFAULT_LIMIT)
+        assert "<memanto-engineering-memory>" in block
+        assert "deterministic" in block
+        assert "idempotency" in block
+    return 0
+
+
+if __name__ == "__main__":
+    if os.environ.get("MEMANTO_SKILLS_SELF_CHECK") == "1":
+        raise SystemExit(_self_check())
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+MODULE_PATH = ROOT / "skill_memory.py"
+spec = importlib.util.spec_from_file_location("skill_memory", MODULE_PATH)
+assert spec and spec.loader
+skill_memory = importlib.util.module_from_spec(spec)
+sys.modules["skill_memory"] = skill_memory
+spec.loader.exec_module(skill_memory)
+
+
+class SkillMemoryTests(unittest.TestCase):
+    def test_local_backend_distill_store_and_inject(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = skill_memory.LocalJsonlBackend(Path(tmp) / "memories.jsonl")
+            completed = skill_memory.SkillRun(
+                skill="grill-with-docs",
+                task="Review retry policy",
+                files=("src/billing/retries.ts",),
+                transcript=(
+                    "Decision: keep retries deterministic in tests. "
+                    "Avoid wall-clock sleeps."
+                ),
+                cwd="/repo/payments",
+            )
+
+            stored = skill_memory.store_completed_run(completed, backend)
+
+            self.assertEqual(stored, 1)
+            later = skill_memory.SkillRun(
+                skill="tdd",
+                task="Add retry tests",
+                files=("src/billing/retries.ts",),
+                cwd="/repo/payments",
+            )
+            block = skill_memory.build_injection_block(later, backend, limit=3)
+            self.assertIn("<memanto-engineering-memory>", block)
+            self.assertIn("deterministic", block)
+            self.assertIn("wall-clock", block)
+
+    def test_wrapper_passes_injected_context_to_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = skill_memory.LocalJsonlBackend(Path(tmp) / "memories.jsonl")
+            skill_memory.store_completed_run(
+                skill_memory.SkillRun(
+                    skill="handoff",
+                    task="Summarize retry policy",
+                    files=("src/billing/retries.ts",),
+                    transcript="Decision: preserve idempotency keys across retries.",
+                    cwd="/repo/payments",
+                ),
+                backend,
+            )
+
+            run = skill_memory.SkillRun(
+                skill="tdd",
+                task="Add billing retry tests",
+                files=("src/billing/retries.ts",),
+                cwd="/repo/payments",
+            )
+            rc = skill_memory.run_wrapped_command(
+                run,
+                [
+                    sys.executable,
+                    "-c",
+                    "import os; assert 'idempotency' in os.environ['MEMANTO_SKILL_CONTEXT']",
+                ],
+                backend,
+                limit=3,
+            )
+
+            self.assertEqual(rc, 0)
+
+    def test_validate_script_runs_without_credentials(self) -> None:
+        env = os.environ.copy()
+        env.pop("MOORCHEH_API_KEY", None)
+        completed = subprocess.run(
+            [sys.executable, str(ROOT / "validate.py")],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        self.assertIn("credential-free validation passed", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Credential-free validation for the skills memory example."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+HOOK = ROOT / "skill_memory.py"
+
+
+def run(args: list[str]) -> str:
+    completed = subprocess.run(args, check=True, capture_output=True, text=True)
+    return completed.stdout
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = str(Path(tmp) / "memories.jsonl")
+
+        post_output = run(
+            [
+                sys.executable,
+                str(HOOK),
+                "--backend",
+                "local",
+                "--store",
+                store,
+                "post",
+                "--skill",
+                "grill-with-docs",
+                "--task",
+                "Review billing retry architecture",
+                "--file",
+                "src/billing/retries.ts",
+                "--cwd",
+                "/repo/payments",
+                "--transcript",
+                "Decision: keep retry delays deterministic in tests. Preserve idempotency keys across retries.",
+            ]
+        )
+        if "stored_memories=1" not in post_output:
+            raise AssertionError(post_output)
+
+        pre_output = run(
+            [
+                sys.executable,
+                str(HOOK),
+                "--backend",
+                "local",
+                "--store",
+                store,
+                "pre",
+                "--skill",
+                "tdd",
+                "--task",
+                "Add billing retry tests",
+                "--file",
+                "src/billing/retries.ts",
+                "--cwd",
+                "/repo/payments",
+            ]
+        )
+        for expected in (
+            "<memanto-engineering-memory>",
+            "deterministic",
+            "idempotency",
+        ):
+            if expected not in pre_output:
+                raise AssertionError(pre_output)
+
+        wrap_output = run(
+            [
+                sys.executable,
+                str(HOOK),
+                "--backend",
+                "local",
+                "--store",
+                store,
+                "wrap",
+                "--skill",
+                "handoff",
+                "--task",
+                "Summarize billing retry test constraints",
+                "--file",
+                "src/billing/retries.ts",
+                "--",
+                sys.executable,
+                "-c",
+                "import os; print('context injected=' + str('MEMANTO_SKILL_CONTEXT' in os.environ))",
+            ]
+        )
+        if "context injected=True" not in wrap_output:
+            raise AssertionError(wrap_output)
+
+    print("credential-free validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `examples/claudecode-skills-memanto` as a reviewable memory bridge for command-style developer skills.
- Supports credential-free local preview mode with a JSONL backend and no network dependency.
- Supports optional live Memanto mode through the existing `memanto` CLI and the developer's active Moorcheh-backed agent.
- Implements the skill lifecycle: `pre` injection, `post` distill/store, and `wrap` for running a skill command between both phases.
- Includes README usage, a concrete demo transcript, a validation script, and stdlib tests.

## Implementation notes
- `skill_memory.py` defines a narrow `MemoryBackend` protocol, `LocalJsonlBackend`, and `MemantoCliBackend`, so reviewer preview and live Memanto usage share the same lifecycle.
- `RuleBasedDistiller` gives deterministic local distillation for credential-free review. In live mode the distilled engineering decision is stored with `memanto remember --type decision` and recalled with `memanto recall --type decision`.
- `wrap` exports recalled context to `MEMANTO_SKILL_CONTEXT`, captures command output, and stores the completed run back as durable engineering memory.
- All new files are scoped to the requested example path; no core package behavior is changed.
- No external social showcase link is included. A maintainer clarified on issue #508 that technical review does not depend on an external social post.

## Verification
```text
$ python3 -m py_compile examples/claudecode-skills-memanto/skill_memory.py examples/claudecode-skills-memanto/validate.py examples/claudecode-skills-memanto/test_skill_memory.py
# passed

$ python3 examples/claudecode-skills-memanto/validate.py
credential-free validation passed

$ python3 -m unittest examples/claudecode-skills-memanto/test_skill_memory.py
...
----------------------------------------------------------------------
Ran 3 tests in 0.207s

OK

$ git diff --cached --check
# passed before commit
```

Bounty payout info, if needed: PayPal https://paypal.me/tanchaowen

Closes #508