### PR TITLE
Add Claude Code skills Memanto memory bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,62 @@
+# Claude Code Skills + Memanto
+
+This example shows how Memanto can act as a global memory companion across
+separate Claude Code / mattpocock-style skill runs.
+
+The bridge wraps a skill command with a small lifecycle:
+
+1. Recall relevant memories for the current skill and task.
+2. Inject them through `MEMANTO_SKILL_CONTEXT`.
+3. Run the original skill command.
+4. Distill durable decisions, conventions, instructions, and caveats from the
+   transcript.
+5. Store those memories for the next isolated skill execution.
+
+## Credential-Free Demo
+
+```bash
+python examples/claudecode-skills-memanto/run_demo.py
+```
+
+The demo uses a local JSONL backend so reviewers can validate cross-session
+recall without a Moorcheh API key.
+
+## Use Real Memanto
+
+Install and configure Memanto first:
+
+```bash
+pip install memanto
+memanto
+```
+
+Then run a command through the bridge:
+
+```bash
+MEMANTO_SKILLS_BACKEND=cli \
+python examples/claudecode-skills-memanto/skill_memory_bridge.py tdd \
+  --task "add tests for the billing adapter" -- \
+  bash -lc "echo 'Decision: keep billing tests deterministic'"
+```
+
+## Generate Claude Command Wrappers
+
+```bash
+python examples/claudecode-skills-memanto/generate_claude_commands.py
+```
+
+This creates `.claude/commands/*-with-memanto.md` wrappers for:
+
+- `/grill-with-docs`
+- `/tdd`
+- `/handoff`
+
+The generated files are intentionally small. They keep the original skills as
+the source of truth while adding Memanto recall and storage around each run.
+
+## Safety Boundary
+
+The distiller stores only durable engineering context such as decisions and
+preferences. It does not store API keys, payment details, or raw hidden prompts.
+Teams can add their own redaction layer before calling `remember` if their
+workflow handles sensitive transcripts.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -21,6 +21,19 @@ python examples/claudecode-skills-memanto/run_demo.py
 The demo uses a local JSONL backend so reviewers can validate cross-session
 recall without a Moorcheh API key.
 
+To inspect the memories that would be available to later skill runs:
+
+```bash
+python examples/claudecode-skills-memanto/run_demo.py \
+  --memory-file /tmp/memanto-skills-demo.jsonl
+cat /tmp/memanto-skills-demo.jsonl
+```
+
+The second and third skill executions print `Relevant Memanto memories:` before
+running. That is the practical productivity gain: each isolated command starts
+with the project decisions and constraints learned by earlier skills, without
+asking the user to repeat them in every prompt.
+
 ## Use Real Memanto
 
 Install and configure Memanto first:
@@ -53,6 +66,18 @@ This creates `.claude/commands/*-with-memanto.md` wrappers for:
 
 The generated files are intentionally small. They keep the original skills as
 the source of truth while adding Memanto recall and storage around each run.
+
+## Review Checklist
+
+- Run the demo once and confirm later skills receive `MEMANTO_SKILL_CONTEXT`.
+- Inspect the JSONL file and confirm only durable decisions, preferences,
+  instructions, and observations are stored.
+- Run the tests to cover recall scoring, transcript distillation, context
+  injection, and child-process exit handling.
+
+```bash
+python -m pytest examples/claudecode-skills-memanto/test_skill_memory_bridge.py -q
+```
 
 ## Safety Boundary
 

--- a/examples/claudecode-skills-memanto/demo_skills.py
+++ b/examples/claudecode-skills-memanto/demo_skills.py
@@ -1,0 +1,34 @@
+"""Tiny fake skills used by the credential-free demo and tests."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["grill-with-docs", "tdd", "handoff"])
+    args = parser.parse_args()
+
+    context = os.getenv("MEMANTO_SKILL_CONTEXT", "")
+    if args.mode == "grill-with-docs":
+        print(
+            "Decision: Use a repository-local adapter instead of patching upstream skills."
+        )
+        print("Convention: Keep generated prompts short and source-linked.")
+        return
+
+    if args.mode == "tdd":
+        if "repository-local adapter" in context:
+            print("saw prior architecture decision")
+        print("Must: Exercise the memory bridge without network credentials.")
+        return
+
+    if "without network credentials" in context:
+        print("handoff includes test constraint from prior skill")
+    print("Avoid: Storing secrets or raw hidden prompts in Memanto.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/generate_claude_commands.py
+++ b/examples/claudecode-skills-memanto/generate_claude_commands.py
@@ -1,0 +1,41 @@
+"""Generate Claude command wrappers for selected mattpocock skills."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+SKILLS = ("grill-with-docs", "tdd", "handoff")
+
+
+TEMPLATE = """---
+description: Run /{skill} with Memanto cross-skill memory
+---
+
+Before executing the skill, recall relevant engineering memories:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory_bridge.py {skill} \\
+  --task "$ARGUMENTS" -- <original-{skill}-command> "$ARGUMENTS"
+```
+
+Use the printed `MEMANTO_SKILL_CONTEXT` as additional constraints for this run.
+After the command exits, the bridge stores durable decisions, conventions,
+instructions, and caveats back into Memanto for the next skill.
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=Path(".claude/commands"))
+    args = parser.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    for skill in SKILLS:
+        path = args.out / f"{skill}-with-memanto.md"
+        path.write_text(TEMPLATE.format(skill=skill), encoding="utf-8")
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/run_demo.py
+++ b/examples/claudecode-skills-memanto/run_demo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 import tempfile
@@ -10,16 +11,37 @@ from pathlib import Path
 from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the credential-free Claude Code skills + Memanto demo.",
+    )
+    parser.add_argument(
+        "--memory-file",
+        type=Path,
+        default=None,
+        help="Write demo memories to this JSONL file for review.",
+    )
+    parser.add_argument(
+        "--keep-memory",
+        action="store_true",
+        help="Keep the temporary JSONL memory file after the demo exits.",
+    )
+    return parser.parse_args()
+
+
 def main() -> int:
+    args = parse_args()
     configured_file = os.getenv("MEMANTO_SKILLS_MEMORY_FILE")
     cleanup = False
-    if configured_file:
+    if args.memory_file:
+        demo_file = args.memory_file
+    elif configured_file:
         demo_file = Path(configured_file)
     else:
         handle = tempfile.NamedTemporaryFile(prefix="memanto-skills-", suffix=".jsonl")
         demo_file = Path(handle.name)
         handle.close()
-        cleanup = True
+        cleanup = not args.keep_memory
 
     bridge = SkillMemoryBridge(LocalJsonlBackend(demo_file))
     base = [sys.executable, str(Path(__file__).with_name("demo_skills.py"))]
@@ -35,6 +57,8 @@ def main() -> int:
             return status
 
     print(f"\nMemory file: {demo_file}")
+    if not cleanup:
+        print("Inspect the JSONL file to see the durable memories stored by each run.")
     if cleanup:
         demo_file.unlink(missing_ok=True)
     return 0

--- a/examples/claudecode-skills-memanto/run_demo.py
+++ b/examples/claudecode-skills-memanto/run_demo.py
@@ -1,0 +1,44 @@
+"""Run three isolated skill executions that share Memanto memory."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge
+
+
+def main() -> int:
+    configured_file = os.getenv("MEMANTO_SKILLS_MEMORY_FILE")
+    cleanup = False
+    if configured_file:
+        demo_file = Path(configured_file)
+    else:
+        handle = tempfile.NamedTemporaryFile(prefix="memanto-skills-", suffix=".jsonl")
+        demo_file = Path(handle.name)
+        handle.close()
+        cleanup = True
+
+    bridge = SkillMemoryBridge(LocalJsonlBackend(demo_file))
+    base = [sys.executable, str(Path(__file__).with_name("demo_skills.py"))]
+    runs = [
+        ("grill-with-docs", "review architecture docs", [*base, "grill-with-docs"]),
+        ("tdd", "write tests for memory bridge", [*base, "tdd"]),
+        ("handoff", "summarize implementation constraints", [*base, "handoff"]),
+    ]
+    for skill, task, command in runs:
+        print(f"\n=== /{skill} ===")
+        status = bridge.run(skill, command, task=task)
+        if status:
+            return status
+
+    print(f"\nMemory file: {demo_file}")
+    if cleanup:
+        demo_file.unlink(missing_ok=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -178,6 +178,11 @@ class TranscriptDistiller:
                 if not match:
                     continue
                 content = _clean_sentence(match.group(1))
+                lowered_line = line.lower()
+                if lowered_line.startswith("avoid"):
+                    content = f"Avoid {_lower_first(content)}"
+                elif lowered_line.startswith("never"):
+                    content = f"Never {_lower_first(content)}"
                 if len(content) < 12 or content.lower() in seen:
                     continue
                 seen.add(content.lower())
@@ -256,6 +261,10 @@ def _tokenize(value: str) -> set[str]:
 def _clean_sentence(value: str) -> str:
     value = re.sub(r"\s+", " ", value).strip()
     return value[:1].upper() + value[1:]
+
+
+def _lower_first(value: str) -> str:
+    return value[:1].lower() + value[1:]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -1,0 +1,279 @@
+"""Memanto memory bridge for Claude Code / mattpocock-style skills.
+
+The module wraps separate skill executions with three steps:
+
+1. recall relevant engineering memories before the command starts,
+2. inject those memories into the child process environment, and
+3. distill durable decisions from the completed transcript.
+
+It ships with a local JSONL backend so reviewers can run the example without
+Moorcheh credentials. Set ``MEMANTO_SKILLS_BACKEND=cli`` to use the real
+``memanto`` command-line client.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Protocol
+
+DEFAULT_AGENT_ID = "claudecode-skills"
+DEFAULT_MEMORY_FILE = Path(".memanto-skills-memory.jsonl")
+
+
+@dataclass(frozen=True)
+class Memory:
+    content: str
+    memory_type: str = "decision"
+    confidence: float = 0.8
+    source: str = DEFAULT_AGENT_ID
+    tags: tuple[str, ...] = ()
+    created_at: float = 0.0
+
+    def to_json(self) -> str:
+        data = asdict(self)
+        data["tags"] = list(self.tags)
+        data["created_at"] = self.created_at or time.time()
+        return json.dumps(data, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, line: str) -> Memory:
+        data = json.loads(line)
+        return cls(
+            content=data["content"],
+            memory_type=data.get("memory_type", "decision"),
+            confidence=float(data.get("confidence", 0.8)),
+            source=data.get("source", DEFAULT_AGENT_ID),
+            tags=tuple(data.get("tags", [])),
+            created_at=float(data.get("created_at", 0.0)),
+        )
+
+
+class MemoryBackend(Protocol):
+    def recall(self, query: str, limit: int = 6) -> list[Memory]:
+        """Return memories relevant to *query*."""
+
+    def remember(self, memory: Memory) -> None:
+        """Store one memory."""
+
+
+class LocalJsonlBackend:
+    """Credential-free backend used for tests, demos, and offline review."""
+
+    def __init__(self, path: Path = DEFAULT_MEMORY_FILE) -> None:
+        self.path = path
+
+    def _load(self) -> list[Memory]:
+        if not self.path.exists():
+            return []
+        memories: list[Memory] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                memories.append(Memory.from_json(line))
+        return memories
+
+    def recall(self, query: str, limit: int = 6) -> list[Memory]:
+        query_terms = _tokenize(query)
+        scored: list[tuple[float, Memory]] = []
+        for memory in self._load():
+            haystack = _tokenize(" ".join([memory.content, *memory.tags]))
+            overlap = len(query_terms & haystack)
+            if overlap:
+                scored.append((overlap + memory.confidence, memory))
+        scored.sort(key=lambda item: (item[0], item[1].created_at), reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+    def remember(self, memory: Memory) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        existing = {item.content for item in self._load()}
+        if memory.content in existing:
+            return
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(memory.to_json() + "\n")
+
+
+class MemantoCliBackend:
+    """Backend that talks to the real Memanto CLI."""
+
+    def __init__(self, agent_id: str = DEFAULT_AGENT_ID) -> None:
+        self.agent_id = agent_id
+        self._ensure_agent()
+
+    def _ensure_agent(self) -> None:
+        activate = subprocess.run(
+            ["memanto", "agent", "activate", self.agent_id],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if activate.returncode == 0:
+            return
+        subprocess.run(["memanto", "agent", "create", self.agent_id], check=True)
+
+    def recall(self, query: str, limit: int = 6) -> list[Memory]:
+        result = subprocess.run(
+            ["memanto", "recall", query, "--limit", str(limit)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        output = result.stdout.strip()
+        if not output:
+            return []
+        return [
+            Memory(
+                content=output,
+                memory_type="context",
+                confidence=0.7,
+                source=self.agent_id,
+                tags=("memanto-cli",),
+            )
+        ]
+
+    def remember(self, memory: Memory) -> None:
+        cmd = [
+            "memanto",
+            "remember",
+            memory.content,
+            "--type",
+            memory.memory_type,
+            "--confidence",
+            str(memory.confidence),
+            "--provenance",
+            "agent_observation",
+            "--source",
+            self.agent_id,
+        ]
+        if memory.tags:
+            cmd.extend(["--tags", ",".join(memory.tags)])
+        subprocess.run(cmd, check=True)
+
+
+class TranscriptDistiller:
+    """Extract stable engineering preferences from skill transcripts."""
+
+    PATTERNS: tuple[tuple[str, str, float], ...] = (
+        (r"\b(?:decision|decided|we will|use|prefer)\b[:\s-]+(.+)", "decision", 0.88),
+        (r"\b(?:convention|preference)\b[:\s-]+(.+)", "preference", 0.82),
+        (r"\b(?:must|always|never|avoid)\b[:\s-]+(.+)", "instruction", 0.9),
+        (r"\b(?:quirk|caveat|gotcha)\b[:\s-]+(.+)", "observation", 0.72),
+    )
+
+    def distill(self, skill_name: str, transcript: str) -> list[Memory]:
+        memories: list[Memory] = []
+        seen: set[str] = set()
+        for raw_line in transcript.splitlines():
+            line = raw_line.strip(" -\t")
+            if not line:
+                continue
+            for pattern, memory_type, confidence in self.PATTERNS:
+                match = re.search(pattern, line, flags=re.IGNORECASE)
+                if not match:
+                    continue
+                content = _clean_sentence(match.group(1))
+                if len(content) < 12 or content.lower() in seen:
+                    continue
+                seen.add(content.lower())
+                memories.append(
+                    Memory(
+                        content=content,
+                        memory_type=memory_type,
+                        confidence=confidence,
+                        source=skill_name,
+                        tags=("claude-code", "skills", skill_name),
+                    )
+                )
+                break
+        return memories
+
+
+class SkillMemoryBridge:
+    def __init__(
+        self,
+        backend: MemoryBackend,
+        distiller: TranscriptDistiller | None = None,
+    ) -> None:
+        self.backend = backend
+        self.distiller = distiller or TranscriptDistiller()
+
+    def build_context(self, skill_name: str, task: str, limit: int = 6) -> str:
+        query = f"claude-code skills {skill_name} {task}"
+        memories = self.backend.recall(query, limit=limit)
+        if not memories:
+            return ""
+        lines = ["Relevant Memanto memories:"]
+        for memory in memories:
+            lines.append(f"- [{memory.memory_type}] {memory.content}")
+        return "\n".join(lines)
+
+    def run(self, skill_name: str, command: list[str], task: str = "") -> int:
+        context = self.build_context(skill_name, task or " ".join(command))
+        env = os.environ.copy()
+        if context:
+            env["MEMANTO_SKILL_CONTEXT"] = context
+            print(context)
+            print()
+
+        completed = subprocess.run(
+            command,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        sys.stdout.write(completed.stdout)
+        sys.stderr.write(completed.stderr)
+
+        # Distill only the child skill transcript. Re-storing injected context
+        # would create duplicate memories on every wrapped execution.
+        transcript = "\n".join([completed.stdout, completed.stderr])
+        for memory in self.distiller.distill(skill_name, transcript):
+            self.backend.remember(memory)
+        return completed.returncode
+
+
+def backend_from_env() -> MemoryBackend:
+    backend = os.getenv("MEMANTO_SKILLS_BACKEND", "local").lower()
+    if backend == "cli":
+        return MemantoCliBackend(os.getenv("MEMANTO_AGENT_ID", DEFAULT_AGENT_ID))
+    if backend != "local":
+        raise ValueError("MEMANTO_SKILLS_BACKEND must be 'local' or 'cli'")
+    path = Path(os.getenv("MEMANTO_SKILLS_MEMORY_FILE", str(DEFAULT_MEMORY_FILE)))
+    return LocalJsonlBackend(path)
+
+
+def _tokenize(value: str) -> set[str]:
+    return {token.lower() for token in re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{2,}", value)}
+
+
+def _clean_sentence(value: str) -> str:
+    value = re.sub(r"\s+", " ", value).strip()
+    return value[:1].upper() + value[1:]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a skill with Memanto memory.")
+    parser.add_argument("skill", help="Skill name, for example grill-with-docs")
+    parser.add_argument("--task", default="", help="Task text used for memory recall")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to execute")
+    args = parser.parse_args(argv)
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("provide a command after --")
+
+    bridge = SkillMemoryBridge(backend_from_env())
+    return bridge.run(args.skill, command, task=args.task)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -36,6 +36,7 @@ def test_distiller_extracts_typed_engineering_memories() -> None:
         "instruction",
     ]
     assert "repository-local adapter" in memories[0].content
+    assert memories[2].content == "Avoid storing secrets or raw hidden prompts."
     assert all("tdd" in memory.tags for memory in memories)
 
 

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from skill_memory_bridge import (
+    LocalJsonlBackend,
+    Memory,
+    SkillMemoryBridge,
+    TranscriptDistiller,
+)
+
+
+def test_local_backend_recalls_relevant_memory(tmp_path: Path) -> None:
+    backend = LocalJsonlBackend(tmp_path / "memory.jsonl")
+    backend.remember(Memory("Use repository-local adapters", tags=("tdd",)))
+    backend.remember(Memory("Prefer unrelated frontend colors", tags=("ui",)))
+
+    recalled = backend.recall("tdd adapter")
+
+    assert [memory.content for memory in recalled] == ["Use repository-local adapters"]
+
+
+def test_distiller_extracts_typed_engineering_memories() -> None:
+    transcript = """
+    Decision: Use a repository-local adapter.
+    Must: Exercise the bridge without credentials.
+    Avoid: Storing secrets or raw hidden prompts.
+    """
+
+    memories = TranscriptDistiller().distill("tdd", transcript)
+
+    assert [memory.memory_type for memory in memories] == [
+        "decision",
+        "instruction",
+        "instruction",
+    ]
+    assert "repository-local adapter" in memories[0].content
+    assert all("tdd" in memory.tags for memory in memories)
+
+
+def test_bridge_injects_previous_context_and_stores_new_memories(
+    tmp_path: Path,
+) -> None:
+    backend = LocalJsonlBackend(tmp_path / "memory.jsonl")
+    backend.remember(Memory("Use a repository-local adapter", tags=("tdd",)))
+    bridge = SkillMemoryBridge(backend)
+
+    status = bridge.run(
+        "tdd",
+        [
+            sys.executable,
+            str(Path(__file__).with_name("demo_skills.py")),
+            "tdd",
+        ],
+        task="adapter tests",
+    )
+
+    assert status == 0
+    stored = backend.recall("network credentials", limit=10)
+    assert any("without network credentials" in memory.content for memory in stored)
+
+
+def test_bridge_returns_child_exit_code(tmp_path: Path) -> None:
+    backend = LocalJsonlBackend(tmp_path / "memory.jsonl")
+    bridge = SkillMemoryBridge(backend)
+
+    status = bridge.run("tdd", [sys.executable, "-c", "raise SystemExit(7)"])
+
+    assert status == 7


### PR DESCRIPTION
Fixes #508
/claim #508

This adds a small example for using Memanto around separate Claude Code / mattpocock-style skill runs.

The wrapper does three things:

- looks up relevant memories before a skill runs
- passes them to the skill through MEMANTO_SKILL_CONTEXT
- saves durable notes from the completed run, like decisions, conventions, caveats, and must/avoid rules

I kept it as an example instead of changing core Memanto behavior. That makes it easy to review and easy to delete or adapt later. The default backend is a local JSONL file so the demo and tests run without a Moorcheh key. There is also a Memanto CLI backend for real use.

The review path is meant to be concrete:

```bash
python examples/claudecode-skills-memanto/run_demo.py \
  --memory-file /tmp/memanto-skills-demo.jsonl
cat /tmp/memanto-skills-demo.jsonl
```

The second and third demo skill runs should start with `Relevant Memanto memories:` from earlier isolated runs. I also fixed the transcript distiller so `Avoid:` / `Never:` lines keep their negation when they are stored as durable memory.

Files added:

- examples/claudecode-skills-memanto/skill_memory_bridge.py
- examples/claudecode-skills-memanto/run_demo.py
- examples/claudecode-skills-memanto/demo_skills.py
- examples/claudecode-skills-memanto/generate_claude_commands.py
- examples/claudecode-skills-memanto/test_skill_memory_bridge.py
- examples/claudecode-skills-memanto/README.md

Showcase:

- X: https://x.com/dnesdan/status/2057008263372141000
- Reddit: https://www.reddit.com/r/ClaudeAI/comments/1tieyjq/small_memory_bridge_for_claude_code_skills_that/ (awaiting moderator approval)

Checked locally:

- python3 -m pytest examples/claudecode-skills-memanto/test_skill_memory_bridge.py -q
- python3 examples/claudecode-skills-memanto/run_demo.py --memory-file /tmp/memanto-skills-demo-fixed.jsonl
- python3 -m py_compile examples/claudecode-skills-memanto/skill_memory_bridge.py examples/claudecode-skills-memanto/demo_skills.py examples/claudecode-skills-memanto/run_demo.py examples/claudecode-skills-memanto/generate_claude_commands.py examples/claudecode-skills-memanto/test_skill_memory_bridge.py
- uvx ruff check examples/claudecode-skills-memanto
- uvx ruff format --check examples/claudecode-skills-memanto
- git diff --check

No keys, payment details, or raw hidden prompts are stored by the example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a memory bridge integration enabling Claude Code skills to recall and store decisions, preferences, and observations across execution runs.

* **Documentation**
  * Added comprehensive example guide demonstrating memory persistence workflow with skills, including setup instructions and a safety-boundary reference.

* **Tests**
  * Added test suite covering memory recall, storage, context injection, and skill execution workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->