### PR TITLE
feat: add Claude skills Memanto memory example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,101 @@
+# Claude Code Skills + Memanto
+
+This example shows how Memanto can act as a shared engineering memory layer for
+single-purpose Claude Code skills such as `/grill-with-docs`, `/tdd`, and
+`/handoff`.
+
+The implementation is intentionally reviewer-safe:
+
+- `local` mode stores memories in a JSONL file and needs no credentials.
+- `sdk` mode uses `memanto.cli.client.sdk_client.SdkClient` when
+  `MOORCHEH_API_KEY` is available.
+- The same lifecycle is used in both modes: recall before a skill runs,
+  distill the completed transcript, then remember durable engineering facts.
+
+## Quick Start
+
+```bash
+cd examples/claudecode-skills-memanto
+python validate.py
+python run_demo.py
+python -m unittest test_skill_memory.py
+```
+
+Expected output:
+
+```text
+validation passed
+demo complete
+```
+
+The demo writes local memories for a first `/grill-with-docs` run, injects the
+same architectural decisions into a later `/tdd` run, and reports how many
+repeated instructions were avoided.
+
+## Live SDK Mode
+
+```bash
+export MOORCHEH_API_KEY=...
+python run_demo.py --backend sdk --agent-id claude-skills-demo
+```
+
+The SDK backend calls Memanto's `remember` and `recall` primitives directly.
+No key is required for validation because the local backend follows the same
+interface.
+
+## Generated Skill Wrappers
+
+```bash
+python validate.py --write-wrappers ./generated
+```
+
+This writes shell wrappers for:
+
+- `grill-with-docs`
+- `tdd`
+- `handoff`
+
+Each wrapper calls `skill_memory.py pre` before the underlying command and
+`skill_memory.py post` after completion. The wrapper is plain shell so it can be
+adapted to an existing `mattpocock/skills` checkout without changing the skills
+themselves.
+
+## Design
+
+```mermaid
+flowchart LR
+    A["Skill input"] --> B["pre: recall relevant engineering memory"]
+    B --> C["Skill command"]
+    C --> D["post: distill transcript"]
+    D --> E["Memanto memory backend"]
+    E --> B
+```
+
+## Demo Transcript
+
+Session 1, `/grill-with-docs`:
+
+```text
+Task: Review auth-refresh architecture.
+Decision: Keep refresh token rotation in AuthGateway, not React components.
+Preference: Use typed Result objects for recoverable API errors.
+```
+
+Session 2, `/tdd` with no repeated instructions:
+
+```text
+Injected memory:
+- Keep refresh token rotation in AuthGateway, not React components.
+- Use typed Result objects for recoverable API errors.
+```
+
+The second session can write tests using the earlier architectural constraints
+without restating them in the current prompt.
+
+## Showcase
+
+In-repo technical showcase: this README plus `run_demo.py` output.
+External social posts are optional for technical review, per the issue thread.
+
+/claim #508
+

--- a/examples/claudecode-skills-memanto/run_demo.py
+++ b/examples/claudecode-skills-memanto/run_demo.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from skill_memory import (
+    LocalJsonlBackend,
+    build_backend,
+    post_skill,
+    pre_skill,
+    repeated_instruction_reduction,
+)
+
+
+SESSION_ONE = """Task: Review auth-refresh architecture.
+Decision: Keep refresh token rotation in AuthGateway, not React components.
+Preference: Use typed Result objects for recoverable API errors.
+Instruction: Never leak refresh tokens into browser-visible logs.
+Artifact: AuthGateway owns refresh-token exchange and retry policy.
+"""
+
+SESSION_TWO_TASK = (
+    "Write TDD coverage for refresh-token retry behavior in AuthGateway "
+    "without repeating the earlier architectural rules."
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", choices=["local", "sdk"], default="local")
+    parser.add_argument("--store", type=Path, default=Path(".demo-memory.jsonl"))
+    parser.add_argument("--agent-id", default="claude-skills-demo")
+    args = parser.parse_args()
+
+    if args.backend == "local" and args.store.exists():
+        args.store.unlink()
+
+    backend = build_backend(args.backend, args.store, args.agent_id)
+    stored = post_skill(backend, "grill-with-docs", SESSION_ONE)
+    injected = pre_skill(backend, "tdd", SESSION_TWO_TASK)
+    score = repeated_instruction_reduction(SESSION_ONE, SESSION_TWO_TASK, injected)
+
+    print(f"stored_memories={stored}")
+    print(injected)
+    print(f"benchmark={score}")
+    print("demo complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,224 @@
+"""Cross-skill Memanto memory hooks for Claude Code-style skills.
+
+The module exposes a tiny lifecycle:
+
+1. ``pre_skill`` recalls relevant memories for the current task.
+2. A skill command runs with that context.
+3. ``post_skill`` distills the transcript into durable engineering memories.
+
+Local JSONL storage is used by default so reviewers can validate the example
+without credentials. The SDK backend can be selected when MOORCHEH_API_KEY is
+available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Protocol
+
+
+DEFAULT_STORE = Path(".memanto-skill-memory.jsonl")
+DEFAULT_AGENT_ID = "claude-code-skills"
+SIGNALS = {
+    "decision": re.compile(r"\b(decision|decided|choose|keep|standardize)\b", re.I),
+    "preference": re.compile(r"\b(prefer|preference|style|convention)\b", re.I),
+    "instruction": re.compile(r"\b(must|always|never|require|constraint)\b", re.I),
+    "artifact": re.compile(r"\b(file|module|component|endpoint|api|schema)\b", re.I),
+}
+
+
+@dataclass(frozen=True)
+class EngineeringMemory:
+    content: str
+    memory_type: str = "decision"
+    source_skill: str = "unknown"
+    confidence: float = 0.75
+    tags: tuple[str, ...] = ()
+
+
+class MemoryBackend(Protocol):
+    def remember(self, memory: EngineeringMemory) -> None:
+        """Persist a memory."""
+
+    def recall(self, query: str, limit: int = 5) -> list[EngineeringMemory]:
+        """Return relevant memories."""
+
+
+class LocalJsonlBackend:
+    def __init__(self, path: Path = DEFAULT_STORE) -> None:
+        self.path = path
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(memory), sort_keys=True) + "\n")
+
+    def recall(self, query: str, limit: int = 5) -> list[EngineeringMemory]:
+        if not self.path.exists():
+            return []
+
+        query_terms = tokenize(query)
+        scored: list[tuple[int, EngineeringMemory]] = []
+        with self.path.open(encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                data = json.loads(line)
+                memory = EngineeringMemory(
+                    content=data["content"],
+                    memory_type=data.get("memory_type", "decision"),
+                    source_skill=data.get("source_skill", "unknown"),
+                    confidence=float(data.get("confidence", 0.75)),
+                    tags=tuple(data.get("tags", ())),
+                )
+                memory_terms = tokenize(memory.content + " " + " ".join(memory.tags))
+                score = len(query_terms & memory_terms)
+                if score:
+                    scored.append((score, memory))
+
+        scored.sort(key=lambda item: (item[0], item[1].confidence), reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+
+class SdkBackend:
+    def __init__(self, agent_id: str = DEFAULT_AGENT_ID) -> None:
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self.agent_id = agent_id
+        self.client = SdkClient(api_key=os.environ.get("MOORCHEH_API_KEY"))
+
+    def remember(self, memory: EngineeringMemory) -> None:
+        self.client.remember(
+            agent_id=self.agent_id,
+            content=memory.content,
+            memory_type=memory.memory_type,
+            tags=",".join(memory.tags),
+            confidence=memory.confidence,
+            source=memory.source_skill,
+        )
+
+    def recall(self, query: str, limit: int = 5) -> list[EngineeringMemory]:
+        result = self.client.recall(agent_id=self.agent_id, query=query, limit=limit)
+        memories = result.get("memories", result if isinstance(result, list) else [])
+        output: list[EngineeringMemory] = []
+        for item in memories[:limit]:
+            content = item.get("content") or item.get("text") or str(item)
+            output.append(EngineeringMemory(content=content, source_skill="memanto"))
+        return output
+
+
+def tokenize(text: str) -> set[str]:
+    return {part.lower() for part in re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{2,}", text)}
+
+
+def build_backend(kind: str, store: Path, agent_id: str) -> MemoryBackend:
+    if kind == "sdk":
+        return SdkBackend(agent_id=agent_id)
+    return LocalJsonlBackend(store)
+
+
+def distill_transcript(skill: str, transcript: str) -> list[EngineeringMemory]:
+    memories: list[EngineeringMemory] = []
+    seen: set[str] = set()
+    for raw_line in transcript.splitlines():
+        line = raw_line.strip(" -*\t")
+        if len(line) < 12 or line in seen:
+            continue
+
+        matched_type = None
+        for memory_type, pattern in SIGNALS.items():
+            if pattern.search(line):
+                matched_type = memory_type
+                break
+
+        if not matched_type:
+            continue
+
+        seen.add(line)
+        confidence = 0.9 if matched_type in {"decision", "instruction"} else 0.8
+        memories.append(
+            EngineeringMemory(
+                content=line,
+                memory_type=matched_type,
+                source_skill=skill,
+                confidence=confidence,
+                tags=tuple(sorted(tokenize(skill + " " + line)))[:8],
+            )
+        )
+
+    return memories
+
+
+def format_injected_context(memories: Iterable[EngineeringMemory]) -> str:
+    lines = [memory.content for memory in memories]
+    if not lines:
+        return "No prior engineering memories found."
+    return "Relevant engineering memories:\n" + "\n".join(f"- {line}" for line in lines)
+
+
+def pre_skill(backend: MemoryBackend, skill: str, task: str, limit: int = 5) -> str:
+    return format_injected_context(backend.recall(f"{skill} {task}", limit=limit))
+
+
+def post_skill(backend: MemoryBackend, skill: str, transcript: str) -> int:
+    memories = distill_transcript(skill, transcript)
+    for memory in memories:
+        backend.remember(memory)
+    return len(memories)
+
+
+def repeated_instruction_reduction(previous: str, current: str, injected: str) -> dict[str, int]:
+    previous_terms = tokenize(previous)
+    current_terms = tokenize(current)
+    injected_terms = tokenize(injected)
+    repeated = previous_terms & current_terms
+    covered = repeated & injected_terms
+    return {
+        "repeated_terms": len(repeated),
+        "covered_by_memory": len(covered),
+        "remaining_repetition": len(repeated - covered),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("phase", choices=["pre", "post", "distill"])
+    parser.add_argument("--backend", choices=["local", "sdk"], default="local")
+    parser.add_argument("--store", type=Path, default=DEFAULT_STORE)
+    parser.add_argument("--agent-id", default=DEFAULT_AGENT_ID)
+    parser.add_argument("--skill", required=True)
+    parser.add_argument("--task", default="")
+    parser.add_argument("--transcript-file", type=Path)
+    args = parser.parse_args(argv)
+
+    backend = build_backend(args.backend, args.store, args.agent_id)
+
+    if args.phase == "pre":
+        print(pre_skill(backend, args.skill, args.task))
+        return 0
+
+    transcript = (
+        args.transcript_file.read_text(encoding="utf-8")
+        if args.transcript_file
+        else sys.stdin.read()
+    )
+
+    if args.phase == "distill":
+        for memory in distill_transcript(args.skill, transcript):
+            print(json.dumps(asdict(memory), sort_keys=True))
+        return 0
+
+    count = post_skill(backend, args.skill, transcript)
+    print(f"stored {count} memories")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from skill_memory import LocalJsonlBackend, distill_transcript, post_skill, pre_skill
+from wrappers import write_wrappers
+
+
+class SkillMemoryTests(unittest.TestCase):
+    def test_distills_decisions_preferences_and_instructions(self) -> None:
+        memories = distill_transcript(
+            "grill-with-docs",
+            "\n".join(
+                [
+                    "Decision: Put auth refresh in AuthGateway.",
+                    "Preference: Use typed Result values.",
+                    "Instruction: Never log refresh tokens.",
+                    "Looks good.",
+                ]
+            ),
+        )
+
+        self.assertEqual([m.memory_type for m in memories], ["decision", "preference", "instruction"])
+
+    def test_local_backend_recalls_across_skills(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = LocalJsonlBackend(Path(tmp) / "memory.jsonl")
+            post_skill(backend, "grill-with-docs", "Decision: Keep retry policy in AuthGateway.")
+            injected = pre_skill(backend, "tdd", "AuthGateway retry tests")
+
+        self.assertIn("AuthGateway", injected)
+
+    def test_wrapper_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = write_wrappers(Path(tmp))
+            names = {path.name for path in paths}
+
+        self.assertEqual(names, {"grill-with-docs", "tdd", "handoff"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+from run_demo import SESSION_ONE, SESSION_TWO_TASK
+from skill_memory import LocalJsonlBackend, post_skill, pre_skill, repeated_instruction_reduction
+from wrappers import write_wrappers
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write-wrappers", type=Path)
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        backend = LocalJsonlBackend(Path(tmp) / "memory.jsonl")
+        stored = post_skill(backend, "grill-with-docs", SESSION_ONE)
+        assert stored >= 3, f"expected at least 3 memories, stored {stored}"
+
+        injected = pre_skill(backend, "tdd", SESSION_TWO_TASK)
+        assert "AuthGateway" in injected
+        assert "typed Result" in injected
+
+        score = repeated_instruction_reduction(SESSION_ONE, SESSION_TWO_TASK, injected)
+        assert score["covered_by_memory"] > 0
+
+    if args.write_wrappers:
+        written = write_wrappers(args.write_wrappers)
+        assert len(written) == 3
+
+    print("validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/examples/claudecode-skills-memanto/wrappers.py
+++ b/examples/claudecode-skills-memanto/wrappers.py
@@ -1,0 +1,37 @@
+"""Generate shell wrappers for Claude Code skill commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SKILLS = {
+    "grill-with-docs": "claude /grill-with-docs \"$@\"",
+    "tdd": "claude /tdd \"$@\"",
+    "handoff": "claude /handoff \"$@\"",
+}
+
+
+def wrapper_script(skill: str, command: str) -> str:
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+TRANSCRIPT="${{MEMANTO_SKILL_TRANSCRIPT:-.memanto-{skill}-transcript.txt}}"
+TASK="$*"
+
+python "$(dirname "$0")/skill_memory.py" pre --skill "{skill}" --task "$TASK"
+{command} 2>&1 | tee "$TRANSCRIPT"
+python "$(dirname "$0")/skill_memory.py" post --skill "{skill}" --transcript-file "$TRANSCRIPT"
+"""
+
+
+def write_wrappers(output_dir: Path) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for skill, command in SKILLS.items():
+        path = output_dir / skill
+        path.write_text(wrapper_script(skill, command), encoding="utf-8")
+        path.chmod(0o755)
+        written.append(path)
+    return written
+


### PR DESCRIPTION
/claim #508

## Summary
Adds `examples/claudecode-skills-memanto`, a reviewer-safe integration showing how Memanto can act as a global engineering memory layer across Claude Code-style skills such as `/grill-with-docs`, `/tdd`, and `/handoff`.

## What is included
- `skill_memory.py`: pre/post lifecycle hooks for recalling prior engineering memories before a skill runs and distilling new decisions/preferences/instructions after the transcript completes.
- Local JSONL backend for credential-free review plus an SDK backend using `memanto.cli.client.sdk_client.SdkClient` when `MOORCHEH_API_KEY` is available.
- Shell wrapper generation for `grill-with-docs`, `tdd`, and `handoff` without modifying the underlying skill commands.
- A deterministic demo showing cross-skill injection and a simple repeated-instruction reduction benchmark.
- README, validation script, and stdlib unit tests.

## Verification
Run from the repository root:

```bash
python examples/claudecode-skills-memanto/validate.py
python examples/claudecode-skills-memanto/run_demo.py
python -m unittest examples/claudecode-skills-memanto/test_skill_memory.py
python -m py_compile examples/claudecode-skills-memanto/skill_memory.py examples/claudecode-skills-memanto/wrappers.py examples/claudecode-skills-memanto/run_demo.py examples/claudecode-skills-memanto/validate.py examples/claudecode-skills-memanto/test_skill_memory.py
git diff --check
```

Local results:
- `validation passed`
- `run_demo.py` stored 3 memories and injected the AuthGateway / typed Result decisions into the later `/tdd` task.
- `unittest` -> 3 tests passed.
- `py_compile` passed.
- `git diff --check` passed.

## Showcase
Technical showcase is included in `examples/claudecode-skills-memanto/README.md` with a demo transcript and Mermaid lifecycle diagram. The issue thread says external social posts are not mandatory for technical review, so this PR keeps the showcase in-repo.

## AI assistance disclosure
I used ChatGPT/Codex as an implementation assistant and reviewed the code path, validation commands, and PR contents before submitting.

BountyHub bounty: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe
