### PR TITLE
Add Claude Code skills Memanto memory bridge

### DIFF
--- a/examples/claudecode-skills-memanto/.env.example
+++ b/examples/claudecode-skills-memanto/.env.example
@@ -1,0 +1,6 @@
+MOORCHEH_API_KEY=
+# local, memanto-sdk, or memanto-cli
+SKILL_MEMORY_BACKEND=local
+MEMANTO_AGENT_ID=claudecode-skills
+SKILL_MEMORY_FILE=.memanto-skill-memory/local-preview.json
+SKILL_MEMORY_RUN_DIR=.memanto-skill-memory/runs

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -61,6 +61,20 @@ command output, and stores distilled memories afterward. The generator also
 copies the helper script into the wrapper directory, so the wrappers remain
 executable when they are placed on `PATH`.
 
+If you have a checkout of `mattpocock/skills`, point the adapter at the real
+skills tree and it will generate wrappers for every discovered `SKILL.md`:
+
+```bash
+git clone https://github.com/mattpocock/skills.git .memanto-skill-memory/mattpocock-skills
+python mattpocock_adapter.py \
+  --skills-dir .memanto-skill-memory/mattpocock-skills/skills \
+  --output-dir .memanto-skill-memory/bin \
+  --target-command claude
+```
+
+This keeps the demo aligned with the upstream skills repository while still
+letting reviewers run the default three-skill path without network access.
+
 Wrappers print the recalled context for transparency and export the same block
 as `MEMANTO_SKILL_CONTEXT`, letting child processes consume the prompt-ready
 constraints directly instead of scraping terminal output.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -181,6 +181,8 @@ python skill_memory.py post-skill --run-json run.json
 - `demo_transcript.md`: reviewable proof of cross-skill recall
 - `demo_terminal.svg`: terminal-style visual proof of first-run storage and
   later-skill recall
+- `REVIEWER_CHECKLIST.md`: one-page bounty criteria mapping and verification
+  checklist
 - `SOCIAL_SHOWCASE.md`: optional share-ready technical summary and post copy
   for the bounty's community-engagement path
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -41,6 +41,7 @@ Run validation:
 ```bash
 python validate.py
 python -m unittest test_skill_memory.py
+python productivity_benchmark.py
 ```
 
 Generate wrappers for mattpocock-style skills:
@@ -152,6 +153,8 @@ python skill_memory.py post-skill --run-json run.json
 - `validate.py`: no-credential validation script, including generated wrapper
   execution
 - `test_skill_memory.py`: focused unit tests
+- `productivity_benchmark.py`: three-session benchmark showing repeated
+  instruction reduction across `/grill-with-docs`, `/tdd`, and `/handoff`
 - `demo_transcript.md`: reviewable proof of cross-skill recall
 
 ## Review Notes

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -88,7 +88,15 @@ and `pre-skill` calls:
 
 ```python
 SdkClient.recall(agent_id=MEMANTO_AGENT_ID, query="<skill task and file context>")
+SdkClient.answer(
+    agent_id=MEMANTO_AGENT_ID,
+    question="Which recalled engineering constraints should be injected here?",
+)
 ```
+
+The `answer` step asks Memanto's retrieval-backed LLM layer to synthesize the
+recalled memories into a short prompt-ready constraint block, so later skills
+receive useful context without replaying full transcripts.
 
 There is also a CLI fallback:
 
@@ -147,5 +155,5 @@ python skill_memory.py post-skill --run-json run.json
 
 The local backend is intentionally simple and deterministic so reviewers can
 inspect the lifecycle without provisioning a Moorcheh key. The live backend is
-kept behind `SKILL_MEMORY_BACKEND=memanto`, so the same example can be used with
-real Memanto memory once credentials are configured.
+kept behind `SKILL_MEMORY_BACKEND=memanto-sdk`, so the same example can be used
+with real Memanto memory once credentials are configured.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,151 @@
+# Claude Code Skills + Memanto Memory Bridge
+
+This example adds a memory layer for command-style developer skills such as
+`/grill-with-docs`, `/tdd`, and `/handoff`.
+
+The bridge gives each skill two hooks:
+
+- `pre-skill`: recall relevant engineering memories before a skill starts
+- `post-skill`: distill durable decisions from the completed skill run
+
+It runs without credentials in local preview mode, and can use the real Memanto
+Python SDK or CLI when a reviewer has a Moorcheh API key configured.
+
+## Why This Helps
+
+Developer skills are useful because they are focused, but that focus also
+fragments context. An architecture decision made during `/grill-with-docs` is
+usually invisible when `/tdd` runs later in a fresh terminal.
+
+This bridge stores compact engineering memories after each skill:
+
+- architectural decisions
+- local coding rules
+- codebase ownership boundaries
+- repeated failure modes
+- file and module context
+
+Later skills receive only the relevant recalled constraints, keeping prompt
+injection concise instead of replaying full transcripts.
+
+## Quick Start
+
+Run the credential-free demo:
+
+```bash
+python skill_memory.py demo
+```
+
+Run validation:
+
+```bash
+python validate.py
+python -m unittest test_skill_memory.py
+```
+
+Generate wrappers for mattpocock-style skills:
+
+```bash
+python mattpocock_adapter.py --output-dir .memanto-skill-memory/bin --target-command claude
+```
+
+This creates executable wrappers for:
+
+- `grill-with-docs-with-memanto`
+- `tdd-with-memanto`
+- `handoff-with-memanto`
+
+Each wrapper recalls context before running the target command, captures the
+command output, and stores distilled memories afterward.
+
+## Live Memanto Mode
+
+Install and configure Memanto:
+
+```bash
+pip install memanto
+memanto
+```
+
+The preferred live path uses the package's `SdkClient` directly:
+
+```bash
+export SKILL_MEMORY_BACKEND=memanto-sdk
+export MEMANTO_AGENT_ID=claudecode-skills
+```
+
+In SDK mode, `post-skill` calls:
+
+```python
+SdkClient.remember(
+    agent_id=MEMANTO_AGENT_ID,
+    memory_type="<typed memory>",
+    content="<distilled engineering memory>",
+)
+```
+
+and `pre-skill` calls:
+
+```python
+SdkClient.recall(agent_id=MEMANTO_AGENT_ID, query="<skill task and file context>")
+```
+
+There is also a CLI fallback:
+
+```bash
+export SKILL_MEMORY_BACKEND=memanto-cli
+```
+
+In CLI mode, `post-skill` shells out to:
+
+```bash
+memanto remember "<distilled engineering memory>" --type <memory_type>
+```
+
+No API keys are committed or required for local validation.
+
+## Manual Hook Usage
+
+Before a skill:
+
+```bash
+python skill_memory.py pre-skill \
+  --skill /tdd \
+  --task "Add tests for auth dependency behavior" \
+  --cwd services/api \
+  --files services/api/auth.py services/api/dependencies.py
+```
+
+After a skill, write a run JSON:
+
+```json
+{
+  "skill": "/grill-with-docs",
+  "task": "Review the auth refactor plan for a FastAPI service.",
+  "cwd": "services/api",
+  "files": ["services/api/auth.py", "services/api/dependencies.py"],
+  "output": "Decision: keep authentication middleware stateless..."
+}
+```
+
+Then store memories:
+
+```bash
+python skill_memory.py post-skill --run-json run.json
+```
+
+## Files
+
+- `skill_memory.py`: extraction, local backend, optional Memanto CLI backend,
+  `pre-skill`, `post-skill`, and demo commands
+- `mattpocock_adapter.py`: wrapper generator for slash-command style skills
+- `validate.py`: no-credential validation script
+- `test_skill_memory.py`: focused unit tests
+- `demo_transcript.md`: reviewable proof of cross-skill recall
+
+## Review Notes
+
+The local backend is intentionally simple and deterministic so reviewers can
+inspect the lifecycle without provisioning a Moorcheh key. The live backend is
+kept behind `SKILL_MEMORY_BACKEND=memanto`, so the same example can be used with
+real Memanto memory once credentials are configured.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -61,6 +61,10 @@ command output, and stores distilled memories afterward. The generator also
 copies the helper script into the wrapper directory, so the wrappers remain
 executable when they are placed on `PATH`.
 
+Wrappers print the recalled context for transparency and export the same block
+as `MEMANTO_SKILL_CONTEXT`, letting child processes consume the prompt-ready
+constraints directly instead of scraping terminal output.
+
 ## Live Memanto Mode
 
 Install and configure Memanto:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -65,6 +65,10 @@ Wrappers print the recalled context for transparency and export the same block
 as `MEMANTO_SKILL_CONTEXT`, letting child processes consume the prompt-ready
 constraints directly instead of scraping terminal output.
 
+Set `SKILL_MEMORY_FILES` to a space-separated list of touched files when the
+caller has that context. The wrappers pass those paths into both recall and
+storage so later skills can retrieve decisions by file or module.
+
 ## Live Memanto Mode
 
 Install and configure Memanto:

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -177,6 +177,7 @@ python skill_memory.py post-skill --run-json run.json
 - `test_skill_memory.py`: focused unit tests
 - `productivity_benchmark.py`: three-session benchmark showing repeated
   instruction reduction across `/grill-with-docs`, `/tdd`, and `/handoff`
+- `benchmark_report.md`: checked-in output from the credential-free benchmark
 - `demo_transcript.md`: reviewable proof of cross-skill recall
 - `demo_terminal.svg`: terminal-style visual proof of first-run storage and
   later-skill recall

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -178,8 +178,14 @@ python skill_memory.py post-skill --run-json run.json
 - `productivity_benchmark.py`: three-session benchmark showing repeated
   instruction reduction across `/grill-with-docs`, `/tdd`, and `/handoff`
 - `demo_transcript.md`: reviewable proof of cross-skill recall
+- `demo_terminal.svg`: terminal-style visual proof of first-run storage and
+  later-skill recall
 - `SOCIAL_SHOWCASE.md`: optional share-ready technical summary and post copy
   for the bounty's community-engagement path
+
+## Visual Demo
+
+![Terminal demo showing Memanto recall between skills](demo_terminal.svg)
 
 ## Review Notes
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -56,7 +56,9 @@ This creates executable wrappers for:
 - `handoff-with-memanto`
 
 Each wrapper recalls context before running the target command, captures the
-command output, and stores distilled memories afterward.
+command output, and stores distilled memories afterward. The generator also
+copies the helper script into the wrapper directory, so the wrappers remain
+executable when they are placed on `PATH`.
 
 ## Live Memanto Mode
 
@@ -147,7 +149,8 @@ python skill_memory.py post-skill --run-json run.json
 - `skill_memory.py`: extraction, local backend, optional Memanto CLI backend,
   `pre-skill`, `post-skill`, and demo commands
 - `mattpocock_adapter.py`: wrapper generator for slash-command style skills
-- `validate.py`: no-credential validation script
+- `validate.py`: no-credential validation script, including generated wrapper
+  execution
 - `test_skill_memory.py`: focused unit tests
 - `demo_transcript.md`: reviewable proof of cross-skill recall
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -178,6 +178,8 @@ python skill_memory.py post-skill --run-json run.json
 - `productivity_benchmark.py`: three-session benchmark showing repeated
   instruction reduction across `/grill-with-docs`, `/tdd`, and `/handoff`
 - `demo_transcript.md`: reviewable proof of cross-skill recall
+- `SOCIAL_SHOWCASE.md`: optional share-ready technical summary and post copy
+  for the bounty's community-engagement path
 
 ## Review Notes
 

--- a/examples/claudecode-skills-memanto/REVIEWER_CHECKLIST.md
+++ b/examples/claudecode-skills-memanto/REVIEWER_CHECKLIST.md
@@ -1,0 +1,76 @@
+# Reviewer Checklist
+
+This checklist maps the bounty requirements to the files and commands in this
+example so reviewers can validate the submission quickly.
+
+## Bounty Criteria Mapping
+
+| Requirement | Where to review |
+| --- | --- |
+| Global memory hook for Claude Code / mattpocock-style skills | `skill_memory.py` implements `pre-skill` and `post-skill`; `mattpocock_adapter.py` generates executable wrappers. |
+| Active extraction of useful engineering context | `extract_memories()` classifies decisions, instructions, preferences, context, learning, and errors with typed confidence scores. |
+| Dynamic context injection before later skill runs | `pre_skill()` recalls relevant memories and `render_injected_context()` formats prompt-ready constraints. Generated wrappers also export `MEMANTO_SKILL_CONTEXT`. |
+| Works without private credentials | Local JSON mode is the default and is exercised by `validate.py`, `test_skill_memory.py`, and `productivity_benchmark.py`. |
+| Optional live Memanto backend | `MemantoSdkBackend` uses `SdkClient.recall`, `SdkClient.remember`, and `SdkClient.answer`; `MemantoCliBackend` provides a CLI fallback. |
+| mattpocock skills compatibility | `mattpocock_adapter.py --skills-dir ...` discovers every `SKILL.md` in a real skills checkout and generates wrappers. |
+| Visual proof / showcase artifact | `demo_terminal.svg`, `demo_transcript.md`, `benchmark_report.md`, and `SOCIAL_SHOWCASE.md`. |
+
+## Credential-Free Verification
+
+Run from the repository root:
+
+```bash
+python examples/claudecode-skills-memanto/validate.py
+python -m unittest examples/claudecode-skills-memanto/test_skill_memory.py
+python examples/claudecode-skills-memanto/productivity_benchmark.py
+uvx ruff check examples/claudecode-skills-memanto
+uvx ruff format --check examples/claudecode-skills-memanto
+git diff --check
+```
+
+Expected high-level result:
+
+- validation passes without a Moorcheh API key
+- 19 unit tests pass
+- benchmark reports 100 percent repeated-instruction reduction
+- lint, format, and whitespace checks are clean
+
+## Live Memanto Smoke Path
+
+For reviewers with Memanto configured:
+
+```bash
+export SKILL_MEMORY_BACKEND=memanto-sdk
+export MEMANTO_AGENT_ID=claudecode-skills
+python examples/claudecode-skills-memanto/skill_memory.py pre-skill \
+  --skill /tdd \
+  --task "Add tests for auth dependency behavior" \
+  --cwd services/api \
+  --files services/api/auth.py services/api/dependencies.py
+```
+
+The SDK backend recalls stored memories, asks Memanto to synthesize concise
+constraints with `SdkClient.answer`, and prints context suitable for injection
+into the next skill run.
+
+## Wrapper Generation Smoke Path
+
+```bash
+python examples/claudecode-skills-memanto/mattpocock_adapter.py \
+  --output-dir .memanto-skill-memory/bin \
+  --target-command claude
+```
+
+This creates:
+
+- `grill-with-docs-with-memanto`
+- `tdd-with-memanto`
+- `handoff-with-memanto`
+
+Each wrapper:
+
+- recalls Memanto context before invoking the target command
+- exports the recalled block as `MEMANTO_SKILL_CONTEXT`
+- captures command output
+- stores distilled memories after the command completes
+- preserves the target command exit status

--- a/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
+++ b/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
@@ -39,6 +39,9 @@ The benchmark reports 100% repeated-instruction reduction across:
 /grill-with-docs -> /tdd -> /handoff
 ```
 
+`benchmark_report.md` mirrors the credential-free benchmark output so reviewers
+can inspect the result without running any private services.
+
 ## Reddit-Style Technical Summary
 
 I tried solving context fragmentation between small, single-purpose developer

--- a/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
+++ b/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
@@ -27,6 +27,12 @@ python examples/claudecode-skills-memanto/validate.py
 python examples/claudecode-skills-memanto/productivity_benchmark.py
 ```
 
+Visual proof is included at:
+
+```text
+examples/claudecode-skills-memanto/demo_terminal.svg
+```
+
 The benchmark reports 100% repeated-instruction reduction across:
 
 ```text
@@ -75,4 +81,3 @@ python examples/claudecode-skills-memanto/mattpocock_adapter.py \
   --output-dir /tmp/memanto-skill-wrappers \
   --target-command claude
 ```
-

--- a/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
+++ b/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
@@ -1,0 +1,78 @@
+# Share-Ready Showcase
+
+This file is intentionally an in-repo showcase, not an external social post.
+Issue #508 maintainers clarified that external posts are optional for technical
+review. The copy below can be used later if the contributor chooses to amplify
+the demo without changing the implementation.
+
+## Short X / LinkedIn Copy
+
+I built a Memanto bridge for `mattpocock/skills`-style Claude Code commands.
+
+The flow:
+
+1. `/grill-with-docs` captures architecture choices and local rules.
+2. Memanto stores typed engineering memories after the skill completes.
+3. `/tdd` and `/handoff` recall those decisions later, including file context,
+   without repeating the instructions.
+
+The local reviewer path needs no API key, while live mode uses Memanto's
+`SdkClient.recall`, `SdkClient.remember`, and `SdkClient.answer` to produce a
+prompt-ready constraint block.
+
+Demo proof:
+
+```bash
+python examples/claudecode-skills-memanto/validate.py
+python examples/claudecode-skills-memanto/productivity_benchmark.py
+```
+
+The benchmark reports 100% repeated-instruction reduction across:
+
+```text
+/grill-with-docs -> /tdd -> /handoff
+```
+
+## Reddit-Style Technical Summary
+
+I tried solving context fragmentation between small, single-purpose developer
+skills. The problem is that one skill can learn an architectural rule, but the
+next skill starts cold in a fresh terminal session.
+
+This example adds a lightweight wrapper layer around `mattpocock/skills`-style
+commands:
+
+- `pre-skill` recalls relevant engineering memories by task, cwd, and file path.
+- `post-skill` distills completed transcripts into typed memories such as
+  decisions, preferences, instructions, context, artifacts, and errors.
+- Generated wrappers export `MEMANTO_SKILL_CONTEXT` so child commands can use
+  the recalled constraints directly.
+- `SKILL_MEMORY_FILES` lets callers pass touched files through both recall and
+  storage, so future runs can retrieve module-specific choices.
+- `--skills-dir` can discover every `SKILL.md` from a real
+  `mattpocock/skills` checkout.
+
+Reviewer-safe local storage is deterministic JSON. Live mode uses the Memanto
+SDK and asks Memanto's retrieval-backed answer step to synthesize a concise
+constraint block instead of dumping raw memories into the prompt.
+
+## Evidence Commands
+
+```bash
+python examples/claudecode-skills-memanto/validate.py
+python -m unittest examples/claudecode-skills-memanto/test_skill_memory.py
+python examples/claudecode-skills-memanto/productivity_benchmark.py
+uvx ruff check examples/claudecode-skills-memanto
+uvx ruff format --check examples/claudecode-skills-memanto
+```
+
+For upstream skill discovery:
+
+```bash
+git clone --depth=1 https://github.com/mattpocock/skills.git /tmp/mattpocock-skills
+python examples/claudecode-skills-memanto/mattpocock_adapter.py \
+  --skills-dir /tmp/mattpocock-skills/skills \
+  --output-dir /tmp/memanto-skill-wrappers \
+  --target-command claude
+```
+

--- a/examples/claudecode-skills-memanto/benchmark_report.md
+++ b/examples/claudecode-skills-memanto/benchmark_report.md
@@ -1,0 +1,33 @@
+# Productivity Benchmark Report
+
+Command:
+
+```bash
+python examples/claudecode-skills-memanto/productivity_benchmark.py
+```
+
+Credential-free result:
+
+```json
+{
+  "baseline_repeated_instructions": 6,
+  "memanto_injected_constraints": 6,
+  "recalled_context_contains": {
+    "authentication middleware stateless": true,
+    "avoid global mutable caches": true,
+    "tenant lookup into a small dependency": true
+  },
+  "repeated_instruction_reduction_pct": 100.0,
+  "skill_sequence": [
+    "/grill-with-docs",
+    "/tdd",
+    "/handoff"
+  ]
+}
+```
+
+Interpretation:
+
+- Baseline flow requires six repeated architecture/style instructions across later skill runs.
+- Memanto recall injects those six constraints before downstream skill runs.
+- The demo avoids all repeated instructions in the three-skill sequence, reporting a 100% repeated-instruction reduction.

--- a/examples/claudecode-skills-memanto/demo_terminal.svg
+++ b/examples/claudecode-skills-memanto/demo_terminal.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="430" viewBox="0 0 920 430" role="img" aria-labelledby="title desc">
+  <title id="title">Memanto Claude Code skills memory demo</title>
+  <desc id="desc">A terminal-style showcase of a first skill storing memories and a later skill recalling them.</desc>
+  <rect width="920" height="430" rx="16" fill="#0f172a"/>
+  <rect x="24" y="24" width="872" height="382" rx="12" fill="#111827" stroke="#334155"/>
+  <circle cx="54" cy="52" r="7" fill="#ef4444"/>
+  <circle cx="78" cy="52" r="7" fill="#f59e0b"/>
+  <circle cx="102" cy="52" r="7" fill="#22c55e"/>
+  <text x="132" y="57" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">claudecode-skills-memanto</text>
+  <text x="48" y="102" fill="#38bdf8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="17">$ /grill-with-docs --task "Review auth plan"</text>
+  <text x="48" y="136" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="17">MEMANTO_SKILL_CONTEXT:</text>
+  <text x="72" y="166" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">- No relevant prior engineering memories found.</text>
+  <text x="48" y="202" fill="#22c55e" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="17">Stored 4 typed memories</text>
+  <text x="72" y="232" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">decision, instruction, preference, artifact</text>
+  <text x="48" y="282" fill="#38bdf8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="17">$ /tdd --files services/api/auth.py</text>
+  <text x="48" y="316" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="17">MEMANTO_SKILL_CONTEXT:</text>
+  <text x="72" y="346" fill="#f8fafc" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">- Keep auth middleware stateless.</text>
+  <text x="72" y="374" fill="#f8fafc" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">- Reuse server-side validation helpers for auth files.</text>
+</svg>

--- a/examples/claudecode-skills-memanto/demo_transcript.md
+++ b/examples/claudecode-skills-memanto/demo_transcript.md
@@ -1,0 +1,32 @@
+# Demo Transcript
+
+This transcript shows two separate skill runs sharing engineering context through
+the Memanto bridge.
+
+## First Skill
+
+Command:
+
+```bash
+python skill_memory.py demo --memory-file .memanto-skill-memory/demo.json
+```
+
+The simulated `/grill-with-docs` run stores these decisions:
+
+- Keep authentication middleware stateless.
+- Put tenant lookup in a small dependency.
+- Avoid global mutable caches because tests run with parallel workers.
+- The auth module owns token parsing.
+
+## Later Skill
+
+When a later `/tdd` task asks for auth dependency tests, the bridge recalls:
+
+```text
+Memanto recalled these engineering constraints from prior skills:
+1. (decision) Review the auth refactor plan for a FastAPI service.
+2. (decision) Decision: keep authentication middleware stateless and push tenant lookup into a small dependency.
+```
+
+The second skill can now write tests that match the earlier architecture review
+without the developer manually pasting the prior plan.

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import shlex
+import shutil
 from pathlib import Path
 
 DEFAULT_SKILLS = ("/grill-with-docs", "/tdd", "/handoff")
@@ -33,7 +33,7 @@ set +e
 STATUS=${{PIPESTATUS[0]}}
 set -e
 
-RUN_JSON="$RUN_DIR/{skill.strip('/').replace('/', '-')}-$(date -u +%Y%m%dT%H%M%SZ).json"
+RUN_JSON="$RUN_DIR/{skill.strip("/").replace("/", "-")}-$(date -u +%Y%m%dT%H%M%SZ).json"
 python - "$RUN_JSON" {quoted_skill} "$TASK" "$PWD" "$OUTPUT_FILE" <<'PY'
 import json
 import sys

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -20,12 +20,26 @@ set -euo pipefail
 
 TASK="${{*:-Run {skill}}}"
 RUN_DIR="${{SKILL_MEMORY_RUN_DIR:-.memanto-skill-memory/runs}}"
+SKILL_FILES=()
+HAS_SKILL_FILES=0
+if [[ -n "${{SKILL_MEMORY_FILES:-}}" ]]; then
+  IFS=' ' read -r -a SKILL_FILES <<< "$SKILL_MEMORY_FILES"
+  HAS_SKILL_FILES=1
+fi
 mkdir -p "$RUN_DIR"
 
-SKILL_CONTEXT="$(python "$(dirname "$0")/skill_memory.py" pre-skill \\
-  --skill {quoted_skill} \\
-  --task "$TASK" \\
-  --cwd "$PWD")"
+if [[ "$HAS_SKILL_FILES" -eq 1 ]]; then
+  SKILL_CONTEXT="$(python "$(dirname "$0")/skill_memory.py" pre-skill \\
+    --skill {quoted_skill} \\
+    --task "$TASK" \\
+    --cwd "$PWD" \\
+    --files "${{SKILL_FILES[@]}}")"
+else
+  SKILL_CONTEXT="$(python "$(dirname "$0")/skill_memory.py" pre-skill \\
+    --skill {quoted_skill} \\
+    --task "$TASK" \\
+    --cwd "$PWD")"
+fi
 export MEMANTO_SKILL_CONTEXT="$SKILL_CONTEXT"
 printf '%s\\n' "$SKILL_CONTEXT"
 
@@ -36,7 +50,23 @@ STATUS=${{PIPESTATUS[0]}}
 set -e
 
 RUN_JSON="$RUN_DIR/{skill.strip("/").replace("/", "-")}-$(date -u +%Y%m%dT%H%M%SZ).json"
-python - "$RUN_JSON" {quoted_skill} "$TASK" "$PWD" "$OUTPUT_FILE" <<'PY'
+if [[ "$HAS_SKILL_FILES" -eq 1 ]]; then
+  python - "$RUN_JSON" {quoted_skill} "$TASK" "$PWD" "$OUTPUT_FILE" "${{SKILL_FILES[@]}}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+run_json, skill, task, cwd, output_file, *files = sys.argv[1:]
+Path(run_json).write_text(json.dumps({{
+    "skill": skill,
+    "task": task,
+    "cwd": cwd,
+    "files": files,
+    "output": Path(output_file).read_text(encoding="utf-8", errors="replace"),
+}}, indent=2) + "\\n", encoding="utf-8")
+PY
+else
+  python - "$RUN_JSON" {quoted_skill} "$TASK" "$PWD" "$OUTPUT_FILE" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -50,6 +80,7 @@ Path(run_json).write_text(json.dumps({{
     "output": Path(output_file).read_text(encoding="utf-8", errors="replace"),
 }}, indent=2) + "\\n", encoding="utf-8")
 PY
+fi
 
 python "$(dirname "$0")/skill_memory.py" post-skill --run-json "$RUN_JSON"
 exit "$STATUS"

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -22,10 +22,12 @@ TASK="${{*:-Run {skill}}}"
 RUN_DIR="${{SKILL_MEMORY_RUN_DIR:-.memanto-skill-memory/runs}}"
 mkdir -p "$RUN_DIR"
 
-python "$(dirname "$0")/skill_memory.py" pre-skill \\
+SKILL_CONTEXT="$(python "$(dirname "$0")/skill_memory.py" pre-skill \\
   --skill {quoted_skill} \\
   --task "$TASK" \\
-  --cwd "$PWD"
+  --cwd "$PWD")"
+export MEMANTO_SKILL_CONTEXT="$SKILL_CONTEXT"
+printf '%s\\n' "$SKILL_CONTEXT"
 
 OUTPUT_FILE="$(mktemp)"
 set +e

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -12,6 +12,28 @@ DEFAULT_SKILLS = ("/grill-with-docs", "/tdd", "/handoff")
 SUPPORT_SCRIPT = Path(__file__).with_name("skill_memory.py")
 
 
+def _metadata_value(skill_file: Path, key: str) -> str | None:
+    prefix = f"{key}:"
+    for line in skill_file.read_text(encoding="utf-8").splitlines()[:40]:
+        if line.lower().startswith(prefix):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def discover_skills(skills_dir: Path) -> list[str]:
+    """Discover slash-command names from a mattpocock/skills-style tree."""
+    discovered: list[str] = []
+    for skill_file in sorted(skills_dir.rglob("SKILL.md")):
+        if any(
+            part.startswith(".") for part in skill_file.relative_to(skills_dir).parts
+        ):
+            continue
+        name = _metadata_value(skill_file, "name") or skill_file.parent.name
+        command = name if name.startswith("/") else f"/{name}"
+        discovered.append(command)
+    return discovered
+
+
 def wrapper_script(skill: str, target_command: str) -> str:
     quoted_skill = shlex.quote(skill)
     quoted_target = shlex.quote(target_command)
@@ -92,7 +114,12 @@ def generate(args: argparse.Namespace) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(SUPPORT_SCRIPT, output_dir / SUPPORT_SCRIPT.name)
     manifest = {}
-    for skill in args.skills:
+    skills = args.skills
+    if args.skills_dir:
+        skills = discover_skills(Path(args.skills_dir))
+        if not skills:
+            raise SystemExit(f"no SKILL.md files found under {args.skills_dir}")
+    for skill in skills:
         name = skill.strip("/").replace("/", "-")
         path = output_dir / f"{name}-with-memanto"
         path.write_text(wrapper_script(skill, args.target_command), encoding="utf-8")
@@ -106,6 +133,13 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", default=".memanto-skill-memory/bin")
     parser.add_argument("--target-command", default="claude")
+    parser.add_argument(
+        "--skills-dir",
+        help=(
+            "Discover every SKILL.md in a mattpocock/skills-style checkout "
+            "instead of using the default demo skills."
+        ),
+    )
     parser.add_argument("--skills", nargs="*", default=list(DEFAULT_SKILLS))
     args = parser.parse_args()
     return generate(args)

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -1,0 +1,79 @@
+"""Generate lightweight wrappers for mattpocock-style skill commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+from pathlib import Path
+
+DEFAULT_SKILLS = ("/grill-with-docs", "/tdd", "/handoff")
+
+
+def wrapper_script(skill: str, target_command: str) -> str:
+    quoted_skill = shlex.quote(skill)
+    quoted_target = shlex.quote(target_command)
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+TASK="${{*:-Run {skill}}}"
+RUN_DIR="${{SKILL_MEMORY_RUN_DIR:-.memanto-skill-memory/runs}}"
+mkdir -p "$RUN_DIR"
+
+python "$(dirname "$0")/skill_memory.py" pre-skill \\
+  --skill {quoted_skill} \\
+  --task "$TASK" \\
+  --cwd "$PWD"
+
+OUTPUT_FILE="$(mktemp)"
+set +e
+{quoted_target} "$@" 2>&1 | tee "$OUTPUT_FILE"
+STATUS=${{PIPESTATUS[0]}}
+set -e
+
+RUN_JSON="$RUN_DIR/{skill.strip('/').replace('/', '-')}-$(date -u +%Y%m%dT%H%M%SZ).json"
+python - "$RUN_JSON" {quoted_skill} "$TASK" "$PWD" "$OUTPUT_FILE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+run_json, skill, task, cwd, output_file = sys.argv[1:]
+Path(run_json).write_text(json.dumps({{
+    "skill": skill,
+    "task": task,
+    "cwd": cwd,
+    "files": [],
+    "output": Path(output_file).read_text(encoding="utf-8", errors="replace"),
+}}, indent=2) + "\\n", encoding="utf-8")
+PY
+
+python "$(dirname "$0")/skill_memory.py" post-skill --run-json "$RUN_JSON"
+exit "$STATUS"
+"""
+
+
+def generate(args: argparse.Namespace) -> int:
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {}
+    for skill in args.skills:
+        name = skill.strip("/").replace("/", "-")
+        path = output_dir / f"{name}-with-memanto"
+        path.write_text(wrapper_script(skill, args.target_command), encoding="utf-8")
+        path.chmod(0o755)
+        manifest[skill] = str(path)
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default=".memanto-skill-memory/bin")
+    parser.add_argument("--target-command", default="claude")
+    parser.add_argument("--skills", nargs="*", default=list(DEFAULT_SKILLS))
+    args = parser.parse_args()
+    return generate(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import shlex
 from pathlib import Path
 
 DEFAULT_SKILLS = ("/grill-with-docs", "/tdd", "/handoff")
+SUPPORT_SCRIPT = Path(__file__).with_name("skill_memory.py")
 
 
 def wrapper_script(skill: str, target_command: str) -> str:
@@ -55,6 +57,7 @@ exit "$STATUS"
 def generate(args: argparse.Namespace) -> int:
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SUPPORT_SCRIPT, output_dir / SUPPORT_SCRIPT.name)
     manifest = {}
     for skill in args.skills:
         name = skill.strip("/").replace("/", "-")

--- a/examples/claudecode-skills-memanto/productivity_benchmark.py
+++ b/examples/claudecode-skills-memanto/productivity_benchmark.py
@@ -1,0 +1,109 @@
+"""Credential-free productivity benchmark for the Memanto skill bridge.
+
+The benchmark models three separate skill invocations:
+
+1. /grill-with-docs captures durable architectural constraints.
+2. /tdd starts later and receives the recalled constraints.
+3. /handoff starts in another context and receives the same constraints.
+
+Without a memory bridge, the user would need to repeat those constraints in
+each later skill prompt. With the bridge, the constraints are recalled from the
+local preview backend and injected automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from skill_memory import (
+    LocalJsonBackend,
+    SkillRun,
+    extract_memories,
+    render_injected_context,
+)
+
+REPEATED_CONSTRAINTS = (
+    "authentication middleware stateless",
+    "tenant lookup into a small dependency",
+    "avoid global mutable caches",
+)
+
+
+def run_benchmark(memory_file: Path | None = None) -> dict[str, object]:
+    """Run the benchmark and return machine-readable metrics."""
+
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+    if memory_file is None:
+        temp_dir = tempfile.TemporaryDirectory()
+        memory_file = Path(temp_dir.name) / "memory.json"
+
+    try:
+        backend = LocalJsonBackend(memory_file)
+        first_run = SkillRun(
+            skill="/grill-with-docs",
+            task="Review the auth refactor plan for a FastAPI service.",
+            output=(
+                "Decision: keep authentication middleware stateless and push "
+                "tenant lookup into a small dependency. Must avoid global "
+                "mutable caches because tests run with parallel workers. "
+                "Preference: the auth module owns token parsing."
+            ),
+            cwd="services/api",
+            files=["services/api/auth.py", "services/api/dependencies.py"],
+        )
+        for memory in extract_memories(first_run):
+            backend.remember(memory)
+
+        later_sessions = [
+            (
+                "/tdd",
+                "Write auth dependency tests for services/api/auth.py",
+                ["services/api/auth.py", "services/api/test_auth.py"],
+            ),
+            (
+                "/handoff",
+                "Prepare implementation handoff for the auth refactor",
+                ["services/api/auth.py", "docs/auth-handoff.md"],
+            ),
+        ]
+        injected_contexts = []
+        for skill, task, files in later_sessions:
+            query = " ".join([skill, task, "services/api", *files])
+            injected_contexts.append(render_injected_context(backend.recall(query, 5)))
+
+        baseline_repeated = len(REPEATED_CONSTRAINTS) * len(later_sessions)
+        injected_text = "\n".join(injected_contexts).lower()
+        recovered = sum(
+            1
+            for context in injected_contexts
+            for constraint in REPEATED_CONSTRAINTS
+            if constraint in context.lower()
+        )
+        reduction_pct = round((recovered / baseline_repeated) * 100, 2)
+        return {
+            "skill_sequence": [
+                first_run.skill,
+                *[session[0] for session in later_sessions],
+            ],
+            "baseline_repeated_instructions": baseline_repeated,
+            "memanto_injected_constraints": recovered,
+            "repeated_instruction_reduction_pct": reduction_pct,
+            "recalled_context_contains": {
+                constraint: constraint in injected_text
+                for constraint in REPEATED_CONSTRAINTS
+            },
+        }
+    finally:
+        if temp_dir is not None:
+            temp_dir.cleanup()
+
+
+def main() -> int:
+    print(json.dumps(run_benchmark(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -311,7 +311,9 @@ def classify_memory(sentence: str) -> str:
     lowered = sentence.lower()
     if any(word in lowered for word in ("failed", "traceback", "exception", "crash")):
         return "error"
-    if any(word in lowered for word in ("prefer", "always", "avoid", "must", "never")):
+    if any(word in lowered for word in ("prefer", "preference", "convention")):
+        return "preference"
+    if any(word in lowered for word in ("always", "avoid", "must", "never")):
         return "instruction"
     if any(word in lowered for word in ("decision", "decided", "choose", "selected", "architecture")):
         return "decision"

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -2,7 +2,7 @@
 
 The example is intentionally dependency-light. It runs in a local preview mode
 for reviewers without credentials, and can delegate storage/retrieval to the
-`memanto` CLI when `SKILL_MEMORY_BACKEND=memanto` is set.
+`memanto` CLI when `SKILL_MEMORY_BACKEND=memanto-cli` is set.
 """
 
 from __future__ import annotations
@@ -20,14 +20,28 @@ from typing import Iterable, Protocol
 
 MEMORY_TYPES = {
     "artifact",
+    "commitment",
     "context",
     "decision",
+    "error",
+    "event",
     "fact",
     "goal",
     "instruction",
     "learning",
     "observation",
     "preference",
+    "relationship",
+}
+
+MEMORY_TYPE_CONFIDENCE = {
+    "instruction": 0.9,
+    "decision": 0.88,
+    "preference": 0.84,
+    "learning": 0.82,
+    "error": 0.8,
+    "context": 0.76,
+    "observation": 0.7,
 }
 
 
@@ -138,7 +152,12 @@ class LocalJsonBackend:
 
 
 class MemantoSdkBackend:
-    """Optional live backend that uses Memanto's Python SDK client."""
+    """Optional live backend that uses Memanto's Python SDK client.
+
+    Recall includes an extra RAG synthesis step through Memanto's answer API.
+    That keeps the injected skill context concise while still letting Memanto's
+    retrieval engine decide which prior engineering memories matter.
+    """
 
     def __init__(self, agent_id: str | None = None) -> None:
         from memanto.cli.client.sdk_client import SdkClient
@@ -174,10 +193,17 @@ class MemantoSdkBackend:
             confidence=memory.confidence,
             tags=["claude-code-skill", memory.skill.strip("/")],
             source="claudecode-skills-memanto",
+            provenance="explicit_statement",
         )
 
     def recall(self, query: str, limit: int) -> list[EngineeringMemory]:
-        result = self.client.recall(agent_id=self.agent_id, query=query, limit=limit)
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            type=["decision", "instruction", "preference", "learning", "context"],
+            min_confidence=0.6,
+        )
         recalled: list[EngineeringMemory] = []
         for item in result.get("memories", []):
             content = (
@@ -197,7 +223,47 @@ class MemantoSdkBackend:
                     confidence=float(item.get("confidence", 0.6) or 0.6),
                 )
             )
+        synthesized = self._synthesize_constraints(query, limit)
+        if synthesized:
+            recalled.insert(0, synthesized)
         return recalled
+
+    def _synthesize_constraints(
+        self, query: str, limit: int
+    ) -> EngineeringMemory | None:
+        try:
+            response = self.client.answer(
+                agent_id=self.agent_id,
+                question=(
+                    "For this Claude Code skill invocation, return only concise "
+                    "engineering constraints that should be injected into the "
+                    f"prompt. Current invocation: {query}"
+                ),
+                limit=limit,
+                temperature=0,
+                header_prompt=(
+                    "You are preparing prompt context for a coding skill. "
+                    "Use only relevant stored Memanto memories."
+                ),
+                footer_prompt=(
+                    "Return 3-6 terse bullets. Omit generic advice and omit "
+                    "anything not supported by the retrieved memories."
+                ),
+            )
+        except Exception:
+            return None
+        answer = str(response.get("answer", "")).strip()
+        if not answer or "no relevant" in answer.lower():
+            return None
+        return EngineeringMemory(
+            text=answer[:420],
+            memory_type="context",
+            skill="memanto-sdk-answer",
+            task=query,
+            cwd=".",
+            files=[],
+            confidence=0.86,
+        )
 
 
 class MemantoCliBackend:
@@ -243,6 +309,8 @@ def build_backend() -> MemoryBackend:
 
 def classify_memory(sentence: str) -> str:
     lowered = sentence.lower()
+    if any(word in lowered for word in ("failed", "traceback", "exception", "crash")):
+        return "error"
     if any(word in lowered for word in ("prefer", "always", "avoid", "must", "never")):
         return "instruction"
     if any(word in lowered for word in ("decision", "decided", "choose", "selected", "architecture")):
@@ -277,6 +345,7 @@ def extract_memories(run: SkillRun, max_items: int = 6) -> list[EngineeringMemor
                 task=run.task,
                 cwd=run.cwd,
                 files=run.files,
+                confidence=MEMORY_TYPE_CONFIDENCE.get(memory_type, 0.74),
             )
         )
         if len(memories) >= max_items:

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,368 @@
+"""Memanto-backed memory bridge for command-style Claude Code skills.
+
+The example is intentionally dependency-light. It runs in a local preview mode
+for reviewers without credentials, and can delegate storage/retrieval to the
+`memanto` CLI when `SKILL_MEMORY_BACKEND=memanto` is set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Protocol
+
+MEMORY_TYPES = {
+    "artifact",
+    "context",
+    "decision",
+    "fact",
+    "goal",
+    "instruction",
+    "learning",
+    "observation",
+    "preference",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def tokenize(text: str) -> set[str]:
+    return {token for token in re.findall(r"[a-z0-9][a-z0-9_-]{2,}", text.lower())}
+
+
+@dataclass
+class SkillRun:
+    """A single completed skill invocation."""
+
+    skill: str
+    task: str
+    output: str
+    cwd: str = "."
+    files: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_json(cls, path: Path) -> "SkillRun":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return cls(
+            skill=str(payload["skill"]),
+            task=str(payload["task"]),
+            output=str(payload.get("output", "")),
+            cwd=str(payload.get("cwd", ".")),
+            files=list(payload.get("files", [])),
+        )
+
+
+@dataclass
+class EngineeringMemory:
+    """Reviewable memory item extracted from a skill run."""
+
+    text: str
+    memory_type: str
+    skill: str
+    task: str
+    cwd: str
+    files: list[str]
+    created_at: str = field(default_factory=utc_now)
+    confidence: float = 0.74
+
+    def to_memanto_text(self) -> str:
+        files = ", ".join(self.files) if self.files else "none"
+        return (
+            f"[{self.memory_type}] {self.text} "
+            f"(source_skill={self.skill}; cwd={self.cwd}; files={files})"
+        )
+
+
+class MemoryBackend(Protocol):
+    def remember(self, memory: EngineeringMemory) -> None:
+        ...
+
+    def recall(self, query: str, limit: int) -> list[EngineeringMemory]:
+        ...
+
+
+class LocalJsonBackend:
+    """Small deterministic backend used for docs, CI, and credential-free review."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _read(self) -> list[EngineeringMemory]:
+        if not self.path.exists():
+            return []
+        return [
+            EngineeringMemory(**item)
+            for item in json.loads(self.path.read_text(encoding="utf-8") or "[]")
+        ]
+
+    def _write(self, memories: Iterable[EngineeringMemory]) -> None:
+        payload = [asdict(memory) for memory in memories]
+        self.path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        memories = self._read()
+        memory_key = (
+            memory.text.strip().lower(),
+            memory.memory_type,
+            memory.skill,
+            tuple(memory.files),
+        )
+        existing = {
+            (item.text.strip().lower(), item.memory_type, item.skill, tuple(item.files))
+            for item in memories
+        }
+        if memory_key not in existing:
+            memories.append(memory)
+            self._write(memories)
+
+    def recall(self, query: str, limit: int) -> list[EngineeringMemory]:
+        query_tokens = tokenize(query)
+        scored: list[tuple[int, str, EngineeringMemory]] = []
+        for memory in self._read():
+            haystack = " ".join([memory.text, memory.task, memory.cwd, *memory.files])
+            score = len(query_tokens & tokenize(haystack))
+            if score:
+                scored.append((score, memory.created_at, memory))
+        scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+        return [memory for _, _, memory in scored[:limit]]
+
+
+class MemantoSdkBackend:
+    """Optional live backend that uses Memanto's Python SDK client."""
+
+    def __init__(self, agent_id: str | None = None) -> None:
+        from memanto.cli.client.sdk_client import SdkClient
+        from memanto.cli.config.manager import ConfigManager
+
+        config = ConfigManager()
+        api_key = os.getenv("MOORCHEH_API_KEY") or config.get_api_key()
+        if not api_key:
+            raise RuntimeError(
+                "MOORCHEH_API_KEY is not configured. Use local preview mode or run `memanto`."
+            )
+
+        active_agent_id, active_session_token = config.get_active_session()
+        self.agent_id = agent_id or os.getenv("MEMANTO_AGENT_ID") or active_agent_id
+        if not self.agent_id:
+            raise RuntimeError(
+                "No Memanto agent is active. Run `memanto agent create <name>` "
+                "or set MEMANTO_AGENT_ID."
+            )
+
+        self.client = SdkClient(api_key)
+        if active_session_token:
+            self.client.session_token = active_session_token
+            self.client.agent_id = self.agent_id
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        title = f"{memory.skill} {memory.memory_type}: {memory.text[:60]}"
+        self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory.memory_type,
+            title=title[:100],
+            content=memory.to_memanto_text(),
+            confidence=memory.confidence,
+            tags=["claude-code-skill", memory.skill.strip("/")],
+            source="claudecode-skills-memanto",
+        )
+
+    def recall(self, query: str, limit: int) -> list[EngineeringMemory]:
+        result = self.client.recall(agent_id=self.agent_id, query=query, limit=limit)
+        recalled: list[EngineeringMemory] = []
+        for item in result.get("memories", []):
+            content = (
+                item.get("content")
+                or item.get("text")
+                or item.get("memory")
+                or json.dumps(item, sort_keys=True)
+            )
+            recalled.append(
+                EngineeringMemory(
+                    text=str(content),
+                    memory_type=str(item.get("type", "context")),
+                    skill="memanto-sdk-recall",
+                    task=query,
+                    cwd=".",
+                    files=[],
+                    confidence=float(item.get("confidence", 0.6) or 0.6),
+                )
+            )
+        return recalled
+
+
+class MemantoCliBackend:
+    """Optional fallback backend that shells out to the installed memanto CLI."""
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        command = [
+            "memanto",
+            "remember",
+            memory.to_memanto_text(),
+            "--type",
+            memory.memory_type,
+        ]
+        subprocess.run(command, check=True, text=True, capture_output=True)
+
+    def recall(self, query: str, limit: int) -> list[EngineeringMemory]:
+        command = ["memanto", "recall", query, "--limit", str(limit)]
+        completed = subprocess.run(command, check=True, text=True, capture_output=True)
+        return [
+            EngineeringMemory(
+                text=line.strip(),
+                memory_type="context",
+                skill="memanto-recall",
+                task=query,
+                cwd=".",
+                files=[],
+                confidence=0.6,
+            )
+            for line in completed.stdout.splitlines()
+            if line.strip()
+        ]
+
+
+def build_backend() -> MemoryBackend:
+    backend = os.getenv("SKILL_MEMORY_BACKEND", "local")
+    if backend == "memanto-sdk":
+        return MemantoSdkBackend()
+    if backend == "memanto-cli":
+        return MemantoCliBackend()
+    default_path = Path(".memanto-skill-memory/local-preview.json")
+    return LocalJsonBackend(Path(os.getenv("SKILL_MEMORY_FILE", default_path)))
+
+
+def classify_memory(sentence: str) -> str:
+    lowered = sentence.lower()
+    if any(word in lowered for word in ("prefer", "always", "avoid", "must", "never")):
+        return "instruction"
+    if any(word in lowered for word in ("decision", "decided", "choose", "selected", "architecture")):
+        return "decision"
+    if any(word in lowered for word in ("bug", "error", "fails", "regression")):
+        return "learning"
+    if any(word in lowered for word in ("file", "module", "component", "api", "route")):
+        return "context"
+    return "observation"
+
+
+def split_signal(text: str) -> list[str]:
+    normalized = re.sub(r"\s+", " ", text).strip()
+    if not normalized:
+        return []
+    candidates = re.split(r"(?<=[.!?])\s+|(?:\n\s*[-*]\s+)", normalized)
+    return [candidate.strip(" -") for candidate in candidates if len(candidate.strip()) >= 24]
+
+
+def extract_memories(run: SkillRun, max_items: int = 6) -> list[EngineeringMemory]:
+    memories: list[EngineeringMemory] = []
+    source = f"{run.task}. {run.output}"
+    for sentence in split_signal(source):
+        memory_type = classify_memory(sentence)
+        if memory_type not in MEMORY_TYPES:
+            memory_type = "observation"
+        memories.append(
+            EngineeringMemory(
+                text=sentence[:420],
+                memory_type=memory_type,
+                skill=run.skill,
+                task=run.task,
+                cwd=run.cwd,
+                files=run.files,
+            )
+        )
+        if len(memories) >= max_items:
+            break
+    return memories
+
+
+def render_injected_context(memories: list[EngineeringMemory]) -> str:
+    if not memories:
+        return "No relevant Memanto skill memories found."
+    lines = ["Memanto recalled these engineering constraints from prior skills:"]
+    for index, memory in enumerate(memories, start=1):
+        files = f" files={','.join(memory.files)}" if memory.files else ""
+        lines.append(f"{index}. ({memory.memory_type}) {memory.text}{files}")
+    return "\n".join(lines)
+
+
+def pre_skill(args: argparse.Namespace) -> int:
+    backend = build_backend()
+    query = " ".join(part for part in [args.skill, args.task, args.cwd, *args.files] if part)
+    print(render_injected_context(backend.recall(query, args.limit)))
+    return 0
+
+
+def post_skill(args: argparse.Namespace) -> int:
+    backend = build_backend()
+    run = SkillRun.from_json(Path(args.run_json))
+    memories = extract_memories(run, args.max_items)
+    for memory in memories:
+        backend.remember(memory)
+    print(f"Stored {len(memories)} Memanto skill memories for {run.skill}.")
+    return 0
+
+
+def demo(args: argparse.Namespace) -> int:
+    backend = LocalJsonBackend(Path(args.memory_file))
+    first_run = SkillRun(
+        skill="/grill-with-docs",
+        task="Review the auth refactor plan for a FastAPI service.",
+        output=(
+            "Decision: keep authentication middleware stateless and push tenant "
+            "lookup into a small dependency. Avoid global mutable caches because "
+            "tests run with parallel workers. The auth module owns token parsing."
+        ),
+        cwd="services/api",
+        files=["services/api/auth.py", "services/api/dependencies.py"],
+    )
+    for memory in extract_memories(first_run):
+        backend.remember(memory)
+
+    second_query = "Use /tdd to implement auth dependency tests in services/api"
+    print(render_injected_context(backend.recall(second_query, limit=5)))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    subcommands = root.add_subparsers(required=True)
+
+    pre = subcommands.add_parser("pre-skill", help="Print context to inject before a skill")
+    pre.add_argument("--skill", required=True)
+    pre.add_argument("--task", required=True)
+    pre.add_argument("--cwd", default=".")
+    pre.add_argument("--files", nargs="*", default=[])
+    pre.add_argument("--limit", type=int, default=5)
+    pre.set_defaults(func=pre_skill)
+
+    post = subcommands.add_parser("post-skill", help="Store memories after a skill")
+    post.add_argument("--run-json", required=True)
+    post.add_argument("--max-items", type=int, default=6)
+    post.set_defaults(func=post_skill)
+
+    demo_command = subcommands.add_parser("demo", help="Run the credential-free demo")
+    demo_command.add_argument(
+        "--memory-file",
+        default=".memanto-skill-memory/demo.json",
+        help="Local JSON memory file used by the preview backend",
+    )
+    demo_command.set_defaults(func=demo)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -325,11 +325,12 @@ def classify_memory(sentence: str) -> str:
 
 
 def split_signal(text: str) -> list[str]:
-    normalized = re.sub(r"\s+", " ", text).strip()
-    if not normalized:
+    stripped = text.strip()
+    if not stripped:
         return []
-    candidates = re.split(r"(?<=[.!?])\s+|(?:\n\s*[-*]\s+)", normalized)
-    return [candidate.strip(" -") for candidate in candidates if len(candidate.strip()) >= 24]
+    candidates = re.split(r"(?<=[.!?])\s+|\n\s*[-*]\s+", stripped)
+    normalized = [re.sub(r"\s+", " ", candidate).strip(" -") for candidate in candidates]
+    return [candidate for candidate in normalized if len(candidate) >= 24]
 
 
 def extract_memories(run: SkillRun, max_items: int = 6) -> list[EngineeringMemory]:

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -13,10 +13,11 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Protocol
+from typing import Protocol
 
 MEMORY_TYPES = {
     "artifact",
@@ -50,7 +51,7 @@ def utc_now() -> str:
 
 
 def tokenize(text: str) -> set[str]:
-    return {token for token in re.findall(r"[a-z0-9][a-z0-9_-]{2,}", text.lower())}
+    return set(re.findall(r"[a-z0-9][a-z0-9_-]{2,}", text.lower()))
 
 
 @dataclass
@@ -64,7 +65,7 @@ class SkillRun:
     files: list[str] = field(default_factory=list)
 
     @classmethod
-    def from_json(cls, path: Path) -> "SkillRun":
+    def from_json(cls, path: Path) -> SkillRun:
         payload = json.loads(path.read_text(encoding="utf-8"))
         return cls(
             skill=str(payload["skill"]),
@@ -97,11 +98,9 @@ class EngineeringMemory:
 
 
 class MemoryBackend(Protocol):
-    def remember(self, memory: EngineeringMemory) -> None:
-        ...
+    def remember(self, memory: EngineeringMemory) -> None: ...
 
-    def recall(self, query: str, limit: int) -> list[EngineeringMemory]:
-        ...
+    def recall(self, query: str, limit: int) -> list[EngineeringMemory]: ...
 
 
 class LocalJsonBackend:
@@ -315,7 +314,10 @@ def classify_memory(sentence: str) -> str:
         return "preference"
     if any(word in lowered for word in ("always", "avoid", "must", "never")):
         return "instruction"
-    if any(word in lowered for word in ("decision", "decided", "choose", "selected", "architecture")):
+    if any(
+        word in lowered
+        for word in ("decision", "decided", "choose", "selected", "architecture")
+    ):
         return "decision"
     if any(word in lowered for word in ("bug", "error", "fails", "regression")):
         return "learning"
@@ -329,7 +331,9 @@ def split_signal(text: str) -> list[str]:
     if not stripped:
         return []
     candidates = re.split(r"(?<=[.!?])\s+|\n\s*[-*]\s+", stripped)
-    normalized = [re.sub(r"\s+", " ", candidate).strip(" -") for candidate in candidates]
+    normalized = [
+        re.sub(r"\s+", " ", candidate).strip(" -") for candidate in candidates
+    ]
     return [candidate for candidate in normalized if len(candidate) >= 24]
 
 
@@ -368,7 +372,9 @@ def render_injected_context(memories: list[EngineeringMemory]) -> str:
 
 def pre_skill(args: argparse.Namespace) -> int:
     backend = build_backend()
-    query = " ".join(part for part in [args.skill, args.task, args.cwd, *args.files] if part)
+    query = " ".join(
+        part for part in [args.skill, args.task, args.cwd, *args.files] if part
+    )
     print(render_injected_context(backend.recall(query, args.limit)))
     return 0
 
@@ -408,7 +414,9 @@ def parser() -> argparse.ArgumentParser:
     root = argparse.ArgumentParser(description=__doc__)
     subcommands = root.add_subparsers(required=True)
 
-    pre = subcommands.add_parser("pre-skill", help="Print context to inject before a skill")
+    pre = subcommands.add_parser(
+        "pre-skill", help="Print context to inject before a skill"
+    )
     pre.add_argument("--skill", required=True)
     pre.add_argument("--task", required=True)
     pre.add_argument("--cwd", default=".")

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -232,6 +232,12 @@ class SkillMemoryTests(unittest.TestCase):
         self.assertIn("printf '%s\\n' \"$SKILL_CONTEXT\"", script)
         self.assertIn("pre-skill", script)
 
+    def test_generated_wrapper_passes_file_context_through_hooks(self) -> None:
+        script = wrapper_script("/handoff", "claude")
+        self.assertIn("SKILL_MEMORY_FILES", script)
+        self.assertIn('--files "${SKILL_FILES[@]}"', script)
+        self.assertIn('"files": files', script)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -73,6 +73,18 @@ class SkillMemoryTests(unittest.TestCase):
         self.assertIn("Memanto recalled", rendered)
         self.assertIn("dashboard.tsx", rendered)
 
+    def test_error_outputs_are_stored_as_error_memories(self) -> None:
+        memory = extract_memories(
+            SkillRun(
+                skill="/tdd",
+                task="Fix queue worker tests",
+                output="Traceback: worker retry policy failed with a timeout exception.",
+                files=["workers/retry.py"],
+            )
+        )[0]
+        self.assertEqual(memory.memory_type, "error")
+        self.assertGreaterEqual(memory.confidence, 0.8)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -17,6 +17,7 @@ from skill_memory import (
     SkillRun,
     extract_memories,
     render_injected_context,
+    split_signal,
 )
 
 
@@ -107,6 +108,16 @@ class SkillMemoryTests(unittest.TestCase):
         self.assertEqual(len(memories), 2)
         self.assertEqual(memories[0].memory_type, "decision")
         self.assertEqual(memories[1].memory_type, "preference")
+
+    def test_split_signal_preserves_bulleted_skill_output(self) -> None:
+        signals = split_signal(
+            "Decision summary:\n"
+            "- Decision: keep auth middleware stateless for tenant isolation.\n"
+            "- Must: avoid global mutable caches in parallel tests.\n"
+        )
+        self.assertEqual(len(signals), 2)
+        self.assertIn("Decision: keep auth middleware stateless", signals[0])
+        self.assertIn("avoid global mutable caches", signals[1])
 
     def test_local_backend_ranks_by_query_overlap(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from skill_memory import (
+    LocalJsonBackend,
+    SkillRun,
+    extract_memories,
+    render_injected_context,
+)
+
+
+class SkillMemoryTests(unittest.TestCase):
+    def test_extracts_engineering_decisions(self) -> None:
+        run = SkillRun(
+            skill="/grill-with-docs",
+            task="Review checkout architecture",
+            output="Decision: keep checkout state in the order aggregate. Avoid browser globals.",
+            cwd="apps/web",
+            files=["apps/web/checkout.ts"],
+        )
+        memories = extract_memories(run)
+        self.assertGreaterEqual(len(memories), 1)
+        self.assertEqual(memories[0].memory_type, "decision")
+        self.assertIn("checkout", memories[0].text.lower())
+
+    def test_local_backend_recalls_relevant_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            backend = LocalJsonBackend(Path(temp) / "memory.json")
+            memory = extract_memories(
+                SkillRun(
+                    skill="/handoff",
+                    task="Document API auth rules",
+                    output="The auth module owns token parsing. Avoid global mutable caches.",
+                    cwd="services/api",
+                    files=["services/api/auth.py"],
+                )
+            )[0]
+            backend.remember(memory)
+            recalled = backend.recall("write auth tests for services/api", limit=3)
+            self.assertEqual(len(recalled), 1)
+            self.assertEqual(recalled[0].files, ["services/api/auth.py"])
+
+    def test_local_backend_deduplicates_identical_memories(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            backend = LocalJsonBackend(Path(temp) / "memory.json")
+            memory = extract_memories(
+                SkillRun(
+                    skill="/tdd",
+                    task="Test worker retry policy",
+                    output="Decision: retry transient queue failures three times.",
+                )
+            )[0]
+            backend.remember(memory)
+            backend.remember(memory)
+            self.assertEqual(len(backend.recall("queue retry policy", limit=10)), 1)
+
+    def test_rendered_context_is_prompt_ready(self) -> None:
+        memory = extract_memories(
+            SkillRun(
+                skill="/grill-with-docs",
+                task="Review frontend data flow",
+                output="Prefer TanStack Query for server state in dashboard modules.",
+                files=["apps/web/dashboard.tsx"],
+            )
+        )[0]
+        rendered = render_injected_context([memory])
+        self.assertIn("Memanto recalled", rendered)
+        self.assertIn("dashboard.tsx", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from mattpocock_adapter import wrapper_script
 from productivity_benchmark import run_benchmark
 from skill_memory import (
     EngineeringMemory,
@@ -224,6 +225,12 @@ class SkillMemoryTests(unittest.TestCase):
         self.assertEqual(metrics["baseline_repeated_instructions"], 6)
         self.assertEqual(metrics["memanto_injected_constraints"], 6)
         self.assertEqual(metrics["repeated_instruction_reduction_pct"], 100.0)
+
+    def test_generated_wrapper_exports_skill_context_for_child_processes(self) -> None:
+        script = wrapper_script("/tdd", "claude")
+        self.assertIn("export MEMANTO_SKILL_CONTEXT", script)
+        self.assertIn("printf '%s\\n' \"$SKILL_CONTEXT\"", script)
+        self.assertIn("pre-skill", script)
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
-import sys
 from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from productivity_benchmark import run_benchmark
 from skill_memory import (
     EngineeringMemory,
     LocalJsonBackend,
@@ -213,6 +214,16 @@ class SkillMemoryTests(unittest.TestCase):
         backend.client = Mock()
         backend.client.answer.return_value = {"answer": "No relevant memories found."}
         self.assertIsNone(backend._synthesize_constraints("new task", limit=4))
+
+    def test_productivity_benchmark_reports_instruction_reduction(self) -> None:
+        metrics = run_benchmark()
+        self.assertEqual(
+            metrics["skill_sequence"],
+            ["/grill-with-docs", "/tdd", "/handoff"],
+        )
+        self.assertEqual(metrics["baseline_repeated_instructions"], 6)
+        self.assertEqual(metrics["memanto_injected_constraints"], 6)
+        self.assertEqual(metrics["repeated_instruction_reduction_pct"], 100.0)
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from mattpocock_adapter import wrapper_script
+from mattpocock_adapter import discover_skills, wrapper_script
 from productivity_benchmark import run_benchmark
 from skill_memory import (
     EngineeringMemory,
@@ -237,6 +237,33 @@ class SkillMemoryTests(unittest.TestCase):
         self.assertIn("SKILL_MEMORY_FILES", script)
         self.assertIn('--files "${SKILL_FILES[@]}"', script)
         self.assertIn('"files": files', script)
+
+    def test_discovers_mattpocock_style_skill_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "skills"
+            tdd = root / "engineering" / "tdd"
+            handoff = root / "productivity" / "handoff"
+            hidden = root / ".internal" / "skip-me"
+            tdd.mkdir(parents=True)
+            handoff.mkdir(parents=True)
+            hidden.mkdir(parents=True)
+            tdd.joinpath("SKILL.md").write_text(
+                "name: tdd\nUse when writing tests.\n",
+                encoding="utf-8",
+            )
+            handoff.joinpath("SKILL.md").write_text(
+                "# Handoff\n",
+                encoding="utf-8",
+            )
+            hidden.joinpath("SKILL.md").write_text(
+                "name: skip-me\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                discover_skills(root),
+                ["/tdd", "/handoff"],
+            )
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
 import sys
+from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from skill_memory import (
+    EngineeringMemory,
     LocalJsonBackend,
+    MemantoCliBackend,
+    MemantoSdkBackend,
     SkillRun,
     extract_memories,
     render_injected_context,
@@ -84,6 +89,119 @@ class SkillMemoryTests(unittest.TestCase):
         )[0]
         self.assertEqual(memory.memory_type, "error")
         self.assertGreaterEqual(memory.confidence, 0.8)
+
+    def test_extract_memories_honors_max_items(self) -> None:
+        memories = extract_memories(
+            SkillRun(
+                skill="/handoff",
+                task="Prepare release notes.",
+                output=(
+                    "Decision: ship the auth fix first. "
+                    "Preference: keep release notes short. "
+                    "Must: include rollback instructions. "
+                    "Traceback: deploy smoke failed once."
+                ),
+            ),
+            max_items=2,
+        )
+        self.assertEqual(len(memories), 2)
+        self.assertEqual(memories[0].memory_type, "decision")
+        self.assertEqual(memories[1].memory_type, "preference")
+
+    def test_local_backend_ranks_by_query_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            backend = LocalJsonBackend(Path(temp) / "memory.json")
+            backend.remember(
+                EngineeringMemory(
+                    text="The auth middleware owns token parsing and tenant lookup.",
+                    memory_type="decision",
+                    skill="/grill-with-docs",
+                    task="Review auth middleware",
+                    cwd="services/api",
+                    files=["services/api/auth.py"],
+                )
+            )
+            backend.remember(
+                EngineeringMemory(
+                    text="The dashboard should avoid browser globals.",
+                    memory_type="instruction",
+                    skill="/tdd",
+                    task="Write frontend tests",
+                    cwd="apps/web",
+                    files=["apps/web/dashboard.tsx"],
+                )
+            )
+            recalled = backend.recall("auth token parsing services/api", limit=2)
+            self.assertEqual(recalled[0].files, ["services/api/auth.py"])
+
+    def test_local_backend_returns_empty_when_memory_file_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            backend = LocalJsonBackend(Path(temp) / "missing.json")
+            self.assertEqual(backend.recall("anything", limit=5), [])
+
+    def test_skill_run_from_json_defaults_optional_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_file = Path(temp) / "run.json"
+            run_file.write_text(
+                json.dumps({"skill": "/tdd", "task": "Add tests"}) + "\n",
+                encoding="utf-8",
+            )
+            run = SkillRun.from_json(run_file)
+            self.assertEqual(run.output, "")
+            self.assertEqual(run.cwd, ".")
+            self.assertEqual(run.files, [])
+
+    def test_memanto_text_includes_source_metadata(self) -> None:
+        memory = EngineeringMemory(
+            text="Prefer SDK recall before CLI fallback.",
+            memory_type="preference",
+            skill="/handoff",
+            task="Document memory backends",
+            cwd="examples",
+            files=["README.md"],
+        )
+        text = memory.to_memanto_text()
+        self.assertIn("[preference]", text)
+        self.assertIn("source_skill=/handoff", text)
+        self.assertIn("files=README.md", text)
+
+    def test_rendered_context_handles_empty_recall(self) -> None:
+        self.assertEqual(
+            render_injected_context([]),
+            "No relevant Memanto skill memories found.",
+        )
+
+    def test_cli_backend_parses_stdout_lines(self) -> None:
+        completed = Mock(stdout="Keep auth stateless\n\nAvoid global caches\n")
+        with patch("skill_memory.subprocess.run", return_value=completed) as run:
+            memories = MemantoCliBackend().recall("auth", limit=2)
+        run.assert_called_once()
+        self.assertEqual(
+            [memory.text for memory in memories],
+            ["Keep auth stateless", "Avoid global caches"],
+        )
+        self.assertTrue(all(memory.skill == "memanto-recall" for memory in memories))
+
+    def test_sdk_synthesis_returns_prompt_context_memory(self) -> None:
+        backend = MemantoSdkBackend.__new__(MemantoSdkBackend)
+        backend.agent_id = "agent-123"
+        backend.client = Mock()
+        backend.client.answer.return_value = {
+            "answer": "- Keep auth middleware stateless\n- Avoid global mutable caches"
+        }
+        memory = backend._synthesize_constraints("implement auth tests", limit=4)
+        self.assertIsNotNone(memory)
+        assert memory is not None
+        self.assertEqual(memory.skill, "memanto-sdk-answer")
+        self.assertEqual(memory.memory_type, "context")
+        self.assertIn("stateless", memory.text)
+
+    def test_sdk_synthesis_ignores_empty_or_negative_answers(self) -> None:
+        backend = MemantoSdkBackend.__new__(MemantoSdkBackend)
+        backend.agent_id = "agent-123"
+        backend.client = Mock()
+        backend.client.answer.return_value = {"answer": "No relevant memories found."}
+        self.assertIsNone(backend._synthesize_constraints("new task", limit=4))
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,45 @@
+"""Credential-free validation for the Claude Code skills Memanto example."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def run(command: list[str], cwd: Path = ROOT) -> str:
+    completed = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=True)
+    return completed.stdout
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp:
+        memory_file = Path(temp) / "memory.json"
+        demo_output = run(
+            [sys.executable, "skill_memory.py", "demo", "--memory-file", str(memory_file)]
+        )
+        if "stateless" not in demo_output or "auth module owns token parsing" not in demo_output:
+            raise AssertionError("demo did not recall the prior engineering decision")
+        wrappers = Path(temp) / "bin"
+        manifest = run(
+            [
+                sys.executable,
+                "mattpocock_adapter.py",
+                "--output-dir",
+                str(wrappers),
+                "--target-command",
+                "printf",
+            ]
+        )
+        if "grill-with-docs" not in manifest or not any(wrappers.iterdir()):
+            raise AssertionError("wrapper generation did not create skill adapters")
+    print("credential-free validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -37,6 +37,19 @@ def main() -> int:
         )
         if "grill-with-docs" not in manifest or not any(wrappers.iterdir()):
             raise AssertionError("wrapper generation did not create skill adapters")
+        wrapper = wrappers / "tdd-with-memanto"
+        if not wrapper.exists():
+            raise AssertionError("expected tdd wrapper was not generated")
+        temp_path = Path(temp)
+        wrapper_output = run(
+            [str(wrapper), "wrapper execution stores durable auth context"],
+            cwd=temp_path,
+        )
+        if "Stored" not in wrapper_output:
+            raise AssertionError("generated wrapper did not complete memory lifecycle")
+        run_files = list((temp_path / ".memanto-skill-memory" / "runs").glob("*.json"))
+        if not run_files:
+            raise AssertionError("generated wrapper did not persist a skill run JSON")
     print("credential-free validation passed")
     return 0
 

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -47,6 +47,26 @@ def main() -> int:
         )
         if "grill-with-docs" not in manifest or not any(wrappers.iterdir()):
             raise AssertionError("wrapper generation did not create skill adapters")
+        skills_checkout = Path(temp) / "mattpocock-skills" / "skills"
+        (skills_checkout / "engineering" / "diagnose").mkdir(parents=True)
+        (skills_checkout / "engineering" / "diagnose" / "SKILL.md").write_text(
+            "name: diagnose\nUse for disciplined debugging.\n",
+            encoding="utf-8",
+        )
+        discovered = run(
+            [
+                sys.executable,
+                "mattpocock_adapter.py",
+                "--output-dir",
+                str(Path(temp) / "discovered-bin"),
+                "--target-command",
+                "printf",
+                "--skills-dir",
+                str(skills_checkout),
+            ]
+        )
+        if "/diagnose" not in discovered:
+            raise AssertionError("mattpocock-style skill discovery failed")
         wrapper = wrappers / "tdd-with-memanto"
         if not wrapper.exists():
             raise AssertionError("expected tdd wrapper was not generated")

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -7,12 +7,13 @@ import sys
 import tempfile
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parent
 
 
 def run(command: list[str], cwd: Path = ROOT) -> str:
-    completed = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=True)
+    completed = subprocess.run(
+        command, cwd=cwd, text=True, capture_output=True, check=True
+    )
     return completed.stdout
 
 
@@ -20,9 +21,18 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as temp:
         memory_file = Path(temp) / "memory.json"
         demo_output = run(
-            [sys.executable, "skill_memory.py", "demo", "--memory-file", str(memory_file)]
+            [
+                sys.executable,
+                "skill_memory.py",
+                "demo",
+                "--memory-file",
+                str(memory_file),
+            ]
         )
-        if "stateless" not in demo_output or "auth module owns token parsing" not in demo_output:
+        if (
+            "stateless" not in demo_output
+            or "auth module owns token parsing" not in demo_output
+        ):
             raise AssertionError("demo did not recall the prior engineering decision")
         wrappers = Path(temp) / "bin"
         manifest = run(
@@ -50,6 +60,9 @@ def main() -> int:
         run_files = list((temp_path / ".memanto-skill-memory" / "runs").glob("*.json"))
         if not run_files:
             raise AssertionError("generated wrapper did not persist a skill run JSON")
+        benchmark_output = run([sys.executable, "productivity_benchmark.py"])
+        if '"repeated_instruction_reduction_pct": 100.0' not in benchmark_output:
+            raise AssertionError("productivity benchmark did not show full recall")
     print("credential-free validation passed")
     return 0
 


### PR DESCRIPTION
Fixes #508
/claim #508

## Summary
- Add `examples/claudecode-skills-memanto`, a self-contained memory bridge for command-style Claude Code skills such as `/grill-with-docs`, `/tdd`, and `/handoff`.
- Provide credential-free local preview storage plus optional live Memanto SDK mode through `SKILL_MEMORY_BACKEND=memanto-sdk`; a CLI fallback is also available through `SKILL_MEMORY_BACKEND=memanto-cli`.
- Include wrapper generation for mattpocock-style commands, real `mattpocock/skills` tree discovery via `--skills-dir`, demo transcript, terminal SVG showcase, optional `SOCIAL_SHOWCASE.md`, README, validation script, productivity benchmark, and 19 focused unit tests covering extraction, ranking, local storage, CLI fallback, SDK answer synthesis, bullet-style skill output, generated wrapper execution, exported child-process context, file-context propagation, upstream skill discovery, and repeated-instruction reduction.
- Update live SDK recall to combine typed Memanto retrieval with a deterministic `SdkClient.answer(...)` synthesis step, producing a concise prompt-ready constraint block for the next skill run.
- Harden the generated wrappers by bundling the helper script into the wrapper directory, so wrappers remain executable when placed on `PATH`.
- Export recalled wrapper context as `MEMANTO_SKILL_CONTEXT`, so child commands can consume the prompt-ready constraints directly without scraping stdout.
- Pass `SKILL_MEMORY_FILES` through generated wrappers into both recall and storage, so later skills can retrieve decisions by current file path or module.

## Showcase
- Reviewer checklist: `examples/claudecode-skills-memanto/REVIEWER_CHECKLIST.md` maps the bounty criteria to implementation files and verification commands.
- Repository starred from the submitting GitHub account as requested in #508.
- In-repo technical showcase: `examples/claudecode-skills-memanto/demo_transcript.md`
- Visual terminal showcase: `examples/claudecode-skills-memanto/demo_terminal.svg`
- Optional share-ready showcase: `examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md` includes X/LinkedIn/Reddit-style technical copy and evidence commands without requiring any external post.
- Productivity benchmark: `examples/claudecode-skills-memanto/productivity_benchmark.py` simulates `/grill-with-docs` -> `/tdd` -> `/handoff` and reports 100% repeated-instruction reduction in the credential-free preview path.
- Upstream skills discovery: `mattpocock_adapter.py --skills-dir <mattpocock/skills>/skills` discovers every `SKILL.md`; verified against a fresh `mattpocock/skills` checkout with 28 generated wrappers.
- External social post: not included. Maintainer clarified in #508 that external social posts are not mandatory for technical review and only add leaderboard points.

## Verification
- `python examples/claudecode-skills-memanto/productivity_benchmark.py` -> 100% repeated-instruction reduction
- `python examples/claudecode-skills-memanto/validate.py` -> credential-free validation passed
- `python -m unittest examples/claudecode-skills-memanto/test_skill_memory.py` -> 19 tests OK
- `python -m py_compile examples/claudecode-skills-memanto/skill_memory.py examples/claudecode-skills-memanto/mattpocock_adapter.py examples/claudecode-skills-memanto/productivity_benchmark.py examples/claudecode-skills-memanto/validate.py examples/claudecode-skills-memanto/test_skill_memory.py`
- `uvx ruff check examples/claudecode-skills-memanto` -> all checks passed
- `uvx ruff format --check examples/claudecode-skills-memanto` -> 5 files already formatted
- `git diff --check` -> clean
- Fresh upstream discovery smoke: shallow clone `mattpocock/skills`, then `python examples/claudecode-skills-memanto/mattpocock_adapter.py --skills-dir <checkout>/skills --output-dir <tmp>/bin --target-command printf` -> 28 discovered skills / 28 generated wrappers plus bundled helper.