### PR TITLE
Add Claude Code skills Memanto memory bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,67 @@
+# Claude Code Skills + Memanto Memory Bridge
+
+This example shows a lightweight integration layer for using Memanto as active
+memory between separate Claude Code skill runs.
+
+The bridge has two modes:
+
+- **Preview mode** works without credentials and stores memories in local JSONL.
+- **Live mode** uses the Memanto CLI when `MOORCHEH_API_KEY` is configured.
+
+## Three-step setup
+
+1. Install Memanto and configure your Moorcheh key:
+
+   ```bash
+   pip install memanto
+   memanto
+   ```
+
+2. Copy this folder into a repo that uses Claude Code skills.
+
+3. Wrap each skill call:
+
+   ```bash
+   python examples/claudecode-skills-memanto/skill_memory.py before \
+     --skill grill-with-docs \
+     --task "Review the API client retry strategy" \
+     --paths "src/api/client.ts"
+
+   # Run the skill and save its transcript, then:
+   python examples/claudecode-skills-memanto/skill_memory.py after \
+     --skill grill-with-docs \
+     --task "Review the API client retry strategy" \
+     --transcript .memanto-skill-memory/session.md
+   ```
+
+The `before` command writes a concise context block to
+`.memanto-skill-memory/injected-context.md`. Paste or include that block in the
+next skill prompt so later skills inherit relevant architectural decisions.
+
+## What it captures
+
+The bridge looks for durable engineering signals such as:
+
+- explicit decisions,
+- "must" and "prefer" constraints,
+- codebase quirks,
+- accepted tradeoffs,
+- follow-up tasks.
+
+In live mode, those memories are sent to Memanto as typed `decision`,
+`preference`, `instruction`, or `context` records. In preview mode, the same
+records are written locally so reviewers can inspect behavior without private
+credentials.
+
+## Files
+
+- `skill_memory.py` - before/after hook wrapper.
+- `skills/memanto-memory-bridge/SKILL.md` - Claude Code skill glue.
+- `demo/demo-transcript.md` - sample two-skill walkthrough.
+- `sample-output/injected-context.md` - example injected memory block.
+
+## Review-safe behavior
+
+The default command path does not require API keys, network calls, package
+installation, or access to private code. Set `MEMANTO_LIVE=1` only when you want
+the hook to call the installed Memanto CLI.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -38,6 +38,19 @@ The `before` command writes a concise context block to
 `.memanto-skill-memory/injected-context.md`. Paste or include that block in the
 next skill prompt so later skills inherit relevant architectural decisions.
 
+For a full lifecycle wrapper, put the target command after `--`:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py wrap \
+  --skill tdd \
+  --task "Implement API client retry handling" \
+  --paths "src/api/client.ts" \
+  -- python -c "print('Decision: keep retries in the transport adapter')"
+```
+
+The wrapper recalls memory, runs the command, captures the transcript, and
+stores durable decisions from the result.
+
 ## What it captures
 
 The bridge looks for durable engineering signals such as:
@@ -56,6 +69,7 @@ credentials.
 ## Files
 
 - `skill_memory.py` - before/after hook wrapper.
+- `validate.py` - credential-free smoke test for reviewers.
 - `skills/memanto-memory-bridge/SKILL.md` - Claude Code skill glue.
 - `demo/demo-transcript.md` - sample two-skill walkthrough.
 - `sample-output/injected-context.md` - example injected memory block.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -84,6 +84,8 @@ credentials.
 - `mattpocock_adapter.py` - generates Claude command wrappers for common
   `mattpocock/skills` workflows.
 - `validate.py` - credential-free smoke test for reviewers.
+- `test_skill_memory.py` - stdlib unit tests for the preview bridge and wrapper
+  generator.
 - `skills/memanto-memory-bridge/SKILL.md` - Claude Code skill glue.
 - `demo/demo-transcript.md` - sample two-skill walkthrough.
 - `sample-output/injected-context.md` - example injected memory block.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -51,6 +51,18 @@ python examples/claudecode-skills-memanto/skill_memory.py wrap \
 The wrapper recalls memory, runs the command, captures the transcript, and
 stores durable decisions from the result.
 
+To generate command wrappers for the common `mattpocock/skills` commands:
+
+```bash
+python examples/claudecode-skills-memanto/mattpocock_adapter.py \
+  --output .claude/commands
+```
+
+This creates reviewable command files such as `grill-with-docs-memory.md`,
+`tdd-memory.md`, and `handoff-memory.md`. Each wrapper tells the agent to recall
+Memanto context before invoking the source skill and store durable decisions
+after it completes.
+
 ## What it captures
 
 The bridge looks for durable engineering signals such as:
@@ -69,6 +81,8 @@ credentials.
 ## Files
 
 - `skill_memory.py` - before/after hook wrapper.
+- `mattpocock_adapter.py` - generates Claude command wrappers for common
+  `mattpocock/skills` workflows.
 - `validate.py` - credential-free smoke test for reviewers.
 - `skills/memanto-memory-bridge/SKILL.md` - Claude Code skill glue.
 - `demo/demo-transcript.md` - sample two-skill walkthrough.

--- a/examples/claudecode-skills-memanto/demo/demo-transcript.md
+++ b/examples/claudecode-skills-memanto/demo/demo-transcript.md
@@ -1,0 +1,59 @@
+# Demo Transcript
+
+This transcript shows the intended lifecycle without requiring private
+credentials.
+
+## Session 1: architecture review
+
+Command:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py before \
+  --skill grill-with-docs \
+  --task "Review API client retry strategy" \
+  --paths "src/api/client.ts"
+```
+
+Result:
+
+```text
+Wrote .memanto-skill-memory/injected-context.md
+```
+
+The first run has no prior context. After review, the session summary says:
+
+- Decision: Keep retries in the transport adapter instead of feature modules.
+- Preference: Error messages should name the upstream service and retry count.
+- Must: Do not retry non-idempotent POST requests unless the caller opts in.
+
+Store it:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py after \
+  --skill grill-with-docs \
+  --task "Review API client retry strategy" \
+  --paths "src/api/client.ts" \
+  --transcript .memanto-skill-memory/session.md
+```
+
+## Session 2: implementation
+
+Command:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py before \
+  --skill tdd \
+  --task "Implement API client retry handling" \
+  --paths "src/api/client.ts"
+```
+
+Expected injected context:
+
+```text
+- [decision] Keep retries in the transport adapter instead of feature modules.
+- [preference] Error messages should name the upstream service and retry count.
+- [instruction] Do not retry non-idempotent POST requests unless the caller opts in.
+```
+
+The implementation skill now starts with the design constraints that were
+created during the separate review skill run.

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Generate command wrappers for mattpocock/skills + Memanto.
+
+This does not install or execute mattpocock/skills. It writes small Claude
+command files that document the lifecycle around selected source skills.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+DEFAULT_SKILLS = {
+    "grill-with-docs": {
+        "source": "/grill-with-docs",
+        "purpose": "stress-test a plan while preserving resolved terms and ADR-worthy decisions",
+        "paths": "CONTEXT.md docs/adr",
+    },
+    "tdd": {
+        "source": "/tdd",
+        "purpose": "implement a vertical slice while preserving prior architectural constraints",
+        "paths": "src tests",
+    },
+    "handoff": {
+        "source": "/handoff",
+        "purpose": "summarize work while carrying forward durable decisions for the next session",
+        "paths": "CONTEXT.md docs/adr .",
+    },
+}
+
+
+TEMPLATE = """---
+name: {name}-memory
+description: Run {source} with Memanto cross-skill memory recall and writeback.
+argument-hint: "Task summary and relevant files"
+---
+
+Before invoking `{source}`, recall relevant engineering memory:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py before \\
+  --skill {name} \\
+  --task "$ARGUMENTS" \\
+  --paths {paths}
+```
+
+Read `.memanto-skill-memory/injected-context.md` and apply it as prior
+engineering context. Treat memory as guidance, not proof; current repository
+state wins if it contradicts memory.
+
+Then run `{source}` for this purpose: {purpose}.
+
+After the source skill completes, save a short transcript to
+`.memanto-skill-memory/session.md` containing only durable outcomes:
+
+- decisions,
+- preferences and project conventions,
+- must/never constraints,
+- codebase quirks,
+- follow-up tasks.
+
+Store the transcript:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py after \\
+  --skill {name} \\
+  --task "$ARGUMENTS" \\
+  --paths {paths} \\
+  --transcript .memanto-skill-memory/session.md
+```
+"""
+
+
+def write_wrappers(output: Path, skills: dict[str, dict[str, str]]) -> list[Path]:
+    output.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for name, config in skills.items():
+        path = output / f"{name}-memory.md"
+        path.write_text(
+            TEMPLATE.format(
+                name=name,
+                source=config["source"],
+                purpose=config["purpose"],
+                paths=config["paths"],
+            ),
+            encoding="utf-8",
+        )
+        written.append(path)
+    return written
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=".claude/commands",
+        help="Directory to write generated command wrappers.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    written = write_wrappers(Path(args.output), DEFAULT_SKILLS)
+    for path in written:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/sample-output/injected-context.md
+++ b/examples/claudecode-skills-memanto/sample-output/injected-context.md
@@ -1,0 +1,8 @@
+<memanto-memory-context>
+mode: preview
+Use these remembered constraints only when they are relevant to the current task.
+
+- [decision] Keep retries in the transport adapter instead of feature modules. (from grill-with-docs; task='Review API client retry strategy' paths=src/api/client.ts)
+- [preference] Error messages should name the upstream service and retry count. (from grill-with-docs; task='Review API client retry strategy' paths=src/api/client.ts)
+- [instruction] Do not retry non-idempotent POST requests unless the caller opts in. (from grill-with-docs; task='Review API client retry strategy' paths=src/api/client.ts)
+</memanto-memory-context>

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -252,6 +252,57 @@ def command_after(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_wrap(args: argparse.Namespace) -> int:
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        print("wrap requires a command after --", file=sys.stderr)
+        return 2
+
+    before_args = argparse.Namespace(
+        skill=args.skill,
+        task=args.task,
+        paths=args.paths,
+        agent=args.agent,
+    )
+    command_before(before_args)
+
+    transcript_path = Path(args.transcript)
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        args.command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    transcript = [
+        f"# Skill transcript: {args.skill}",
+        "",
+        f"Task: {args.task}",
+        f"Command: {' '.join(args.command)}",
+        "",
+        "## stdout",
+        result.stdout.strip(),
+        "",
+        "## stderr",
+        result.stderr.strip(),
+        "",
+    ]
+    transcript_path.write_text("\n".join(transcript), encoding="utf-8")
+
+    after_args = argparse.Namespace(
+        skill=args.skill,
+        task=args.task,
+        paths=args.paths,
+        transcript=str(transcript_path),
+        agent=args.agent,
+    )
+    command_after(after_args)
+    return result.returncode
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -270,6 +321,15 @@ def build_parser() -> argparse.ArgumentParser:
     after.add_argument("--transcript", required=True)
     after.add_argument("--agent", default=DEFAULT_AGENT)
     after.set_defaults(func=command_after)
+
+    wrap = subparsers.add_parser("wrap", help="run a skill command with memory hooks")
+    wrap.add_argument("--skill", required=True)
+    wrap.add_argument("--task", required=True)
+    wrap.add_argument("--paths", nargs="*", default=[])
+    wrap.add_argument("--transcript", default=str(STATE_DIR / "session.md"))
+    wrap.add_argument("--agent", default=DEFAULT_AGENT)
+    wrap.add_argument("command", nargs=argparse.REMAINDER)
+    wrap.set_defaults(func=command_wrap)
 
     return parser
 

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Bridge Claude Code skill runs through Memanto memory.
+
+The script intentionally keeps a credential-free preview path so reviewers can
+exercise the lifecycle without a Moorcheh key. Live mode shells out to the
+Memanto CLI only when MEMANTO_LIVE=1 is set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+STATE_DIR = Path(".memanto-skill-memory")
+MEMORY_FILE = STATE_DIR / "memories.jsonl"
+INJECTION_FILE = STATE_DIR / "injected-context.md"
+DEFAULT_AGENT = "claude-code-skills"
+
+
+@dataclass
+class Memory:
+    content: str
+    memory_type: str
+    skill: str
+    task: str
+    paths: list[str]
+    source: str
+    created_at: str
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def normalize_words(text: str) -> set[str]:
+    return {
+        word
+        for word in re.findall(r"[a-zA-Z0-9_./-]{3,}", text.lower())
+        if word not in {"the", "and", "for", "with", "that", "this"}
+    }
+
+
+def classify_memory(line: str) -> str:
+    lowered = line.lower()
+    if any(marker in lowered for marker in ("decision:", "decided", "choose ")):
+        return "decision"
+    if any(marker in lowered for marker in ("prefer", "style", "convention")):
+        return "preference"
+    if any(marker in lowered for marker in ("must", "never", "always", "required")):
+        return "instruction"
+    return "context"
+
+
+def extract_memories(
+    transcript: str,
+    *,
+    skill: str,
+    task: str,
+    paths: list[str],
+    source: str,
+) -> list[Memory]:
+    memories: list[Memory] = []
+    seen: set[str] = set()
+    durable_markers = re.compile(
+        r"\b(decision|decided|prefer|preference|must|never|always|required|constraint|"
+        r"tradeoff|quirk|follow-up|todo|style|convention)\b",
+        re.IGNORECASE,
+    )
+
+    for raw_line in transcript.splitlines():
+        line = raw_line.strip(" -\t")
+        if len(line) < 24 or not durable_markers.search(line):
+            continue
+        memory_type = classify_memory(line)
+        line = re.sub(r"^(decision|preference|must|instruction|context):\s*", "", line, flags=re.IGNORECASE)
+        line = re.sub(r"\s+", " ", line)
+        dedupe_key = line.lower()
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        memories.append(
+            Memory(
+                content=line[:500],
+                memory_type=memory_type,
+                skill=skill,
+                task=task,
+                paths=paths,
+                source=source,
+                created_at=utc_now(),
+            )
+        )
+
+    return memories[:12]
+
+
+def append_preview_memories(memories: Iterable[Memory]) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with MEMORY_FILE.open("a", encoding="utf-8") as fh:
+        for memory in memories:
+            fh.write(json.dumps(asdict(memory), ensure_ascii=False) + "\n")
+
+
+def load_preview_memories() -> list[Memory]:
+    if not MEMORY_FILE.exists():
+        return []
+    loaded: list[Memory] = []
+    for line in MEMORY_FILE.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            loaded.append(Memory(**json.loads(line)))
+        except (TypeError, json.JSONDecodeError):
+            continue
+    return loaded
+
+
+def live_enabled() -> bool:
+    return os.environ.get("MEMANTO_LIVE") == "1"
+
+
+def memanto_available() -> bool:
+    return shutil.which("memanto") is not None and bool(os.environ.get("MOORCHEH_API_KEY"))
+
+
+def run_memanto(args: list[str]) -> str:
+    result = subprocess.run(
+        ["memanto", *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return result.stdout.strip()
+
+
+def store_live_memories(memories: Iterable[Memory], agent: str) -> None:
+    run_memanto(["agent", "create", agent])
+    for memory in memories:
+        metadata = {
+            "skill": memory.skill,
+            "task": memory.task,
+            "paths": memory.paths,
+            "source": memory.source,
+        }
+        run_memanto(
+            [
+                "remember",
+                memory.content,
+                "--type",
+                memory.memory_type,
+                "--metadata",
+                json.dumps(metadata),
+            ]
+        )
+
+
+def recall_live(task: str, paths: list[str], agent: str) -> str:
+    query = " ".join([task, *paths]).strip()
+    run_memanto(["agent", "create", agent])
+    return run_memanto(["recall", query or task, "--limit", "5"])
+
+
+def recall_preview(task: str, paths: list[str]) -> list[Memory]:
+    query_words = normalize_words(" ".join([task, *paths]))
+    scored: list[tuple[int, Memory]] = []
+    for memory in load_preview_memories():
+        haystack = " ".join(
+            [memory.content, memory.skill, memory.task, " ".join(memory.paths)]
+        )
+        score = len(query_words & normalize_words(haystack))
+        if score:
+            scored.append((score, memory))
+    scored.sort(key=lambda item: (item[0], item[1].created_at), reverse=True)
+    return [memory for _, memory in scored[:5]]
+
+
+def write_injection(context: str, *, mode: str) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    body = [
+        "<memanto-memory-context>",
+        f"mode: {mode}",
+        "Use these remembered constraints only when they are relevant to the current task.",
+        "",
+        context.strip() or "No relevant prior skill memories found.",
+        "</memanto-memory-context>",
+        "",
+    ]
+    INJECTION_FILE.write_text("\n".join(body), encoding="utf-8")
+    print(f"Wrote {INJECTION_FILE}")
+
+
+def format_preview_context(memories: list[Memory]) -> str:
+    if not memories:
+        return ""
+    lines = []
+    for memory in memories:
+        path_hint = f" paths={','.join(memory.paths)}" if memory.paths else ""
+        lines.append(
+            f"- [{memory.memory_type}] {memory.content} "
+            f"(from {memory.skill}; task={memory.task!r}{path_hint})"
+        )
+    return "\n".join(lines)
+
+
+def command_before(args: argparse.Namespace) -> int:
+    if live_enabled() and memanto_available():
+        context = recall_live(args.task, args.paths, args.agent)
+        write_injection(context, mode="live")
+    else:
+        memories = recall_preview(args.task, args.paths)
+        write_injection(format_preview_context(memories), mode="preview")
+    return 0
+
+
+def command_after(args: argparse.Namespace) -> int:
+    transcript_path = Path(args.transcript)
+    if not transcript_path.exists():
+        print(f"Transcript not found: {transcript_path}", file=sys.stderr)
+        return 2
+
+    transcript = transcript_path.read_text(encoding="utf-8")
+    memories = extract_memories(
+        transcript,
+        skill=args.skill,
+        task=args.task,
+        paths=args.paths,
+        source=str(transcript_path),
+    )
+
+    if not memories:
+        print("No durable memories extracted.")
+        return 0
+
+    if live_enabled() and memanto_available():
+        store_live_memories(memories, args.agent)
+        print(f"Stored {len(memories)} memories in Memanto agent {args.agent!r}.")
+    else:
+        append_preview_memories(memories)
+        print(f"Stored {len(memories)} preview memories in {MEMORY_FILE}.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    before = subparsers.add_parser("before", help="recall context before a skill run")
+    before.add_argument("--skill", required=True)
+    before.add_argument("--task", required=True)
+    before.add_argument("--paths", nargs="*", default=[])
+    before.add_argument("--agent", default=DEFAULT_AGENT)
+    before.set_defaults(func=command_before)
+
+    after = subparsers.add_parser("after", help="store durable context after a skill run")
+    after.add_argument("--skill", required=True)
+    after.add_argument("--task", required=True)
+    after.add_argument("--paths", nargs="*", default=[])
+    after.add_argument("--transcript", required=True)
+    after.add_argument("--agent", default=DEFAULT_AGENT)
+    after.set_defaults(func=command_after)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skills/memanto-memory-bridge/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/memanto-memory-bridge/SKILL.md
@@ -1,0 +1,46 @@
+# Memanto Memory Bridge
+
+Use this skill glue when a Claude Code skill should inherit remembered
+engineering context from previous skill runs.
+
+## Before Running Another Skill
+
+Run:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py before \
+  --skill "$TARGET_SKILL" \
+  --task "$TASK_SUMMARY" \
+  --paths "$PRIMARY_PATH"
+```
+
+Then include `.memanto-skill-memory/injected-context.md` in the next prompt.
+Treat it as constraints, not as proof. If the current code contradicts memory,
+prefer current code and store the correction after the run.
+
+## After The Skill Finishes
+
+Save the useful terminal/session summary to a transcript file, then run:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory.py after \
+  --skill "$TARGET_SKILL" \
+  --task "$TASK_SUMMARY" \
+  --paths "$PRIMARY_PATH" \
+  --transcript .memanto-skill-memory/session.md
+```
+
+The bridge stores durable decisions, preferences, instructions, and codebase
+quirks so later skills do not need the same manual context again.
+
+## Live Memanto Mode
+
+Preview mode is the default. To use Memanto:
+
+```bash
+export MOORCHEH_API_KEY=...
+export MEMANTO_LIVE=1
+```
+
+Live mode uses the installed `memanto` CLI and the `claude-code-skills` agent
+namespace by default.

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Unit tests for the credential-free Memanto skills bridge preview path."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+skill_memory = load_module("skill_memory", ROOT / "skill_memory.py")
+mattpocock_adapter = load_module("mattpocock_adapter", ROOT / "mattpocock_adapter.py")
+
+
+class SkillMemoryPreviewTests(unittest.TestCase):
+    def test_extract_memories_classifies_durable_signals(self) -> None:
+        memories = skill_memory.extract_memories(
+            "\n".join(
+                [
+                    "Decision: Keep retries in the transport adapter.",
+                    "Preference: Error messages name the upstream service.",
+                    "Must: Never retry POST requests unless callers opt in.",
+                    "Short note",
+                ]
+            ),
+            skill="grill-with-docs",
+            task="Review retry policy",
+            paths=["src/api/client.ts"],
+            source="session.md",
+        )
+
+        self.assertEqual(
+            [memory.memory_type for memory in memories],
+            ["decision", "preference", "instruction"],
+        )
+        self.assertTrue(all(memory.skill == "grill-with-docs" for memory in memories))
+        self.assertEqual(memories[0].paths, ["src/api/client.ts"])
+
+    def test_preview_after_before_round_trip_writes_relevant_context(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="memanto-preview-test-") as tmp:
+            workdir = Path(tmp)
+            transcript = workdir / "session.md"
+            transcript.write_text(
+                "\n".join(
+                    [
+                        "Decision: Keep retries in the transport adapter.",
+                        "Preference: Error messages name the upstream service.",
+                        "Must: Do not retry POST requests unless the caller opts in.",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(skill_memory, "STATE_DIR", workdir / ".memanto-skill-memory"), \
+                mock.patch.object(skill_memory, "MEMORY_FILE", workdir / ".memanto-skill-memory" / "memories.jsonl"), \
+                mock.patch.object(skill_memory, "INJECTION_FILE", workdir / ".memanto-skill-memory" / "injected-context.md"):
+                after_code = skill_memory.command_after(
+                    Namespace(
+                        skill="grill-with-docs",
+                        task="Review API client retry strategy",
+                        paths=["src/api/client.ts"],
+                        transcript=str(transcript),
+                        agent="test-agent",
+                    )
+                )
+                before_code = skill_memory.command_before(
+                    Namespace(
+                        task="Implement API client retry handling",
+                        paths=["src/api/client.ts"],
+                        agent="test-agent",
+                    )
+                )
+
+                context = (workdir / ".memanto-skill-memory" / "injected-context.md").read_text(
+                    encoding="utf-8"
+                )
+
+        self.assertEqual(after_code, 0)
+        self.assertEqual(before_code, 0)
+        self.assertIn("mode: preview", context)
+        self.assertIn("[decision]", context)
+        self.assertIn("[preference]", context)
+        self.assertIn("[instruction]", context)
+        self.assertIn("transport adapter", context)
+
+    def test_missing_transcript_returns_usage_error(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="memanto-preview-test-") as tmp:
+            result = skill_memory.command_after(
+                Namespace(
+                    skill="handoff",
+                    task="Summarize constraints",
+                    paths=[],
+                    transcript=str(Path(tmp) / "missing.md"),
+                    agent="test-agent",
+                )
+            )
+
+        self.assertEqual(result, 2)
+
+    def test_mattpocock_adapter_generates_memory_wrappers(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="memanto-adapter-test-") as tmp:
+            output = Path(tmp) / "commands"
+            written = mattpocock_adapter.write_wrappers(
+                output,
+                {
+                    "tdd": {
+                        "source": "/tdd",
+                        "purpose": "test-drive one implementation slice",
+                        "paths": "src tests",
+                    }
+                },
+            )
+
+            wrapper = written[0].read_text(encoding="utf-8")
+
+        self.assertEqual(len(written), 1)
+        self.assertIn("skill_memory.py before", wrapper)
+        self.assertIn("skill_memory.py after", wrapper)
+        self.assertIn("/tdd", wrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Credential-free validation for the Claude Code skills Memanto example."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SCRIPT = ROOT / "skill_memory.py"
+
+
+def run(command: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr or result.stdout)
+    return result.stdout
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="memanto-skills-") as tmp:
+        workdir = Path(tmp)
+        demo = workdir / "session.md"
+        demo.write_text(
+            "\n".join(
+                [
+                    "- Decision: Keep retries in the transport adapter.",
+                    "- Preference: Error messages name the upstream service.",
+                    "- Must: Do not retry POST requests unless the caller opts in.",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "after",
+                "--skill",
+                "grill-with-docs",
+                "--task",
+                "Review API client retry strategy",
+                "--paths",
+                "src/api/client.ts",
+                "--transcript",
+                str(demo),
+            ],
+            workdir,
+        )
+        run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "before",
+                "--skill",
+                "tdd",
+                "--task",
+                "Implement API client retry handling",
+                "--paths",
+                "src/api/client.ts",
+            ],
+            workdir,
+        )
+
+        context = (workdir / ".memanto-skill-memory" / "injected-context.md").read_text(
+            encoding="utf-8"
+        )
+        required = ["[decision]", "[preference]", "[instruction]"]
+        missing = [item for item in required if item not in context]
+        if missing:
+            raise AssertionError(f"Missing expected context markers: {missing}")
+
+        if shutil.which(sys.executable):
+            run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "wrap",
+                    "--skill",
+                    "handoff",
+                    "--task",
+                    "Summarize retry implementation constraints",
+                    "--paths",
+                    "src/api/client.ts",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "print('Decision: Handoff must include retry ownership.')",
+                ],
+                workdir,
+            )
+
+    print("credential-free validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
 SCRIPT = ROOT / "skill_memory.py"
+ADAPTER = ROOT / "mattpocock_adapter.py"
 
 
 def run(command: list[str], cwd: Path) -> str:
@@ -101,6 +102,23 @@ def main() -> int:
                 ],
                 workdir,
             )
+
+        generated = workdir / "commands"
+        run([sys.executable, str(ADAPTER), "--output", str(generated)], workdir)
+        expected = [
+            generated / "grill-with-docs-memory.md",
+            generated / "tdd-memory.md",
+            generated / "handoff-memory.md",
+        ]
+        missing_files = [str(path) for path in expected if not path.exists()]
+        if missing_files:
+            raise AssertionError(f"Missing generated wrappers: {missing_files}")
+
+        wrapper_text = (generated / "grill-with-docs-memory.md").read_text(
+            encoding="utf-8"
+        )
+        if "/grill-with-docs" not in wrapper_text or "skill_memory.py before" not in wrapper_text:
+            raise AssertionError("Generated wrapper is missing source skill hooks")
 
     print("credential-free validation passed")
     return 0


### PR DESCRIPTION
## Summary
- adds `examples/claudecode-skills-memanto` as a focused cross-skill memory bridge for bounty #508
- includes credential-free preview mode, optional live Memanto CLI mode, `before` / `after` / `wrap` lifecycle hooks, Claude Code skill glue, demo transcript, sample injected context, a local validator, and stdlib unit tests
- adds `mattpocock_adapter.py`, which generates concrete Claude command wrappers for `/grill-with-docs`, `/tdd`, and `/handoff` so the example maps directly onto the mattpocock/skills workflow named in the issue
- keeps the implementation isolated from existing package code so reviewers can inspect the lifecycle safely

## Bounty
Closes #508
BountyHub: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe

## Verification
- `python3 -m py_compile examples/claudecode-skills-memanto/skill_memory.py examples/claudecode-skills-memanto/validate.py examples/claudecode-skills-memanto/mattpocock_adapter.py examples/claudecode-skills-memanto/test_skill_memory.py`
- `python3 examples/claudecode-skills-memanto/validate.py`
- `python3 -m unittest examples/claudecode-skills-memanto/test_skill_memory.py` (4 tests)
- preview lifecycle smoke test: `after` extracted decision/preference/instruction memories and `before` wrote `.memanto-skill-memory/injected-context.md`
- adapter smoke test: generated `grill-with-docs-memory.md`, `tdd-memory.md`, and `handoff-memory.md` wrappers
- `git diff --check`

## Notes
No private API key was used. I did not install dependencies or run the project test suite; verification was limited to the new standalone example and local preview mode.

Social showcase: the PR includes `examples/claudecode-skills-memanto/demo/demo-transcript.md` as a public, reviewable technical walkthrough. External social amplification is intentionally omitted for now because the maintainer clarified that it is not mandatory for technical review.

/claim #508