### PR TITLE
Add Claude Code skills Memanto memory companion example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ coverage.xml
 *.cover
 *.log
 .pytest_cache/
+.memanto-local/
+**/.memanto-local/
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,103 @@
+# Claude Code Skills + Memanto
+
+This example shows how Memanto can act as a global memory companion for
+`mattpocock/skills`-style command workflows. It captures the result of one
+skill run, stores durable engineering memories, and injects only relevant
+memories into later skill prompts.
+
+The example is reviewer-safe by default:
+
+- `local` backend stores JSONL memories under `.memanto-local/`
+- `memanto` backend uses `memanto.cli.client.sdk_client.SdkClient` when
+  `MOORCHEH_API_KEY` is configured
+- no private API keys, prompts, or terminal transcripts are required for the
+  offline demo
+
+## Files
+
+```text
+examples/claudecode-skills-memanto/
+├── README.md
+├── requirements.txt
+├── skill_memory.py
+├── mattpocock_adapter.py
+├── run_demo.py
+├── benchmark_report.md
+├── validate.py
+├── test_skill_memory.py
+├── demo_transcript.md
+└── sample_injected_context.md
+```
+
+## Quickstart
+
+```bash
+cd examples/claudecode-skills-memanto
+python validate.py
+python run_demo.py --backend local --reset
+python -m unittest test_skill_memory.py
+```
+
+Optional live Memanto mode:
+
+```bash
+export MOORCHEH_API_KEY=...
+python run_demo.py --backend memanto --agent-id claudecode-skills-demo
+```
+
+## How It Works
+
+The wrapper has two lifecycle hooks.
+
+`before_skill(skill_name, user_prompt, paths)`:
+
+1. Builds a retrieval query from the skill name, prompt, and touched paths.
+2. Recalls matching Memanto memories.
+3. Emits a short injected context block for the skill prompt.
+
+`after_skill(skill_name, user_prompt, transcript, paths)`:
+
+1. Extracts durable decisions, preferences, constraints, and artifacts from the
+   finished skill transcript.
+2. Stores them as typed Memanto memories.
+3. Returns a structured summary that can be logged by a shell wrapper.
+
+## Demo Transcript
+
+See [demo_transcript.md](demo_transcript.md) for a full credential-free run.
+The second skill invocation recalls an architecture decision made during the
+first skill invocation, even though the prompt does not repeat it.
+
+![Terminal demo](demo_terminal.svg)
+
+## Why This Reduces Repeated Instructions
+
+The demonstration captures a rule from `/grill-with-docs`:
+
+> Prefer server-side validation helpers over duplicating schema checks in React
+> components.
+
+When `/tdd` starts later, the wrapper injects that rule automatically because
+the prompt and file path match the saved memory. The user does not have to
+repeat the architectural decision.
+
+`run_demo.py` writes `benchmark_report.md` with the deterministic productivity
+check used by `validate.py`:
+
+```text
+Baseline repeated instructions needed: 1
+Memanto repeated instructions needed: 0
+Repeated-instruction reduction: 100%
+```
+
+## Hook Into Skills
+
+Generate shell wrappers for common mattpocock-style commands:
+
+```bash
+python mattpocock_adapter.py --skills /grill-with-docs /tdd /handoff --out .skill-wrappers
+```
+
+Each generated wrapper delegates to `skill_memory.py before` and
+`skill_memory.py after` around the real command. In a production setup, replace
+the placeholder `echo` with the actual skill executable.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -10,6 +10,8 @@ The example is reviewer-safe by default:
 - `local` backend stores JSONL memories under `.memanto-local/`
 - `memanto` backend uses `memanto.cli.client.sdk_client.SdkClient` when
   `MOORCHEH_API_KEY` is configured
+- live mode uses Memanto's `remember`, `recall`, and `answer` primitives:
+  `answer` adds a short grounded engineering constraint before the next skill
 - no private API keys, prompts, or terminal transcripts are required for the
   offline demo
 
@@ -53,7 +55,8 @@ The wrapper has two lifecycle hooks.
 
 1. Builds a retrieval query from the skill name, prompt, and touched paths.
 2. Recalls matching Memanto memories.
-3. Emits a short injected context block for the skill prompt.
+3. Asks Memanto for a concise grounded answer from the same remembered context.
+4. Emits a short injected context block for the skill prompt.
 
 `after_skill(skill_name, user_prompt, transcript, paths)`:
 
@@ -99,5 +102,8 @@ python mattpocock_adapter.py --skills /grill-with-docs /tdd /handoff --out .skil
 ```
 
 Each generated wrapper delegates to `skill_memory.py before` and
-`skill_memory.py after` around the real command. In a production setup, replace
-the placeholder `echo` with the actual skill executable.
+`skill_memory.py after` around the real command. The wrapper exports
+`MEMANTO_SKILL_CONTEXT` before invoking the child process, so real skill
+executables can read the injected context from the environment as well as
+stdout. In a production setup, replace the placeholder `echo` with the actual
+skill executable.

--- a/examples/claudecode-skills-memanto/benchmark_report.md
+++ b/examples/claudecode-skills-memanto/benchmark_report.md
@@ -1,0 +1,17 @@
+# Claude Code Skills + Memanto Benchmark
+
+This credential-free benchmark compares a two-skill workflow with and
+without Memanto memory injection.
+
+| Metric | Value |
+| --- | ---: |
+| Memories stored after `/grill-with-docs` | 3 |
+| Expected architecture rule recalled before `/tdd` | True |
+| Baseline repeated instructions needed | 1 |
+| Memanto repeated instructions needed | 0 |
+| Repeated instructions avoided | 1 |
+| Repeated-instruction reduction | 100% |
+
+The benchmark is intentionally tiny and deterministic: `/grill-with-docs`
+records one architectural validation rule, then `/tdd` recalls that rule
+without the user restating it in the second prompt.

--- a/examples/claudecode-skills-memanto/demo_terminal.svg
+++ b/examples/claudecode-skills-memanto/demo_terminal.svg
@@ -13,7 +13,7 @@
   <text x="24" y="207" fill="#86efac" font-family="Menlo, Consolas, monospace" font-size="18">Stored 3 memories</text>
   <text x="24" y="254" fill="#93c5fd" font-family="Menlo, Consolas, monospace" font-size="18">== Session 2: /tdd ==</text>
   <text x="24" y="287" fill="#e5e7eb" font-family="Menlo, Consolas, monospace" font-size="18">MEMANTO_SKILL_CONTEXT:</text>
-  <text x="24" y="316" fill="#fde68a" font-family="Menlo, Consolas, monospace" font-size="18">- [decision] Prefer server-side validation helpers...</text>
-  <text x="24" y="345" fill="#e5e7eb" font-family="Menlo, Consolas, monospace" font-size="18">  recalled from /grill-with-docs, not repeated by the user</text>
-  <text x="24" y="374" fill="#fde68a" font-family="Menlo, Consolas, monospace" font-size="18">- [preference] Keep PRs small enough for obvious ownership.</text>
+  <text x="24" y="316" fill="#fde68a" font-family="Menlo, Consolas, monospace" font-size="18">- [memanto-answer] Apply remembered context...</text>
+  <text x="24" y="345" fill="#fde68a" font-family="Menlo, Consolas, monospace" font-size="18">- [decision] Prefer server-side validation helpers...</text>
+  <text x="24" y="374" fill="#e5e7eb" font-family="Menlo, Consolas, monospace" font-size="18">  recalled from /grill-with-docs, not repeated by the user</text>
 </svg>

--- a/examples/claudecode-skills-memanto/demo_terminal.svg
+++ b/examples/claudecode-skills-memanto/demo_terminal.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="420" viewBox="0 0 980 420" role="img" aria-labelledby="title desc">
+  <title id="title">Claude Code Skills + Memanto terminal demo</title>
+  <desc id="desc">A terminal transcript showing a first skill run storing memories and a later skill run receiving injected context.</desc>
+  <rect width="980" height="420" rx="12" fill="#0f172a"/>
+  <rect x="0" y="0" width="980" height="38" rx="12" fill="#111827"/>
+  <circle cx="22" cy="19" r="6" fill="#ef4444"/>
+  <circle cx="44" cy="19" r="6" fill="#f59e0b"/>
+  <circle cx="66" cy="19" r="6" fill="#22c55e"/>
+  <text x="24" y="74" fill="#e5e7eb" font-family="Menlo, Consolas, monospace" font-size="18">$ python run_demo.py --backend local --reset</text>
+  <text x="24" y="112" fill="#93c5fd" font-family="Menlo, Consolas, monospace" font-size="18">== Session 1: /grill-with-docs ==</text>
+  <text x="24" y="145" fill="#e5e7eb" font-family="Menlo, Consolas, monospace" font-size="18">MEMANTO_SKILL_CONTEXT:</text>
+  <text x="24" y="174" fill="#e5e7eb" font-family="Menlo, Consolas, monospace" font-size="18">- No relevant prior engineering memories found.</text>
+  <text x="24" y="207" fill="#86efac" font-family="Menlo, Consolas, monospace" font-size="18">Stored 3 memories</text>
+  <text x="24" y="254" fill="#93c5fd" font-family="Menlo, Consolas, monospace" font-size="18">== Session 2: /tdd ==</text>
+  <text x="24" y="287" fill="#e5e7eb" font-family="Menlo, Consolas, monospace" font-size="18">MEMANTO_SKILL_CONTEXT:</text>
+  <text x="24" y="316" fill="#fde68a" font-family="Menlo, Consolas, monospace" font-size="18">- [decision] Prefer server-side validation helpers...</text>
+  <text x="24" y="345" fill="#e5e7eb" font-family="Menlo, Consolas, monospace" font-size="18">  recalled from /grill-with-docs, not repeated by the user</text>
+  <text x="24" y="374" fill="#fde68a" font-family="Menlo, Consolas, monospace" font-size="18">- [preference] Keep PRs small enough for obvious ownership.</text>
+</svg>

--- a/examples/claudecode-skills-memanto/demo_transcript.md
+++ b/examples/claudecode-skills-memanto/demo_transcript.md
@@ -1,0 +1,21 @@
+# Demo Transcript
+
+```text
+$ python run_demo.py --backend local --reset
+
+== Session 1: /grill-with-docs ==
+MEMANTO_SKILL_CONTEXT:
+- No relevant prior engineering memories found.
+Stored 3 memories
+
+== Session 2: /tdd ==
+MEMANTO_SKILL_CONTEXT:
+- [decision] Prefer server-side validation helpers over duplicating schema checks in React components. (grill-with-docs, docs, review, architecture)
+  Prefer server-side validation helpers over duplicating schema checks in React components.
+- [preference] Keep PRs small enough that each skill handoff has one obvious owner. (grill-with-docs, docs, review, architecture)
+  Keep PRs small enough that each skill handoff has one obvious owner.
+```
+
+The `/tdd` prompt did not repeat the validation architecture decision. Memanto
+recalled it from a prior `/grill-with-docs` run and produced a concise context
+block for injection.

--- a/examples/claudecode-skills-memanto/demo_transcript.md
+++ b/examples/claudecode-skills-memanto/demo_transcript.md
@@ -10,10 +10,13 @@ Stored 3 memories
 
 == Session 2: /tdd ==
 MEMANTO_SKILL_CONTEXT:
-- [decision] Prefer server-side validation helpers over duplicating schema checks in React components. (grill-with-docs, docs, review, architecture)
+- [memanto-answer] Apply remembered context: docs/architecture/forms.md records the validation boundary. Prefer server-side validation helpers over duplicating schema checks in React components.
+- [artifact] docs/architecture/forms.md records the validation boundary. (grill-with-docs, docs, forms, architecture, review)
+  docs/architecture/forms.md records the validation boundary.
+- [decision] Prefer server-side validation helpers over duplicating schema checks in React components. (grill-with-docs, docs, forms, architecture, review)
   Prefer server-side validation helpers over duplicating schema checks in React components.
-- [preference] Keep PRs small enough that each skill handoff has one obvious owner. (grill-with-docs, docs, review, architecture)
-  Keep PRs small enough that each skill handoff has one obvious owner.
+
+Benchmark: 1/1 repeated instructions avoided (100% reduction)
 ```
 
 The `/tdd` prompt did not repeat the validation architecture decision. Memanto

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -15,7 +15,9 @@ SKILL_NAME={skill_name}
 PROMPT="${{*:-}}"
 TRANSCRIPT_FILE="$(mktemp)"
 
-python "$(dirname "$0")/../skill_memory.py" before --skill "$SKILL_NAME" --prompt "$PROMPT"
+MEMANTO_SKILL_CONTEXT="$(python "$(dirname "$0")/../skill_memory.py" before --skill "$SKILL_NAME" --prompt "$PROMPT")"
+export MEMANTO_SKILL_CONTEXT
+printf '%s\n' "$MEMANTO_SKILL_CONTEXT"
 
 # Replace this echo with the real skill executable, for example:
 # claude "$SKILL_NAME $PROMPT"

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Generate shell wrappers for mattpocock/skills-style commands."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+from pathlib import Path
+
+
+WRAPPER_TEMPLATE = """#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL_NAME={skill_name}
+PROMPT="${{*:-}}"
+TRANSCRIPT_FILE="$(mktemp)"
+
+python "$(dirname "$0")/../skill_memory.py" before --skill "$SKILL_NAME" --prompt "$PROMPT"
+
+# Replace this echo with the real skill executable, for example:
+# claude "$SKILL_NAME $PROMPT"
+echo "Running $SKILL_NAME with prompt: $PROMPT" | tee "$TRANSCRIPT_FILE"
+
+python "$(dirname "$0")/../skill_memory.py" after \
+  --skill "$SKILL_NAME" \
+  --prompt "$PROMPT" \
+  --transcript "$TRANSCRIPT_FILE"
+"""
+
+
+def write_wrappers(skills: list[str], out: Path) -> list[Path]:
+    out.mkdir(parents=True, exist_ok=True)
+    written = []
+    for skill in skills:
+        name = skill.strip()
+        filename = name.strip("/").replace("/", "-") or "skill"
+        path = out / filename
+        path.write_text(
+            WRAPPER_TEMPLATE.format(skill_name=shlex.quote(name)),
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+        written.append(path)
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills", nargs="+", required=True)
+    parser.add_argument("--out", default=".skill-wrappers")
+    args = parser.parse_args()
+
+    for path in write_wrappers(args.skills, Path(args.out)):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,0 +1,2 @@
+# The offline demo uses only Python's standard library.
+# Optional live mode uses the repository's memanto package and MOORCHEH_API_KEY.

--- a/examples/claudecode-skills-memanto/run_demo.py
+++ b/examples/claudecode-skills-memanto/run_demo.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Run a two-session skill-memory demo."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from skill_memory import after_skill, backend_from_args, before_skill
+
+
+TRANSCRIPT_ONE = """
+Decision: Prefer server-side validation helpers over duplicating schema checks in React components.
+Preference: Keep PRs small enough that each skill handoff has one obvious owner.
+Artifact: docs/architecture/forms.md records the validation boundary.
+"""
+
+EXPECTED_RECALLED_RULE = (
+    "Prefer server-side validation helpers over duplicating schema checks in React components."
+)
+
+
+@dataclass(frozen=True)
+class DemoResult:
+    stored_memories: int
+    recalled_expected_rule: bool
+    baseline_repeated_instructions: int
+    memanto_repeated_instructions: int
+
+    @property
+    def avoided_repeated_instructions(self) -> int:
+        return self.baseline_repeated_instructions - self.memanto_repeated_instructions
+
+    @property
+    def reduction_percent(self) -> int:
+        if self.baseline_repeated_instructions == 0:
+            return 0
+        return round(
+            (self.avoided_repeated_instructions / self.baseline_repeated_instructions) * 100
+        )
+
+
+def write_benchmark_report(result: DemoResult, path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "# Claude Code Skills + Memanto Benchmark",
+                "",
+                "This credential-free benchmark compares a two-skill workflow with and",
+                "without Memanto memory injection.",
+                "",
+                "| Metric | Value |",
+                "| --- | ---: |",
+                f"| Memories stored after `/grill-with-docs` | {result.stored_memories} |",
+                f"| Expected architecture rule recalled before `/tdd` | {str(result.recalled_expected_rule)} |",
+                f"| Baseline repeated instructions needed | {result.baseline_repeated_instructions} |",
+                f"| Memanto repeated instructions needed | {result.memanto_repeated_instructions} |",
+                f"| Repeated instructions avoided | {result.avoided_repeated_instructions} |",
+                f"| Repeated-instruction reduction | {result.reduction_percent}% |",
+                "",
+                "The benchmark is intentionally tiny and deterministic: `/grill-with-docs`",
+                "records one architectural validation rule, then `/tdd` recalls that rule",
+                "without the user restating it in the second prompt.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=["local", "memanto"], default="local")
+    parser.add_argument("--store", default=".memanto-local/skill-memory.jsonl")
+    parser.add_argument("--agent-id", default="claudecode-skills-demo")
+    parser.add_argument("--benchmark-out", default="benchmark_report.md")
+    parser.add_argument("--reset", action="store_true")
+    args = parser.parse_args()
+
+    store = Path(args.store)
+    if args.reset and store.exists():
+        store.unlink()
+
+    backend = backend_from_args(args)
+
+    print("== Session 1: /grill-with-docs ==")
+    print(
+        before_skill(
+            backend,
+            "/grill-with-docs",
+            "Review the form architecture docs",
+            ["docs/architecture/forms.md"],
+        )
+    )
+    stored = after_skill(
+        backend,
+        "/grill-with-docs",
+        "Review the form architecture docs",
+        TRANSCRIPT_ONE,
+        ["docs/architecture/forms.md"],
+    )
+    print(f"Stored {len(stored)} memories")
+
+    print("\n== Session 2: /tdd ==")
+    injected = before_skill(
+        backend,
+        "/tdd",
+        "Write tests for the form validation path",
+        ["app/forms/signup.py", "tests/test_signup_forms.py"],
+    )
+    print(injected)
+
+    recalled_expected_rule = "server-side validation helpers" in injected
+    result = DemoResult(
+        stored_memories=len(stored),
+        recalled_expected_rule=recalled_expected_rule,
+        baseline_repeated_instructions=1,
+        memanto_repeated_instructions=0 if recalled_expected_rule else 1,
+    )
+    write_benchmark_report(result, Path(args.benchmark_out))
+    print(
+        "\nBenchmark: "
+        f"{result.avoided_repeated_instructions}/"
+        f"{result.baseline_repeated_instructions} repeated instructions avoided "
+        f"({result.reduction_percent}% reduction)"
+    )
+
+    if not recalled_expected_rule:
+        raise SystemExit("demo failed: expected validation decision was not recalled")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/sample_injected_context.md
+++ b/examples/claudecode-skills-memanto/sample_injected_context.md
@@ -2,10 +2,11 @@
 
 ```text
 MEMANTO_SKILL_CONTEXT:
-- [decision] Prefer server-side validation helpers over duplicating schema checks in React components. (grill-with-docs, docs, review, architecture)
+- [memanto-answer] Apply remembered context: docs/architecture/forms.md records the validation boundary. Prefer server-side validation helpers over duplicating schema checks in React components.
+- [artifact] docs/architecture/forms.md records the validation boundary. (grill-with-docs, docs, forms, architecture, review)
+  docs/architecture/forms.md records the validation boundary.
+- [decision] Prefer server-side validation helpers over duplicating schema checks in React components. (grill-with-docs, docs, forms, architecture, review)
   Prefer server-side validation helpers over duplicating schema checks in React components.
-- [preference] Keep PRs small enough that each skill handoff has one obvious owner. (grill-with-docs, docs, review, architecture)
-  Keep PRs small enough that each skill handoff has one obvious owner.
 ```
 
 This is the exact style of block the wrapper can append to a later skill prompt.

--- a/examples/claudecode-skills-memanto/sample_injected_context.md
+++ b/examples/claudecode-skills-memanto/sample_injected_context.md
@@ -1,0 +1,11 @@
+# Sample Injected Context
+
+```text
+MEMANTO_SKILL_CONTEXT:
+- [decision] Prefer server-side validation helpers over duplicating schema checks in React components. (grill-with-docs, docs, review, architecture)
+  Prefer server-side validation helpers over duplicating schema checks in React components.
+- [preference] Keep PRs small enough that each skill handoff has one obvious owner. (grill-with-docs, docs, review, architecture)
+  Keep PRs small enough that each skill handoff has one obvious owner.
+```
+
+This is the exact style of block the wrapper can append to a later skill prompt.

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -51,6 +51,9 @@ class MemoryBackend(Protocol):
     def recall(self, query: str, limit: int = 5) -> list[SkillMemory]:
         """Return memories relevant to a new skill invocation."""
 
+    def answer(self, question: str, limit: int = 5) -> str | None:
+        """Return grounded guidance from remembered context when available."""
+
 
 class LocalJsonBackend:
     """Credential-free backend for tests, demos, and reviewer validation."""
@@ -89,6 +92,12 @@ class LocalJsonBackend:
                 scored.append((score, memory))
         scored.sort(key=lambda item: (item[0], item[1].created_at), reverse=True)
         return [memory for _, memory in scored[:limit]]
+
+    def answer(self, question: str, limit: int = 5) -> str | None:
+        memories = self.recall(question, limit=limit)
+        if not memories:
+            return None
+        return "Apply remembered context: " + " ".join(memory.content for memory in memories[:2])
 
     def _read(self) -> list[dict[str, object]]:
         if not self.path.exists():
@@ -151,6 +160,19 @@ class MemantoSdkBackend:
             )
         return memories
 
+    def answer(self, question: str, limit: int = 5) -> str | None:
+        result = self.client.answer(
+            self.agent_id,
+            question=question,
+            limit=limit,
+            header_prompt=(
+                "Answer as a concise engineering constraint for the next Claude Code "
+                "skill invocation. Use only remembered facts."
+            ),
+        )
+        answer = str(result.get("answer", "")).strip()
+        return answer or None
+
 
 def backend_from_args(args: argparse.Namespace) -> MemoryBackend:
     if args.backend == "memanto":
@@ -167,6 +189,7 @@ def before_skill(
     prompt: str,
     paths: list[str],
     limit: int = 5,
+    include_answer: bool = True,
 ) -> str:
     query = " ".join([skill, prompt, *paths])
     memories = backend.recall(query, limit=limit)
@@ -174,6 +197,9 @@ def before_skill(
         return "MEMANTO_SKILL_CONTEXT:\n- No relevant prior engineering memories found."
 
     lines = ["MEMANTO_SKILL_CONTEXT:"]
+    answer = backend.answer(query, limit=limit) if include_answer else None
+    if answer:
+        lines.append(f"- [memanto-answer] {answer}")
     for memory in memories:
         tags = ", ".join(memory.tags) if memory.tags else "untagged"
         lines.append(f"- [{memory.type}] {memory.title} ({tags})")
@@ -280,7 +306,7 @@ def _tags(skill: str, prompt: str, paths: list[str]) -> list[str]:
             raw.append(parsed.parts[0])
         if parsed.stem:
             raw.append(parsed.stem)
-    raw.extend(term for term in _terms(prompt) if len(term) > 5)
+    raw.extend(term for term in sorted(_terms(prompt)) if len(term) > 5)
     tags = []
     for tag in raw:
         cleaned = re.sub(r"[^a-zA-Z0-9_-]+", "-", tag.lower()).strip("-")
@@ -319,6 +345,7 @@ def build_parser() -> argparse.ArgumentParser:
     before.add_argument("--skill", required=True)
     before.add_argument("--prompt", required=True)
     before.add_argument("--path", action="append", default=[])
+    before.add_argument("--no-answer", action="store_true")
 
     after = subparsers.add_parser("after")
     after.add_argument("--skill", required=True)
@@ -334,7 +361,15 @@ def main() -> int:
     backend = backend_from_args(args)
 
     if args.command == "before":
-        print(before_skill(backend, args.skill, args.prompt, args.path))
+        print(
+            before_skill(
+                backend,
+                args.skill,
+                args.prompt,
+                args.path,
+                include_answer=not args.no_answer,
+            )
+        )
         return 0
 
     transcript = _read_text_arg(args.transcript)

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Memanto lifecycle hooks for mattpocock/skills-style commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+
+VALID_TYPES = {
+    "instruction",
+    "fact",
+    "decision",
+    "goal",
+    "commitment",
+    "preference",
+    "relationship",
+    "context",
+    "event",
+    "learning",
+    "observation",
+    "artifact",
+    "error",
+}
+
+
+@dataclass
+class SkillMemory:
+    """A portable memory shape that maps cleanly to Memanto's typed schema."""
+
+    type: str
+    title: str
+    content: str
+    confidence: float
+    tags: list[str]
+    source_skill: str
+    paths: list[str]
+    created_at: str
+
+
+class MemoryBackend(Protocol):
+    def remember(self, memory: SkillMemory) -> str:
+        """Persist one extracted memory and return its id."""
+
+    def recall(self, query: str, limit: int = 5) -> list[SkillMemory]:
+        """Return memories relevant to a new skill invocation."""
+
+
+class LocalJsonBackend:
+    """Credential-free backend for tests, demos, and reviewer validation."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def remember(self, memory: SkillMemory) -> str:
+        existing = self._read()
+        memory_id = f"local-{len(existing) + 1:04d}"
+        payload = asdict(memory) | {"id": memory_id}
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        return memory_id
+
+    def recall(self, query: str, limit: int = 5) -> list[SkillMemory]:
+        query_terms = _terms(query)
+        scored: list[tuple[int, SkillMemory]] = []
+        for payload in self._read():
+            memory = SkillMemory(
+                type=payload["type"],
+                title=payload["title"],
+                content=payload["content"],
+                confidence=float(payload["confidence"]),
+                tags=list(payload["tags"]),
+                source_skill=payload["source_skill"],
+                paths=list(payload["paths"]),
+                created_at=payload["created_at"],
+            )
+            haystack = " ".join(
+                [memory.title, memory.content, memory.source_skill, *memory.tags, *memory.paths]
+            )
+            score = len(query_terms & _terms(haystack))
+            if score:
+                scored.append((score, memory))
+        scored.sort(key=lambda item: (item[0], item[1].created_at), reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+    def _read(self) -> list[dict[str, object]]:
+        if not self.path.exists():
+            return []
+        rows = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                rows.append(json.loads(line))
+        return rows
+
+
+class MemantoSdkBackend:
+    """Live backend using Memanto's SdkClient when credentials are available."""
+
+    def __init__(self, api_key: str, agent_id: str) -> None:
+        from memanto.app.utils.errors import AgentNotFoundError
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self.client = SdkClient(api_key)
+        self.agent_id = agent_id
+
+        try:
+            self.client.get_agent(agent_id)
+        except AgentNotFoundError:
+            self.client.create_agent(
+                agent_id,
+                pattern="tool",
+                description="Shared memory for Claude Code skill executions",
+            )
+        self.client.activate_agent(agent_id)
+
+    def remember(self, memory: SkillMemory) -> str:
+        result = self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=memory.type,
+            title=memory.title[:100],
+            content=memory.content,
+            confidence=memory.confidence,
+            tags=memory.tags,
+            source=memory.source_skill,
+            provenance="explicit_statement",
+        )
+        return str(result["memory_id"])
+
+    def recall(self, query: str, limit: int = 5) -> list[SkillMemory]:
+        result = self.client.recall(self.agent_id, query=query, limit=limit)
+        memories = []
+        for item in result.get("memories", []):
+            memories.append(
+                SkillMemory(
+                    type=str(item.get("type", "context")),
+                    title=str(item.get("title", "Untitled memory")),
+                    content=str(item.get("content", "")),
+                    confidence=float(item.get("confidence", 0.8)),
+                    tags=list(item.get("tags", [])),
+                    source_skill=str(item.get("source", "memanto")),
+                    paths=[],
+                    created_at=str(item.get("created_at", "")),
+                )
+            )
+        return memories
+
+
+def backend_from_args(args: argparse.Namespace) -> MemoryBackend:
+    if args.backend == "memanto":
+        api_key = os.environ.get("MOORCHEH_API_KEY")
+        if not api_key:
+            raise SystemExit("MOORCHEH_API_KEY is required for --backend memanto")
+        return MemantoSdkBackend(api_key, args.agent_id)
+    return LocalJsonBackend(Path(args.store))
+
+
+def before_skill(
+    backend: MemoryBackend,
+    skill: str,
+    prompt: str,
+    paths: list[str],
+    limit: int = 5,
+) -> str:
+    query = " ".join([skill, prompt, *paths])
+    memories = backend.recall(query, limit=limit)
+    if not memories:
+        return "MEMANTO_SKILL_CONTEXT:\n- No relevant prior engineering memories found."
+
+    lines = ["MEMANTO_SKILL_CONTEXT:"]
+    for memory in memories:
+        tags = ", ".join(memory.tags) if memory.tags else "untagged"
+        lines.append(f"- [{memory.type}] {memory.title} ({tags})")
+        lines.append(f"  {memory.content}")
+    return "\n".join(lines)
+
+
+def after_skill(
+    backend: MemoryBackend,
+    skill: str,
+    prompt: str,
+    transcript: str,
+    paths: list[str],
+) -> list[tuple[str, SkillMemory]]:
+    memories = extract_memories(skill, prompt, transcript, paths)
+    return [(backend.remember(memory), memory) for memory in memories]
+
+
+def extract_memories(
+    skill: str,
+    prompt: str,
+    transcript: str,
+    paths: list[str],
+) -> list[SkillMemory]:
+    """Extract durable engineering memories from a finished skill transcript."""
+
+    lines = [line.strip(" -\t") for line in transcript.splitlines() if line.strip()]
+    memories: list[SkillMemory] = []
+    seen: set[str] = set()
+
+    patterns = [
+        (
+            "decision",
+            0.9,
+            r"(?i)^(?:decision|decided|architecture decision)[:\-]\s*(.+)$",
+            "Decision from skill run",
+        ),
+        (
+            "preference",
+            0.8,
+            r"(?i)^(?:preference|style rule|convention)[:\-]\s*(.+)$",
+            "Developer preference from skill run",
+        ),
+        (
+            "instruction",
+            0.85,
+            r"(?i)^(?:rule|constraint|must|do not)[:\-]\s*(.+)$",
+            "Instruction from skill run",
+        ),
+        (
+            "artifact",
+            0.75,
+            r"(?i)^(?:artifact|changed file|output)[:\-]\s*(.+)$",
+            "Artifact from skill run",
+        ),
+    ]
+
+    for line in lines:
+        for memory_type, confidence, pattern, fallback_title in patterns:
+            match = re.match(pattern, line)
+            if not match:
+                continue
+            content = match.group(1).strip()
+            if not content or content in seen:
+                continue
+            seen.add(content)
+            memories.append(
+                SkillMemory(
+                    type=memory_type,
+                    title=_title(content, fallback_title),
+                    content=content,
+                    confidence=confidence,
+                    tags=_tags(skill, prompt, paths),
+                    source_skill=skill,
+                    paths=paths,
+                    created_at=_now(),
+                )
+            )
+
+    if not memories:
+        summary = " ".join(lines[:3])[:500]
+        if summary:
+            memories.append(
+                SkillMemory(
+                    type="context",
+                    title=f"Summary from {skill}",
+                    content=summary,
+                    confidence=0.55,
+                    tags=_tags(skill, prompt, paths),
+                    source_skill=skill,
+                    paths=paths,
+                    created_at=_now(),
+                )
+            )
+
+    return memories
+
+
+def _tags(skill: str, prompt: str, paths: list[str]) -> list[str]:
+    raw = [skill.strip("/").replace("_", "-")]
+    for path in paths:
+        parsed = Path(path)
+        if parsed.parts:
+            raw.append(parsed.parts[0])
+        if parsed.stem:
+            raw.append(parsed.stem)
+    raw.extend(term for term in _terms(prompt) if len(term) > 5)
+    tags = []
+    for tag in raw:
+        cleaned = re.sub(r"[^a-zA-Z0-9_-]+", "-", tag.lower()).strip("-")
+        if cleaned and cleaned not in tags:
+            tags.append(cleaned)
+    return tags[:8]
+
+
+def _terms(text: str) -> set[str]:
+    return {term.lower() for term in re.findall(r"[a-zA-Z0-9_/-]{3,}", text)}
+
+
+def _title(content: str, fallback: str) -> str:
+    title = re.sub(r"\s+", " ", content).strip()
+    return title[:96] + "..." if len(title) > 99 else title or fallback
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _read_text_arg(value: str) -> str:
+    path = Path(value)
+    return path.read_text(encoding="utf-8") if path.exists() else value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=["local", "memanto"], default="local")
+    parser.add_argument("--store", default=".memanto-local/skill-memory.jsonl")
+    parser.add_argument("--agent-id", default="claudecode-skills-demo")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    before = subparsers.add_parser("before")
+    before.add_argument("--skill", required=True)
+    before.add_argument("--prompt", required=True)
+    before.add_argument("--path", action="append", default=[])
+
+    after = subparsers.add_parser("after")
+    after.add_argument("--skill", required=True)
+    after.add_argument("--prompt", required=True)
+    after.add_argument("--transcript", required=True)
+    after.add_argument("--path", action="append", default=[])
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    backend = backend_from_args(args)
+
+    if args.command == "before":
+        print(before_skill(backend, args.skill, args.prompt, args.path))
+        return 0
+
+    transcript = _read_text_arg(args.transcript)
+    stored = after_skill(backend, args.skill, args.prompt, transcript, args.path)
+    print(json.dumps({"stored": len(stored), "memory_ids": [item[0] for item in stored]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from run_demo import DemoResult, write_benchmark_report
+from skill_memory import (
+    LocalJsonBackend,
+    after_skill,
+    before_skill,
+    extract_memories,
+)
+
+
+class SkillMemoryTests(unittest.TestCase):
+    def test_extracts_typed_memories_from_transcript(self) -> None:
+        transcript = "\n".join(
+            [
+                "Decision: Use shared API client for billing mutations.",
+                "Preference: Keep generated wrappers checked into examples only.",
+                "Rule: Never store private API keys in memory payloads.",
+            ]
+        )
+
+        memories = extract_memories(
+            "/grill-with-docs",
+            "review billing client",
+            transcript,
+            ["src/billing/client.py"],
+        )
+
+        self.assertEqual(["decision", "preference", "instruction"], [m.type for m in memories])
+        self.assertIn("billing", memories[0].tags)
+
+    def test_local_backend_recalls_relevant_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            backend = LocalJsonBackend(Path(tmpdir) / "memory.jsonl")
+            stored = after_skill(
+                backend,
+                "/grill-with-docs",
+                "review form architecture",
+                "Decision: Prefer server-side validation helpers.",
+                ["docs/forms.md"],
+            )
+
+            self.assertEqual(1, len(stored))
+            injected = before_skill(
+                backend,
+                "/tdd",
+                "write tests for server-side form validation",
+                ["tests/test_forms.py"],
+            )
+
+            self.assertIn("server-side validation helpers", injected)
+
+    def test_before_skill_reports_empty_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            backend = LocalJsonBackend(Path(tmpdir) / "memory.jsonl")
+            injected = before_skill(backend, "/handoff", "summarize unrelated work", [])
+
+            self.assertIn("No relevant prior engineering memories", injected)
+
+    def test_fallback_summary_is_stored_when_no_pattern_matches(self) -> None:
+        memories = extract_memories(
+            "/handoff",
+            "handoff work",
+            "Finished the parser repair. Tests pass.",
+            ["src/parser.py"],
+        )
+
+        self.assertEqual(1, len(memories))
+        self.assertEqual("context", memories[0].type)
+        self.assertIn("parser", memories[0].tags)
+
+    def test_benchmark_report_quantifies_repeated_instruction_reduction(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = Path(tmpdir) / "benchmark.md"
+            write_benchmark_report(
+                DemoResult(
+                    stored_memories=3,
+                    recalled_expected_rule=True,
+                    baseline_repeated_instructions=1,
+                    memanto_repeated_instructions=0,
+                ),
+                report,
+            )
+
+            content = report.read_text(encoding="utf-8")
+            self.assertIn("Repeated instructions avoided | 1", content)
+            self.assertIn("Repeated-instruction reduction | 100%", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from mattpocock_adapter import write_wrappers
 from run_demo import DemoResult, write_benchmark_report
 from skill_memory import (
     LocalJsonBackend,
@@ -57,6 +58,27 @@ class SkillMemoryTests(unittest.TestCase):
 
             self.assertIn("server-side validation helpers", injected)
 
+    def test_before_skill_includes_grounded_answer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            backend = LocalJsonBackend(Path(tmpdir) / "memory.jsonl")
+            after_skill(
+                backend,
+                "/grill-with-docs",
+                "review form architecture",
+                "Decision: Prefer server-side validation helpers.",
+                ["docs/forms.md"],
+            )
+
+            injected = before_skill(
+                backend,
+                "/tdd",
+                "write tests for server-side form validation",
+                ["tests/test_forms.py"],
+            )
+
+            self.assertIn("[memanto-answer]", injected)
+            self.assertIn("Apply remembered context", injected)
+
     def test_before_skill_reports_empty_context(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             backend = LocalJsonBackend(Path(tmpdir) / "memory.jsonl")
@@ -92,6 +114,14 @@ class SkillMemoryTests(unittest.TestCase):
             content = report.read_text(encoding="utf-8")
             self.assertIn("Repeated instructions avoided | 1", content)
             self.assertIn("Repeated-instruction reduction | 100%", content)
+
+    def test_generated_wrapper_exports_memanto_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wrappers = write_wrappers(["/tdd"], Path(tmpdir))
+            wrapper = wrappers[0].read_text(encoding="utf-8")
+
+            self.assertIn("MEMANTO_SKILL_CONTEXT=\"$(python", wrapper)
+            self.assertIn("export MEMANTO_SKILL_CONTEXT", wrapper)
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Credential-free validation for the Claude Code skills example."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def run(command: list[str]) -> None:
+    subprocess.run(command, cwd=ROOT, check=True)
+
+
+def main() -> int:
+    files = [
+        "skill_memory.py",
+        "mattpocock_adapter.py",
+        "run_demo.py",
+        "validate.py",
+        "test_skill_memory.py",
+    ]
+    run([sys.executable, "-m", "py_compile", *files])
+    run([sys.executable, "run_demo.py", "--backend", "local", "--reset"])
+    run([sys.executable, "-m", "unittest", "test_skill_memory.py"])
+    benchmark = ROOT / "benchmark_report.md"
+    if "Repeated-instruction reduction | 100%" not in benchmark.read_text(encoding="utf-8"):
+        raise SystemExit("benchmark failed: expected 100% repeated-instruction reduction")
+    print("validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
/claim #508

## Summary

Adds `examples/claudecode-skills-memanto`, a focused integration showing Memanto as a global active memory companion for `mattpocock/skills`-style command workflows.

## What is included

- Credential-free `local` JSONL backend for reviewer validation
- Optional live `memanto` backend using `memanto.cli.client.sdk_client.SdkClient` when `MOORCHEH_API_KEY` is present
- Live backend uses Memanto `remember`, `recall`, and `answer`; `answer` adds a concise grounded engineering constraint before the next skill
- `before_skill` hook recalls relevant engineering memories and emits a concise prompt-injection block
- `after_skill` hook that distills completed skill transcripts into typed Memanto memories
- `mattpocock_adapter.py` wrapper generator for `/grill-with-docs`, `/tdd`, and `/handoff`, exporting `MEMANTO_SKILL_CONTEXT` for child commands
- Deterministic `benchmark_report.md` showing repeated-instruction reduction in the demo flow
- README, demo transcript, terminal SVG showcase, validation script, and stdlib unit tests

## Showcase

In-repo technical showcase:
`examples/claudecode-skills-memanto/README.md#demo-transcript`

Benchmark report:
`examples/claudecode-skills-memanto/benchmark_report.md`

External social posts are intentionally omitted for now. The maintainer clarified in #508 that external social posts are not mandatory for technical review; they only add community-engagement points.

## Validation

```text
python3 -m py_compile examples/claudecode-skills-memanto/*.py
python3 examples/claudecode-skills-memanto/validate.py
python3 -m unittest examples/claudecode-skills-memanto/test_skill_memory.py
git diff --check
```

Observed:

```text
== Session 1: /grill-with-docs ==
MEMANTO_SKILL_CONTEXT:
- No relevant prior engineering memories found.
Stored 3 memories

== Session 2: /tdd ==
MEMANTO_SKILL_CONTEXT:
- [memanto-answer] Apply remembered context: docs/architecture/forms.md records the validation boundary. Prefer server-side validation helpers over duplicating schema checks in React components.
- [artifact] docs/architecture/forms.md records the validation boundary.
- [decision] Prefer server-side validation helpers over duplicating schema checks in React components.

Benchmark: 1/1 repeated instructions avoided (100% reduction)

Ran 7 tests in 0.005s
OK
validation passed
```

Root-level unittest also passes:

```text
python3 -m unittest examples/claudecode-skills-memanto/test_skill_memory.py
.......
Ran 7 tests in 0.004s
OK
```

## Notes

The offline path uses only the Python standard library. Live Memanto mode is available without requiring reviewers to provide credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code Skills + Memanto example enabling memory persistence across skill sessions, automatically injecting prior context to reduce repeated instructions.

* **Documentation**
  * Complete example guide with quickstart commands, benchmark report, and demo transcript.

* **Tests**
  * Comprehensive test coverage for skill memory extraction and recall functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->