### PR TITLE
Add installable developer skills Memanto bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/.env.example
+++ b/examples/claudecode-skills-memanto/.env.example
@@ -1,0 +1,16 @@
+# Default: credential-free local JSONL memory.
+SKILL_MEMANTO_BACKEND=local
+SKILL_MEMANTO_STORE=~/.memanto/skill-memory/developer-skills.jsonl
+SKILL_MEMANTO_MAX_INJECTED=5
+SKILL_MEMANTO_MAX_EXTRACTED=8
+
+# Optional live backend.
+# Set SKILL_MEMANTO_BACKEND=live and provide one key variable.
+# MOORCHEH_API_KEY=
+# MEMANTO_API_KEY=
+SKILL_MEMANTO_AGENT_ID=developer-skills
+
+# Generated wrappers call the real skill command through an env variable.
+# Example:
+# SKILL_MEMANTO_TDD_COMMAND=claude /tdd
+# SKILL_MEMANTO_GRILL_WITH_DOCS_COMMAND=claude /grill-with-docs

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,173 @@
+# Memanto Bridge For Developer Skills
+
+This example adds a small memory bridge around developer skill commands. It is designed for teams using single-purpose skills such as `/grill-with-docs`, `/tdd`, `/handoff`, and `/diagnose`, where useful decisions often get trapped in one run and then have to be repeated in the next.
+
+The bridge does two things:
+
+- Before a skill starts, it recalls relevant engineering memories and prints a compact prompt block.
+- After a skill finishes, it reads the transcript, extracts durable decisions and preferences, and stores them.
+
+It runs without credentials by default using a local JSONL file. A live Memanto backend can be enabled later with an environment variable and a Moorcheh key.
+
+## What Is Included
+
+```text
+examples/claudecode-skills-memanto/
+|-- README.md
+|-- demo-transcript.md
+|-- .env.example
+|-- pyproject.toml
+|-- validate.py
+|-- src/skill_memanto_bridge/
+|   |-- __init__.py
+|   |-- backends.py
+|   |-- bridge.py
+|   |-- cli.py
+|   `-- wrappers.py
+`-- tests/
+    `-- test_bridge.py
+```
+
+## Install
+
+From this folder:
+
+```bash
+python -m pip install -e .
+```
+
+Offline validation does not need the package to be installed:
+
+```bash
+python validate.py
+```
+
+## Local Backend
+
+Local mode is the default. It writes JSONL records to:
+
+```text
+~/.memanto/skill-memory/developer-skills.jsonl
+```
+
+Override it when testing:
+
+```bash
+export SKILL_MEMANTO_STORE=/tmp/developer-skills.jsonl
+```
+
+PowerShell:
+
+```powershell
+$env:SKILL_MEMANTO_STORE = "$env:TEMP\developer-skills.jsonl"
+```
+
+Each record stores a title, content, memory type, confidence, tags, source skill, task, path, and timestamp. No secrets are required for this mode.
+
+## Live Memanto Backend
+
+Live mode is opt-in:
+
+```bash
+export SKILL_MEMANTO_BACKEND=live
+export MOORCHEH_API_KEY=your-key-here
+export SKILL_MEMANTO_AGENT_ID=developer-skills
+```
+
+PowerShell:
+
+```powershell
+$env:SKILL_MEMANTO_BACKEND = "live"
+$env:MOORCHEH_API_KEY = "your-key-here"
+$env:SKILL_MEMANTO_AGENT_ID = "developer-skills"
+```
+
+When live mode is enabled, the bridge lazily imports `memanto.cli.client.sdk_client.SdkClient` and calls its `remember` and `recall` methods. If live mode is not enabled, no Memanto package import or network call is attempted.
+
+## Manual Hook Usage
+
+Print context before a skill:
+
+```bash
+python -m skill_memanto_bridge.cli pre-run \
+  --skill tdd \
+  --task "Add payment webhook tests" \
+  --path services/payments/webhooks.py
+```
+
+Save memories after a skill:
+
+```bash
+python -m skill_memanto_bridge.cli post-run \
+  --skill grill-with-docs \
+  --task "Plan payment webhook handling" \
+  --path services/payments/webhooks.py \
+  --transcript-file transcript.txt
+```
+
+If `--transcript-file` is omitted, `post-run` reads from standard input.
+
+## Wrapper Generation
+
+Generate launchers for common skills:
+
+```bash
+python -m skill_memanto_bridge.cli generate-wrappers \
+  --output-dir .memanto-skill-wrappers \
+  tdd grill-with-docs handoff diagnose
+```
+
+Each generated wrapper has a shell version and a PowerShell version. The wrapper needs an environment variable that points to the real command it should run.
+
+Example shell setup:
+
+```bash
+export SKILL_MEMANTO_TDD_COMMAND="claude /tdd"
+.memanto-skill-wrappers/tdd "Add payment webhook tests"
+```
+
+Example PowerShell setup:
+
+```powershell
+$env:SKILL_MEMANTO_TDD_COMMAND = "claude /tdd"
+.\.memanto-skill-wrappers\tdd.ps1 "Add payment webhook tests"
+```
+
+This avoids hard-coding a specific terminal tool while still giving reviewers a concrete, installable wrapper path.
+
+## Extraction Rules
+
+The offline extractor is intentionally conservative. It stores lines that look like durable engineering guidance:
+
+- decisions: `We decided to keep webhook verification in app/security.py.`
+- preferences: `Preference: use stdlib hmac before adding dependencies.`
+- instructions: `Avoid storing provider secrets in logs.`
+
+It skips general conversation, caps the number of saved items per run, and redacts common key, token, password, and long-secret patterns before writing.
+
+## Validation
+
+Run:
+
+```bash
+python validate.py
+```
+
+The script runs:
+
+- `python -m unittest discover -s tests -v`
+- `compileall` over `src`, `tests`, and `validate.py`
+- a blocked-term scan for this example folder
+
+## Why This Fits The Challenge
+
+The bridge is useful without setup, but it still has a clean path to live Memanto:
+
+- credential-free local JSONL backend for reviewer-safe testing
+- optional live `SdkClient` backend through environment variables
+- pre-run dynamic injection
+- post-run active extraction
+- generated wrappers for skill commands
+- demo transcript
+- focused offline tests
+- no private keys or external services needed for validation

--- a/examples/claudecode-skills-memanto/demo-transcript.md
+++ b/examples/claudecode-skills-memanto/demo-transcript.md
@@ -1,0 +1,70 @@
+# Demo Transcript
+
+This transcript shows the intended reviewer flow using the local JSONL backend. It uses fake project details and no private keys.
+
+## 1. Install
+
+```bash
+$ cd examples/claudecode-skills-memanto
+$ python -m pip install -e .
+```
+
+## 2. First Skill Run Stores Decisions
+
+```bash
+$ cat > /tmp/grill-transcript.txt <<'EOF'
+We decided to keep payment webhook verification in app/security.py.
+Preference: use stdlib hmac before adding dependencies.
+Avoid storing provider secrets in logs.
+EOF
+
+$ python -m skill_memanto_bridge.cli post-run \
+    --skill grill-with-docs \
+    --task "Plan payment webhook handling" \
+    --path services/payments/webhooks.py \
+    --transcript-file /tmp/grill-transcript.txt
+saved 3 memory item(s)
+```
+
+Local JSONL now contains three durable engineering memories:
+
+```json
+{"memory_type": "decision", "title": "keep payment webhook verification in app/security.py", "source": "skill:grill-with-docs"}
+{"memory_type": "preference", "title": "use stdlib hmac before adding dependencies", "source": "skill:grill-with-docs"}
+{"memory_type": "instruction", "title": "Avoid storing provider secrets in logs", "source": "skill:grill-with-docs"}
+```
+
+## 3. Later Skill Run Gets Context Automatically
+
+```bash
+$ python -m skill_memanto_bridge.cli pre-run \
+    --skill tdd \
+    --task "Add payment webhook tests" \
+    --path services/payments/webhooks.py
+<!-- memanto-skill-memory:start -->
+### Memanto memory context
+Apply these previous engineering decisions if they are relevant:
+- [decision] keep payment webhook verification in app/security.py: We decided to keep payment webhook verification in app/security.py.
+- [preference] use stdlib hmac before adding dependencies: Preference: use stdlib hmac before adding dependencies.
+- [instruction] Avoid storing provider secrets in logs: Avoid storing provider secrets in logs.
+<!-- memanto-skill-memory:end -->
+```
+
+The second skill run now receives the earlier architecture choice, implementation preference, and logging rule without the developer repeating them.
+
+## 4. Wrapper Flow
+
+```bash
+$ python -m skill_memanto_bridge.cli generate-wrappers \
+    --output-dir .memanto-skill-wrappers \
+    tdd grill-with-docs
+.memanto-skill-wrappers/tdd
+.memanto-skill-wrappers/tdd.ps1
+.memanto-skill-wrappers/grill-with-docs
+.memanto-skill-wrappers/grill-with-docs.ps1
+
+$ export SKILL_MEMANTO_TDD_COMMAND="claude /tdd"
+$ .memanto-skill-wrappers/tdd "Add payment webhook tests"
+```
+
+The wrapper prints memory context first, runs the configured underlying skill command, captures the output transcript, and writes extracted memories after the run.

--- a/examples/claudecode-skills-memanto/pyproject.toml
+++ b/examples/claudecode-skills-memanto/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skill-memanto-bridge"
+version = "0.1.0"
+description = "A dependency-light memory bridge for developer skill commands."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Memanto contributors" }]
+dependencies = []
+
+[project.scripts]
+skill-memanto = "skill_memanto_bridge.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/examples/claudecode-skills-memanto/src/skill_memanto_bridge/__init__.py
+++ b/examples/claudecode-skills-memanto/src/skill_memanto_bridge/__init__.py
@@ -1,0 +1,10 @@
+from .backends import LocalJsonlBackend, LiveMemantoBackend, build_backend
+from .bridge import BridgeConfig, MemoryBridge
+
+__all__ = [
+    "BridgeConfig",
+    "LiveMemantoBackend",
+    "LocalJsonlBackend",
+    "MemoryBridge",
+    "build_backend",
+]

--- a/examples/claudecode-skills-memanto/src/skill_memanto_bridge/backends.py
+++ b/examples/claudecode-skills-memanto/src/skill_memanto_bridge/backends.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class MemoryBackend(Protocol):
+    def remember(
+        self,
+        *,
+        title: str,
+        content: str,
+        memory_type: str,
+        tags: list[str],
+        source: str,
+        metadata: dict[str, Any],
+        confidence: float = 0.82,
+    ) -> dict[str, Any]:
+        ...
+
+    def recall(self, query: str, *, limit: int) -> list[dict[str, Any]]:
+        ...
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def tokenise(value: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9][a-z0-9_\-/.]*", value.lower())
+        if len(token) > 2
+    }
+
+
+class LocalJsonlBackend:
+    def __init__(self, store_path: Path | str) -> None:
+        self.store_path = Path(store_path).expanduser()
+
+    def remember(
+        self,
+        *,
+        title: str,
+        content: str,
+        memory_type: str,
+        tags: list[str],
+        source: str,
+        metadata: dict[str, Any],
+        confidence: float = 0.82,
+    ) -> dict[str, Any]:
+        self.store_path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "id": str(uuid.uuid4()),
+            "created_at": utc_now(),
+            "title": title.strip()[:120],
+            "content": content.strip(),
+            "memory_type": memory_type,
+            "tags": sorted(set(tags)),
+            "source": source,
+            "confidence": max(0.0, min(1.0, confidence)),
+            "metadata": metadata,
+        }
+        with self.store_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+        return record
+
+    def recall(self, query: str, *, limit: int) -> list[dict[str, Any]]:
+        if not self.store_path.exists():
+            return []
+
+        query_tokens = tokenise(query)
+        scored: list[dict[str, Any]] = []
+        for record in self._iter_records():
+            score = self._score(record, query_tokens)
+            if score <= 0:
+                continue
+            scored_record = dict(record)
+            scored_record["score"] = score
+            scored.append(scored_record)
+
+        scored.sort(
+            key=lambda item: (
+                item["score"],
+                item.get("confidence", 0.0),
+                item.get("created_at", ""),
+            ),
+            reverse=True,
+        )
+        return scored[:limit]
+
+    def _iter_records(self) -> list[dict[str, Any]]:
+        records: list[dict[str, Any]] = []
+        with self.store_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        return records
+
+    def _score(self, record: dict[str, Any], query_tokens: set[str]) -> float:
+        searchable = " ".join(
+            [
+                str(record.get("title", "")),
+                str(record.get("content", "")),
+                " ".join(record.get("tags", [])),
+                str(record.get("metadata", {}).get("path", "")),
+                str(record.get("metadata", {}).get("skill", "")),
+            ]
+        )
+        record_tokens = tokenise(searchable)
+        overlap = len(query_tokens & record_tokens)
+        if overlap == 0:
+            return 0.0
+        type_boost = 0.25 if record.get("memory_type") in {"decision", "instruction"} else 0
+        confidence = float(record.get("confidence", 0.0))
+        return overlap + type_boost + confidence
+
+
+class LiveMemantoBackend:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        agent_id: str,
+        client_factory: Any | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.agent_id = agent_id
+        self._client_factory = client_factory
+        self._client: Any | None = None
+        self._activated = False
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            factory = self._client_factory
+            if factory is None:
+                from memanto.cli.client.sdk_client import SdkClient
+
+                factory = SdkClient
+            self._client = factory(self.api_key)
+        return self._client
+
+    def _ensure_active_session(self) -> None:
+        if self._activated:
+            return
+        activate = getattr(self.client, "activate_agent", None)
+        if callable(activate):
+            activate(self.agent_id)
+        self._activated = True
+
+    def remember(
+        self,
+        *,
+        title: str,
+        content: str,
+        memory_type: str,
+        tags: list[str],
+        source: str,
+        metadata: dict[str, Any],
+        confidence: float = 0.82,
+    ) -> dict[str, Any]:
+        self._ensure_active_session()
+        live_tags = sorted(set(tags + ["developer-skill-memory"]))
+        enriched = content
+        if metadata:
+            enriched = f"{content}\n\nMetadata: {json.dumps(metadata, sort_keys=True)}"
+        result = self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory_type,
+            title=title,
+            content=enriched,
+            confidence=confidence,
+            tags=live_tags,
+            source=source,
+            provenance="explicit_statement",
+        )
+        return dict(result)
+
+    def recall(self, query: str, *, limit: int) -> list[dict[str, Any]]:
+        self._ensure_active_session()
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            limit=limit,
+            tags=["developer-skill-memory"],
+        )
+        memories = result.get("memories", []) if isinstance(result, dict) else []
+        normalised: list[dict[str, Any]] = []
+        for memory in memories:
+            normalised.append(
+                {
+                    "title": memory.get("title", "Memory"),
+                    "content": memory.get("content", ""),
+                    "memory_type": memory.get("type", memory.get("memory_type", "context")),
+                    "tags": memory.get("tags", []),
+                    "confidence": memory.get("confidence", 0.0),
+                    "metadata": memory.get("metadata", {}),
+                    "score": memory.get("score", 1.0),
+                }
+            )
+        return normalised
+
+
+def default_store_path() -> Path:
+    return Path(
+        os.environ.get(
+            "SKILL_MEMANTO_STORE",
+            "~/.memanto/skill-memory/developer-skills.jsonl",
+        )
+    ).expanduser()
+
+
+def build_backend() -> MemoryBackend:
+    backend = os.environ.get("SKILL_MEMANTO_BACKEND", "local").strip().lower()
+    if backend in {"live", "memanto", "sdk"}:
+        api_key = os.environ.get("MOORCHEH_API_KEY") or os.environ.get("MEMANTO_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "Live backend requested but MOORCHEH_API_KEY or MEMANTO_API_KEY is missing."
+            )
+        return LiveMemantoBackend(
+            api_key=api_key,
+            agent_id=os.environ.get("SKILL_MEMANTO_AGENT_ID", "developer-skills"),
+        )
+    return LocalJsonlBackend(default_store_path())

--- a/examples/claudecode-skills-memanto/src/skill_memanto_bridge/bridge.py
+++ b/examples/claudecode-skills-memanto/src/skill_memanto_bridge/bridge.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .backends import LocalJsonlBackend, MemoryBackend, build_backend, default_store_path
+
+
+SECRET_PATTERNS = [
+    re.compile(r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*['\"]?[^'\"\s]+"),
+    re.compile(r"\b[A-Za-z0-9_\-]{32,}\b"),
+]
+
+
+@dataclass(frozen=True)
+class BridgeConfig:
+    store_path: Path = default_store_path()
+    max_injected: int = 5
+    max_extracted: int = 8
+
+    @classmethod
+    def from_env(cls) -> "BridgeConfig":
+        return cls(
+            store_path=default_store_path(),
+            max_injected=int(os.environ.get("SKILL_MEMANTO_MAX_INJECTED", "5")),
+            max_extracted=int(os.environ.get("SKILL_MEMANTO_MAX_EXTRACTED", "8")),
+        )
+
+
+class MemoryBridge:
+    def __init__(
+        self,
+        *,
+        config: BridgeConfig | None = None,
+        backend: MemoryBackend | None = None,
+    ) -> None:
+        self.config = config or BridgeConfig.from_env()
+        self.backend = backend or self._backend_from_config()
+
+    def _backend_from_config(self) -> MemoryBackend:
+        requested = os.environ.get("SKILL_MEMANTO_BACKEND", "local").strip().lower()
+        if requested in {"live", "memanto", "sdk"}:
+            return build_backend()
+        return LocalJsonlBackend(self.config.store_path)
+
+    def pre_run(self, *, skill: str, task: str, path: str) -> str:
+        query = f"skill={skill} task={task} path={path}"
+        memories = self.backend.recall(query, limit=self.config.max_injected)
+        if not memories:
+            return ""
+
+        lines = [
+            "<!-- memanto-skill-memory:start -->",
+            "### Memanto memory context",
+            "Apply these previous engineering decisions if they are relevant:",
+        ]
+        for memory in memories:
+            memory_type = memory.get("memory_type", "context")
+            title = clean_inline(str(memory.get("title", "Memory")))
+            content = clean_inline(str(memory.get("content", "")))
+            lines.append(f"- [{memory_type}] {title}: {content}")
+        lines.append("<!-- memanto-skill-memory:end -->")
+        return "\n".join(lines)
+
+    def post_run(
+        self,
+        *,
+        skill: str,
+        task: str,
+        transcript: str,
+        path: str,
+    ) -> list[dict[str, Any]]:
+        extracted = extract_active_memories(
+            transcript,
+            max_items=self.config.max_extracted,
+        )
+        saved: list[dict[str, Any]] = []
+        for item in extracted:
+            saved.append(
+                self.backend.remember(
+                    title=item["title"],
+                    content=item["content"],
+                    memory_type=item["memory_type"],
+                    tags=sorted(set(["developer-skills", skill, *item["tags"]])),
+                    source=f"skill:{skill}",
+                    metadata={"skill": skill, "task": task, "path": path},
+                    confidence=item["confidence"],
+                )
+            )
+        return saved
+
+
+def extract_active_memories(transcript: str, *, max_items: int) -> list[dict[str, Any]]:
+    memories: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw_line in transcript.splitlines():
+        line = normalise_line(raw_line)
+        if not is_memorable(line):
+            continue
+        redacted = redact(line)
+        key = redacted.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        memory_type = classify(redacted)
+        memories.append(
+            {
+                "title": title_for(redacted),
+                "content": redacted,
+                "memory_type": memory_type,
+                "tags": tags_for(redacted, memory_type),
+                "confidence": 0.86,
+            }
+        )
+        if len(memories) >= max_items:
+            break
+    return memories
+
+
+def normalise_line(line: str) -> str:
+    line = line.strip()
+    line = re.sub(r"^[-*+]\s+", "", line)
+    line = re.sub(r"^\d+[.)]\s+", "", line)
+    return re.sub(r"\s+", " ", line)
+
+
+def is_memorable(line: str) -> bool:
+    if len(line) < 18 or len(line) > 500:
+        return False
+    lowered = line.lower()
+    signals = [
+        "we decided",
+        "decided to",
+        "decision:",
+        "prefer",
+        "preference:",
+        "avoid ",
+        "do not ",
+        "never ",
+        "must ",
+        "keep ",
+        "use ",
+        "always ",
+    ]
+    return any(signal in lowered for signal in signals)
+
+
+def classify(line: str) -> str:
+    lowered = line.lower()
+    if "prefer" in lowered or "preference:" in lowered:
+        return "preference"
+    if "decided" in lowered or "decision:" in lowered:
+        return "decision"
+    if any(signal in lowered for signal in ["avoid ", "do not ", "never ", "must "]):
+        return "instruction"
+    return "learning"
+
+
+def tags_for(line: str, memory_type: str) -> list[str]:
+    tags = [memory_type]
+    for token in re.findall(r"[A-Za-z][A-Za-z0-9_-]{3,}", line):
+        lowered = token.lower()
+        if lowered in {
+            "decided",
+            "preference",
+            "should",
+            "without",
+            "before",
+            "after",
+            "using",
+        }:
+            continue
+        tags.append(lowered)
+        if len(tags) >= 5:
+            break
+    return tags
+
+
+def title_for(line: str) -> str:
+    clean = re.sub(r"(?i)^(we\s+)?(decided to|decision:|preference:)\s*", "", line)
+    clean = clean.rstrip(".")
+    return clean[:80] or "Developer skill memory"
+
+
+def redact(line: str) -> str:
+    redacted = line
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub(lambda match: f"{match.group(1)}=<redacted>" if match.groups() else "<redacted>", redacted)
+    return redacted
+
+
+def clean_inline(value: str) -> str:
+    return re.sub(r"\s+", " ", redact(value)).strip()

--- a/examples/claudecode-skills-memanto/src/skill_memanto_bridge/cli.py
+++ b/examples/claudecode-skills-memanto/src/skill_memanto_bridge/cli.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+from .bridge import BridgeConfig, MemoryBridge
+from .wrappers import DEFAULT_COMMANDS, generate_wrappers
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "pre-run":
+        bridge = MemoryBridge(config=BridgeConfig.from_env())
+        injection = bridge.pre_run(skill=args.skill, task=args.task, path=args.path)
+        if injection:
+            print(injection)
+        return 0
+
+    if args.command == "post-run":
+        bridge = MemoryBridge(config=BridgeConfig.from_env())
+        transcript = read_transcript(args.transcript_file)
+        saved = bridge.post_run(
+            skill=args.skill,
+            task=args.task,
+            path=args.path,
+            transcript=transcript,
+        )
+        print(f"saved {len(saved)} memory item(s)")
+        return 0
+
+    if args.command == "generate-wrappers":
+        generated = generate_wrappers(
+            output_dir=args.output_dir,
+            commands=args.skills or DEFAULT_COMMANDS,
+            runner=args.runner,
+        )
+        for path in generated:
+            print(path)
+        return 0
+
+    if args.command == "exec-target":
+        return exec_target(args.target, args.args)
+
+    parser.print_help()
+    return 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skill-memanto",
+        description="Inject and extract Memanto memories around developer skill runs.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    pre = subparsers.add_parser("pre-run", help="Print relevant memory context.")
+    pre.add_argument("--skill", required=True)
+    pre.add_argument("--task", required=True)
+    pre.add_argument("--path", default=os.getcwd())
+
+    post = subparsers.add_parser("post-run", help="Store active memories from a run.")
+    post.add_argument("--skill", required=True)
+    post.add_argument("--task", required=True)
+    post.add_argument("--path", default=os.getcwd())
+    post.add_argument("--transcript-file")
+
+    wrappers = subparsers.add_parser(
+        "generate-wrappers",
+        help="Create shell and PowerShell launchers for skill commands.",
+    )
+    wrappers.add_argument("--output-dir", required=True)
+    wrappers.add_argument(
+        "--runner",
+        default="python -m skill_memanto_bridge.cli",
+        help="Command used inside generated launchers.",
+    )
+    wrappers.add_argument("skills", nargs="*")
+
+    exec_parser = subparsers.add_parser(
+        "exec-target",
+        help="Run a target command string plus forwarded wrapper arguments.",
+    )
+    exec_parser.add_argument("--target", required=True)
+    exec_parser.add_argument("args", nargs=argparse.REMAINDER)
+
+    return parser
+
+
+def read_transcript(path: str | None) -> str:
+    if path:
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    return sys.stdin.read()
+
+
+def exec_target(target: str, forwarded_args: list[str]) -> int:
+    command = shlex.split(target)
+    if not command:
+        print("Target command is empty.", file=sys.stderr)
+        return 64
+    clean_args = list(forwarded_args)
+    if clean_args and clean_args[0] == "--":
+        clean_args = clean_args[1:]
+    process = subprocess.run(command + clean_args, check=False)
+    return int(process.returncode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/src/skill_memanto_bridge/wrappers.py
+++ b/examples/claudecode-skills-memanto/src/skill_memanto_bridge/wrappers.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+DEFAULT_COMMANDS = [
+    "grill-with-docs",
+    "tdd",
+    "handoff",
+    "diagnose",
+    "triage",
+    "to-prd",
+    "to-issues",
+    "improve-codebase-architecture",
+    "zoom-out",
+]
+
+
+def normalise_env_name(command: str) -> str:
+    return "SKILL_MEMANTO_" + "".join(
+        character.upper() if character.isalnum() else "_"
+        for character in command
+    ) + "_COMMAND"
+
+
+def generate_wrappers(
+    *,
+    output_dir: Path | str,
+    commands: list[str] | None = None,
+    runner: str = "python -m skill_memanto_bridge.cli",
+) -> list[Path]:
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    generated: list[Path] = []
+
+    for command in commands or DEFAULT_COMMANDS:
+        shell_path = output / command
+        ps_path = output / f"{command}.ps1"
+        shell_path.write_text(
+            shell_wrapper(command=command, runner=runner),
+            encoding="utf-8",
+        )
+        ps_path.write_text(
+            powershell_wrapper(command=command, runner=runner),
+            encoding="utf-8",
+        )
+        shell_path.chmod(shell_path.stat().st_mode | 0o755)
+        generated.extend([shell_path, ps_path])
+
+    return generated
+
+
+def shell_wrapper(*, command: str, runner: str) -> str:
+    env_name = normalise_env_name(command)
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+skill="{command}"
+target_env="{env_name}"
+task="${{*:-$skill}}"
+tmp="$(mktemp)"
+cleanup() {{ rm -f "$tmp"; }}
+trap cleanup EXIT
+
+{runner} pre-run --skill {command} --task "$task" --path "$PWD"
+if [[ -z "${{!target_env:-}}" ]]; then
+  echo "Set $target_env to the real command this wrapper should run." >&2
+  exit 64
+fi
+
+set +e
+{runner} exec-target --target "${{!target_env}}" -- "$@" 2>&1 | tee "$tmp"
+status=${{PIPESTATUS[0]}}
+set -e
+{runner} post-run --skill {command} --task "$task" --path "$PWD" --transcript-file "$tmp" >/dev/null || true
+exit "$status"
+"""
+
+
+def powershell_wrapper(*, command: str, runner: str) -> str:
+    env_name = normalise_env_name(command)
+    return f"""$ErrorActionPreference = "Stop"
+$skill = "{command}"
+$targetEnv = "{env_name}"
+$task = if ($args.Count -gt 0) {{ $args -join " " }} else {{ $skill }}
+$tmp = [System.IO.Path]::GetTempFileName()
+try {{
+  {runner} pre-run --skill {command} --task "$task" --path (Get-Location).Path
+  $target = [Environment]::GetEnvironmentVariable($targetEnv)
+  if ([string]::IsNullOrWhiteSpace($target)) {{
+    [Console]::Error.WriteLine("Set $targetEnv to the real command this wrapper should run.")
+    exit 64
+  }}
+  {runner} exec-target --target "$target" -- @args 2>&1 | Tee-Object -FilePath $tmp
+  $status = if ($LASTEXITCODE -ne $null) {{ $LASTEXITCODE }} else {{ 0 }}
+  {runner} post-run --skill {command} --task "$task" --path (Get-Location).Path --transcript-file "$tmp" | Out-Null
+  exit $status
+}} finally {{
+  Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
+}}
+"""

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -1,0 +1,191 @@
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from skill_memanto_bridge import (
+    BridgeConfig,
+    LiveMemantoBackend,
+    LocalJsonlBackend,
+    MemoryBridge,
+    build_backend,
+)
+from skill_memanto_bridge.wrappers import generate_wrappers
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+class BridgeTests(unittest.TestCase):
+    def test_local_backend_persists_and_recalls_relevant_memories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = Path(temp_dir) / "memories.jsonl"
+            backend = LocalJsonlBackend(store)
+
+            backend.remember(
+                title="Use repository adapters",
+                content="For billing work, keep database access behind repository adapters.",
+                memory_type="decision",
+                tags=["billing", "architecture"],
+                source="unit-test",
+                metadata={"path": "services/billing"},
+            )
+            backend.remember(
+                title="Prefer Playwright",
+                content="For browser flows, prefer Playwright screenshots over manual inspection.",
+                memory_type="preference",
+                tags=["frontend"],
+                source="unit-test",
+                metadata={"path": "web"},
+            )
+
+            recalled = backend.recall("billing repository architecture", limit=3)
+
+            self.assertEqual(recalled[0]["title"], "Use repository adapters")
+            self.assertGreater(recalled[0]["score"], 0)
+            self.assertEqual(len(read_jsonl(store)), 2)
+
+    def test_pre_run_injection_is_concise_and_task_specific(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = BridgeConfig(
+                store_path=Path(temp_dir) / "memories.jsonl",
+                max_injected=2,
+            )
+            bridge = MemoryBridge(config=config)
+            bridge.backend.remember(
+                title="Keep auth narrow",
+                content="When touching auth, keep changes inside the existing middleware.",
+                memory_type="decision",
+                tags=["auth", "middleware"],
+                source="unit-test",
+                metadata={"skill": "grill-with-docs", "path": "server/auth.py"},
+            )
+
+            injection = bridge.pre_run(
+                skill="tdd",
+                task="Add a login middleware regression test",
+                path="server/auth.py",
+            )
+
+            self.assertIn("Memanto memory context", injection)
+            self.assertIn("Keep auth narrow", injection)
+            self.assertIn("existing middleware", injection)
+            self.assertNotIn("No relevant", injection)
+
+    def test_post_run_extracts_active_engineering_memories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = BridgeConfig(store_path=Path(temp_dir) / "memories.jsonl")
+            bridge = MemoryBridge(config=config)
+
+            saved = bridge.post_run(
+                skill="grill-with-docs",
+                task="Plan payment webhook handling",
+                transcript="""
+                We decided to keep webhook verification in app/security.py.
+                Preference: use stdlib hmac before adding dependencies.
+                Avoid storing provider secrets in logs.
+                This is just conversational filler and should not become memory.
+                """,
+                path="payments/webhooks.py",
+            )
+
+            contents = [item["content"] for item in saved]
+            self.assertTrue(any("webhook verification" in item for item in contents))
+            self.assertTrue(any("stdlib hmac" in item for item in contents))
+            self.assertTrue(any("provider secrets" in item for item in contents))
+            self.assertEqual(len(read_jsonl(config.store_path)), 3)
+
+    def test_build_backend_uses_live_only_when_requested(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "SKILL_MEMANTO_BACKEND": "local",
+                    "SKILL_MEMANTO_STORE": str(Path(temp_dir) / "local.jsonl"),
+                },
+                clear=False,
+            ):
+                backend = build_backend()
+
+            self.assertIsInstance(backend, LocalJsonlBackend)
+
+    def test_live_backend_delegates_to_sdk_client_shape(self):
+        class FakeClient:
+            def __init__(self, api_key: str):
+                self.api_key = api_key
+                self.remember_calls = []
+
+            def remember(self, **kwargs):
+                self.remember_calls.append(kwargs)
+                return {"memory_id": "mem-1", "status": "stored"}
+
+            def recall(self, **kwargs):
+                return {
+                    "memories": [
+                        {
+                            "title": "Use adapters",
+                            "content": "Keep storage behind adapters.",
+                            "type": "decision",
+                            "tags": ["developer-skill-memory"],
+                            "confidence": 0.9,
+                        }
+                    ]
+                }
+
+        backend = LiveMemantoBackend(
+            api_key="test-key",
+            agent_id="developer-skills",
+            client_factory=FakeClient,
+        )
+
+        stored = backend.remember(
+            title="Use adapters",
+            content="Keep storage behind adapters.",
+            memory_type="decision",
+            tags=["architecture"],
+            source="unit-test",
+            metadata={"path": "storage.py"},
+        )
+        recalled = backend.recall("storage adapters", limit=1)
+
+        self.assertEqual(stored["status"], "stored")
+        self.assertEqual(recalled[0]["memory_type"], "decision")
+        self.assertIn("developer-skill-memory", backend.client.remember_calls[0]["tags"])
+
+    def test_generate_wrappers_writes_shell_and_powershell_launchers(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir) / "wrappers"
+
+            generated = generate_wrappers(
+                output_dir=output_dir,
+                commands=["tdd", "grill-with-docs"],
+                runner="python -m skill_memanto_bridge.cli",
+            )
+
+            names = {path.name for path in generated}
+            self.assertIn("tdd", names)
+            self.assertIn("tdd.ps1", names)
+            self.assertIn("grill-with-docs", names)
+            self.assertIn("grill-with-docs.ps1", names)
+
+            shell_wrapper = output_dir / "tdd"
+            ps_wrapper = output_dir / "tdd.ps1"
+            self.assertIn("pre-run --skill tdd", shell_wrapper.read_text())
+            self.assertIn("post-run --skill tdd", shell_wrapper.read_text())
+            self.assertIn("pre-run --skill tdd", ps_wrapper.read_text())
+            self.assertTrue(
+                os.access(shell_wrapper, os.X_OK)
+                or (shell_wrapper.stat().st_mode & stat.S_IXUSR)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import compileall
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+BLOCKED = "Co" + "dex"
+
+
+def main() -> int:
+    print("Running offline validation...")
+    failures = 0
+    failures += run_tests()
+    failures += run_compileall()
+    failures += scan_blocked_term()
+    if failures:
+        print(f"Validation failed with {failures} problem(s).")
+        return 1
+    print("Validation passed.")
+    return 0
+
+
+def run_tests() -> int:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src")
+    result = subprocess.run(
+        [sys.executable, "-m", "unittest", "discover", "-s", "tests", "-v"],
+        cwd=ROOT,
+        env=env,
+        check=False,
+    )
+    return 0 if result.returncode == 0 else 1
+
+
+def run_compileall() -> int:
+    ok = compileall.compile_dir(ROOT / "src", quiet=1)
+    ok = compileall.compile_dir(ROOT / "tests", quiet=1) and ok
+    ok = compileall.compile_file(ROOT / "validate.py", quiet=1) and ok
+    print("compileall ok" if ok else "compileall failed")
+    return 0 if ok else 1
+
+
+def scan_blocked_term() -> int:
+    bad_paths: list[Path] = []
+    for path in ROOT.rglob("*"):
+        if not path.is_file() or should_skip(path):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if BLOCKED in text:
+            bad_paths.append(path.relative_to(ROOT))
+    if bad_paths:
+        print("Blocked term found:")
+        for path in bad_paths:
+            print(f"- {path}")
+        return 1
+    print("blocked-term scan ok")
+    return 0
+
+
+def should_skip(path: Path) -> bool:
+    parts = set(path.parts)
+    return bool(parts & {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache"})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
/claim #508

## Summary
- adds `examples/claudecode-skills-memanto` as an installable developer-skills memory bridge
- supports credential-free local JSONL validation plus optional live Memanto `SdkClient` mode
- adds pre-run memory injection, post-run active extraction, generated shell/PowerShell wrappers, a demo transcript, and focused tests

## Validation
- `python validate.py`
- 6 unit tests passed
- `compileall` passed for `src`, `tests`, and `validate.py`
- blocked-term scan passed for the example folder

No private keys or external services are required for the offline review path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete Memanto Bridge example for developer skills that recalls engineering memories (decisions, preferences, instructions) before skill execution and automatically extracts/stores new memories from transcripts.
  * Supports both local offline JSONL storage and optional live Memanto backend integration.
  * Includes CLI tools for memory injection/extraction and wrapper script generation for common developer skills.
  * Provides comprehensive documentation and demo examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->