### PR TITLE
Add Claude Code skills Memanto hook integration

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -107,16 +107,26 @@ The hook returns JSON with:
 
 ## SDK Mode
 
-Set a Moorcheh API key and use the SDK backend:
+Install Memanto with its runtime dependencies, then set a Moorcheh API key and
+use the SDK backend:
 
 ```bash
+python3 -m pip install memanto
 export MOORCHEH_API_KEY="..."
-python3 examples/claudecode-skills-memanto/claude_memory_hooks.py benchmark
+
+printf '%s' '{
+  "hook_event_name": "UserPromptSubmit",
+  "session_id": "demo-sdk",
+  "cwd": "/repo/clinicpulse",
+  "prompt": "/tdd prepare public PR"
+}' | python3 examples/claudecode-skills-memanto/claude_memory_hooks.py inject \
+  --backend sdk
 ```
 
 Then adapt `settings.example.json` into your Claude Code project or user
 settings file. The SDK backend creates or activates the `claude-code-skills`
-Memanto agent and stores memories through the normal Memanto client.
+Memanto agent and stores memories through the normal Memanto client. The source
+checkout's local validation mode does not require package installation.
 
 ## Hook Strategy
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,146 @@
+# Claude Code Skills + Memanto
+
+This example makes Memanto a global memory companion for Claude Code skill
+workflows such as `/grill-with-docs`, `/tdd`, and `/handoff`.
+
+The integration uses Claude Code's hook lifecycle directly:
+
+- `SessionStart`, `UserPromptSubmit`, `UserPromptExpansion`, and `PostToolBatch`
+  recall relevant engineering memory and return `additionalContext`.
+- `Stop` captures the completed skill transcript, distills durable decisions,
+  preferences, instructions, and codebase quirks, then stores them in Memanto.
+
+That means the next skill run starts with the decisions from the previous skill
+without asking the developer to repeat them manually.
+
+References:
+
+- Claude Code hooks: https://code.claude.com/docs/en/hooks
+- Memanto agent integration guide: ../../docs/AGENT_INTEGRATION_GUIDE.md
+
+## What Makes This Different
+
+Most wrapper-only approaches can log that a command ran, but they do not reliably
+add useful context back into Claude Code. This example targets the hook events
+that Claude Code documents as context-bearing and returns the event-specific
+`additionalContext` payload.
+
+The result is a concrete before/after loop:
+
+1. `/grill-with-docs` decides that planning docs must stay out of public PRs.
+2. `Stop` stores that rule as a typed Memanto instruction.
+3. A later `/tdd` invocation asks for PR prep.
+4. `UserPromptExpansion` injects the prior docs-hygiene rule into context.
+
+## Files
+
+```text
+examples/claudecode-skills-memanto/
++-- README.md
++-- claude_memory_hooks.py       # hook CLI and local/SDK backends
++-- settings.example.json        # Claude Code hook configuration
++-- validate.py                  # credential-free lifecycle validation
++-- test_claude_memory_hooks.py  # stdlib regression tests
+```
+
+## Quick Validation, No API Key
+
+```bash
+python3 examples/claudecode-skills-memanto/validate.py
+python3 -m unittest discover -s examples/claudecode-skills-memanto -p 'test_*.py' -v
+```
+
+Expected output:
+
+```text
+credential-free validation passed
+...
+OK
+```
+
+## Local Hook Demo
+
+Capture memories from a completed skill transcript:
+
+```bash
+cat > /tmp/claude-skill-transcript.jsonl <<'EOF'
+{"type":"assistant","message":{"content":"Decision: keep planning docs out of public PR branches."}}
+{"type":"assistant","message":{"content":"Preference: run make verify before posting review updates."}}
+EOF
+
+printf '%s' '{
+  "hook_event_name": "Stop",
+  "session_id": "demo-1",
+  "cwd": "/repo/clinicpulse",
+  "transcript_path": "/tmp/claude-skill-transcript.jsonl"
+}' | python3 examples/claudecode-skills-memanto/claude_memory_hooks.py capture \
+  --backend local \
+  --store /tmp/claude-skills-memory.jsonl
+```
+
+Inject that memory into a later skill:
+
+```bash
+printf '%s' '{
+  "hook_event_name": "UserPromptExpansion",
+  "session_id": "demo-2",
+  "cwd": "/repo/clinicpulse",
+  "command_name": "tdd",
+  "command_args": "prepare public PR",
+  "prompt": "/tdd prepare public PR"
+}' | python3 examples/claudecode-skills-memanto/claude_memory_hooks.py inject \
+  --backend local \
+  --store /tmp/claude-skills-memory.jsonl
+```
+
+The hook returns JSON with:
+
+```json
+{
+  "suppressOutput": true,
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptExpansion",
+    "additionalContext": "Memanto engineering memory relevant to this Claude Code skill:\n- [decision 0.88] Decision: keep planning docs out of public PR branches.\n- [preference 0.80] Preference: run make verify before posting review updates.\nApply these as constraints unless the current user prompt overrides them."
+  }
+}
+```
+
+## SDK Mode
+
+Set a Moorcheh API key and use the SDK backend:
+
+```bash
+export MOORCHEH_API_KEY="..."
+python3 examples/claudecode-skills-memanto/claude_memory_hooks.py benchmark
+```
+
+Then adapt `settings.example.json` into your Claude Code project or user
+settings file. The SDK backend creates or activates the `claude-code-skills`
+Memanto agent and stores memories through the normal Memanto client.
+
+## Hook Strategy
+
+| Hook event | Mode | Purpose |
+| --- | --- | --- |
+| `SessionStart` | inject | Warm the session with recent engineering memory |
+| `UserPromptSubmit` | inject | Add relevant constraints before Claude processes a prompt |
+| `UserPromptExpansion` | inject | Add memory when slash skills expand |
+| `PostToolBatch` | inject | Rehydrate context after batched tool activity |
+| `Stop` | capture | Store durable decisions from the completed transcript |
+
+The capture path only stores lines that look like reusable engineering memory:
+decisions, preferences, instructions, context caveats, and error/fix notes. It
+does not blindly upload whole transcripts.
+
+## Bounty Criteria Mapping
+
+- Global memory hook: `claude_memory_hooks.py inject` and `capture` plug into
+  Claude Code's documented hook configuration.
+- Active extraction: `distill_memories()` turns transcript lines into typed
+  decision, preference, instruction, context, and error memories.
+- Dynamic injection: `build_context()` searches Memanto or local JSONL and
+  returns `hookSpecificOutput.additionalContext` for the current hook event.
+- Reviewer-safe validation: local JSONL mode proves the full lifecycle without
+  private credentials.
+- Productivity multiplier: `benchmark` reports how many repeated instruction
+  lines were injected automatically into a second skill session.

--- a/examples/claudecode-skills-memanto/claude_memory_hooks.py
+++ b/examples/claudecode-skills-memanto/claude_memory_hooks.py
@@ -1,0 +1,562 @@
+"""Claude Code hook bridge for mattpocock-style skills and Memanto.
+
+The example is intentionally dependency-light for reviewers: local JSONL mode
+exercises the complete hook lifecycle without private API keys, while SDK mode
+uses the real Memanto client when Moorcheh credentials are present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+DEFAULT_AGENT_ID = "claude-code-skills"
+DEFAULT_LIMIT = 5
+DEFAULT_STORE = Path.home() / ".memanto" / "claude-code-skills-memory.jsonl"
+CONTEXT_EVENTS = {
+    "SessionStart",
+    "UserPromptSubmit",
+    "UserPromptExpansion",
+    "PostToolBatch",
+    "SubagentStart",
+}
+CAPTURE_EVENTS = {"Stop", "SessionEnd", "PostToolUse", "PostToolBatch"}
+STOPWORDS = {
+    "about",
+    "after",
+    "again",
+    "because",
+    "before",
+    "branch",
+    "current",
+    "decision",
+    "during",
+    "implementation",
+    "prefer",
+    "should",
+    "their",
+    "there",
+    "these",
+    "thing",
+    "using",
+    "where",
+    "which",
+    "with",
+}
+
+
+class MemoryStore(Protocol):
+    def add(self, memory: dict[str, Any]) -> bool:
+        """Store one memory. Return True when it was newly stored."""
+
+    def search(
+        self, query: str, *, cwd: str | None, limit: int
+    ) -> list[dict[str, Any]]:
+        """Return memories ranked for a hook event."""
+
+
+@dataclass(frozen=True)
+class HookEvent:
+    name: str
+    session_id: str
+    cwd: str | None
+    transcript_path: str | None
+    payload: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> HookEvent:
+        return cls(
+            name=str(payload.get("hook_event_name") or payload.get("event") or ""),
+            session_id=str(payload.get("session_id") or payload.get("sessionId") or ""),
+            cwd=_coerce_optional_str(payload.get("cwd")),
+            transcript_path=_coerce_optional_str(payload.get("transcript_path")),
+            payload=payload,
+        )
+
+    def query_text(self) -> str:
+        parts = [
+            self.name,
+            self.cwd or "",
+            _coerce_optional_str(self.payload.get("prompt")) or "",
+            _coerce_optional_str(self.payload.get("command_name")) or "",
+            _coerce_optional_str(self.payload.get("command_args")) or "",
+            _coerce_optional_str(self.payload.get("tool_name")) or "",
+            _extract_text(self.payload.get("summary")),
+            _extract_text(self.payload.get("tool_input")),
+            _extract_text(self.payload.get("tool_response")),
+            _extract_text(self.payload.get("tool_calls")),
+        ]
+        return "\n".join(part for part in parts if part)
+
+
+class LocalMemoryStore:
+    """Tiny JSONL backend for credential-free hook validation."""
+
+    def __init__(self, path: Path = DEFAULT_STORE) -> None:
+        self.path = path
+
+    def add(self, memory: dict[str, Any]) -> bool:
+        normalized = dict(memory)
+        normalized.setdefault("created_at", _now_iso())
+        normalized.setdefault("tags", [])
+        normalized.setdefault("confidence", 0.75)
+        normalized["id"] = normalized.get("id") or _fingerprint(
+            normalized.get("type", ""),
+            normalized.get("content", ""),
+            normalized.get("cwd", ""),
+        )
+
+        existing_ids = {item.get("id") for item in self._read_all()}
+        if normalized["id"] in existing_ids:
+            return False
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(normalized, sort_keys=True) + "\n")
+        return True
+
+    def search(
+        self, query: str, *, cwd: str | None, limit: int
+    ) -> list[dict[str, Any]]:
+        query_tokens = _tokens(query)
+        cwd_parts = set(_path_tokens(cwd))
+        ranked: list[tuple[float, dict[str, Any]]] = []
+
+        for memory in self._read_all():
+            memory_tokens = _tokens(
+                " ".join(
+                    [
+                        str(memory.get("title", "")),
+                        str(memory.get("content", "")),
+                        " ".join(map(str, memory.get("tags", []))),
+                        str(memory.get("cwd", "")),
+                    ]
+                )
+            )
+            if not query_tokens:
+                overlap = 0
+            else:
+                overlap = len(query_tokens & memory_tokens)
+            path_boost = 1.5 if cwd_parts & set(_path_tokens(memory.get("cwd"))) else 0
+            type_boost = 0.6 if memory.get("type") in {"instruction", "decision"} else 0
+            confidence = float(memory.get("confidence", 0.7))
+            score = overlap + path_boost + type_boost + confidence
+            if overlap or path_boost:
+                ranked.append((score, memory))
+
+        ranked.sort(key=lambda item: item[0], reverse=True)
+        return [memory for _, memory in ranked[:limit]]
+
+    def _read_all(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+
+        memories: list[dict[str, Any]] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                memories.append(record)
+        return memories
+
+
+class SdkMemoryStore:
+    """Direct Memanto SDK backend used outside credential-free review."""
+
+    def __init__(self, api_key: str, agent_id: str = DEFAULT_AGENT_ID) -> None:
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self.agent_id = agent_id
+        self.client = SdkClient(api_key)
+        self._ensure_agent()
+
+    def add(self, memory: dict[str, Any]) -> bool:
+        self.client.remember(
+            agent_id=self.agent_id,
+            memory_type=str(memory.get("type", "context")),
+            title=str(memory.get("title", "Claude Code skill memory"))[:100],
+            content=str(memory.get("content", "")),
+            confidence=float(memory.get("confidence", 0.75)),
+            tags=list(memory.get("tags", [])),
+            source="claude-code-hooks",
+            provenance="observed",
+        )
+        return True
+
+    def search(
+        self, query: str, *, cwd: str | None, limit: int
+    ) -> list[dict[str, Any]]:
+        search_query = f"{query}\nworkspace: {cwd or ''}".strip()
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=search_query,
+            limit=limit,
+        )
+        return [_normalize_sdk_memory(item) for item in result.get("memories", [])]
+
+    def _ensure_agent(self) -> None:
+        try:
+            self.client.get_agent(self.agent_id)
+        except Exception:
+            self.client.create_agent(
+                self.agent_id,
+                pattern="tool",
+                description="Claude Code skills cross-session engineering memory",
+            )
+        self.client.activate_agent(self.agent_id)
+
+
+def build_context(
+    event: HookEvent,
+    store: MemoryStore,
+    *,
+    limit: int = DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    matches = store.search(event.query_text(), cwd=event.cwd, limit=limit)
+    if not matches:
+        return {"suppressOutput": True}
+
+    additional_context = format_context(matches)
+    return {
+        "suppressOutput": True,
+        "hookSpecificOutput": {
+            "hookEventName": event.name,
+            "additionalContext": additional_context,
+        },
+    }
+
+
+def capture_memories(event: HookEvent, store: MemoryStore) -> int:
+    text = "\n".join(
+        part
+        for part in [
+            event.query_text(),
+            read_transcript_text(event.transcript_path),
+        ]
+        if part
+    )
+    memories = distill_memories(
+        text,
+        source_event=event.name,
+        session_id=event.session_id,
+        cwd=event.cwd,
+    )
+    stored = 0
+    for memory in memories:
+        if store.add(memory):
+            stored += 1
+    return stored
+
+
+def distill_memories(
+    text: str,
+    *,
+    source_event: str,
+    session_id: str,
+    cwd: str | None,
+) -> list[dict[str, Any]]:
+    memories: list[dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        line = _clean_line(raw_line)
+        if len(line) < 12:
+            continue
+
+        memory_type: str | None = None
+        confidence = 0.72
+        content = line
+
+        prefixed = re.match(
+            r"^(Decision|Decided|Preference|Prefer|Instruction|Rule|Caveat|Quirk|"
+            r"Constraint|Gotcha|Note|Error|Fix):\s*(.+)$",
+            line,
+            flags=re.IGNORECASE,
+        )
+        if prefixed:
+            label = prefixed.group(1).lower()
+            content = f"{prefixed.group(1)}: {prefixed.group(2).strip()}"
+            if label in {"decision", "decided"}:
+                memory_type, confidence = "decision", 0.88
+            elif label in {"preference", "prefer"}:
+                memory_type, confidence = "preference", 0.8
+            elif label in {"instruction", "rule"}:
+                memory_type, confidence = "instruction", 0.92
+            elif label in {"error", "fix"}:
+                memory_type, confidence = "error", 0.82
+            else:
+                memory_type, confidence = "context", 0.74
+        elif re.match(r"^(Never|Always|Must|Do not|Don't)\b", line, re.IGNORECASE):
+            memory_type, confidence = "instruction", 0.94
+        elif re.search(r"\bwe (will|chose|choose|decided)\b", line, re.IGNORECASE):
+            memory_type, confidence = "decision", 0.78
+        elif re.search(r"\b(prefer|convention|style guide)\b", line, re.IGNORECASE):
+            memory_type, confidence = "preference", 0.76
+
+        if not memory_type:
+            continue
+
+        memories.append(
+            {
+                "type": memory_type,
+                "title": _title_for(content),
+                "content": content,
+                "confidence": confidence,
+                "tags": _tags_for(content, cwd),
+                "source_event": source_event,
+                "session_id": session_id,
+                "cwd": cwd,
+                "created_at": _now_iso(),
+            }
+        )
+
+    return _dedupe_memories(memories)
+
+
+def read_transcript_text(transcript_path: str | None, *, max_lines: int = 40) -> str:
+    if not transcript_path:
+        return ""
+
+    path = Path(transcript_path)
+    if not path.exists():
+        return ""
+
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()[-max_lines:]
+    parts: list[str] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            parts.append(line)
+            continue
+        parts.append(_extract_text(payload))
+    return "\n".join(part for part in parts if part)
+
+
+def format_context(memories: list[dict[str, Any]]) -> str:
+    bullets = []
+    for memory in memories:
+        memory_type = str(memory.get("type", "context"))
+        confidence = float(memory.get("confidence", 0.75))
+        content = str(memory.get("content", "")).strip()
+        if not content:
+            continue
+        bullets.append(f"- [{memory_type} {confidence:.2f}] {content}")
+
+    return "\n".join(
+        [
+            "Memanto engineering memory relevant to this Claude Code skill:",
+            *bullets,
+            "Apply these as constraints unless the current user prompt overrides them.",
+        ]
+    )
+
+
+def run_benchmark() -> dict[str, Any]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = LocalMemoryStore(Path(temp_dir) / "benchmark.jsonl")
+        capture_memories(
+            HookEvent.from_dict(
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": "session-1",
+                    "cwd": "/repo/clinicpulse",
+                    "prompt": "/grill-with-docs plan release",
+                    "summary": "Decision: docs/ is local-only except tracked showcase docs.\n"
+                    "Preference: verify with make verify before PR updates.\n"
+                    "Never include local planning docs in public branches.",
+                }
+            ),
+            store,
+        )
+        event = HookEvent.from_dict(
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "session_id": "session-2",
+                "cwd": "/repo/clinicpulse",
+                "prompt": "/tdd prepare public branch and PR",
+            }
+        )
+        payload = build_context(event, store, limit=5)
+        context = payload.get("hookSpecificOutput", {}).get("additionalContext", "")
+        injected = context.count("\n- [")
+        return {
+            "sessions": 2,
+            "memories_injected": injected,
+            "manual_reprompt_lines_avoided": injected,
+            "additional_context": context,
+        }
+
+
+def main(argv: list[str] | None = None, *, stdin: str | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Memanto Claude Code hooks for cross-skill engineering memory."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command in ("inject", "capture"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--backend", choices=["local", "sdk"], default=None)
+        subparser.add_argument("--store", type=Path, default=DEFAULT_STORE)
+        subparser.add_argument("--agent-id", default=DEFAULT_AGENT_ID)
+        subparser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+
+    subparsers.add_parser("benchmark")
+    args = parser.parse_args(argv)
+
+    if args.command == "benchmark":
+        print(json.dumps(run_benchmark(), indent=2))
+        return 0
+
+    event_input = stdin if stdin is not None else sys.stdin.read()
+    event = HookEvent.from_dict(json.loads(event_input or "{}"))
+    store = _store_from_args(args)
+
+    if args.command == "inject":
+        if event.name not in CONTEXT_EVENTS:
+            return 0
+        payload = build_context(event, store, limit=args.limit)
+        if payload.get("hookSpecificOutput"):
+            print(json.dumps(payload))
+        return 0
+
+    if args.command == "capture":
+        if event.name not in CAPTURE_EVENTS:
+            print(json.dumps({"suppressOutput": True, "stored_memories": 0}))
+            return 0
+        stored = capture_memories(event, store)
+        print(json.dumps({"suppressOutput": True, "stored_memories": stored}))
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+def _store_from_args(args: argparse.Namespace) -> MemoryStore:
+    backend = args.backend or os.getenv("MEMANTO_SKILLS_BACKEND", "local")
+    if backend == "sdk":
+        api_key = os.getenv("MOORCHEH_API_KEY")
+        if not api_key:
+            raise SystemExit("MOORCHEH_API_KEY is required for --backend sdk")
+        return SdkMemoryStore(api_key=api_key, agent_id=args.agent_id)
+    return LocalMemoryStore(args.store)
+
+
+def _normalize_sdk_memory(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": item.get("type") or item.get("memory_type") or "context",
+        "title": item.get("title") or item.get("content", "")[:80],
+        "content": item.get("content") or item.get("text") or str(item),
+        "confidence": item.get("confidence", item.get("score", 0.75)),
+        "tags": item.get("tags", []),
+    }
+
+
+def _extract_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(_extract_text(item) for item in value)
+    if isinstance(value, dict):
+        parts = []
+        for key in (
+            "prompt",
+            "command_name",
+            "command_args",
+            "content",
+            "text",
+            "summary",
+            "message",
+            "tool_input",
+            "tool_response",
+            "tool_calls",
+        ):
+            if key in value:
+                parts.append(_extract_text(value[key]))
+        return "\n".join(part for part in parts if part)
+    return str(value)
+
+
+def _clean_line(line: str) -> str:
+    return re.sub(r"\s+", " ", line.strip(" \t\r\n-*`"))
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9][a-z0-9_-]{2,}", text.lower())
+        if token not in STOPWORDS
+    }
+
+
+def _path_tokens(path: str | None) -> list[str]:
+    if not path:
+        return []
+    return [part.lower() for part in Path(path).parts if part not in {"/", ""}]
+
+
+def _tags_for(content: str, cwd: str | None) -> list[str]:
+    tags = [token for token in _tokens(content) if len(token) <= 20][:5]
+    for token in _path_tokens(cwd)[-2:]:
+        if token not in tags:
+            tags.append(token)
+    return tags
+
+
+def _title_for(content: str) -> str:
+    title = re.sub(
+        r"^(Decision|Preference|Instruction|Rule|Caveat|Quirk|Note):\s*", "", content
+    )
+    return title[:80].rstrip(".")
+
+
+def _dedupe_memories(memories: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    unique = []
+    for memory in memories:
+        key = _fingerprint(
+            memory.get("type", ""), memory.get("content", ""), memory.get("cwd", "")
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        memory["id"] = key
+        unique.append(memory)
+    return unique
+
+
+def _fingerprint(*parts: object) -> str:
+    digest = hashlib.sha256()
+    for part in parts:
+        digest.update(str(part).encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()[:16]
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/claude_memory_hooks.py
+++ b/examples/claudecode-skills-memanto/claude_memory_hooks.py
@@ -91,6 +91,7 @@ class HookEvent:
             _coerce_optional_str(self.payload.get("command_args")) or "",
             _coerce_optional_str(self.payload.get("tool_name")) or "",
             _extract_text(self.payload.get("summary")),
+            _extract_text(self.payload.get("last_assistant_message")),
             _extract_text(self.payload.get("tool_input")),
             _extract_text(self.payload.get("tool_response")),
             _extract_text(self.payload.get("tool_calls")),
@@ -451,7 +452,14 @@ def _store_from_args(args: argparse.Namespace) -> MemoryStore:
         api_key = os.getenv("MOORCHEH_API_KEY")
         if not api_key:
             raise SystemExit("MOORCHEH_API_KEY is required for --backend sdk")
-        return SdkMemoryStore(api_key=api_key, agent_id=args.agent_id)
+        try:
+            return SdkMemoryStore(api_key=api_key, agent_id=args.agent_id)
+        except ModuleNotFoundError as exc:
+            raise SystemExit(
+                "Install Memanto with its runtime dependencies before using "
+                "--backend sdk. Local reviewer mode is available with "
+                "--backend local."
+            ) from exc
     return LocalMemoryStore(args.store)
 
 

--- a/examples/claudecode-skills-memanto/demo-transcript.md
+++ b/examples/claudecode-skills-memanto/demo-transcript.md
@@ -1,0 +1,47 @@
+# Demo Transcript
+
+## Session 1: `/grill-with-docs`
+
+User:
+
+```text
+/grill-with-docs plan this release branch and make sure the public PR is clean
+```
+
+Assistant summary captured by the `Stop` hook:
+
+```text
+Decision: docs/ is local-only except tracked showcase docs.
+Preference: verify with make verify before PR updates.
+Never include local planning docs in public branches.
+```
+
+The hook stores three typed memories:
+
+```json
+{"type":"decision","content":"Decision: docs/ is local-only except tracked showcase docs."}
+{"type":"preference","content":"Preference: verify with make verify before PR updates."}
+{"type":"instruction","content":"Never include local planning docs in public branches."}
+```
+
+## Session 2: `/tdd`
+
+User:
+
+```text
+/tdd prepare the public branch and PR
+```
+
+Claude Code runs the `UserPromptExpansion` hook before expanding the slash
+command. The hook injects:
+
+```text
+Memanto engineering memory relevant to this Claude Code skill:
+- [instruction 0.94] Never include local planning docs in public branches.
+- [decision 0.88] Decision: docs/ is local-only except tracked showcase docs.
+- [preference 0.80] Preference: verify with make verify before PR updates.
+Apply these as constraints unless the current user prompt overrides them.
+```
+
+The user did not repeat the docs-hygiene rule, but the `/tdd` skill receives it
+anyway.

--- a/examples/claudecode-skills-memanto/settings.example.json
+++ b/examples/claudecode-skills-memanto/settings.example.json
@@ -1,0 +1,62 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PROJECT_DIR}/examples/claudecode-skills-memanto/claude_memory_hooks.py inject --backend sdk",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PROJECT_DIR}/examples/claudecode-skills-memanto/claude_memory_hooks.py inject --backend sdk",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptExpansion": [
+      {
+        "matcher": "grill-with-docs|tdd|handoff",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PROJECT_DIR}/examples/claudecode-skills-memanto/claude_memory_hooks.py inject --backend sdk",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PostToolBatch": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PROJECT_DIR}/examples/claudecode-skills-memanto/claude_memory_hooks.py inject --backend sdk",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PROJECT_DIR}/examples/claudecode-skills-memanto/claude_memory_hooks.py capture --backend sdk",
+            "async": true,
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/claudecode-skills-memanto/test_claude_memory_hooks.py
+++ b/examples/claudecode-skills-memanto/test_claude_memory_hooks.py
@@ -1,0 +1,217 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from claude_memory_hooks import (
+    HookEvent,
+    LocalMemoryStore,
+    build_context,
+    capture_memories,
+    distill_memories,
+    main,
+)
+
+
+class LocalMemoryStoreTest(unittest.TestCase):
+    def test_search_prioritizes_matching_tags_and_content(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = LocalMemoryStore(Path(temp_dir) / "memory.jsonl")
+            store.add(
+                {
+                    "type": "decision",
+                    "title": "Use repository adapters",
+                    "content": "Decision: keep billing code behind repository adapters.",
+                    "confidence": 0.9,
+                    "tags": ["billing", "architecture"],
+                    "source_event": "Stop",
+                    "session_id": "s1",
+                    "cwd": "/work/acme",
+                }
+            )
+            store.add(
+                {
+                    "type": "preference",
+                    "title": "Prefer compact docs",
+                    "content": "Preference: keep README examples short.",
+                    "confidence": 0.7,
+                    "tags": ["docs"],
+                    "source_event": "Stop",
+                    "session_id": "s1",
+                    "cwd": "/work/acme",
+                }
+            )
+
+            matches = store.search(
+                "billing adapter implementation",
+                cwd="/work/acme",
+                limit=1,
+            )
+
+            self.assertEqual(len(matches), 1)
+            self.assertEqual(matches[0]["title"], "Use repository adapters")
+
+
+class DistillationTest(unittest.TestCase):
+    def test_distills_engineering_decisions_preferences_and_instructions(self):
+        memories = distill_memories(
+            """
+            Decision: keep writes behind the PartnerRepository boundary.
+            Preference: use small focused Playwright tests for browser regressions.
+            Never commit local planning docs to public branches.
+            Caveat: the auth seed only exists after make db-bootstrap.
+            """,
+            source_event="Stop",
+            session_id="s2",
+            cwd="/repo/app",
+        )
+
+        by_type = {memory["type"]: memory for memory in memories}
+
+        self.assertIn("decision", by_type)
+        self.assertIn("preference", by_type)
+        self.assertIn("instruction", by_type)
+        self.assertIn("context", by_type)
+        self.assertGreaterEqual(by_type["instruction"]["confidence"], 0.9)
+        self.assertIn("PartnerRepository", by_type["decision"]["content"])
+
+
+class HookContextTest(unittest.TestCase):
+    def test_build_context_uses_user_prompt_submit_additional_context(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = LocalMemoryStore(Path(temp_dir) / "memory.jsonl")
+            store.add(
+                {
+                    "type": "instruction",
+                    "title": "Keep docs local",
+                    "content": "Never commit local planning docs to public branches.",
+                    "confidence": 0.95,
+                    "tags": ["docs", "git"],
+                    "source_event": "Stop",
+                    "session_id": "old",
+                    "cwd": "/repo/app",
+                }
+            )
+            event = HookEvent.from_dict(
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "session_id": "new",
+                    "cwd": "/repo/app",
+                    "prompt": "Prepare docs and branch for a GitHub PR",
+                }
+            )
+
+            payload = build_context(event, store, limit=3)
+
+            self.assertEqual(
+                payload["hookSpecificOutput"]["hookEventName"],
+                "UserPromptSubmit",
+            )
+            self.assertIn(
+                "Never commit local planning docs",
+                payload["hookSpecificOutput"]["additionalContext"],
+            )
+            self.assertNotIn("decision", payload)
+
+
+class CaptureTest(unittest.TestCase):
+    def test_capture_reads_transcript_and_stores_distilled_memories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transcript = Path(temp_dir) / "transcript.jsonl"
+            transcript.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "type": "user",
+                                "message": {
+                                    "content": "Use the local auth seed path.",
+                                },
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "type": "assistant",
+                                "message": {
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Decision: auth tests must run after db-bootstrap.",
+                                        }
+                                    ]
+                                },
+                            }
+                        ),
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            store = LocalMemoryStore(Path(temp_dir) / "memory.jsonl")
+            event = HookEvent.from_dict(
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": "s3",
+                    "cwd": "/repo/app",
+                    "transcript_path": str(transcript),
+                }
+            )
+
+            stored = capture_memories(event, store)
+
+            self.assertEqual(stored, 1)
+            self.assertIn(
+                "db-bootstrap",
+                store.search("auth tests bootstrap", cwd="/repo/app", limit=1)[0][
+                    "content"
+                ],
+            )
+
+
+class CliTest(unittest.TestCase):
+    def test_cli_inject_outputs_json_context(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store_path = Path(temp_dir) / "memory.jsonl"
+            LocalMemoryStore(store_path).add(
+                {
+                    "type": "decision",
+                    "title": "Use route loaders",
+                    "content": "Decision: prefer route loaders for dashboard data.",
+                    "confidence": 0.86,
+                    "tags": ["dashboard"],
+                    "source_event": "Stop",
+                    "session_id": "old",
+                    "cwd": "/repo/app",
+                }
+            )
+            event = {
+                "hook_event_name": "UserPromptExpansion",
+                "session_id": "new",
+                "cwd": "/repo/app",
+                "command_name": "tdd",
+                "command_args": "dashboard route loader",
+                "prompt": "/tdd dashboard route loader",
+            }
+            output = io.StringIO()
+
+            with redirect_stdout(output):
+                code = main(
+                    ["inject", "--backend", "local", "--store", str(store_path)],
+                    stdin=json.dumps(event),
+                )
+
+            self.assertEqual(code, 0)
+            payload = json.loads(output.getvalue())
+            self.assertEqual(
+                payload["hookSpecificOutput"]["hookEventName"],
+                "UserPromptExpansion",
+            )
+            self.assertIn(
+                "prefer route loaders",
+                payload["hookSpecificOutput"]["additionalContext"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/test_claude_memory_hooks.py
+++ b/examples/claudecode-skills-memanto/test_claude_memory_hooks.py
@@ -1,9 +1,11 @@
 import io
 import json
+import os
 import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 from claude_memory_hooks import (
     HookEvent,
@@ -117,6 +119,28 @@ class HookContextTest(unittest.TestCase):
 
 
 class CaptureTest(unittest.TestCase):
+    def test_capture_uses_stop_last_assistant_message_without_transcript(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = LocalMemoryStore(Path(temp_dir) / "memory.jsonl")
+            event = HookEvent.from_dict(
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": "s-stop",
+                    "cwd": "/repo/app",
+                    "last_assistant_message": "Decision: keep route data behind loader contracts.",
+                }
+            )
+
+            stored = capture_memories(event, store)
+
+            self.assertEqual(stored, 1)
+            self.assertIn(
+                "loader contracts",
+                store.search("route loader contracts", cwd="/repo/app", limit=1)[0][
+                    "content"
+                ],
+            )
+
     def test_capture_reads_transcript_and_stores_distilled_memories(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             transcript = Path(temp_dir) / "transcript.jsonl"
@@ -170,6 +194,26 @@ class CaptureTest(unittest.TestCase):
 
 
 class CliTest(unittest.TestCase):
+    def test_cli_sdk_backend_explains_missing_memanto_install(self):
+        event = {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "new",
+            "cwd": "/repo/app",
+            "prompt": "Use prior memory",
+        }
+
+        with (
+            patch.dict(os.environ, {"MOORCHEH_API_KEY": "fake"}),
+            patch(
+                "claude_memory_hooks.SdkMemoryStore",
+                side_effect=ModuleNotFoundError("memanto"),
+            ),
+            self.assertRaises(SystemExit) as error,
+        ):
+            main(["inject", "--backend", "sdk"], stdin=json.dumps(event))
+
+        self.assertIn("Install Memanto", str(error.exception))
+
     def test_cli_inject_outputs_json_context(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             store_path = Path(temp_dir) / "memory.jsonl"

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,99 @@
+"""Credential-free validation for the Claude Code skills Memanto hook example."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+HOOK = ROOT / "claude_memory_hooks.py"
+
+
+def run() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = Path(temp_dir) / "memory.jsonl"
+        transcript = Path(temp_dir) / "transcript.jsonl"
+        transcript.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "type": "assistant",
+                            "message": {
+                                "content": "Decision: keep skill memory in Memanto, not per-command temp files."
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "assistant",
+                            "message": {
+                                "content": "Never repeat the repository's docs hygiene rules manually."
+                            },
+                        }
+                    ),
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        capture_event = {
+            "hook_event_name": "Stop",
+            "session_id": "validation-1",
+            "cwd": str(ROOT),
+            "transcript_path": str(transcript),
+        }
+        capture = subprocess.run(
+            [
+                sys.executable,
+                str(HOOK),
+                "capture",
+                "--backend",
+                "local",
+                "--store",
+                str(store),
+            ],
+            input=json.dumps(capture_event),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        capture_payload = json.loads(capture.stdout)
+        assert capture_payload["stored_memories"] == 2, capture.stdout
+
+        inject_event = {
+            "hook_event_name": "UserPromptExpansion",
+            "session_id": "validation-2",
+            "cwd": str(ROOT),
+            "command_name": "tdd",
+            "command_args": "docs hygiene memory",
+            "prompt": "/tdd docs hygiene memory",
+        }
+        inject = subprocess.run(
+            [
+                sys.executable,
+                str(HOOK),
+                "inject",
+                "--backend",
+                "local",
+                "--store",
+                str(store),
+            ],
+            input=json.dumps(inject_event),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        inject_payload = json.loads(inject.stdout)
+        context = inject_payload["hookSpecificOutput"]["additionalContext"]
+        assert "Never repeat the repository" in context, context
+        assert "hookSpecificOutput" in inject_payload
+
+    print("credential-free validation passed")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
/claim #508

BountyHub bounty: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe

## Summary

Adds `examples/claudecode-skills-memanto`, a Claude Code hook-based Memanto integration for mattpocock-style skills such as `/grill-with-docs`, `/tdd`, and `/handoff`.

The implementation focuses on the actual Claude Code hook lifecycle rather than a wrapper-only flow:

- `SessionStart`, `UserPromptSubmit`, `UserPromptExpansion`, and `PostToolBatch` recall relevant engineering memory and return `hookSpecificOutput.additionalContext`.
- `Stop` captures the completed transcript, distills durable decisions, preferences, instructions, context caveats, and error/fix notes, then stores them.
- Local JSONL mode proves the full lifecycle without private credentials.
- SDK mode uses `memanto.cli.client.sdk_client.SdkClient` with `MOORCHEH_API_KEY` and a `claude-code-skills` agent.

## Why this approach

A lot of submissions log or wrap skill commands. This one targets the Claude Code events that can actually inject context back into the model before the next skill runs, so prior architectural decisions become active constraints instead of passive logs.

Example flow:

1. `/grill-with-docs` decides planning docs must stay out of public PR branches.
2. `Stop` stores that as a typed Memanto instruction.
3. A later `/tdd` invocation asks for PR prep.
4. `UserPromptExpansion` injects the prior docs-hygiene rule as `additionalContext`.

## Files

- `examples/claudecode-skills-memanto/claude_memory_hooks.py` - hook CLI, local backend, SDK backend, distillation, context formatting, benchmark
- `examples/claudecode-skills-memanto/settings.example.json` - Claude Code hook config
- `examples/claudecode-skills-memanto/validate.py` - credential-free lifecycle validation
- `examples/claudecode-skills-memanto/test_claude_memory_hooks.py` - stdlib regression tests
- `examples/claudecode-skills-memanto/demo-transcript.md` - before/after showcase transcript
- `examples/claudecode-skills-memanto/README.md` - setup and bounty criteria mapping

## Verification

```bash
python3 -m unittest discover -s examples/claudecode-skills-memanto -p 'test_*.py' -v
# Ran 5 tests in 0.017s
# OK

python3 -m py_compile examples/claudecode-skills-memanto/claude_memory_hooks.py examples/claudecode-skills-memanto/validate.py examples/claudecode-skills-memanto/test_claude_memory_hooks.py
# passed

python3 examples/claudecode-skills-memanto/validate.py
# credential-free validation passed

ruff check examples/claudecode-skills-memanto
# All checks passed!

ruff format --check examples/claudecode-skills-memanto
# 3 files already formatted

git diff --check
# passed
```

Benchmark output:

```json
{
  "sessions": 2,
  "memories_injected": 3,
  "manual_reprompt_lines_avoided": 3
}
```

## Showcase

In-repo showcase: `examples/claudecode-skills-memanto/demo-transcript.md`

No private payout details are included here. If BountyHub needs an additional signed-in claim/import step, I can complete that from the dashboard.

Refs #508
