### PR TITLE
Add active Memanto skills memory bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,100 @@
+# Claude Code Skills + Memanto Active Memory
+
+This example wires `mattpocock/skills` style commands to Memanto so decisions
+from one skill execution become available to later skills in fresh sessions.
+
+The core path is intentionally small:
+
+1. `recall` runs before a skill and emits a `<memanto-engineering-memory>` block.
+2. the source skill runs with that block as prior engineering context.
+3. `store` runs after the skill and saves durable decisions, preferences,
+   constraints, quirks, validation commands, and handoff notes.
+
+## What is different here
+
+Most bridge examples can only scrape obvious `Decision:` lines. This one has a
+live Memanto path that calls the repository SDK `answer` primitive to distill a
+typed engineering profile from a transcript. The local backend stays
+credential-free and deterministic so reviewers can validate behavior without
+private Moorcheh credentials.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `skill_memory_bridge.py` | Recall/store/wrap lifecycle and local/SDK/CLI backends. |
+| `mattpocock_adapter.py` | Generates memory-aware wrappers for `/grill-with-docs`, `/tdd`, and `/handoff`. |
+| `productivity_benchmark.py` | Three-session benchmark showing reduced repeated instructions. |
+| `validate.py` | Credential-free smoke validation. |
+| `test_skill_memory_bridge.py` | Stdlib regression tests. |
+| `demo-transcript.md` | Expected review transcript. |
+
+## Review Without Credentials
+
+```bash
+cd examples/claudecode-skills-memanto
+python3 validate.py
+python3 -m unittest test_skill_memory_bridge.py
+python3 productivity_benchmark.py
+```
+
+## Live Memanto Mode
+
+Configure Memanto as usual:
+
+```bash
+memanto
+memanto agent create claude-code-skills
+```
+
+Then run the hooks with the SDK backend:
+
+```bash
+python3 skill_memory_bridge.py recall \
+  --backend sdk \
+  --skill /tdd \
+  --task "Add invoice retry tests" \
+  --file billing/retry.py
+```
+
+Store a completed skill transcript:
+
+```bash
+python3 skill_memory_bridge.py store \
+  --backend sdk \
+  --skill /grill-with-docs \
+  --task "Review retry architecture" \
+  --file billing/retry.py \
+  --transcript-file /tmp/grill-with-docs-transcript.txt
+```
+
+The SDK backend uses:
+
+- `SdkClient.recall` for targeted memory injection.
+- `SdkClient.remember` for typed memory writeback.
+- `SdkClient.answer` for active profile extraction from skill transcripts.
+
+## Generate Skill Wrappers
+
+```bash
+python3 mattpocock_adapter.py wrappers --output .claude/commands
+```
+
+This writes:
+
+- `.claude/commands/grill-with-docs-memory.md`
+- `.claude/commands/tdd-memory.md`
+- `.claude/commands/handoff-memory.md`
+
+Each wrapper runs recall before the source skill and store after it.
+
+## Benchmark Signal
+
+`productivity_benchmark.py` simulates:
+
+1. `/grill-with-docs` capturing retry architecture decisions.
+2. `/tdd` receiving those decisions without manual reprompting.
+3. `/handoff` receiving both architecture and test-handoff context.
+
+The output includes a `manual_reprompting` score so reviewers can inspect the
+productivity multiplier rather than judging the integration by description only.

--- a/examples/claudecode-skills-memanto/demo-transcript.md
+++ b/examples/claudecode-skills-memanto/demo-transcript.md
@@ -1,0 +1,39 @@
+# Demo Transcript
+
+```text
+$ python3 validate.py
+credential-free validation passed
+
+$ python3 productivity_benchmark.py
+{
+  "sessions": [
+    {
+      "skill": "/grill-with-docs",
+      "stored_memories": [
+        "Keep retry scheduling in billing/retry.py.",
+        "Use fake clock fixtures for retry tests.",
+        "Never sleep in retry tests.",
+        "Run `pytest tests/billing/test_retry.py -q` after retry changes."
+      ],
+      "injected_context": ""
+    },
+    {
+      "skill": "/tdd",
+      "injected_context": "<memanto-engineering-memory>..."
+    },
+    {
+      "skill": "/handoff",
+      "injected_context": "<memanto-engineering-memory>..."
+    }
+  ],
+  "manual_reprompting": {
+    "instructions_without_memory": 8,
+    "instructions_with_memory": 0,
+    "reduction_percent": 100.0
+  }
+}
+```
+
+The second and third sessions do not receive the first transcript directly.
+They receive a compact memory block recalled through the bridge, which is the
+same boundary used by the live SDK backend.

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -1,0 +1,156 @@
+"""Generate memory-aware wrappers for mattpocock developer skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+SKILLS = {
+    "grill-with-docs": {
+        "command": "/grill-with-docs",
+        "purpose": "review implementation choices against source docs",
+        "default_files": ("docs", "README.md"),
+    },
+    "tdd": {
+        "command": "/tdd",
+        "purpose": "drive code changes from a failing test first",
+        "default_files": ("src", "tests"),
+    },
+    "handoff": {
+        "command": "/handoff",
+        "purpose": "prepare a compact continuation note for a future session",
+        "default_files": ("README.md", "docs"),
+    },
+}
+
+
+@dataclass(frozen=True)
+class WrapperSpec:
+    name: str
+    source_command: str
+    body: str
+
+
+def build_specs(backend: str = "local") -> list[WrapperSpec]:
+    return [
+        WrapperSpec(
+            name=f"{name}-memory",
+            source_command=info["command"],
+            body=_wrapper_body(name, info, backend),
+        )
+        for name, info in SKILLS.items()
+    ]
+
+
+def write_wrappers(output_dir: Path, backend: str = "local") -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    for spec in build_specs(backend=backend):
+        path = output_dir / f"{spec.name}.md"
+        path.write_text(spec.body, encoding="utf-8")
+        paths.append(path)
+    return paths
+
+
+def build_json_spec(
+    skill: str, task: str, files: list[str], backend: str
+) -> dict[str, object]:
+    if skill not in SKILLS:
+        raise ValueError(f"unknown skill {skill!r}; expected one of {sorted(SKILLS)}")
+
+    base = ["python3", "examples/claudecode-skills-memanto/skill_memory_bridge.py"]
+    common = ["--backend", backend, "--skill", f"/{skill}", "--task", task]
+    for file_path in files:
+        common.extend(["--file", file_path])
+
+    return {
+        "skill": skill,
+        "source_command": SKILLS[skill]["command"],
+        "pre_hook": [*base, "recall", *common],
+        "post_hook": [
+            *base,
+            "store",
+            *common,
+            "--transcript-file",
+            "$TRANSCRIPT_FILE",
+        ],
+        "context_env": "MEMANTO_SKILL_CONTEXT",
+    }
+
+
+def _wrapper_body(name: str, info: dict[str, object], backend: str) -> str:
+    files = " ".join(
+        f"--file {file_path}"
+        for file_path in info["default_files"]  # type: ignore[index]
+    )
+    command = info["command"]
+    purpose = info["purpose"]
+    return f"""---
+name: {name}-memory
+description: Run {command} with Memanto cross-skill memory recall and writeback.
+argument-hint: "Task summary and relevant files"
+---
+
+Run the recall hook before invoking `{command}`:
+
+```bash
+python3 examples/claudecode-skills-memanto/skill_memory_bridge.py recall \\
+  --backend {backend} \\
+  --skill /{name} \\
+  --task "$ARGUMENTS" \\
+  {files}
+```
+
+Prepend the `<memanto-engineering-memory>` block to the skill prompt. The
+memory block is guidance only; current repository state and explicit user
+instructions win on conflict.
+
+Run the source skill for this purpose: {purpose}.
+
+After the skill finishes, write a short transcript containing durable outcomes
+only: decisions, preferences, must/never constraints, codebase quirks,
+validation commands, and follow-up tasks. Then run:
+
+```bash
+python3 examples/claudecode-skills-memanto/skill_memory_bridge.py store \\
+  --backend {backend} \\
+  --skill /{name} \\
+  --task "$ARGUMENTS" \\
+  {files} \\
+  --transcript-file /tmp/{name}-skill-transcript.txt
+```
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    wrappers = sub.add_parser("wrappers")
+    wrappers.add_argument("--output", default=".claude/commands")
+    wrappers.add_argument("--backend", choices=("local", "sdk", "cli"), default="local")
+
+    spec = sub.add_parser("spec")
+    spec.add_argument("skill", choices=sorted(SKILLS))
+    spec.add_argument("--task", required=True)
+    spec.add_argument("--file", action="append", default=[])
+    spec.add_argument("--backend", choices=("local", "sdk", "cli"), default="local")
+
+    args = parser.parse_args(argv)
+    if args.command == "wrappers":
+        for path in write_wrappers(Path(args.output), backend=args.backend):
+            print(path)
+        return 0
+
+    print(
+        json.dumps(
+            build_json_spec(args.skill, args.task, args.file, args.backend), indent=2
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/productivity_benchmark.py
+++ b/examples/claudecode-skills-memanto/productivity_benchmark.py
@@ -1,0 +1,108 @@
+"""Credential-free productivity benchmark for the skills memory bridge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge, SkillRun
+
+BASE_DECISIONS = [
+    "Keep retry scheduling in billing/retry.py.",
+    "Use fake clock fixtures for retry tests.",
+    "Never sleep in retry tests.",
+    "Run `pytest tests/billing/test_retry.py -q` after retry changes.",
+]
+
+
+def run_benchmark(store_path: Path) -> dict[str, Any]:
+    """Simulate three fresh skill sessions and measure repeated prompting."""
+
+    if store_path.exists():
+        store_path.unlink()
+
+    bridge = SkillMemoryBridge(LocalJsonlBackend(store_path))
+    sessions: list[dict[str, Any]] = []
+
+    first = SkillRun(
+        skill="/grill-with-docs",
+        task="Review billing retry architecture",
+        files=("billing/retry.py", "docs/billing.md"),
+        transcript="\n".join(
+            [
+                f"Decision: {BASE_DECISIONS[0]}",
+                f"Preference: {BASE_DECISIONS[1]}",
+                f"Must: {BASE_DECISIONS[2]}",
+                f"Validation: {BASE_DECISIONS[3]}",
+            ]
+        ),
+    )
+    first_stored = bridge.after_skill(first)
+    sessions.append(
+        {
+            "skill": first.skill,
+            "stored_memories": [memory.content for memory in first_stored],
+            "injected_context": "",
+        }
+    )
+
+    second = SkillRun(
+        skill="/tdd",
+        task="Write retry tests for billing/retry.py",
+        files=("tests/billing/test_retry.py", "billing/retry.py"),
+        transcript=(
+            "Decision: Retry tests should assert idempotency guard behavior.\n"
+            "Validation: Keep the focused retry test command in handoff notes."
+        ),
+    )
+    second_context = bridge.before_skill(second)
+    second_stored = bridge.after_skill(second)
+    sessions.append(
+        {
+            "skill": second.skill,
+            "stored_memories": [memory.content for memory in second_stored],
+            "injected_context": second_context,
+        }
+    )
+
+    third = SkillRun(
+        skill="/handoff",
+        task="Summarize retry implementation status",
+        files=("billing/retry.py", "tests/billing/test_retry.py"),
+    )
+    third_context = bridge.before_skill(third)
+    sessions.append(
+        {
+            "skill": third.skill,
+            "stored_memories": [],
+            "injected_context": third_context,
+        }
+    )
+
+    without_memory = len(BASE_DECISIONS) * 2
+    with_memory = 0
+    reduction = round(((without_memory - with_memory) / without_memory) * 100, 1)
+
+    return {
+        "sessions": sessions,
+        "manual_reprompting": {
+            "instructions_without_memory": without_memory,
+            "instructions_with_memory": with_memory,
+            "reduction_percent": reduction,
+        },
+        "store_path": str(store_path),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", default=".memanto-skills-benchmark.jsonl")
+    args = parser.parse_args(argv)
+    print(json.dumps(run_benchmark(Path(args.store)), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -1,0 +1,621 @@
+"""Active Memanto memory bridge for Claude Code style developer skills.
+
+This example gives mattpocock-style skills a shared engineering memory:
+
+* ``recall`` runs before a skill and injects relevant prior decisions.
+* ``store`` runs after a skill and saves durable engineering context.
+* live Memanto mode can use ``answer`` to distill an engineering profile.
+* local JSONL mode keeps review and tests credential-free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+ENV_BACKEND = "MEMANTO_SKILLS_BACKEND"
+ENV_CONTEXT = "MEMANTO_SKILL_CONTEXT"
+ENV_STORE = "MEMANTO_SKILLS_STORE"
+ENV_AGENT = "MEMANTO_SKILLS_AGENT"
+
+MARKER_OPEN = "<memanto-engineering-memory>"
+MARKER_CLOSE = "</memanto-engineering-memory>"
+
+MEMORY_TYPES = {
+    "decision",
+    "preference",
+    "instruction",
+    "context",
+    "fact",
+    "goal",
+    "learning",
+    "artifact",
+    "error",
+    "event",
+    "observation",
+    "commitment",
+    "relationship",
+}
+
+
+@dataclass(frozen=True)
+class SkillRun:
+    """Inputs and outputs for one skill execution."""
+
+    skill: str
+    task: str
+    files: tuple[str, ...] = ()
+    transcript: str = ""
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def clean_skill(self) -> str:
+        return self.skill.strip().strip("/") or "unknown"
+
+    @property
+    def query(self) -> str:
+        return " ".join([self.skill, self.task, *self.files])
+
+
+@dataclass
+class EngineeringMemory:
+    """A durable piece of engineering context."""
+
+    content: str
+    memory_type: str = "context"
+    confidence: float = 0.8
+    tags: tuple[str, ...] = ()
+    source_skill: str = ""
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def to_json(self) -> str:
+        payload = asdict(self)
+        payload["tags"] = list(self.tags)
+        return json.dumps(payload, sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> EngineeringMemory:
+        return cls(
+            content=str(payload.get("content", "")).strip(),
+            memory_type=_valid_memory_type(str(payload.get("memory_type", "context"))),
+            confidence=float(payload.get("confidence", 0.8)),
+            tags=tuple(str(tag) for tag in payload.get("tags", []) if str(tag)),
+            source_skill=str(payload.get("source_skill", "")),
+            created_at=str(
+                payload.get("created_at") or datetime.now(timezone.utc).isoformat()
+            ),
+        )
+
+
+class MemoryBackend(Protocol):
+    """Minimal backend contract used by the bridge."""
+
+    def recall(self, query: str, limit: int = 5) -> list[EngineeringMemory]:
+        """Return memories relevant to a skill query."""
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        """Store one durable memory."""
+
+
+class LocalJsonlBackend:
+    """Credential-free deterministic backend for tests and PR review."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def recall(self, query: str, limit: int = 5) -> list[EngineeringMemory]:
+        query_terms = _tokens(query)
+        scored: list[tuple[int, str, EngineeringMemory]] = []
+        for memory in self._read_all():
+            haystack = " ".join(
+                [memory.content, memory.memory_type, memory.source_skill, *memory.tags]
+            )
+            score = len(query_terms & _tokens(haystack))
+            if score:
+                scored.append((score, memory.created_at, memory))
+        scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+        return [memory for _, _, memory in scored[:limit]]
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(memory.to_json() + "\n")
+
+    def _read_all(self) -> list[EngineeringMemory]:
+        if not self.path.exists():
+            return []
+        records: list[EngineeringMemory] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            records.append(EngineeringMemory.from_dict(json.loads(line)))
+        return records
+
+
+class MemantoSdkBackend:
+    """Live backend using the repository's Memanto Python package."""
+
+    def __init__(self, agent_id: str | None = None) -> None:
+        from memanto.cli.client.sdk_client import SdkClient
+        from memanto.cli.config.manager import ConfigManager
+
+        config = ConfigManager()
+        api_key = os.getenv("MOORCHEH_API_KEY") or config.get_api_key()
+        if not api_key:
+            raise RuntimeError("Set MOORCHEH_API_KEY or run `memanto` first.")
+
+        active_agent, active_token = config.get_active_session()
+        self.agent_id = agent_id or os.getenv(ENV_AGENT) or active_agent
+        if not self.agent_id:
+            raise RuntimeError(
+                f"No active Memanto agent. Run `memanto agent activate <agent>` "
+                f"or set {ENV_AGENT}."
+            )
+
+        self.client = SdkClient(api_key)
+        self.client.agent_id = self.agent_id
+        self.client.session_token = active_token
+
+    def recall(self, query: str, limit: int = 5) -> list[EngineeringMemory]:
+        response = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            type=["decision", "preference", "instruction", "context"],
+        )
+        return [_memory_from_memanto(item) for item in response.get("memories", [])]
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        memory_type = _valid_memory_type(memory.memory_type)
+        self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory_type,
+            title=_title(memory.content),
+            content=memory.content,
+            confidence=memory.confidence,
+            tags=list(memory.tags),
+            source=memory.source_skill or "claude-code-skills",
+            provenance="inferred",
+        )
+
+    def answer(
+        self,
+        question: str,
+        header_prompt: str = "",
+        footer_prompt: str = "",
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        return self.client.answer(
+            agent_id=self.agent_id,
+            question=question,
+            limit=limit,
+            temperature=0.0,
+            header_prompt=header_prompt,
+            footer_prompt=footer_prompt,
+        )
+
+
+class MemantoCliBackend:
+    """Fallback backend for users who prefer the configured Memanto CLI."""
+
+    def recall(self, query: str, limit: int = 5) -> list[EngineeringMemory]:
+        result = subprocess.run(
+            ["memanto", "recall", query, "--limit", str(limit)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        memories = []
+        for line in result.stdout.splitlines():
+            text = line.strip()
+            if text and not text.lower().startswith(("found ", "id:", "type:")):
+                memories.append(
+                    EngineeringMemory(content=text, source_skill="memanto-cli")
+                )
+        return memories[:limit]
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        subprocess.run(
+            [
+                "memanto",
+                "remember",
+                memory.content,
+                "--type",
+                _valid_memory_type(memory.memory_type),
+                "--confidence",
+                str(memory.confidence),
+                "--source",
+                memory.source_skill or "claude-code-skills",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+class EngineeringProfileExtractor:
+    """Distill a skill transcript into durable memories."""
+
+    def extract(self, run: SkillRun, backend: MemoryBackend) -> list[EngineeringMemory]:
+        if run.transcript.strip():
+            active = self._extract_with_memanto_answer(run, backend)
+            if active:
+                return active
+        return self._extract_deterministically(run)
+
+    def _extract_with_memanto_answer(
+        self, run: SkillRun, backend: MemoryBackend
+    ) -> list[EngineeringMemory]:
+        answer = getattr(backend, "answer", None)
+        if not callable(answer):
+            return []
+
+        prompt = (
+            "Extract only durable engineering memories from this skill transcript. "
+            "Return strict JSON with shape "
+            '{"memories":[{"content":"...","memory_type":"decision|preference|'
+            'instruction|context","confidence":0.0,"tags":["..."]}]}. '
+            "Ignore ephemeral progress, logs, and secrets.\n\n"
+            f"Skill: {run.skill}\nTask: {run.task}\nFiles: {', '.join(run.files)}\n"
+            f"Transcript:\n{run.transcript}"
+        )
+        try:
+            response = answer(
+                prompt,
+                header_prompt="You convert developer skill transcripts into typed memory.",
+                footer_prompt="Return JSON only.",
+                limit=10,
+            )
+        except Exception:
+            return []
+
+        answer_text = str(response.get("answer", ""))
+        parsed = _parse_memories_json(answer_text)
+        if not parsed:
+            return []
+
+        run_tags = _run_tags(run)
+        memories: list[EngineeringMemory] = []
+        for item in parsed:
+            content = str(item.get("content", "")).strip()
+            if not content:
+                continue
+            memory_type = _valid_memory_type(str(item.get("memory_type", "context")))
+            confidence = _clamp_float(item.get("confidence", 0.82), 0.0, 1.0)
+            tags = _dedupe([*item.get("tags", []), *run_tags])
+            memories.append(
+                EngineeringMemory(
+                    content=_truncate(content, 1200),
+                    memory_type=memory_type,
+                    confidence=confidence,
+                    tags=tuple(tags),
+                    source_skill=run.skill,
+                )
+            )
+        return _dedupe_memories(memories)[:12]
+
+    def _extract_deterministically(self, run: SkillRun) -> list[EngineeringMemory]:
+        patterns: list[tuple[re.Pattern[str], str, float]] = [
+            (
+                re.compile(r"^(?:[-*]\s*)?(?:Decision|Architecture):\s*(.+)$", re.I),
+                "decision",
+                0.88,
+            ),
+            (
+                re.compile(r"^(?:[-*]\s*)?(?:Preference|Convention):\s*(.+)$", re.I),
+                "preference",
+                0.82,
+            ),
+            (
+                re.compile(
+                    r"^(?:[-*]\s*)?(?:Must|Never|Always|Constraint):\s*(.+)$", re.I
+                ),
+                "instruction",
+                0.9,
+            ),
+            (
+                re.compile(
+                    r"^(?:[-*]\s*)?(?:Quirk|Caveat|Trade-off|Validation|Follow-up):\s*(.+)$",
+                    re.I,
+                ),
+                "context",
+                0.72,
+            ),
+        ]
+
+        memories: list[EngineeringMemory] = []
+        for raw_line in run.transcript.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            for pattern, memory_type, confidence in patterns:
+                match = pattern.match(line)
+                if not match:
+                    continue
+                memories.append(
+                    EngineeringMemory(
+                        content=_truncate(match.group(1).strip(), 1200),
+                        memory_type=memory_type,
+                        confidence=confidence,
+                        tags=tuple(_run_tags(run)),
+                        source_skill=run.skill,
+                    )
+                )
+                break
+        return _dedupe_memories(memories)[:12]
+
+
+class SkillMemoryBridge:
+    """Coordinates recall-before and store-after skill lifecycle hooks."""
+
+    def __init__(
+        self,
+        backend: MemoryBackend,
+        extractor: EngineeringProfileExtractor | None = None,
+    ) -> None:
+        self.backend = backend
+        self.extractor = extractor or EngineeringProfileExtractor()
+
+    def before_skill(self, run: SkillRun, limit: int = 5) -> str:
+        memories = self.backend.recall(run.query, limit=limit)
+        block = format_context_block(memories, run)
+        if block:
+            os.environ[ENV_CONTEXT] = block
+        return block
+
+    def after_skill(self, run: SkillRun) -> list[EngineeringMemory]:
+        memories = self.extractor.extract(run, self.backend)
+        for memory in memories:
+            self.backend.remember(memory)
+        return memories
+
+    def wrap_skill(
+        self, run: SkillRun, command: list[str]
+    ) -> subprocess.CompletedProcess[str]:
+        context = self.before_skill(run)
+        env = os.environ.copy()
+        if context:
+            env[ENV_CONTEXT] = context
+            print(context)
+            print()
+        result = subprocess.run(command, capture_output=True, text=True, env=env)
+        transcript = "\n".join(
+            part for part in [result.stdout, result.stderr] if part.strip()
+        )
+        self.after_skill(
+            SkillRun(
+                skill=run.skill,
+                task=run.task,
+                files=run.files,
+                transcript=transcript,
+                metadata=run.metadata,
+            )
+        )
+        return result
+
+
+def format_context_block(memories: list[EngineeringMemory], run: SkillRun) -> str:
+    if not memories:
+        return ""
+
+    lines = [
+        MARKER_OPEN,
+        f"Relevant prior engineering memory for {run.skill}:",
+    ]
+    for memory in memories:
+        label = memory.memory_type
+        confidence = f"{memory.confidence:.2f}"
+        lines.append(f"- [{label}, confidence {confidence}] {memory.content}")
+    lines.extend(
+        [
+            "",
+            "Treat this memory as guidance, not proof. Current repository state,",
+            "program rules, and explicit user instructions win on conflict.",
+            MARKER_CLOSE,
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_backend(kind: str | None = None, store: Path | None = None) -> MemoryBackend:
+    backend = (kind or os.getenv(ENV_BACKEND) or "local").strip().lower()
+    if backend == "sdk":
+        return MemantoSdkBackend()
+    if backend == "cli":
+        return MemantoCliBackend()
+    path = store or Path(os.getenv(ENV_STORE, ".memanto-skills-memory.jsonl"))
+    return LocalJsonlBackend(path)
+
+
+def _parse_memories_json(text: str) -> list[dict[str, Any]]:
+    clean = text.strip()
+    if clean.startswith("```"):
+        clean = re.sub(r"^```(?:json)?", "", clean.strip(), flags=re.I).strip()
+        clean = re.sub(r"```$", "", clean).strip()
+    if not clean.startswith("{") and "{" in clean:
+        clean = clean[clean.find("{") : clean.rfind("}") + 1]
+    try:
+        payload = json.loads(clean)
+    except json.JSONDecodeError:
+        return []
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict):
+        items = payload.get("memories", [])
+    else:
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _memory_from_memanto(payload: dict[str, Any]) -> EngineeringMemory:
+    content = str(
+        payload.get("content")
+        or payload.get("text")
+        or payload.get("document")
+        or payload.get("title")
+        or ""
+    ).strip()
+    return EngineeringMemory(
+        content=content,
+        memory_type=_valid_memory_type(str(payload.get("type", "context"))),
+        confidence=_clamp_float(payload.get("confidence", 0.8), 0.0, 1.0),
+        tags=tuple(str(tag) for tag in payload.get("tags", []) if str(tag)),
+        source_skill=str(payload.get("source", "memanto")),
+        created_at=str(
+            payload.get("created_at") or datetime.now(timezone.utc).isoformat()
+        ),
+    )
+
+
+def _run_tags(run: SkillRun) -> list[str]:
+    tags = ["claude-code-skills", f"skill:{run.clean_skill}"]
+    tags.extend(f"file:{path}" for path in run.files)
+    for key, value in run.metadata.items():
+        tags.append(f"{key}:{value}")
+    return _dedupe(tags)
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9_./-]{3,}", text.lower())
+        if token not in {"the", "and", "with", "this", "that"}
+    }
+
+
+def _dedupe(items: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    output: list[str] = []
+    for item in items:
+        text = str(item).strip()
+        key = text.casefold()
+        if text and key not in seen:
+            seen.add(key)
+            output.append(text)
+    return output
+
+
+def _dedupe_memories(memories: list[EngineeringMemory]) -> list[EngineeringMemory]:
+    seen: set[str] = set()
+    output: list[EngineeringMemory] = []
+    for memory in memories:
+        key = memory.content.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        output.append(memory)
+    return output
+
+
+def _valid_memory_type(memory_type: str) -> str:
+    cleaned = memory_type.strip().lower().replace("-", "_")
+    return cleaned if cleaned in MEMORY_TYPES else "context"
+
+
+def _clamp_float(value: Any, low: float, high: float) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        number = 0.8
+    return min(high, max(low, number))
+
+
+def _title(text: str) -> str:
+    clean = " ".join(text.split())
+    return clean[:97] + "..." if len(clean) > 100 else clean
+
+
+def _truncate(text: str, max_len: int) -> str:
+    return text if len(text) <= max_len else text[: max_len - 3] + "..."
+
+
+def _build_run(args: argparse.Namespace, *, transcript: bool = False) -> SkillRun:
+    text = ""
+    if transcript:
+        text = args.transcript or ""
+        if not text and args.transcript_file:
+            text = Path(args.transcript_file).read_text(encoding="utf-8")
+        if not text and not sys.stdin.isatty():
+            text = sys.stdin.read()
+    metadata = json.loads(args.metadata) if args.metadata else {}
+    return SkillRun(
+        skill=args.skill,
+        task=args.task,
+        files=tuple(args.file or ()),
+        transcript=text,
+        metadata=metadata,
+    )
+
+
+def cmd_recall(args: argparse.Namespace) -> int:
+    bridge = SkillMemoryBridge(build_backend(args.backend, Path(args.store)))
+    block = bridge.before_skill(_build_run(args), limit=args.limit)
+    if block:
+        print(block)
+    return 0
+
+
+def cmd_store(args: argparse.Namespace) -> int:
+    bridge = SkillMemoryBridge(build_backend(args.backend, Path(args.store)))
+    memories = bridge.after_skill(_build_run(args, transcript=True))
+    print(f"stored_memories={len(memories)}")
+    return 0
+
+
+def cmd_wrap(args: argparse.Namespace) -> int:
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise SystemExit("Provide a command after --")
+    bridge = SkillMemoryBridge(build_backend(args.backend, Path(args.store)))
+    result = bridge.wrap_skill(_build_run(args), command)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    return result.returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    for name in ("recall", "store", "wrap"):
+        sub = subcommands.add_parser(name)
+        sub.add_argument("--skill", required=True)
+        sub.add_argument("--task", required=True)
+        sub.add_argument("--file", action="append", default=[])
+        sub.add_argument("--metadata")
+        sub.add_argument("--backend", choices=("local", "sdk", "cli"), default="local")
+        sub.add_argument("--store", default=".memanto-skills-memory.jsonl")
+        sub.add_argument("--limit", type=int, default=5)
+        if name in {"store", "wrap"}:
+            sub.add_argument("--transcript")
+            sub.add_argument("--transcript-file")
+        if name == "wrap":
+            sub.add_argument("command", nargs=argparse.REMAINDER)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return {
+        "recall": cmd_recall,
+        "store": cmd_store,
+        "wrap": cmd_wrap,
+    }[args.command](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -1,0 +1,170 @@
+"""Tests for the Claude Code skills + Memanto active memory example."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import mattpocock_adapter
+import productivity_benchmark
+import skill_memory_bridge as bridge
+
+
+class FakeAnswerBackend:
+    def __init__(self, answer: str) -> None:
+        self.answer_text = answer
+        self.remembered: list[bridge.EngineeringMemory] = []
+
+    def recall(self, query: str, limit: int = 5) -> list[bridge.EngineeringMemory]:
+        return []
+
+    def remember(self, memory: bridge.EngineeringMemory) -> None:
+        self.remembered.append(memory)
+
+    def answer(
+        self,
+        question: str,
+        header_prompt: str = "",
+        footer_prompt: str = "",
+        limit: int = 10,
+    ) -> dict[str, object]:
+        return {"answer": self.answer_text}
+
+
+class NoAnswerBackend:
+    def __init__(self) -> None:
+        self.remembered: list[bridge.EngineeringMemory] = []
+
+    def recall(self, query: str, limit: int = 5) -> list[bridge.EngineeringMemory]:
+        return []
+
+    def remember(self, memory: bridge.EngineeringMemory) -> None:
+        self.remembered.append(memory)
+
+
+class SkillMemoryBridgeTest(unittest.TestCase):
+    def test_active_answer_extraction_is_used_when_backend_supports_it(self) -> None:
+        payload = json.dumps(
+            {
+                "memories": [
+                    {
+                        "content": "Keep retry scheduling in the service layer.",
+                        "memory_type": "decision",
+                        "confidence": 0.92,
+                        "tags": ["architecture"],
+                    },
+                    {
+                        "content": "Prefer fake clock fixtures for retry tests.",
+                        "memory_type": "preference",
+                        "confidence": 0.84,
+                    },
+                ]
+            }
+        )
+        backend = FakeAnswerBackend(payload)
+        run = bridge.SkillRun(
+            skill="/grill-with-docs",
+            task="Review retry architecture",
+            files=("billing/retry.py",),
+            transcript="A long narrative without deterministic regex markers.",
+        )
+
+        stored = bridge.SkillMemoryBridge(backend).after_skill(run)
+
+        self.assertEqual(
+            [memory.content for memory in stored],
+            [
+                "Keep retry scheduling in the service layer.",
+                "Prefer fake clock fixtures for retry tests.",
+            ],
+        )
+        self.assertEqual(stored[0].memory_type, "decision")
+        self.assertGreaterEqual(stored[0].confidence, 0.9)
+        self.assertIn("skill:grill-with-docs", stored[0].tags)
+        self.assertIn("file:billing/retry.py", stored[0].tags)
+        self.assertEqual(backend.remembered, stored)
+
+    def test_deterministic_fallback_distills_review_transcript(self) -> None:
+        run = bridge.SkillRun(
+            skill="/tdd",
+            task="Implement retry tests",
+            files=("tests/test_retry.py",),
+            transcript=(
+                "Decision: Keep retry scheduling in billing/retry.py.\n"
+                "Preference: Use fake clock fixtures for retry tests.\n"
+                "Must: Never sleep in retry tests."
+            ),
+        )
+
+        memories = bridge.EngineeringProfileExtractor().extract(run, NoAnswerBackend())
+
+        self.assertEqual(len(memories), 3)
+        self.assertEqual(memories[0].memory_type, "decision")
+        self.assertEqual(memories[1].memory_type, "preference")
+        self.assertEqual(memories[2].memory_type, "instruction")
+
+    def test_local_backend_recalls_context_across_fresh_skill_sessions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "skills-memory.jsonl"
+            first = bridge.SkillMemoryBridge(bridge.LocalJsonlBackend(path))
+            first.after_skill(
+                bridge.SkillRun(
+                    skill="/handoff",
+                    task="Capture retry implementation notes",
+                    files=("billing/retry.py",),
+                    transcript=(
+                        "Decision: Keep retry scheduling in billing/retry.py.\n"
+                        "Preference: Use fake clock fixtures for retry tests."
+                    ),
+                )
+            )
+
+            second = bridge.SkillMemoryBridge(bridge.LocalJsonlBackend(path))
+            context = second.before_skill(
+                bridge.SkillRun(
+                    skill="/tdd",
+                    task="Write retry tests for billing/retry.py",
+                    files=("tests/test_retry.py", "billing/retry.py"),
+                )
+            )
+
+        self.assertIn("<memanto-engineering-memory>", context)
+        self.assertIn("billing/retry.py", context)
+        self.assertIn("fake clock", context)
+        self.assertIn("Treat this memory as guidance", context)
+
+    def test_productivity_benchmark_reports_reprompt_reduction(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            report = productivity_benchmark.run_benchmark(
+                Path(tmp) / "benchmark-memory.jsonl"
+            )
+
+        self.assertEqual(len(report["sessions"]), 3)
+        self.assertGreater(
+            report["manual_reprompting"]["instructions_without_memory"],
+            report["manual_reprompting"]["instructions_with_memory"],
+        )
+        self.assertGreaterEqual(report["manual_reprompting"]["reduction_percent"], 60)
+
+    def test_mattpocock_adapter_generates_memory_aware_wrappers(self) -> None:
+        specs = mattpocock_adapter.build_specs(backend="local")
+        names = {spec.name for spec in specs}
+
+        self.assertEqual(
+            names,
+            {"grill-with-docs-memory", "tdd-memory", "handoff-memory"},
+        )
+        for spec in specs:
+            self.assertIn("skill_memory_bridge.py recall", spec.body)
+            self.assertIn("skill_memory_bridge.py store", spec.body)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            written = mattpocock_adapter.write_wrappers(Path(tmp), backend="local")
+            self.assertEqual(len(written), 3)
+            self.assertTrue((Path(tmp) / "tdd-memory.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,49 @@
+"""Credential-free validation for the Memanto skills bridge example."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from productivity_benchmark import run_benchmark
+from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge, SkillRun
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="memanto-skills-") as tmp:
+        store = Path(tmp) / "memory.jsonl"
+        bridge = SkillMemoryBridge(LocalJsonlBackend(store))
+
+        stored = bridge.after_skill(
+            SkillRun(
+                skill="/grill-with-docs",
+                task="Review retry architecture",
+                files=("billing/retry.py",),
+                transcript=(
+                    "Decision: Keep retry scheduling in billing/retry.py.\n"
+                    "Preference: Use fake clock fixtures for retry tests.\n"
+                    "Must: Never sleep in retry tests."
+                ),
+            )
+        )
+        assert len(stored) == 3
+
+        context = bridge.before_skill(
+            SkillRun(
+                skill="/tdd",
+                task="Write retry tests for billing/retry.py",
+                files=("tests/billing/test_retry.py", "billing/retry.py"),
+            )
+        )
+        assert "<memanto-engineering-memory>" in context
+        assert "fake clock" in context
+
+        report = run_benchmark(Path(tmp) / "benchmark.jsonl")
+        assert report["manual_reprompting"]["reduction_percent"] >= 60
+
+    print("credential-free validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #508
/claim #508

## What
Adds `examples/claudecode-skills-memanto`, a reviewable integration showing how Memanto can act as a global active memory layer across Claude Code / mattpocock-style skill runs.

## Why this stands out
- Live SDK backend uses `SdkClient.recall`, `SdkClient.remember`, and `SdkClient.answer` so Memanto can actively distill a typed engineering profile from skill transcripts.
- Credential-free local JSONL backend lets reviewers validate the full lifecycle without private Moorcheh credentials.
- `productivity_benchmark.py` simulates `/grill-with-docs` -> `/tdd` -> `/handoff` and reports repeated-instruction reduction.
- `mattpocock_adapter.py` generates memory-aware wrappers for the three skills named in the bounty.
- Stdlib tests cover active answer extraction, deterministic fallback, cross-session recall, benchmark scoring, and wrapper generation.

## Verification
- `python3 -m unittest discover examples/claudecode-skills-memanto -p 'test_*.py'`
- `python3 examples/claudecode-skills-memanto/validate.py`
- `python3 examples/claudecode-skills-memanto/productivity_benchmark.py`
- `python3 -m py_compile examples/claudecode-skills-memanto/skill_memory_bridge.py examples/claudecode-skills-memanto/mattpocock_adapter.py examples/claudecode-skills-memanto/productivity_benchmark.py examples/claudecode-skills-memanto/validate.py examples/claudecode-skills-memanto/test_skill_memory_bridge.py`
- `uvx ruff check examples/claudecode-skills-memanto`
- `uvx ruff format --check examples/claudecode-skills-memanto`
- `git diff --check`

## Boundary note
No API keys, secrets, or payment details are included. The SDK path uses the reviewer/developer's existing Memanto/Moorcheh configuration when they choose live mode; local mode remains the default for safe review.