### PR TITLE
Add Claude Code skills Memanto memory example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,107 @@
+# Claude Code Skills + Memanto
+
+This example shows how Memanto can act as a shared engineering memory layer
+across mattpocock-style skill runs such as `/grill-with-docs`, `/tdd`, and
+`/handoff`.
+
+It is designed for safe review:
+
+- The default backend is a local JSONL file, so no private API key is required.
+- The live backend uses `memanto.cli.client.sdk_client.SdkClient` only when
+  `MEMANTO_MEMORY_BACKEND=sdk` and `MOORCHEH_API_KEY` are configured.
+- The hook stores typed engineering memories after a skill finishes, then
+  injects relevant memories before later skill runs.
+
+## What This Demonstrates
+
+- **Cross-skill recall**: decisions from one skill run are available to the next.
+- **Active extraction**: skill transcripts are distilled into typed memories.
+- **Dynamic injection**: relevant memories become a compact context block.
+- **Credential-free validation**: tests and demo run locally without network calls.
+- **Adapter path**: wrapper generation for common developer skill commands.
+
+## Quick Demo
+
+```bash
+cd examples/claudecode-skills-memanto
+
+# Store memories from a completed architecture discussion.
+python3 skill_memory.py after \
+  --skill grill-with-docs \
+  --task "Plan invoice import architecture" \
+  --transcript demo_transcript.md \
+  --workspace example-shop
+
+# Start a later TDD session and inject relevant context.
+python3 skill_memory.py before \
+  --skill tdd \
+  --task "Write tests for the invoice import parser" \
+  --file src/invoices/parser.ts \
+  --workspace example-shop
+```
+
+Expected output from the second command includes remembered constraints such as:
+
+- prefer a streaming parser for large invoice exports
+- keep raw import rows for auditability
+- avoid adding a second queue system
+
+Those memories are not passed through the current task prompt. They come from
+the previous skill run stored in the shared memory backend.
+
+## Live Memanto Mode
+
+```bash
+export MEMANTO_MEMORY_BACKEND=sdk
+export MOORCHEH_API_KEY=...
+export MEMANTO_AGENT_ID=developer-skills
+
+python3 skill_memory.py after \
+  --skill grill-with-docs \
+  --task "Plan invoice import architecture" \
+  --transcript demo_transcript.md
+
+python3 skill_memory.py before \
+  --skill tdd \
+  --task "Write tests for the invoice import parser"
+```
+
+The SDK backend creates the agent if needed, activates a session, then uses
+Memanto `remember` and `recall` operations with typed memory records.
+
+## Generate Skill Wrappers
+
+```bash
+python3 mattpocock_adapter.py generate --out .generated-wrappers
+```
+
+The generated shell wrappers surround each skill command with:
+
+1. a `before` hook that writes relevant memories into a context file
+2. the original skill command
+3. an `after` hook that distills the transcript and stores new memories
+
+This keeps the integration outside the skills themselves, so teams can adopt it
+incrementally.
+
+## Validation
+
+```bash
+python3 validate.py
+python3 -m unittest test_skill_memory.py
+python3 -m py_compile skill_memory.py mattpocock_adapter.py validate.py test_skill_memory.py
+```
+
+These commands do not require credentials or network access.
+
+## File Structure
+
+```text
+examples/claudecode-skills-memanto/
+├── README.md
+├── demo_transcript.md
+├── mattpocock_adapter.py
+├── skill_memory.py
+├── test_skill_memory.py
+└── validate.py
+```

--- a/examples/claudecode-skills-memanto/demo_transcript.md
+++ b/examples/claudecode-skills-memanto/demo_transcript.md
@@ -1,0 +1,19 @@
+# Demo Transcript
+
+Skill: `/grill-with-docs`
+Task: Plan invoice import architecture
+
+Decision: Use a streaming parser for invoice CSV imports because customers can
+upload exports with hundreds of thousands of rows.
+
+Decision: Keep raw import rows in storage for auditability before converting
+them into normalized invoice records.
+
+Preference: The codebase prefers explicit domain services over framework magic
+for billing workflows.
+
+Constraint: Avoid adding a second queue system; reuse the existing background
+job runner unless load testing proves it cannot keep up.
+
+Artifact: The parser contract should return accepted rows, rejected rows, and a
+stable import batch id for reconciliation.

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -1,0 +1,110 @@
+"""Generate wrappers for mattpocock-style developer skill commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+DEFAULT_SKILLS = (
+    "grill-with-docs",
+    "tdd",
+    "handoff",
+    "triage",
+    "diagnose",
+)
+
+
+@dataclass(frozen=True)
+class SkillWrapperSpec:
+    skill: str
+    original_command: str
+    context_file: str
+    transcript_file: str
+
+
+def default_specs() -> list[SkillWrapperSpec]:
+    return [
+        SkillWrapperSpec(
+            skill=skill,
+            original_command=skill,
+            context_file=f".memanto/{skill}-context.md",
+            transcript_file=f".memanto/{skill}-transcript.md",
+        )
+        for skill in DEFAULT_SKILLS
+    ]
+
+
+def render_wrapper(spec: SkillWrapperSpec) -> str:
+    quoted_skill = shlex.quote(spec.skill)
+    quoted_context = shlex.quote(spec.context_file)
+    quoted_transcript = shlex.quote(spec.transcript_file)
+    quoted_command = shlex.quote(spec.original_command)
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+TASK="${{1:-}}"
+WORKSPACE="${{MEMANTO_WORKSPACE:-default}}"
+mkdir -p "$(dirname {quoted_context})"
+
+python3 skill_memory.py before \\
+  --skill {quoted_skill} \\
+  --task "$TASK" \\
+  --workspace "$WORKSPACE" > {quoted_context}
+
+echo "Memanto context written to {quoted_context}" >&2
+
+set +e
+{quoted_command} "$@" 2>&1 | tee {quoted_transcript}
+STATUS=${{PIPESTATUS[0]}}
+set -e
+
+python3 skill_memory.py after \\
+  --skill {quoted_skill} \\
+  --task "$TASK" \\
+  --workspace "$WORKSPACE" \\
+  --transcript {quoted_transcript} >/dev/null
+
+exit "$STATUS"
+"""
+
+
+def write_wrappers(out_dir: Path, specs: list[SkillWrapperSpec]) -> list[Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for spec in specs:
+        path = out_dir / spec.skill
+        path.write_text(render_wrapper(spec), encoding="utf-8")
+        path.chmod(0o755)
+        written.append(path)
+    manifest = {
+        "description": "Memanto lifecycle wrappers for developer skills",
+        "wrappers": [asdict(spec) for spec in specs],
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    written.append(out_dir / "manifest.json")
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate", help="write wrapper scripts")
+    generate.add_argument("--out", default=".memanto-wrappers")
+    args = parser.parse_args(argv)
+
+    if args.command == "generate":
+        paths = write_wrappers(Path(args.out), default_specs())
+        print(json.dumps({"written": [str(path) for path in paths]}, indent=2))
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,451 @@
+"""Lifecycle memory hooks for developer skill executions.
+
+The module has two backends:
+
+* LocalJsonlBackend: credential-free review and tests.
+* MemantoSdkBackend: optional live Memanto storage through SdkClient.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+from uuid import uuid4
+
+VALID_MEMORY_TYPES = {
+    "fact",
+    "preference",
+    "goal",
+    "decision",
+    "artifact",
+    "learning",
+    "event",
+    "instruction",
+    "relationship",
+    "context",
+    "observation",
+    "commitment",
+    "error",
+}
+
+DEFAULT_LOCAL_STORE = Path(".memanto-skill-memory.jsonl")
+DEFAULT_AGENT_ID = "developer-skills"
+
+
+@dataclass(frozen=True)
+class EngineeringMemory:
+    """A typed engineering memory extracted from a skill run."""
+
+    memory_type: str
+    title: str
+    content: str
+    confidence: float = 0.8
+    tags: list[str] = field(default_factory=list)
+    source: str = "skill-memory-hook"
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+class MemoryBackend(Protocol):
+    """Storage interface shared by local and live Memanto backends."""
+
+    def remember(self, memory: EngineeringMemory) -> str:
+        """Store a memory and return its identifier."""
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int = 6,
+        tags: list[str] | None = None,
+    ) -> list[EngineeringMemory]:
+        """Return memories relevant to the query."""
+
+
+class LocalJsonlBackend:
+    """Small deterministic backend for local demos and pull request review."""
+
+    def __init__(self, path: Path = DEFAULT_LOCAL_STORE) -> None:
+        self.path = path
+
+    def remember(self, memory: EngineeringMemory) -> str:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        memory_id = str(uuid4())
+        payload = {"id": memory_id, **asdict(memory)}
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        return memory_id
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int = 6,
+        tags: list[str] | None = None,
+    ) -> list[EngineeringMemory]:
+        if not self.path.exists():
+            return []
+
+        query_tokens = _tokens(query)
+        requested_tags = set(tags or [])
+        scored: list[tuple[float, EngineeringMemory]] = []
+
+        with self.path.open(encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                raw = json.loads(line)
+                memory = EngineeringMemory(
+                    memory_type=raw["memory_type"],
+                    title=raw["title"],
+                    content=raw["content"],
+                    confidence=float(raw.get("confidence", 0.8)),
+                    tags=list(raw.get("tags", [])),
+                    source=raw.get("source", "skill-memory-hook"),
+                    created_at=raw.get("created_at", ""),
+                )
+                tag_overlap = requested_tags.intersection(memory.tags)
+                text = f"{memory.title} {memory.content} {' '.join(memory.tags)}"
+                token_overlap = query_tokens.intersection(_tokens(text))
+                score = len(token_overlap) + (2 * len(tag_overlap))
+                if score > 0 or not query_tokens:
+                    scored.append((score + memory.confidence, memory))
+
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+
+class MemantoSdkBackend:
+    """Live backend using Memanto's SDK client.
+
+    Importing SdkClient lazily keeps local validation free of optional network
+    setup and private credentials.
+    """
+
+    def __init__(self, api_key: str, agent_id: str = DEFAULT_AGENT_ID) -> None:
+        if not api_key.strip():
+            raise ValueError("api_key must be provided for sdk backend")
+
+        from memanto.app.utils.errors import AgentAlreadyExistsError
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self.agent_id = agent_id
+        self.client = SdkClient(api_key=api_key)
+        try:
+            self.client.create_agent(
+                agent_id,
+                pattern="tool",
+                description="Shared memory for developer skill executions",
+            )
+        except AgentAlreadyExistsError:
+            pass
+        self.client.activate_agent(agent_id)
+
+    def remember(self, memory: EngineeringMemory) -> str:
+        result = self.client.remember(
+            self.agent_id,
+            memory.memory_type,
+            memory.title,
+            memory.content,
+            confidence=memory.confidence,
+            tags=memory.tags,
+            source=memory.source,
+            provenance="observed",
+        )
+        return str(result["memory_id"])
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int = 6,
+        tags: list[str] | None = None,
+    ) -> list[EngineeringMemory]:
+        result = self.client.recall(
+            self.agent_id,
+            query,
+            limit=limit,
+            tags=tags,
+            min_confidence=0.45,
+        )
+        memories: list[EngineeringMemory] = []
+        for raw in result.get("memories", []):
+            memories.append(_memory_from_sdk_result(raw))
+        return memories
+
+
+@dataclass(frozen=True)
+class SkillRun:
+    """Metadata describing one developer skill execution."""
+
+    skill: str
+    task: str
+    workspace: str = "default"
+    files: tuple[str, ...] = ()
+
+    @property
+    def tags(self) -> list[str]:
+        file_tags = [f"path:{Path(file_name).parent}" for file_name in self.files]
+        return [f"skill:{self.skill}", f"workspace:{self.workspace}", *file_tags]
+
+    @property
+    def query(self) -> str:
+        return " ".join([self.skill, self.task, self.workspace, *self.files])
+
+
+class SkillMemoryHook:
+    """Coordinates extraction after a run and context injection before a run."""
+
+    def __init__(self, backend: MemoryBackend) -> None:
+        self.backend = backend
+
+    def before_skill(self, run: SkillRun, limit: int = 6) -> str:
+        memories = self.backend.recall(
+            run.query,
+            limit=limit,
+            tags=[f"workspace:{run.workspace}"],
+        )
+        return render_injection_block(run, memories)
+
+    def after_skill(self, run: SkillRun, transcript: str) -> list[EngineeringMemory]:
+        memories = distill_memories(transcript, run)
+        for memory in memories:
+            self.backend.remember(memory)
+        return memories
+
+
+def distill_memories(transcript: str, run: SkillRun) -> list[EngineeringMemory]:
+    """Extract high-signal engineering memories from a skill transcript."""
+
+    memories: list[EngineeringMemory] = []
+    seen: set[str] = set()
+
+    for raw_line in transcript.splitlines():
+        line = raw_line.strip(" -\t")
+        if not line:
+            continue
+
+        memory_type = _classify_line(line)
+        if not memory_type:
+            continue
+
+        content = _strip_label(line)
+        key = re.sub(r"\W+", " ", f"{memory_type} {content}").lower().strip()
+        if key in seen:
+            continue
+        seen.add(key)
+
+        confidence = _confidence_for(memory_type, line)
+        memories.append(
+            EngineeringMemory(
+                memory_type=memory_type,
+                title=_title_for(content),
+                content=content,
+                confidence=confidence,
+                tags=[*run.tags, f"type:{memory_type}"],
+            )
+        )
+
+    if not memories and transcript.strip():
+        summary = " ".join(transcript.strip().split())[:400]
+        memories.append(
+            EngineeringMemory(
+                memory_type="observation",
+                title=f"{run.skill} run summary",
+                content=summary,
+                confidence=0.45,
+                tags=[*run.tags, "type:observation"],
+            )
+        )
+
+    return memories
+
+
+def render_injection_block(run: SkillRun, memories: list[EngineeringMemory]) -> str:
+    """Render a compact prompt block for a later skill invocation."""
+
+    if not memories:
+        return (
+            "## Memanto Skill Memory\n"
+            f"No relevant memories found for `{run.skill}` in workspace "
+            f"`{run.workspace}`.\n"
+        )
+
+    lines = [
+        "## Memanto Skill Memory",
+        f"Relevant prior engineering context for `{run.skill}`:",
+    ]
+    for index, memory in enumerate(memories, start=1):
+        lines.append(
+            f"{index}. [{memory.memory_type}] {memory.title}: {memory.content}"
+        )
+    lines.append("")
+    lines.append(
+        "Use these memories as constraints when they fit the current task; "
+        "ignore any that conflict with newer user instructions."
+    )
+    return "\n".join(lines)
+
+
+def build_backend_from_env() -> MemoryBackend:
+    backend_name = os.environ.get("MEMANTO_MEMORY_BACKEND", "local").lower()
+    if backend_name == "sdk":
+        api_key = os.environ.get("MOORCHEH_API_KEY", "")
+        agent_id = os.environ.get("MEMANTO_AGENT_ID", DEFAULT_AGENT_ID)
+        return MemantoSdkBackend(api_key=api_key, agent_id=agent_id)
+
+    store_path = Path(os.environ.get("MEMANTO_LOCAL_STORE", str(DEFAULT_LOCAL_STORE)))
+    return LocalJsonlBackend(store_path)
+
+
+def _classify_line(line: str) -> str | None:
+    lowered = line.lower()
+    prefix = lowered.split(":", 1)[0]
+    prefix_map = {
+        "decision": "decision",
+        "preference": "preference",
+        "constraint": "instruction",
+        "instruction": "instruction",
+        "artifact": "artifact",
+        "goal": "goal",
+        "learning": "learning",
+        "error": "error",
+        "context": "context",
+    }
+    if prefix in prefix_map:
+        return prefix_map[prefix]
+
+    patterns = [
+        (r"\b(decided|choose|selected|accepted)\b", "decision"),
+        (r"\b(prefer|preference|convention|style)\b", "preference"),
+        (r"\b(must|should|avoid|do not|never|always)\b", "instruction"),
+        (r"\b(adr|artifact|contract|schema|interface)\b", "artifact"),
+        (r"\b(goal|objective|target)\b", "goal"),
+        (r"\b(regression|failure|bug|error)\b", "error"),
+    ]
+    for pattern, memory_type in patterns:
+        if re.search(pattern, lowered):
+            return memory_type
+    return None
+
+
+def _strip_label(line: str) -> str:
+    if ":" in line:
+        label, rest = line.split(":", 1)
+        if len(label.split()) <= 4:
+            return rest.strip()
+    return line
+
+
+def _title_for(content: str) -> str:
+    words = content.strip().split()
+    title = " ".join(words[:10])
+    if len(words) > 10:
+        title += "..."
+    return title[:100]
+
+
+def _confidence_for(memory_type: str, line: str) -> float:
+    if ":" in line and _classify_line(line):
+        return 0.9
+    if memory_type in {"decision", "instruction"}:
+        return 0.82
+    if memory_type in {"preference", "artifact"}:
+        return 0.75
+    return 0.65
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9][a-z0-9_-]{2,}", text.lower())
+        if token
+        not in {
+            "and",
+            "for",
+            "the",
+            "this",
+            "that",
+            "with",
+            "from",
+            "into",
+            "skill",
+        }
+    }
+
+
+def _memory_from_sdk_result(raw: dict[str, Any]) -> EngineeringMemory:
+    memory_type = raw.get("type") or raw.get("memory_type") or "context"
+    if memory_type not in VALID_MEMORY_TYPES:
+        memory_type = "context"
+
+    content = raw.get("content") or raw.get("text") or json.dumps(raw, sort_keys=True)
+    title = raw.get("title") or _title_for(str(content))
+    return EngineeringMemory(
+        memory_type=str(memory_type),
+        title=str(title),
+        content=str(content),
+        confidence=float(raw.get("confidence", 0.7)),
+        tags=list(raw.get("tags", [])),
+        source=str(raw.get("source", "memanto-sdk")),
+        created_at=str(raw.get("created_at", "")),
+    )
+
+
+def _read_transcript(path: str | None) -> str:
+    if path:
+        return Path(path).read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def _build_run(args: argparse.Namespace) -> SkillRun:
+    return SkillRun(
+        skill=args.skill,
+        task=args.task,
+        workspace=args.workspace,
+        files=tuple(args.file or ()),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    before = subparsers.add_parser("before", help="render memory context")
+    before.add_argument("--skill", required=True)
+    before.add_argument("--task", required=True)
+    before.add_argument("--workspace", default="default")
+    before.add_argument("--file", action="append")
+    before.add_argument("--limit", type=int, default=6)
+
+    after = subparsers.add_parser("after", help="store memories from a transcript")
+    after.add_argument("--skill", required=True)
+    after.add_argument("--task", required=True)
+    after.add_argument("--workspace", default="default")
+    after.add_argument("--file", action="append")
+    after.add_argument("--transcript")
+
+    args = parser.parse_args(argv)
+    hook = SkillMemoryHook(build_backend_from_env())
+    run = _build_run(args)
+
+    if args.command == "before":
+        print(hook.before_skill(run, limit=args.limit))
+        return 0
+
+    transcript = _read_transcript(args.transcript)
+    memories = hook.after_skill(run, transcript)
+    print(json.dumps({"stored": len(memories), "memories": [asdict(m) for m in memories]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from mattpocock_adapter import default_specs, render_wrapper, write_wrappers
+from skill_memory import (
+    EngineeringMemory,
+    LocalJsonlBackend,
+    SkillMemoryHook,
+    SkillRun,
+    distill_memories,
+)
+
+
+class SkillMemoryTests(unittest.TestCase):
+    def test_distill_memories_extracts_typed_records(self) -> None:
+        run = SkillRun(skill="grill-with-docs", task="Plan importer")
+        memories = distill_memories(
+            "\n".join(
+                [
+                    "Decision: Use streaming parser",
+                    "Preference: Keep services explicit",
+                    "Constraint: Avoid a second queue system",
+                ]
+            ),
+            run,
+        )
+
+        self.assertEqual(
+            [memory.memory_type for memory in memories],
+            ["decision", "preference", "instruction"],
+        )
+        self.assertTrue(all("skill:grill-with-docs" in m.tags for m in memories))
+
+    def test_local_backend_recalls_across_skill_runs(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            backend = LocalJsonlBackend(Path(temp_dir) / "memory.jsonl")
+            hook = SkillMemoryHook(backend)
+            first_run = SkillRun(
+                skill="grill-with-docs",
+                task="Plan invoice import architecture",
+                workspace="billing",
+                files=("src/invoices/parser.ts",),
+            )
+            hook.after_skill(
+                first_run,
+                "Decision: Use a streaming parser for invoice imports.",
+            )
+
+            second_run = SkillRun(
+                skill="tdd",
+                task="Write invoice parser tests",
+                workspace="billing",
+                files=("src/invoices/parser.ts",),
+            )
+            context = hook.before_skill(second_run)
+
+        self.assertIn("streaming parser", context)
+        self.assertIn("Memanto Skill Memory", context)
+
+    def test_local_backend_writes_jsonl(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "memory.jsonl"
+            backend = LocalJsonlBackend(path)
+            backend.remember(
+                EngineeringMemory(
+                    memory_type="decision",
+                    title="Use local backend",
+                    content="Use JSONL for review-safe validation.",
+                )
+            )
+            payload = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["memory_type"], "decision")
+        self.assertIn("id", payload)
+
+    def test_adapter_generates_executable_wrappers(self) -> None:
+        spec = default_specs()[0]
+        wrapper = render_wrapper(spec)
+        self.assertIn("skill_memory.py before", wrapper)
+        self.assertIn("skill_memory.py after", wrapper)
+
+        with TemporaryDirectory() as temp_dir:
+            written = write_wrappers(Path(temp_dir), [spec])
+            paths = {path.name for path in written}
+
+        self.assertEqual(paths, {spec.skill, "manifest.json"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,52 @@
+"""Credential-free validation for the Claude Code skills example."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from mattpocock_adapter import default_specs, write_wrappers
+from skill_memory import LocalJsonlBackend, SkillMemoryHook, SkillRun
+
+
+def main() -> int:
+    with TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        backend = LocalJsonlBackend(root / "memory.jsonl")
+        hook = SkillMemoryHook(backend)
+        transcript = Path("demo_transcript.md").read_text(encoding="utf-8")
+        first_run = SkillRun(
+            skill="grill-with-docs",
+            task="Plan invoice import architecture",
+            workspace="example-shop",
+            files=("src/invoices/parser.ts",),
+        )
+        stored = hook.after_skill(first_run, transcript)
+        if len(stored) < 4:
+            raise AssertionError(f"expected at least 4 memories, got {len(stored)}")
+
+        second_run = SkillRun(
+            skill="tdd",
+            task="Write tests for the invoice import parser",
+            workspace="example-shop",
+            files=("src/invoices/parser.ts",),
+        )
+        context = hook.before_skill(second_run)
+        required = ["streaming parser", "auditability", "queue system"]
+        missing = [term for term in required if term not in context]
+        if missing:
+            raise AssertionError(f"context is missing expected memories: {missing}")
+
+        wrapper_dir = root / "wrappers"
+        written = write_wrappers(wrapper_dir, default_specs())
+        if not (wrapper_dir / "tdd").exists():
+            raise AssertionError("expected tdd wrapper to be generated")
+        if len(written) < 2:
+            raise AssertionError("expected wrapper scripts and manifest")
+
+    print("credential-free validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Addresses #508 by adding a self-contained `examples/claudecode-skills-memanto` integration path for using Memanto as shared memory across mattpocock-style developer skill executions.

This adds:
- credential-free local JSONL backend for safe review without private keys
- optional live Memanto SDK backend via `MOORCHEH_API_KEY`
- before/after lifecycle hooks that inject relevant memories and store distilled skill-run memories
- typed transcript distillation for decisions, preferences, instructions, artifacts, goals, and errors
- wrapper generation for commands such as `/grill-with-docs`, `/tdd`, and `/handoff`
- README, demo transcript, validation script, and unit tests

AI-assisted implementation; the account owner is responsible for this submission.

## Validation

- `python3 validate.py`
- `python3 -m unittest test_skill_memory.py`
- `python3 -m py_compile skill_memory.py mattpocock_adapter.py validate.py test_skill_memory.py`
- `python3 -m ruff check examples/claudecode-skills-memanto`
- `git diff --check HEAD~1 HEAD`

## Notes

The example defaults to local mode so reviewers can verify behavior without credentials. Live Memanto mode is opt-in with `MEMANTO_MEMORY_BACKEND=sdk` and `MOORCHEH_API_KEY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example demonstrating cross-skill engineering memory that stores and recalls decisions, preferences, and instructions across multiple skill runs, with credential-free local storage and optional cloud integration.

* **Documentation**
  * Added comprehensive example documentation, demo transcript, and validation workflow.

* **Tests**
  * Added test coverage for memory lifecycle, storage operations, wrapper generation, and end-to-end workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->