### PR TITLE
Add Claude Code skills Memanto memory bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/.env.example
+++ b/examples/claudecode-skills-memanto/.env.example
@@ -1,0 +1,10 @@
+# Reviewer-safe default: no credentials required.
+MEMANTO_SKILL_BACKEND=local
+MEMANTO_SKILL_STORE=.memanto-skills-memory.json
+
+# Live mode:
+# 1. Install and configure the Memanto CLI.
+# 2. Set MEMANTO_SKILL_BACKEND=memanto.
+# 3. Keep MOORCHEH_API_KEY in your normal Memanto environment.
+# MEMANTO_SKILL_BACKEND=memanto
+# MEMANTO_CLI=memanto

--- a/examples/claudecode-skills-memanto/.env.example
+++ b/examples/claudecode-skills-memanto/.env.example
@@ -8,3 +8,11 @@ MEMANTO_SKILL_STORE=.memanto-skills-memory.json
 # 3. Keep MOORCHEH_API_KEY in your normal Memanto environment.
 # MEMANTO_SKILL_BACKEND=memanto
 # MEMANTO_CLI=memanto
+
+# Direct SDK mode:
+# 1. Run from a Memanto checkout or installed memanto package.
+# 2. Set MOORCHEH_API_KEY and the target agent id.
+# 3. Set MEMANTO_SKILL_BACKEND=sdk.
+# MEMANTO_SKILL_BACKEND=sdk
+# MOORCHEH_API_KEY=mch_your_key_here
+# MEMANTO_AGENT_ID=claudecode-skills

--- a/examples/claudecode-skills-memanto/.gitignore
+++ b/examples/claudecode-skills-memanto/.gitignore
@@ -1,0 +1,3 @@
+.memanto-skills-memory.json
+demo/latest-transcript.log
+demo/memory.json

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -14,6 +14,8 @@ The integration is intentionally small and reviewer-safe:
 - `local` backend stores memories in JSON so the demo works without credentials.
 - `memanto` backend shells out to the real Memanto CLI for live recall and
   remember operations.
+- `sdk` backend calls Memanto's in-repo `SdkClient` directly for apps that want
+  the live Moorcheh path without shelling out to a subprocess.
 
 ## What The Bridge Solves
 
@@ -125,6 +127,32 @@ python bridge.py --backend memanto before \
 The live backend keeps the same public interface as the local backend, but
 persists and recalls memories through the configured Memanto CLI.
 
+## Direct SDK Mode
+
+If your integration runs inside a Python process and should avoid shelling out
+to the CLI, use the direct SDK backend:
+
+```bash
+export MOORCHEH_API_KEY="mch_..."
+export MEMANTO_AGENT_ID="claudecode-skills"
+
+python bridge.py --backend sdk after \
+  --skill grill-with-docs \
+  --task "review API pagination design" \
+  --path docs/api-pagination.md \
+  --transcript demo/session-one-transcript.md
+
+python bridge.py --backend sdk before \
+  --skill tdd \
+  --task "add pagination tests" \
+  --path tests/test_api.py
+```
+
+SDK mode uses `memanto.cli.client.sdk_client.SdkClient` directly, activates the
+configured agent, stores typed memories through `client.remember(...)`, and
+recalls through `client.recall(...)`. The local mode remains the default so
+reviewers can validate the example without credentials.
+
 ## Shell Hook
 
 Wrap a command with the skill lifecycle:
@@ -144,6 +172,7 @@ CLI and Moorcheh API key.
 python -m py_compile bridge.py
 python -m py_compile skills_manifest.py
 PYTHONPATH=. python -m unittest discover -s tests
+ruff check .
 python bridge.py --backend local --store demo/memory.json after \
   --skill grill-with-docs \
   --task "review API pagination design" \

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,161 @@
+# Claude Code Skills + Memanto
+
+This example shows how Memanto can act as a persistent memory companion for
+Claude Code style skill workflows such as `/grill-with-docs`, `/tdd`, and
+`/handoff`.
+
+The integration is intentionally small and reviewer-safe:
+
+- `bridge.py` exposes `before` and `after` lifecycle hooks.
+- `skills_manifest.py` reads the real `.claude-plugin/plugin.json` shape used by
+  `mattpocock/skills`, so the demo can list available skill names from a local
+  checkout.
+- `skill_memory_hook.sh` wraps any skill command and stores a transcript.
+- `local` backend stores memories in JSON so the demo works without credentials.
+- `memanto` backend shells out to the real Memanto CLI for live recall and
+  remember operations.
+
+## What The Bridge Solves
+
+Skills are usually run as isolated commands. A review skill may discover that a
+project requires backwards-compatible API fields, but a later TDD skill will not
+see that decision unless the developer manually repeats it.
+
+This bridge turns each skill run into a memory event:
+
+1. Before a skill starts, query Memanto for memories relevant to the skill name,
+   task, and touched paths.
+2. Print a compact context block that can be injected into the next prompt.
+3. After the skill completes, distill the transcript into typed memories:
+   `decision`, `instruction`, `preference`, `learning`, `artifact`, or
+   `context`.
+4. Store those memories so the next skill run gets the project-specific context
+   automatically.
+
+## Reviewer-Safe Offline Demo
+
+Run from this directory:
+
+```bash
+./run_offline_demo.sh
+```
+
+The full expected output is captured in
+[`demo/expected-output.md`](demo/expected-output.md), and the flow is shown in
+[`demo/terminal-demo.svg`](demo/terminal-demo.svg).
+
+Manual commands:
+
+```bash
+python bridge.py \
+  --backend local \
+  --store demo/memory.json \
+  after \
+  --skill grill-with-docs \
+  --task "review API pagination design" \
+  --path docs/api-pagination.md \
+  --transcript demo/session-one-transcript.md
+
+python bridge.py \
+  --backend local \
+  --store demo/memory.json \
+  before \
+  --skill tdd \
+  --task "add pagination tests" \
+  --path tests/test_api.py
+```
+
+Expected behavior: the second command prints remembered decisions and
+constraints from the first transcript, including the Postgres choice,
+backwards-compatibility rule, dependency-light preference, and useful pytest
+command.
+
+## mattpocock/skills Manifest Check
+
+The upstream `mattpocock/skills` repo lists runnable skills in
+`.claude-plugin/plugin.json`, with each skill described by a `SKILL.md`
+frontmatter block. To verify this example against a local checkout:
+
+```bash
+git clone https://github.com/mattpocock/skills /tmp/mattpocock-skills
+python skills_manifest.py /tmp/mattpocock-skills --format markdown
+```
+
+Use any listed skill name, such as `grill-with-docs`, `tdd`, `diagnose`, or
+`handoff`, as the `--skill` value for `bridge.py` or `skill_memory_hook.sh`.
+
+## Live Memanto Mode
+
+Install and configure Memanto first:
+
+```bash
+pip install memanto
+memanto
+memanto agent create claudecode-skills
+```
+
+Then run the same lifecycle with the live backend:
+
+```bash
+python bridge.py --backend memanto after \
+  --skill grill-with-docs \
+  --task "review API pagination design" \
+  --path docs/api-pagination.md \
+  --transcript demo/session-one-transcript.md
+
+python bridge.py --backend memanto before \
+  --skill tdd \
+  --task "add pagination tests" \
+  --path tests/test_api.py
+```
+
+The live backend keeps the same public interface as the local backend, but
+persists and recalls memories through the configured Memanto CLI.
+
+## Shell Hook
+
+Wrap a command with the skill lifecycle:
+
+```bash
+MEMANTO_SKILL_BACKEND=local \
+./skill_memory_hook.sh tdd "add pagination tests" -- \
+  python -m unittest discover -s tests
+```
+
+For live use, set `MEMANTO_SKILL_BACKEND=memanto` after configuring the Memanto
+CLI and Moorcheh API key.
+
+## Validation
+
+```bash
+python -m py_compile bridge.py
+python -m py_compile skills_manifest.py
+PYTHONPATH=. python -m unittest discover -s tests
+python bridge.py --backend local --store demo/memory.json after \
+  --skill grill-with-docs \
+  --task "review API pagination design" \
+  --path docs/api-pagination.md \
+  --transcript demo/session-one-transcript.md
+python bridge.py --backend local --store demo/memory.json before \
+  --skill tdd \
+  --task "add pagination tests" \
+  --path tests/test_api.py
+```
+
+## Files
+
+```text
+examples/claudecode-skills-memanto/
+├── README.md
+├── .env.example
+├── bridge.py
+├── skills_manifest.py
+├── run_offline_demo.sh
+├── skill_memory_hook.sh
+├── demo/
+│   ├── expected-output.md
+│   ├── terminal-demo.svg
+│   └── session-one-transcript.md
+└── tests/
+    └── test_bridge.py
+```

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -70,6 +70,16 @@ constraints from the first transcript, including the Postgres choice,
 backwards-compatibility rule, dependency-light preference, and useful pytest
 command.
 
+To score the productivity goal directly, run:
+
+```bash
+python productivity_check.py
+```
+
+It performs the same two-skill local flow and fails if a later `/tdd` run does
+not recover the architectural decision, response-compatibility rule,
+dependency-light preference, and pytest command without repeated instructions.
+
 ## mattpocock/skills Manifest Check
 
 The upstream `mattpocock/skills` repo lists runnable skills in
@@ -140,6 +150,7 @@ python bridge.py --backend local --store demo/memory.json before \
   --skill tdd \
   --task "add pagination tests" \
   --path tests/test_api.py
+python productivity_check.py
 ```
 
 ## Files
@@ -150,6 +161,7 @@ examples/claudecode-skills-memanto/
 ├── .env.example
 ├── bridge.py
 ├── skills_manifest.py
+├── productivity_check.py
 ├── run_offline_demo.sh
 ├── skill_memory_hook.sh
 ├── demo/

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -80,6 +80,9 @@ It performs the same two-skill local flow and fails if a later `/tdd` run does
 not recover the architectural decision, response-compatibility rule,
 dependency-light preference, and pytest command without repeated instructions.
 
+For share-ready X, LinkedIn, or Reddit copy, see
+[`SOCIAL_SHOWCASE.md`](SOCIAL_SHOWCASE.md).
+
 ## mattpocock/skills Manifest Check
 
 The upstream `mattpocock/skills` repo lists runnable skills in
@@ -162,6 +165,7 @@ examples/claudecode-skills-memanto/
 ├── bridge.py
 ├── skills_manifest.py
 ├── productivity_check.py
+├── SOCIAL_SHOWCASE.md
 ├── run_offline_demo.sh
 ├── skill_memory_hook.sh
 ├── demo/

--- a/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
+++ b/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
@@ -28,6 +28,8 @@ The bridge:
 - after hook distills the transcript into typed memories
 - local JSON backend lets reviewers run it without credentials
 - live Memanto CLI backend keeps the same interface for real persistent memory
+- direct SDK backend uses Memanto's in-repo `SdkClient` for Python apps that
+  should avoid shelling out to the CLI
 - mattpocock/skills manifest reader lists installed skill names from .claude-plugin/plugin.json
 
 The productivity check proves the later /tdd run recovers:

--- a/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
+++ b/examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md
@@ -1,0 +1,63 @@
+# Claude Code Skills + Memanto Social Showcase
+
+Use this file when sharing the demo for the Memanto + mattpocock Developer Skills bounty. The technical proof is runnable without credentials, while the post copy is ready for X, LinkedIn, or Reddit.
+
+## Short Post
+
+```text
+I built a Claude Code skills memory bridge for Memanto.
+
+It lets a later /tdd skill recover prior engineering decisions, constraints, preferences, and commands without manual re-prompting.
+
+The local productivity check recovers 4/4 remembered items across skill runs.
+
+PR: https://github.com/moorcheh-ai/memanto/pull/515
+#Memanto @moorcheh-ai
+```
+
+## Longer Post
+
+```text
+I built a Memanto example for Claude Code-style skills.
+
+The problem:
+Skill runs like /grill-with-docs, /tdd, and /handoff are useful, but each run can lose project decisions unless the developer repeats them manually.
+
+The bridge:
+- before hook recalls relevant memories by skill, task, and path
+- after hook distills the transcript into typed memories
+- local JSON backend lets reviewers run it without credentials
+- live Memanto CLI backend keeps the same interface for real persistent memory
+- mattpocock/skills manifest reader lists installed skill names from .claude-plugin/plugin.json
+
+The productivity check proves the later /tdd run recovers:
+- PostgreSQL storage decision
+- backwards-compatible response rule
+- dependency-light preference
+- pytest command
+
+PR: https://github.com/moorcheh-ai/memanto/pull/515
+#Memanto @moorcheh-ai
+```
+
+## Demo Proof
+
+Run from `examples/claudecode-skills-memanto`:
+
+```bash
+python productivity_check.py
+PYTHONPATH=. python -m unittest discover -s tests
+```
+
+Expected productivity result:
+
+```text
+Repeated instructions avoided: 4 / 4
+```
+
+## What The Demo Shows
+
+1. A `/grill-with-docs` session records project decisions, constraints, preferences, artifacts, and commands.
+2. A later `/tdd` session starts without repeating those instructions.
+3. The bridge recalls the relevant memories through Memanto-style retrieval.
+4. `productivity_check.py` fails unless all four expected context items are recovered.

--- a/examples/claudecode-skills-memanto/bridge.py
+++ b/examples/claudecode-skills-memanto/bridge.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Claude Code skills memory bridge for Memanto.
+
+The bridge has two execution modes:
+
+* ``local`` stores memories in a JSON file so reviewers can run the example
+  without credentials.
+* ``memanto`` shells out to the installed ``memanto`` CLI and uses the active
+  Memanto agent configured in the user's environment.
+
+Both modes expose the same before/after lifecycle used by Claude Code skills:
+query relevant engineering memories before a skill starts, then distill the
+finished transcript into typed memories after the skill completes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Protocol
+
+DEFAULT_STORE = Path(".memanto-skills-memory.json")
+MEMORY_TYPES = {
+    "decision",
+    "instruction",
+    "preference",
+    "context",
+    "learning",
+    "artifact",
+}
+
+
+@dataclass(slots=True)
+class Memory:
+    content: str
+    memory_type: str
+    source: str
+    tags: list[str]
+    confidence: float = 0.82
+    created_at: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.memory_type not in MEMORY_TYPES:
+            raise ValueError(f"Unsupported memory type: {self.memory_type}")
+        if not self.created_at:
+            self.created_at = time.time()
+
+
+class Backend(Protocol):
+    def remember(self, memory: Memory) -> None:
+        """Persist a memory."""
+
+    def recall(self, query: str, limit: int) -> list[Memory]:
+        """Return relevant memories."""
+
+
+class LocalJsonBackend:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def _read(self) -> list[Memory]:
+        if not self.path.exists():
+            return []
+        raw = json.loads(self.path.read_text(encoding="utf-8"))
+        return [Memory(**item) for item in raw]
+
+    def _write(self, memories: Iterable[Memory]) -> None:
+        payload = [asdict(memory) for memory in memories]
+        self.path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def remember(self, memory: Memory) -> None:
+        memories = self._read()
+        memories.append(memory)
+        self._write(memories)
+
+    def recall(self, query: str, limit: int) -> list[Memory]:
+        query_terms = tokenize(query)
+
+        def score(memory: Memory) -> tuple[int, float]:
+            haystack = tokenize(
+                " ".join([memory.content, memory.memory_type, *memory.tags])
+            )
+            overlap = len(query_terms & haystack)
+            return overlap, memory.created_at
+
+        ranked = sorted(self._read(), key=score, reverse=True)
+        return [memory for memory in ranked if score(memory)[0] > 0][:limit]
+
+
+class MemantoCliBackend:
+    def __init__(self, command: str = "memanto") -> None:
+        self.command = command
+
+    def remember(self, memory: Memory) -> None:
+        cmd = [
+            self.command,
+            "remember",
+            memory.content,
+            "--type",
+            memory.memory_type,
+            "--confidence",
+            str(memory.confidence),
+            "--provenance",
+            "skill_transcript",
+            "--source",
+            memory.source,
+        ]
+        if memory.tags:
+            cmd.extend(["--tags", ",".join(memory.tags)])
+        run(cmd)
+
+    def recall(self, query: str, limit: int) -> list[Memory]:
+        result = run(
+            [self.command, "recall", query, "--limit", str(limit)],
+            capture_output=True,
+        )
+        text = result.stdout.strip()
+        if not text:
+            return []
+        return [
+            Memory(
+                content=line.strip(),
+                memory_type="context",
+                source="memanto-recall",
+                tags=["live", "recall"],
+            )
+            for line in text.splitlines()
+            if line.strip()
+        ][:limit]
+
+
+def run(
+    cmd: list[str],
+    *,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            cmd,
+            check=True,
+            capture_output=capture_output,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise SystemExit(
+            "memanto CLI was not found. Install it with `pip install memanto` "
+            "or use `--backend local` for the reviewer-safe preview."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        if capture_output and exc.stderr:
+            print(exc.stderr, file=sys.stderr)
+        raise
+
+
+def tokenize(text: str) -> set[str]:
+    return {token.lower() for token in re.findall(r"[a-zA-Z0-9_./-]{3,}", text)}
+
+
+def select_backend(args: argparse.Namespace) -> Backend:
+    if args.backend == "local":
+        return LocalJsonBackend(Path(args.store))
+    return MemantoCliBackend(args.memanto_command)
+
+
+def infer_tags(skill: str, task: str, paths: list[str]) -> list[str]:
+    tags = ["claudecode-skills", skill]
+    tags.extend(Path(path).parts[-1] for path in paths if path)
+    tags.extend(sorted(tokenize(task))[:8])
+    return dedupe(tags)
+
+
+def dedupe(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        cleaned = item.strip().lower()
+        if cleaned and cleaned not in seen:
+            result.append(cleaned)
+            seen.add(cleaned)
+    return result
+
+
+def distill_transcript(
+    transcript: str,
+    *,
+    skill: str,
+    task: str,
+    paths: list[str],
+) -> list[Memory]:
+    base_tags = infer_tags(skill, task, paths)
+    memories: list[Memory] = []
+
+    patterns: list[tuple[str, str]] = [
+        (r"^\s*(decision|decided)\s*[:=-]\s*(.+)$", "decision"),
+        (r"^\s*(constraint|rule|must)\s*[:=-]\s*(.+)$", "instruction"),
+        (r"^\s*(preference|prefer)\s*[:=-]\s*(.+)$", "preference"),
+        (r"^\s*(learned|lesson)\s*[:=-]\s*(.+)$", "learning"),
+        (r"^\s*(artifact|output)\s*[:=-]\s*(.+)$", "artifact"),
+    ]
+
+    for line in transcript.splitlines():
+        stripped = line.strip("-* \t")
+        for pattern, memory_type in patterns:
+            match = re.match(pattern, stripped, flags=re.IGNORECASE)
+            if match:
+                content = f"{match.group(1).capitalize()}: {match.group(2).strip()}"
+                memories.append(
+                    Memory(
+                        content=content,
+                        memory_type=memory_type,
+                        source=f"skill:{skill}",
+                        tags=base_tags,
+                    )
+                )
+
+    command_memories = extract_commands(transcript)
+    for command in command_memories:
+        memories.append(
+            Memory(
+                content=f"Useful command for {skill}: {command}",
+                memory_type="learning",
+                source=f"skill:{skill}",
+                tags=[*base_tags, "command"],
+                confidence=0.74,
+            )
+        )
+
+    if not memories:
+        summary = summarize_fallback(transcript, task)
+        memories.append(
+            Memory(
+                content=summary,
+                memory_type="context",
+                source=f"skill:{skill}",
+                tags=base_tags,
+                confidence=0.62,
+            )
+        )
+
+    return collapse_similar(memories)
+
+
+def extract_commands(transcript: str) -> list[str]:
+    commands: list[str] = []
+    for line in transcript.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("$ "):
+            commands.append(stripped[2:])
+        elif re.match(r"^(uv|python|pytest|npm|pnpm|git) ", stripped):
+            commands.append(stripped)
+    return commands[:6]
+
+
+def summarize_fallback(transcript: str, task: str) -> str:
+    words = transcript.split()
+    excerpt = " ".join(words[:48])
+    if len(words) > 48:
+        excerpt += "..."
+    return f"Context from previous skill run for task `{task}`: {excerpt}"
+
+
+def collapse_similar(memories: list[Memory]) -> list[Memory]:
+    result: list[Memory] = []
+    seen: set[str] = set()
+    for memory in memories:
+        key = re.sub(r"\s+", " ", memory.content.lower()).strip()
+        if key not in seen:
+            result.append(memory)
+            seen.add(key)
+    return result
+
+
+def render_context(memories: list[Memory], task: str) -> str:
+    if not memories:
+        return (
+            "No relevant Memanto memories were found for this skill run.\n"
+            f"Task: {task}\n"
+        )
+    lines = [
+        "Memanto context for this skill run:",
+        f"Task: {task}",
+        "",
+        "Apply these remembered engineering constraints when relevant:",
+    ]
+    for index, memory in enumerate(memories, start=1):
+        tags = ", ".join(memory.tags[:6])
+        lines.append(
+            f"{index}. [{memory.memory_type}; {memory.source}; tags: {tags}] "
+            f"{memory.content}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def command_before(args: argparse.Namespace) -> int:
+    backend = select_backend(args)
+    query = " ".join([args.skill, args.task, *args.path])
+    memories = backend.recall(query, args.limit)
+    print(render_context(memories, args.task), end="")
+    return 0
+
+
+def command_after(args: argparse.Namespace) -> int:
+    backend = select_backend(args)
+    transcript = Path(args.transcript).read_text(encoding="utf-8")
+    memories = distill_transcript(
+        transcript,
+        skill=args.skill,
+        task=args.task,
+        paths=args.path,
+    )
+    for memory in memories:
+        backend.remember(memory)
+    print(f"Stored {len(memories)} memory item(s) for skill `{args.skill}`.")
+    for memory in memories:
+        print(f"- {memory.memory_type}: {memory.content}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Memanto bridge for Claude Code skill lifecycle hooks."
+    )
+    parser.add_argument("--backend", choices=["local", "memanto"], default="local")
+    parser.add_argument("--store", default=str(DEFAULT_STORE))
+    parser.add_argument("--memanto-command", default=os.environ.get("MEMANTO_CLI", "memanto"))
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    before = subparsers.add_parser("before", help="recall memory before a skill run")
+    before.add_argument("--skill", required=True)
+    before.add_argument("--task", required=True)
+    before.add_argument("--path", action="append", default=[])
+    before.add_argument("--limit", type=int, default=5)
+    before.set_defaults(func=command_before)
+
+    after = subparsers.add_parser("after", help="store memory after a skill run")
+    after.add_argument("--skill", required=True)
+    after.add_argument("--task", required=True)
+    after.add_argument("--transcript", required=True)
+    after.add_argument("--path", action="append", default=[])
+    after.set_defaults(func=command_after)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/bridge.py
+++ b/examples/claudecode-skills-memanto/bridge.py
@@ -7,6 +7,8 @@ The bridge has two execution modes:
   without credentials.
 * ``memanto`` shells out to the installed ``memanto`` CLI and uses the active
   Memanto agent configured in the user's environment.
+* ``sdk`` calls Memanto's in-repo ``SdkClient`` directly for applications that
+  want to bypass shell commands while still using the real Moorcheh backend.
 
 Both modes expose the same before/after lifecycle used by Claude Code skills:
 query relevant engineering memories before a skill starts, then distill the
@@ -140,6 +142,71 @@ class MemantoCliBackend:
         ][:limit]
 
 
+class MemantoSdkBackend:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        agent_id: str,
+        client: object | None = None,
+    ) -> None:
+        if not api_key.strip():
+            raise SystemExit(
+                "MOORCHEH_API_KEY is required for `--backend sdk`. "
+                "Use `--backend local` for the reviewer-safe preview."
+            )
+        if not agent_id.strip():
+            raise SystemExit(
+                "MEMANTO_AGENT_ID or `--agent-id` is required for `--backend sdk`."
+            )
+        self.agent_id = agent_id
+        self.client = client or self._build_client(api_key, agent_id)
+
+    @staticmethod
+    def _build_client(api_key: str, agent_id: str) -> object:
+        try:
+            from memanto.cli.client.sdk_client import SdkClient
+        except ImportError as exc:
+            raise SystemExit(
+                "Memanto SdkClient is not importable. Run this example from a "
+                "Memanto checkout or install the memanto package."
+            ) from exc
+
+        client = SdkClient(api_key=api_key)
+        try:
+            client.activate_agent(agent_id)
+        except Exception as exc:
+            raise SystemExit(
+                f"Could not activate Memanto agent `{agent_id}` for SDK mode. "
+                "Create or configure the agent first, or use `--backend local`."
+            ) from exc
+        return client
+
+    def remember(self, memory: Memory) -> None:
+        self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory.memory_type,
+            title=memory.content[:100],
+            content=memory.content,
+            confidence=memory.confidence,
+            tags=memory.tags,
+            source=memory.source,
+            provenance="inferred",
+        )
+
+    def recall(self, query: str, limit: int) -> list[Memory]:
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            type=list(MEMORY_TYPES),
+        )
+        raw_memories = result.get("memories", []) if isinstance(result, dict) else []
+        return [memory for memory in map(memory_from_sdk_result, raw_memories) if memory][
+            :limit
+        ]
+
+
 def run(
     cmd: list[str],
     *,
@@ -170,7 +237,43 @@ def tokenize(text: str) -> set[str]:
 def select_backend(args: argparse.Namespace) -> Backend:
     if args.backend == "local":
         return LocalJsonBackend(Path(args.store))
+    if args.backend == "sdk":
+        return MemantoSdkBackend(
+            api_key=args.moorcheh_api_key,
+            agent_id=args.agent_id,
+        )
     return MemantoCliBackend(args.memanto_command)
+
+
+def memory_from_sdk_result(raw: object) -> Memory | None:
+    if not isinstance(raw, dict):
+        return None
+    content = str(
+        raw.get("content")
+        or raw.get("text")
+        or raw.get("memory")
+        or raw.get("document")
+        or ""
+    ).strip()
+    if not content:
+        metadata = raw.get("metadata")
+        if isinstance(metadata, dict):
+            content = str(metadata.get("content") or metadata.get("text") or "").strip()
+    if not content:
+        return None
+
+    memory_type = str(raw.get("type") or raw.get("memory_type") or "context")
+    if memory_type not in MEMORY_TYPES:
+        memory_type = "context"
+    source = str(raw.get("source") or "memanto-sdk")
+    raw_tags = raw.get("tags", [])
+    tags = [str(tag) for tag in raw_tags] if isinstance(raw_tags, list) else []
+    return Memory(
+        content=content,
+        memory_type=memory_type,
+        source=source,
+        tags=tags or ["live", "sdk"],
+    )
 
 
 def infer_tags(skill: str, task: str, paths: list[str]) -> list[str]:
@@ -331,9 +434,23 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Memanto bridge for Claude Code skill lifecycle hooks."
     )
-    parser.add_argument("--backend", choices=["local", "memanto"], default="local")
+    parser.add_argument(
+        "--backend",
+        choices=["local", "memanto", "sdk"],
+        default=os.environ.get("MEMANTO_SKILL_BACKEND", "local"),
+    )
     parser.add_argument("--store", default=str(DEFAULT_STORE))
     parser.add_argument("--memanto-command", default=os.environ.get("MEMANTO_CLI", "memanto"))
+    parser.add_argument(
+        "--moorcheh-api-key",
+        default=os.environ.get("MOORCHEH_API_KEY", ""),
+        help="Moorcheh API key for the direct SDK backend.",
+    )
+    parser.add_argument(
+        "--agent-id",
+        default=os.environ.get("MEMANTO_AGENT_ID", "claudecode-skills"),
+        help="Memanto agent id for the direct SDK backend.",
+    )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 

--- a/examples/claudecode-skills-memanto/demo/expected-output.md
+++ b/examples/claudecode-skills-memanto/demo/expected-output.md
@@ -1,0 +1,38 @@
+# Offline Demo Output
+
+Command:
+
+```bash
+./run_offline_demo.sh
+```
+
+Expected output:
+
+```text
+Stored 5 memory item(s) for skill `grill-with-docs`.
+- decision: Decision: Use PostgreSQL for durable project state because the team already runs Postgres in production.
+- instruction: Constraint: API changes must preserve backwards-compatible response fields.
+- preference: Preference: Keep service code dependency-light and avoid new runtime frameworks for small routes.
+- artifact: Artifact: Added pagination notes to docs/api-pagination.md for the next skill run.
+- learning: Useful command for grill-with-docs: pytest tests/test_api.py
+
+Memanto context for this skill run:
+Task: add pagination tests
+
+Apply these remembered engineering constraints when relevant:
+1. [learning; skill:grill-with-docs; tags: claudecode-skills, grill-with-docs, api-pagination.md, api, design, pagination] Useful command for grill-with-docs: pytest tests/test_api.py
+2. [artifact; skill:grill-with-docs; tags: claudecode-skills, grill-with-docs, api-pagination.md, api, design, pagination] Artifact: Added pagination notes to docs/api-pagination.md for the next skill run.
+3. [preference; skill:grill-with-docs; tags: claudecode-skills, grill-with-docs, api-pagination.md, api, design, pagination] Preference: Keep service code dependency-light and avoid new runtime frameworks for small routes.
+4. [instruction; skill:grill-with-docs; tags: claudecode-skills, grill-with-docs, api-pagination.md, api, design, pagination] Constraint: API changes must preserve backwards-compatible response fields.
+5. [decision; skill:grill-with-docs; tags: claudecode-skills, grill-with-docs, api-pagination.md, api, design, pagination] Decision: Use PostgreSQL for durable project state because the team already runs Postgres in production.
+```
+
+Optional manifest check:
+
+```bash
+python skills_manifest.py /tmp/mattpocock-skills --format markdown
+```
+
+This prints a table of skills from the real `.claude-plugin/plugin.json`
+manifest, including names such as `grill-with-docs`, `tdd`, `diagnose`, and
+`handoff`.

--- a/examples/claudecode-skills-memanto/demo/session-one-transcript.md
+++ b/examples/claudecode-skills-memanto/demo/session-one-transcript.md
@@ -1,0 +1,7 @@
+Decision: Use PostgreSQL for durable project state because the team already runs Postgres in production.
+Constraint: API changes must preserve backwards-compatible response fields.
+Preference: Keep service code dependency-light and avoid new runtime frameworks for small routes.
+
+$ pytest tests/test_api.py
+
+Artifact: Added pagination notes to docs/api-pagination.md for the next skill run.

--- a/examples/claudecode-skills-memanto/demo/terminal-demo.svg
+++ b/examples/claudecode-skills-memanto/demo/terminal-demo.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="520" viewBox="0 0 920 520" role="img" aria-labelledby="title desc">
+  <title id="title">Claude Code skills Memanto offline demo</title>
+  <desc id="desc">Terminal-style screenshot showing a first skill run storing memories and a second skill run recalling them.</desc>
+  <rect width="920" height="520" rx="10" fill="#101419"/>
+  <rect x="0" y="0" width="920" height="34" rx="10" fill="#202832"/>
+  <circle cx="22" cy="17" r="6" fill="#ff5f57"/>
+  <circle cx="44" cy="17" r="6" fill="#ffbd2e"/>
+  <circle cx="66" cy="17" r="6" fill="#28c840"/>
+  <text x="84" y="22" fill="#c7d0dc" font-family="SFMono-Regular, Consolas, monospace" font-size="13">examples/claudecode-skills-memanto</text>
+
+  <g font-family="SFMono-Regular, Consolas, monospace" font-size="15">
+    <text x="28" y="68" fill="#7dd3fc">$ ./run_offline_demo.sh</text>
+    <text x="28" y="104" fill="#e6edf3">Stored 5 memory item(s) for skill `grill-with-docs`.</text>
+    <text x="48" y="132" fill="#a7f3d0">- decision: Use PostgreSQL for durable project state.</text>
+    <text x="48" y="160" fill="#a7f3d0">- instruction: Preserve backwards-compatible API fields.</text>
+    <text x="48" y="188" fill="#a7f3d0">- preference: Keep service code dependency-light.</text>
+    <text x="48" y="216" fill="#a7f3d0">- artifact: Added docs/api-pagination.md handoff notes.</text>
+    <text x="48" y="244" fill="#a7f3d0">- learning: pytest tests/test_api.py</text>
+
+    <text x="28" y="300" fill="#e6edf3">Memanto context for this skill run:</text>
+    <text x="28" y="328" fill="#e6edf3">Task: add pagination tests</text>
+    <text x="28" y="372" fill="#facc15">Apply remembered engineering constraints when relevant:</text>
+    <text x="48" y="400" fill="#c7d0dc">1. Useful command for grill-with-docs: pytest tests/test_api.py</text>
+    <text x="48" y="428" fill="#c7d0dc">2. Artifact: Added pagination notes for the next skill run.</text>
+    <text x="48" y="456" fill="#c7d0dc">3. Preference: Keep service code dependency-light.</text>
+    <text x="48" y="484" fill="#c7d0dc">4. Constraint: API changes must preserve response fields.</text>
+  </g>
+</svg>

--- a/examples/claudecode-skills-memanto/productivity_check.py
+++ b/examples/claudecode-skills-memanto/productivity_check.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Measure whether the demo avoids repeated cross-skill instructions.
+
+The bounty asks for a productivity multiplier: later skills should inherit
+architectural choices and preferences without manual context shoving. This
+script runs the reviewer-safe local backend through that exact loop and fails
+if the second skill run does not receive the expected remembered constraints.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from bridge import LocalJsonBackend, distill_transcript, render_context
+
+HERE = Path(__file__).resolve().parent
+DEMO_TRANSCRIPT = HERE / "demo" / "session-one-transcript.md"
+
+EXPECTED_CONTEXT = {
+    "postgres": "Postgres storage decision",
+    "backwards-compatible response fields": "backwards-compatible response rule",
+    "avoid new runtime frameworks": "dependency-light preference",
+    "pytest tests/test_api.py": "reusable pytest command",
+}
+
+
+def run_productivity_check() -> tuple[int, str]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = Path(tmpdir) / "memory.json"
+        backend = LocalJsonBackend(store)
+        transcript = DEMO_TRANSCRIPT.read_text(encoding="utf-8")
+
+        for memory in distill_transcript(
+            transcript,
+            skill="grill-with-docs",
+            task="review API pagination design",
+            paths=["docs/api-pagination.md"],
+        ):
+            backend.remember(memory)
+
+        recalled = backend.recall(
+            "tdd pagination tests postgres response fields runtime frameworks pytest",
+            limit=8,
+        )
+        context = render_context(recalled, "add pagination tests")
+
+    found = {
+        label: phrase
+        for phrase, label in EXPECTED_CONTEXT.items()
+        if phrase in context.lower()
+    }
+    missing = {
+        label: phrase
+        for phrase, label in EXPECTED_CONTEXT.items()
+        if phrase not in context.lower()
+    }
+
+    lines = [
+        "# Productivity Check",
+        "",
+        f"Repeated instructions avoided: {len(found)} / {len(EXPECTED_CONTEXT)}",
+        "",
+        "Recovered without manual re-prompting:",
+    ]
+    for label in found:
+        lines.append(f"- {label}")
+
+    if missing:
+        lines.append("")
+        lines.append("Missing expected context:")
+        for label in missing:
+            lines.append(f"- {label}")
+        return 1, "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "",
+            "Rendered context block:",
+            "",
+            "```text",
+            context.rstrip(),
+            "```",
+        ]
+    )
+    return 0, "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    exit_code, report = run_productivity_check()
+    print(report, end="")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/run_offline_demo.sh
+++ b/examples/claudecode-skills-memanto/run_offline_demo.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STORE="${1:-$ROOT_DIR/demo/memory.json}"
+
+rm -f "$STORE"
+
+python "$ROOT_DIR/bridge.py" \
+  --backend local \
+  --store "$STORE" \
+  after \
+  --skill grill-with-docs \
+  --task "review API pagination design" \
+  --path docs/api-pagination.md \
+  --transcript "$ROOT_DIR/demo/session-one-transcript.md"
+
+echo
+
+python "$ROOT_DIR/bridge.py" \
+  --backend local \
+  --store "$STORE" \
+  before \
+  --skill tdd \
+  --task "add pagination tests" \
+  --path tests/test_api.py

--- a/examples/claudecode-skills-memanto/skill_memory_hook.sh
+++ b/examples/claudecode-skills-memanto/skill_memory_hook.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  cat >&2 <<'USAGE'
+Usage:
+  skill_memory_hook.sh <skill-name> <task-summary> -- <command> [args...]
+
+Example:
+  ./skill_memory_hook.sh tdd "Add API pagination tests" -- pytest tests/test_api.py
+USAGE
+  exit 2
+fi
+
+SKILL_NAME="$1"
+TASK_SUMMARY="$2"
+shift 2
+
+if [[ "${1:-}" != "--" ]]; then
+  echo "Expected -- before the command to run." >&2
+  exit 2
+fi
+shift
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRANSCRIPT="${MEMANTO_SKILL_TRANSCRIPT:-$ROOT_DIR/demo/latest-transcript.log}"
+BACKEND="${MEMANTO_SKILL_BACKEND:-local}"
+STORE="${MEMANTO_SKILL_STORE:-$ROOT_DIR/.memanto-skills-memory.json}"
+
+mkdir -p "$(dirname "$TRANSCRIPT")"
+
+python "$ROOT_DIR/bridge.py" \
+  --backend "$BACKEND" \
+  --store "$STORE" \
+  before \
+  --skill "$SKILL_NAME" \
+  --task "$TASK_SUMMARY"
+
+{
+  echo "$ $*"
+  "$@"
+} 2>&1 | tee "$TRANSCRIPT"
+
+python "$ROOT_DIR/bridge.py" \
+  --backend "$BACKEND" \
+  --store "$STORE" \
+  after \
+  --skill "$SKILL_NAME" \
+  --task "$TASK_SUMMARY" \
+  --transcript "$TRANSCRIPT"

--- a/examples/claudecode-skills-memanto/skills_manifest.py
+++ b/examples/claudecode-skills-memanto/skills_manifest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Read mattpocock/skills-style plugin manifests.
+
+The upstream skills repository exposes skill paths through
+``.claude-plugin/plugin.json``. This helper lets reviewers point the example at
+a local checkout and list the exact skill names/descriptions that can be used
+with ``bridge.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class SkillEntry:
+    name: str
+    description: str
+    path: str
+
+
+def load_skill_entries(repo_root: Path) -> list[SkillEntry]:
+    plugin_path = repo_root / ".claude-plugin" / "plugin.json"
+    plugin = json.loads(plugin_path.read_text(encoding="utf-8"))
+    entries: list[SkillEntry] = []
+    for raw_path in plugin.get("skills", []):
+        skill_dir = (repo_root / raw_path).resolve()
+        skill_md = skill_dir / "SKILL.md"
+        metadata = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        entries.append(
+            SkillEntry(
+                name=metadata.get("name", skill_dir.name),
+                description=metadata.get("description", ""),
+                path=raw_path,
+            )
+        )
+    return entries
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    match = re.match(r"^---\n(?P<body>.*?)\n---", text, flags=re.DOTALL)
+    if not match:
+        return {}
+    metadata: dict[str, str] = {}
+    for line in match.group("body").splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    return metadata
+
+
+def render_markdown(entries: list[SkillEntry]) -> str:
+    lines = [
+        "| Skill | Path | Description |",
+        "| --- | --- | --- |",
+    ]
+    for entry in entries:
+        lines.append(
+            f"| `{entry.name}` | `{entry.path}` | {entry.description or '-'} |"
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="List skills from a mattpocock/skills-style plugin manifest."
+    )
+    parser.add_argument("repo_root", help="Path to the local mattpocock/skills checkout")
+    parser.add_argument("--format", choices=["json", "markdown"], default="markdown")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    entries = load_skill_entries(Path(args.repo_root))
+    if args.format == "json":
+        print(json.dumps([entry.__dict__ for entry in entries], indent=2))
+    else:
+        print(render_markdown(entries))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -3,8 +3,12 @@ import unittest
 from pathlib import Path
 
 from bridge import (
+    MEMORY_TYPES,
     LocalJsonBackend,
+    MemantoSdkBackend,
+    Memory,
     distill_transcript,
+    memory_from_sdk_result,
     render_context,
 )
 from productivity_check import EXPECTED_CONTEXT, run_productivity_check
@@ -106,6 +110,64 @@ $ pytest tests/test_api.py
             report,
         )
         self.assertIn("Rendered context block", report)
+
+    def test_sdk_backend_uses_memanto_client_interface(self) -> None:
+        class FakeSdkClient:
+            def __init__(self) -> None:
+                self.remember_calls = []
+                self.recall_calls = []
+
+            def remember(self, **kwargs):
+                self.remember_calls.append(kwargs)
+                return {"memory_id": "mem-1"}
+
+            def recall(self, **kwargs):
+                self.recall_calls.append(kwargs)
+                return {
+                    "memories": [
+                        {
+                            "content": "Decision: Keep route responses stable.",
+                            "type": "decision",
+                            "source": "skill:tdd",
+                            "tags": ["tdd", "routes"],
+                        }
+                    ]
+                }
+
+        client = FakeSdkClient()
+        backend = MemantoSdkBackend(
+            api_key="test-key",
+            agent_id="claudecode-skills",
+            client=client,
+        )
+        backend.remember(
+            Memory(
+                content="Decision: Keep route responses stable.",
+                memory_type="decision",
+                source="skill:tdd",
+                tags=["tdd", "routes"],
+            )
+        )
+        recalled = backend.recall("route response stability", limit=3)
+
+        self.assertEqual(client.remember_calls[0]["agent_id"], "claudecode-skills")
+        self.assertEqual(client.remember_calls[0]["provenance"], "inferred")
+        self.assertEqual(client.recall_calls[0]["type"], list(MEMORY_TYPES))
+        self.assertEqual(recalled[0].memory_type, "decision")
+        self.assertIn("route responses stable", recalled[0].content)
+
+    def test_sdk_result_parser_handles_metadata_content(self) -> None:
+        memory = memory_from_sdk_result(
+            {
+                "metadata": {"content": "Preference: Avoid new dependencies."},
+                "memory_type": "preference",
+            }
+        )
+
+        self.assertIsNotNone(memory)
+        assert memory is not None
+        self.assertEqual(memory.memory_type, "preference")
+        self.assertIn("Avoid new dependencies", memory.content)
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -1,0 +1,101 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from bridge import (
+    LocalJsonBackend,
+    distill_transcript,
+    render_context,
+)
+from skills_manifest import load_skill_entries, parse_frontmatter, render_markdown
+
+
+class BridgeTest(unittest.TestCase):
+    def test_distill_transcript_extracts_typed_memories(self) -> None:
+        transcript = """Decision: Use Postgres for project state.
+Constraint: Preserve response fields.
+Preference: Avoid new runtime frameworks.
+$ pytest tests/test_api.py
+"""
+
+        memories = distill_transcript(
+            transcript,
+            skill="tdd",
+            task="add pagination tests",
+            paths=["tests/test_api.py"],
+        )
+
+        memory_types = {memory.memory_type for memory in memories}
+        self.assertIn("decision", memory_types)
+        self.assertIn("instruction", memory_types)
+        self.assertIn("preference", memory_types)
+        self.assertIn("learning", memory_types)
+        self.assertTrue(
+            any("pytest tests/test_api.py" in memory.content for memory in memories)
+        )
+
+    def test_local_backend_recalls_relevant_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = Path(tmpdir) / "memory.json"
+            backend = LocalJsonBackend(store)
+            memories = distill_transcript(
+                "Decision: Use Postgres for project state.",
+                skill="grill-with-docs",
+                task="review database docs",
+                paths=["docs/database.md"],
+            )
+            for memory in memories:
+                backend.remember(memory)
+
+            recalled = backend.recall("database docs postgres", limit=3)
+
+            self.assertTrue(recalled)
+            self.assertIn("Postgres", recalled[0].content)
+
+    def test_render_context_is_copy_pasteable(self) -> None:
+        memories = distill_transcript(
+            "Constraint: Keep handlers backwards compatible.",
+            skill="handoff",
+            task="prepare route handoff",
+            paths=["memanto/app/routes/memory.py"],
+        )
+
+        output = render_context(memories, "prepare route handoff")
+
+        self.assertIn("Memanto context for this skill run", output)
+        self.assertIn("backwards compatible", output)
+        self.assertIn("prepare route handoff", output)
+
+    def test_manifest_reader_matches_matt_pocock_plugin_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            plugin_dir = root / ".claude-plugin"
+            skill_dir = root / "skills" / "engineering" / "tdd"
+            plugin_dir.mkdir()
+            skill_dir.mkdir(parents=True)
+            (plugin_dir / "plugin.json").write_text(
+                '{"name":"demo","skills":["./skills/engineering/tdd"]}',
+                encoding="utf-8",
+            )
+            (skill_dir / "SKILL.md").write_text(
+                "---\n"
+                "name: tdd\n"
+                "description: Test-driven development loop.\n"
+                "---\n\n"
+                "# TDD\n",
+                encoding="utf-8",
+            )
+
+            entries = load_skill_entries(root)
+            markdown = render_markdown(entries)
+
+            self.assertEqual(entries[0].name, "tdd")
+            self.assertIn("Test-driven development loop", entries[0].description)
+            self.assertIn("skills/engineering/tdd", markdown)
+
+    def test_parse_frontmatter_without_metadata_is_empty(self) -> None:
+        self.assertEqual(parse_frontmatter("# No metadata\n"), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -7,6 +7,7 @@ from bridge import (
     distill_transcript,
     render_context,
 )
+from productivity_check import EXPECTED_CONTEXT, run_productivity_check
 from skills_manifest import load_skill_entries, parse_frontmatter, render_markdown
 
 
@@ -95,6 +96,16 @@ $ pytest tests/test_api.py
 
     def test_parse_frontmatter_without_metadata_is_empty(self) -> None:
         self.assertEqual(parse_frontmatter("# No metadata\n"), {})
+
+    def test_productivity_check_recovers_expected_context(self) -> None:
+        exit_code, report = run_productivity_check()
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            f"Repeated instructions avoided: {len(EXPECTED_CONTEXT)} / {len(EXPECTED_CONTEXT)}",
+            report,
+        )
+        self.assertIn("Rendered context block", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #508
/claim #508

Closes #508

Summary:
- Adds `examples/claudecode-skills-memanto`, a focused Claude Code skills memory bridge example.
- Provides `before` and `after` lifecycle hooks for cross-skill memory recall and transcript distillation.
- Reads `mattpocock/skills`-style `.claude-plugin/plugin.json` manifests so reviewers can list the actual installed skill names/descriptions.
- Supports a reviewer-safe `local` JSON backend that requires no credentials.
- Supports a live `memanto` backend that shells out to the configured Memanto CLI.
- Supports a direct `sdk` backend that calls `memanto.cli.client.sdk_client.SdkClient` without shelling out.
- Includes a shell wrapper, runnable offline demo script, `.env.example`, demo transcript, expected output, terminal SVG, README, and unit tests.

Showcase:
- The README includes a complete offline demo that proves a `grill-with-docs` run can store decisions, constraints, preferences, artifacts, and commands that a later `tdd` skill run recalls automatically.
- `demo/expected-output.md` and `demo/terminal-demo.svg` give reviewers a quick visual/readback check before running the demo.
- No external Reddit/X showcase is included in this first PR; the issue maintainer clarified that external social posts are not mandatory for technical review and only affect community-engagement scoring.

Share-ready showcase:
- Added `examples/claudecode-skills-memanto/SOCIAL_SHOWCASE.md` with ready-to-post X/LinkedIn/Reddit copy, demo proof commands, expected productivity output, and a concise explanation of the cross-skill memory bridge for the community-engagement part of the bounty.

Validation:
- `ruff check examples/claudecode-skills-memanto`
- `python -m py_compile examples/claudecode-skills-memanto/bridge.py examples/claudecode-skills-memanto/skills_manifest.py`
- `PYTHONPATH=examples/claudecode-skills-memanto python -m unittest discover -s examples/claudecode-skills-memanto/tests`
- `./examples/claudecode-skills-memanto/run_offline_demo.sh /tmp/memanto-skills-demo.json`
- `python examples/claudecode-skills-memanto/bridge.py --backend local --store /tmp/memanto-skills-demo.json after --skill grill-with-docs --task 'review API pagination design' --path docs/api-pagination.md --transcript examples/claudecode-skills-memanto/demo/session-one-transcript.md`
- `python examples/claudecode-skills-memanto/bridge.py --backend local --store /tmp/memanto-skills-demo.json before --skill tdd --task 'add pagination tests' --path tests/test_api.py`
- `git diff --check`

Latest update:
- Adds `productivity_check.py`, a reviewer-safe scoring proof for the bounty's productivity goal.
- The script runs the local two-skill flow and verifies a later `/tdd` run recovers 4/4 remembered items without repeated instructions: PostgreSQL decision, backwards-compatible response rule, dependency-light preference, and pytest command.

Additional validation:
- `python examples/claudecode-skills-memanto/productivity_check.py` -> `Repeated instructions avoided: 4 / 4`

Latest SDK update:
- Adds an opt-in `--backend sdk` mode for Python integrations that want the live Moorcheh path without subprocess calls.
- SDK mode activates the configured `MEMANTO_AGENT_ID`, stores typed memories via `SdkClient.remember(...)`, and recalls through `SdkClient.recall(...)`.
- Adds fake-client unit coverage so reviewers can validate SDK wiring without a Moorcheh API key.

SDK validation:
- `python -m py_compile examples/claudecode-skills-memanto/bridge.py examples/claudecode-skills-memanto/skills_manifest.py examples/claudecode-skills-memanto/productivity_check.py`
- `PYTHONPATH=examples/claudecode-skills-memanto python -m unittest discover -s examples/claudecode-skills-memanto/tests` -> 8 tests OK
- `python examples/claudecode-skills-memanto/productivity_check.py` -> `Repeated instructions avoided: 4 / 4`
- `ruff check examples/claudecode-skills-memanto`
- `git diff --check`


