### PR TITLE
feat(examples): add claudecode-skills-memanto memory bridge

### DIFF
--- a/examples/claudecode-skills-memanto/.env.example
+++ b/examples/claudecode-skills-memanto/.env.example
@@ -1,0 +1,12 @@
+# Memanto API key — get a free key at https://console.moorcheh.ai/api-keys
+# Free tier: 100K operations/month
+# Leave unset to use LOCAL PREVIEW mode (no API key required)
+MOORCHEH_API_KEY=your_key_here
+
+# Set to "true" to force local JSONL preview mode even if API key is set
+# Useful for CI/CD and testing
+LOCAL_PREVIEW=false
+
+# Namespace for memory isolation (optional, default: developer-skills)
+# Use different namespaces for different projects
+MEMANTO_NAMESPACE=developer-skills

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -12,7 +12,7 @@ The `mattpocock/skills` ecosystem provides sharp, single-purpose command-line pr
 
 Memanto acts as a global, active memory companion that persists across all skill executions. The `SkillMemoryBridge` wraps any skill with two lifecycle hooks:
 
-```
+```text
                  ┌─────────────────────────────────────────────────┐
                  │              Developer Skill Execution           │
                  │                                                  │
@@ -123,7 +123,7 @@ def run_skill(skill_name: str, task: str) -> str:
 
 Running `python demo.py` produces this output (abbreviated):
 
-```
+```text
 SESSION 1: /tdd — Auth Service Rate Limiting
 🧠 [before_skill:tdd] Querying memory...
    No relevant memories found.
@@ -156,7 +156,7 @@ python validate.py
 ```
 
 Expected output:
-```
+```text
   ✅ PASS: Bridge initializes correctly
   ✅ PASS: after_skill() stores memory
   ✅ PASS: before_skill() returns empty when no memories
@@ -171,7 +171,7 @@ Results: 7/7 passed
 
 ## File Structure
 
-```
+```text
 examples/claudecode-skills-memanto/
 ├── skill_memory_bridge.py   # Core bridge: SkillMemoryBridge class
 ├── demo.py                  # Runnable demo (4 simulated skill sessions)

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,196 @@
+# Claude Code Skills + Memanto Memory Bridge
+
+This example shows how to integrate [Memanto](https://memanto.ai/) as a persistent memory layer for [mattpocock/skills](https://github.com/mattpocock/skills)-style developer workflows — including Claude Code's `/grill-with-docs`, `/tdd`, `/handoff`, and other command-line skills.
+
+## The Problem: Context Fragmentation
+
+The `mattpocock/skills` ecosystem provides sharp, single-purpose command-line primitives. But each skill execution is isolated — when you run `/tdd` to add rate limiting to your auth service, then later run `/grill-with-docs` to document it, the documentation skill has no memory of the architectural decisions made during the TDD session.
+
+**The result:** You repeat yourself constantly. "We use Redis for distributed state." "The connection string is `REDIS_URL`." "We use token buckets, not leaky buckets." Over and over, across every new terminal session.
+
+## The Solution: Engineering Profile
+
+Memanto acts as a global, active memory companion that persists across all skill executions. The `SkillMemoryBridge` wraps any skill with two lifecycle hooks:
+
+```
+                 ┌─────────────────────────────────────────────────┐
+                 │              Developer Skill Execution           │
+                 │                                                  │
+  before_skill() │  ┌──────────────┐    ┌──────────────────────┐  │
+  ───────────────┼─►│ Query Memanto│    │  Inject memories as  │  │
+                 │  │ for relevant │───►│  system constraints  │  │
+                 │  │  memories    │    │  into skill prompt   │  │
+                 │  └──────────────┘    └──────────────────────┘  │
+                 │                                                  │
+                 │         [Skill executes with context]           │
+                 │                                                  │
+  after_skill()  │  ┌──────────────┐    ┌──────────────────────┐  │
+  ───────────────┼─►│ Distill key  │    │  Store to Memanto    │  │
+                 │  │ learnings    │───►│  Engineering Profile  │  │
+                 │  │ from output  │    │  (persistent memory)  │  │
+                 │  └──────────────┘    └──────────────────────┘  │
+                 └─────────────────────────────────────────────────┘
+```
+
+## Two Modes
+
+| Mode | When | API Key Required |
+|---|---|---|
+| **Local Preview** | `LOCAL_PREVIEW=true` or no API key set | No |
+| **Live Memanto** | `MOORCHEH_API_KEY` is set | Yes (free tier available) |
+
+Local Preview uses a JSONL file as a mock memory store — perfect for testing, CI, and evaluating the bridge without any credentials.
+
+## Quick Start
+
+### Option A: Local Preview (no API key required)
+
+```bash
+cd examples/claudecode-skills-memanto
+pip install -r requirements.txt
+
+# Run the demo
+python demo.py
+
+# Run validation tests
+python validate.py
+```
+
+### Option B: Live Memanto API
+
+```bash
+# Get a free API key at https://console.moorcheh.ai/api-keys
+export MOORCHEH_API_KEY=your_key_here
+
+pip install -r requirements.txt
+python demo.py
+```
+
+## Usage in Your Skill Workflow
+
+```python
+from skill_memory_bridge import SkillMemoryBridge
+
+bridge = SkillMemoryBridge()
+
+# 1. Before running a skill — get relevant context to inject
+context = bridge.before_skill(
+    skill_name="tdd",
+    task_description="Add rate limiting to the auth service"
+)
+# context is a formatted string ready to inject into the skill's system prompt
+# e.g.: "## Engineering Profile\n1. [tdd] We use Redis for distributed state..."
+
+# 2. After the skill completes — store what was learned
+bridge.after_skill(
+    skill_name="tdd",
+    summary="Used token bucket rate limiter in auth/rate_limit.py. Redis via REDIS_URL.",
+    tags=["tdd", "auth", "redis", "rate-limiting"]
+)
+```
+
+### Integration with Claude Code
+
+Add the bridge to your Claude Code skill wrapper:
+
+```python
+# In your skill runner / MCP tool
+import subprocess
+from skill_memory_bridge import SkillMemoryBridge
+
+bridge = SkillMemoryBridge()
+
+def run_skill(skill_name: str, task: str) -> str:
+    # Inject memories before execution
+    memory_context = bridge.before_skill(skill_name, task)
+
+    # Build the prompt with injected context
+    prompt = f"{memory_context}\n\n{task}" if memory_context else task
+
+    # Run the skill (example: Claude Code CLI)
+    result = subprocess.run(
+        ["claude", f"/{skill_name}", prompt],
+        capture_output=True, text=True
+    )
+
+    # Store learnings after execution
+    bridge.after_skill(skill_name, result.stdout[:500])
+
+    return result.stdout
+```
+
+## Demo Transcript
+
+Running `python demo.py` produces this output (abbreviated):
+
+```
+SESSION 1: /tdd — Auth Service Rate Limiting
+🧠 [before_skill:tdd] Querying memory...
+   No relevant memories found.
+⚙️  [/tdd executing...] Writing tests for token bucket rate limiter...
+💾 [after_skill:tdd] Storing memory: Implemented token bucket rate limiter...
+
+SESSION 2: /grill-with-docs — Auth Module Documentation
+🧠 [before_skill:grill-with-docs] Querying memory...
+   Found 1 relevant memory.
+📋 Injected context:
+   1. [tdd] Implemented token bucket rate limiter in auth/rate_limit.py.
+      Used Redis for distributed state. Key decision: 100 req/min per user.
+
+SESSION 4: /tdd — Payment Service (Redis also used here)
+🧠 [before_skill:tdd] Querying memory...
+   Found 3 relevant memories.
+📋 Injected context (Redis memory surfaces from auth work):
+   1. [tdd] Implemented token bucket rate limiter... Used Redis...
+   2. [grill-with-docs] Redis connection string must be set via REDIS_URL env var.
+   3. [handoff] Handoff document covers rate limiter implementation, Redis dependency.
+
+✅ Key insight: In SESSION 4, the Redis knowledge from SESSION 1 was
+   automatically surfaced — no repeated instructions needed.
+```
+
+## Validation
+
+```bash
+python validate.py
+```
+
+Expected output:
+```
+  ✅ PASS: Bridge initializes correctly
+  ✅ PASS: after_skill() stores memory
+  ✅ PASS: before_skill() returns empty when no memories
+  ✅ PASS: before_skill() returns relevant memories
+  ✅ PASS: Cross-skill memory retrieval works
+  ✅ PASS: Multiple memories stored and retrieved
+  ✅ PASS: Tags improve retrieval precision
+
+Results: 7/7 passed
+✅ All tests passed!
+```
+
+## File Structure
+
+```
+examples/claudecode-skills-memanto/
+├── skill_memory_bridge.py   # Core bridge: SkillMemoryBridge class
+├── demo.py                  # Runnable demo (4 simulated skill sessions)
+├── validate.py              # Automated validation suite (7 tests)
+├── requirements.txt         # Dependencies
+├── .env.example             # Environment variable template
+└── README.md                # This file
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `MOORCHEH_API_KEY` | For live mode | Get free at [console.moorcheh.ai](https://console.moorcheh.ai/api-keys) |
+| `LOCAL_PREVIEW` | No | Set to `true` to force local JSONL mode |
+| `MEMANTO_NAMESPACE` | No | Namespace for memory isolation (default: `developer-skills`) |
+
+## Prerequisites
+
+- Python 3.10+
+- No API key required for local preview mode
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys) for live mode (free tier: 100K ops/month)

--- a/examples/claudecode-skills-memanto/demo.py
+++ b/examples/claudecode-skills-memanto/demo.py
@@ -1,0 +1,150 @@
+"""
+demo.py
+=======
+A runnable demonstration of the SkillMemoryBridge showing how Memanto
+acts as a persistent memory layer across multiple developer skill executions.
+
+Run this script to see the bridge in action:
+    python demo.py
+
+No API key required — runs in LOCAL PREVIEW mode by default.
+Set MOORCHEH_API_KEY to use the live Memanto API.
+"""
+
+import os
+import time
+from skill_memory_bridge import SkillMemoryBridge
+
+# Force local preview for this demo (remove to use live API)
+os.environ.setdefault("LOCAL_PREVIEW", "true")
+
+DEMO_STORE = ".demo_memories.jsonl"
+
+def separator(title: str = "") -> None:
+    width = 60
+    if title:
+        pad = (width - len(title) - 2) // 2
+        print(f"\n{'─' * pad} {title} {'─' * pad}")
+    else:
+        print(f"\n{'─' * width}")
+
+def main() -> None:
+    print("=" * 60)
+    print("  Memanto + Developer Skills Memory Bridge — Demo")
+    print("=" * 60)
+
+    # Clean up any previous demo run
+    import pathlib
+    pathlib.Path(DEMO_STORE).unlink(missing_ok=True)
+
+    bridge = SkillMemoryBridge(local_store_path=DEMO_STORE, verbose=True)
+
+    # -----------------------------------------------------------------------
+    # SESSION 1: Developer runs /tdd on the auth service
+    # -----------------------------------------------------------------------
+    separator("SESSION 1: /tdd — Auth Service Rate Limiting")
+
+    # Before: query for relevant context (empty on first run)
+    ctx = bridge.before_skill("tdd", "Add rate limiting to the auth service")
+    if ctx:
+        print(f"\n📋 Injected context:\n{ctx}")
+    else:
+        print("\n📋 No prior context — starting fresh.")
+
+    # Simulate skill execution
+    print("\n⚙️  [/tdd executing...] Writing tests for token bucket rate limiter...")
+    time.sleep(0.5)
+
+    # After: store what was learned
+    bridge.after_skill(
+        "tdd",
+        "Implemented token bucket rate limiter in auth/rate_limit.py. "
+        "Used Redis for distributed state. Tests in tests/test_rate_limit.py. "
+        "Key decision: 100 req/min per user, burst of 20.",
+        tags=["tdd", "auth", "rate-limiting", "redis"],
+    )
+
+    # -----------------------------------------------------------------------
+    # SESSION 2: Developer runs /grill-with-docs on the same auth module
+    # -----------------------------------------------------------------------
+    separator("SESSION 2: /grill-with-docs — Auth Module Documentation")
+
+    ctx = bridge.before_skill("grill-with-docs", "Document the auth service rate limiting module")
+    if ctx:
+        print(f"\n📋 Injected context:\n{ctx}")
+
+    print("\n⚙️  [/grill-with-docs executing...] Generating docs for auth/rate_limit.py...")
+    time.sleep(0.5)
+
+    bridge.after_skill(
+        "grill-with-docs",
+        "Documented auth/rate_limit.py. Added docstrings and a RATE_LIMITING.md guide. "
+        "Noted that Redis connection string must be set via REDIS_URL env var.",
+        tags=["grill-with-docs", "auth", "documentation", "redis"],
+    )
+
+    # -----------------------------------------------------------------------
+    # SESSION 3: Developer runs /handoff — memory from both prior sessions injected
+    # -----------------------------------------------------------------------
+    separator("SESSION 3: /handoff — Prepare Handoff for Auth Changes")
+
+    ctx = bridge.before_skill("handoff", "Prepare handoff notes for auth service changes")
+    if ctx:
+        print(f"\n📋 Injected context (from prior sessions):\n{ctx}")
+    else:
+        print("\n📋 No context found.")
+
+    print("\n⚙️  [/handoff executing...] Generating handoff document...")
+    time.sleep(0.5)
+
+    bridge.after_skill(
+        "handoff",
+        "Handoff document created: HANDOFF_AUTH_2026-05-20.md. "
+        "Covers rate limiter implementation, Redis dependency, and documentation location.",
+        tags=["handoff", "auth"],
+    )
+
+    # -----------------------------------------------------------------------
+    # SESSION 4: New session — /tdd on a different feature, but auth context surfaces
+    # -----------------------------------------------------------------------
+    separator("SESSION 4: /tdd — Payment Service (Redis also used here)")
+
+    ctx = bridge.before_skill("tdd", "Add idempotency keys to the payment service using Redis")
+    if ctx:
+        print(f"\n📋 Injected context (Redis memory surfaces from auth work):\n{ctx}")
+
+    print("\n⚙️  [/tdd executing...] Writing tests for payment idempotency...")
+    time.sleep(0.5)
+
+    bridge.after_skill(
+        "tdd",
+        "Implemented idempotency keys in payments/idempotency.py using Redis. "
+        "Reused the same Redis connection pattern from auth/rate_limit.py (REDIS_URL env var).",
+        tags=["tdd", "payments", "idempotency", "redis"],
+    )
+
+    # -----------------------------------------------------------------------
+    # Final: Show the full Engineering Profile
+    # -----------------------------------------------------------------------
+    separator("Engineering Profile — All Stored Memories")
+
+    profile = bridge.get_engineering_profile()
+    for i, mem in enumerate(profile, 1):
+        print(f"\n{i}. [{mem['skill']}] {mem['content'][:100]}...")
+        print(f"   Tags: {mem['tags']} | Time: {mem['timestamp'][:19]}")
+
+    separator()
+    print("\n✅ Demo complete!")
+    print(f"   {len(profile)} memories stored in: {DEMO_STORE}")
+    print("\n   Key insight: In SESSION 4, the Redis knowledge from SESSION 1")
+    print("   was automatically surfaced — no repeated instructions needed.")
+    print("\n   This is the Engineering Profile in action: zero repeated context,")
+    print("   consistent architectural decisions across all skill executions.")
+
+    # Clean up demo store
+    import pathlib
+    pathlib.Path(DEMO_STORE).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,0 +1,3 @@
+# Required for live Memanto API mode
+# Not required for local preview mode (LOCAL_PREVIEW=true)
+memanto>=0.1.0

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import json
 import os
 import time
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -122,8 +123,10 @@ class LocalMemoryStore:
         self._memories.append(memory)
 
     def write(self, skill: str, content: str, tags: list[str] | None = None) -> Memory:
+        # Combine ms timestamp with a short uuid4 suffix so rapid writes
+        # within the same millisecond never collide on id.
         memory = Memory(
-            id=f"local-{int(time.time() * 1000)}",
+            id=f"local-{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}",
             skill=skill,
             content=content,
             timestamp=datetime.now(timezone.utc).isoformat(),
@@ -231,13 +234,21 @@ class SkillMemoryBridge:
 
     def __init__(
         self,
-        namespace: str = "developer-skills",
+        namespace: Optional[str] = None,
         local_store_path: str = ".memanto_local.jsonl",
         verbose: bool = True,
     ):
         self.verbose = verbose
         self._mode: str
         self._store: LocalMemoryStore | LiveMementoStore
+
+        # Resolve namespace: explicit arg > MEMANTO_NAMESPACE env > default.
+        # The .env.example and README advertise MEMANTO_NAMESPACE, so honor it.
+        resolved_namespace = (
+            namespace
+            or os.environ.get("MEMANTO_NAMESPACE")
+            or "developer-skills"
+        )
 
         use_local = (
             os.environ.get("LOCAL_PREVIEW", "").lower() == "true"
@@ -251,11 +262,11 @@ class SkillMemoryBridge:
                 print("🔒 SkillMemoryBridge: LOCAL PREVIEW mode (no API key required)")
                 print(f"   Memory store: {local_store_path}")
         else:
-            self._store = LiveMementoStore(namespace=namespace)
+            self._store = LiveMementoStore(namespace=resolved_namespace)
             self._mode = "live"
             if verbose:
                 print("🌐 SkillMemoryBridge: LIVE MEMANTO mode")
-                print(f"   Namespace: {namespace}")
+                print(f"   Namespace: {resolved_namespace}")
 
     @property
     def mode(self) -> str:

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -1,0 +1,347 @@
+"""
+skill_memory_bridge.py
+======================
+A lightweight memory bridge that integrates Memanto's persistent memory layer
+into mattpocock/skills-style developer workflows (Claude Code, /grill-with-docs,
+/tdd, /handoff, etc.).
+
+Architecture
+------------
+                 ┌─────────────────────────────────────────────────┐
+                 │              Developer Skill Execution           │
+                 │                                                  │
+  before_skill() │  ┌──────────────┐    ┌──────────────────────┐  │
+  ───────────────┼─►│ Query Memanto│    │  Inject memories as  │  │
+                 │  │ for relevant │───►│  system constraints  │  │
+                 │  │  memories    │    │  into skill prompt   │  │
+                 │  └──────────────┘    └──────────────────────┘  │
+                 │                                                  │
+                 │         [Skill executes with context]           │
+                 │                                                  │
+  after_skill()  │  ┌──────────────┐    ┌──────────────────────┐  │
+  ───────────────┼─►│ Distill key  │    │  Store to Memanto    │  │
+                 │  │ learnings    │───►│  Engineering Profile  │  │
+                 │  │ from output  │    │  (persistent memory)  │  │
+                 │  └──────────────┘    └──────────────────────┘  │
+                 └─────────────────────────────────────────────────┘
+
+Two modes
+---------
+- LOCAL PREVIEW (default): Uses a JSONL file as a mock memory store.
+  No API key required. Perfect for testing and CI.
+- LIVE MEMANTO: Uses the real Memanto API via the `memanto` Python package.
+  Requires a MOORCHEH_API_KEY environment variable.
+
+Usage
+-----
+    from skill_memory_bridge import SkillMemoryBridge
+
+    bridge = SkillMemoryBridge()  # auto-detects mode from env
+
+    # Before running a skill
+    context = bridge.before_skill("tdd", "Add rate limiting to the auth service")
+    print(context)  # Prints relevant past memories to inject
+
+    # After a skill completes
+    bridge.after_skill("tdd", "Added token bucket rate limiter in auth/rate_limit.py")
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Memory:
+    """A single memory entry in the Engineering Profile."""
+    id: str
+    skill: str
+    content: str
+    timestamp: str
+    tags: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "skill": self.skill,
+            "content": self.content,
+            "timestamp": self.timestamp,
+            "tags": self.tags,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Memory":
+        return cls(
+            id=d["id"],
+            skill=d["skill"],
+            content=d["content"],
+            timestamp=d["timestamp"],
+            tags=d.get("tags", []),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Local preview backend (no API key required)
+# ---------------------------------------------------------------------------
+
+class LocalMemoryStore:
+    """
+    A JSONL-backed memory store for credential-free local preview.
+    Each line in the JSONL file is a serialized Memory object.
+    """
+
+    def __init__(self, store_path: str = ".memanto_local.jsonl"):
+        self.store_path = Path(store_path)
+        self._memories: list[Memory] = []
+        self._load()
+
+    def _load(self) -> None:
+        if self.store_path.exists():
+            with open(self.store_path, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        try:
+                            self._memories.append(Memory.from_dict(json.loads(line)))
+                        except (json.JSONDecodeError, KeyError):
+                            pass
+
+    def _save(self, memory: Memory) -> None:
+        with open(self.store_path, "a") as f:
+            f.write(json.dumps(memory.to_dict()) + "\n")
+        self._memories.append(memory)
+
+    def write(self, skill: str, content: str, tags: list[str] | None = None) -> Memory:
+        memory = Memory(
+            id=f"local-{int(time.time() * 1000)}",
+            skill=skill,
+            content=content,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tags=tags or [skill],
+        )
+        self._save(memory)
+        return memory
+
+    def query(self, skill: str, query: str, limit: int = 5) -> list[Memory]:
+        """
+        Simple keyword-based retrieval for local mode.
+        Returns memories most relevant to the current skill and query.
+        """
+        query_words = set(query.lower().split() + [skill.lower()])
+        scored: list[tuple[float, Memory]] = []
+
+        for mem in self._memories:
+            mem_words = set(mem.content.lower().split())
+            mem_tags = set(t.lower() for t in mem.tags)
+            # Score: tag match (2pts each) + word overlap (1pt each)
+            score = (
+                2 * len(query_words & mem_tags)
+                + len(query_words & mem_words)
+            )
+            if score > 0:
+                scored.append((score, mem))
+
+        scored.sort(key=lambda x: (-x[0], x[1].timestamp), reverse=False)
+        return [m for _, m in scored[:limit]]
+
+    def clear(self) -> None:
+        """Remove all local memories (useful for testing)."""
+        self._memories.clear()
+        if self.store_path.exists():
+            self.store_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Live Memanto backend
+# ---------------------------------------------------------------------------
+
+class LiveMementoStore:
+    """
+    Wraps the official `memanto` Python package for live API access.
+    Requires MOORCHEH_API_KEY in the environment.
+    """
+
+    def __init__(self, namespace: str = "developer-skills"):
+        try:
+            from memanto.cli.client.sdk_client import SDKClient  # type: ignore
+        except ImportError as e:
+            raise ImportError(
+                "The `memanto` package is required for live mode. "
+                "Install it with: pip install memanto"
+            ) from e
+
+        self.namespace = namespace
+        api_key = os.environ.get("MOORCHEH_API_KEY")
+        if not api_key:
+            raise EnvironmentError(
+                "MOORCHEH_API_KEY is not set. "
+                "Get a free key at https://console.moorcheh.ai/api-keys "
+                "or use LOCAL_PREVIEW=true for credential-free mode."
+            )
+        self._client = SDKClient(api_key=api_key)
+
+    def write(self, skill: str, content: str, tags: list[str] | None = None) -> dict:
+        return self._client.add_memory(
+            content=content,
+            namespace=self.namespace,
+            metadata={"skill": skill, "tags": tags or [skill]},
+        )
+
+    def query(self, skill: str, query: str, limit: int = 5) -> list[dict]:
+        results = self._client.search_memories(
+            query=f"[{skill}] {query}",
+            namespace=self.namespace,
+            limit=limit,
+        )
+        return results.get("memories", [])
+
+
+# ---------------------------------------------------------------------------
+# Main bridge
+# ---------------------------------------------------------------------------
+
+class SkillMemoryBridge:
+    """
+    The primary interface for integrating Memanto memory into developer skills.
+
+    Auto-detects mode:
+    - If MOORCHEH_API_KEY is set and LOCAL_PREVIEW != 'true': uses live Memanto API
+    - Otherwise: uses local JSONL preview store
+
+    Example
+    -------
+        bridge = SkillMemoryBridge()
+
+        # Inject memories before a skill runs
+        context = bridge.before_skill("tdd", "Add rate limiting to auth service")
+
+        # Store learnings after a skill completes
+        bridge.after_skill("tdd", "Used token bucket algorithm in auth/rate_limit.py")
+    """
+
+    def __init__(
+        self,
+        namespace: str = "developer-skills",
+        local_store_path: str = ".memanto_local.jsonl",
+        verbose: bool = True,
+    ):
+        self.verbose = verbose
+        self._mode: str
+        self._store: LocalMemoryStore | LiveMementoStore
+
+        use_local = (
+            os.environ.get("LOCAL_PREVIEW", "").lower() == "true"
+            or not os.environ.get("MOORCHEH_API_KEY")
+        )
+
+        if use_local:
+            self._store = LocalMemoryStore(store_path=local_store_path)
+            self._mode = "local"
+            if verbose:
+                print("🔒 SkillMemoryBridge: LOCAL PREVIEW mode (no API key required)")
+                print(f"   Memory store: {local_store_path}")
+        else:
+            self._store = LiveMementoStore(namespace=namespace)
+            self._mode = "live"
+            if verbose:
+                print("🌐 SkillMemoryBridge: LIVE MEMANTO mode")
+                print(f"   Namespace: {namespace}")
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    def before_skill(self, skill_name: str, task_description: str) -> str:
+        """
+        Called before a skill executes.
+        Queries Memanto for relevant past memories and returns them as a
+        formatted string to inject into the skill's system prompt.
+
+        Parameters
+        ----------
+        skill_name : str
+            The name of the skill being invoked (e.g., "tdd", "grill-with-docs").
+        task_description : str
+            A brief description of what the skill is about to do.
+
+        Returns
+        -------
+        str
+            A formatted block of relevant memories to inject as system constraints.
+            Returns an empty string if no relevant memories are found.
+        """
+        if self.verbose:
+            print(f"\n🧠 [before_skill:{skill_name}] Querying memory for: {task_description[:60]}...")
+
+        memories = self._store.query(skill=skill_name, query=task_description)
+
+        if not memories:
+            if self.verbose:
+                print("   No relevant memories found.")
+            return ""
+
+        lines = [
+            f"## Engineering Profile — Relevant Past Context",
+            f"The following memories from past skill executions are relevant to this task:",
+            "",
+        ]
+        for i, mem in enumerate(memories, 1):
+            if isinstance(mem, Memory):
+                lines.append(f"{i}. [{mem.skill}] {mem.content}")
+            else:
+                # Live API returns dicts
+                lines.append(f"{i}. {mem.get('content', str(mem))}")
+
+        context = "\n".join(lines)
+        if self.verbose:
+            print(f"   Found {len(memories)} relevant memories.")
+            print(f"   Context preview: {context[:120]}...")
+        return context
+
+    def after_skill(
+        self,
+        skill_name: str,
+        summary: str,
+        tags: Optional[list[str]] = None,
+    ) -> None:
+        """
+        Called after a skill completes.
+        Distills the key learnings from the skill output and stores them
+        in Memanto to update the developer's Engineering Profile.
+
+        Parameters
+        ----------
+        skill_name : str
+            The name of the skill that just ran.
+        summary : str
+            A concise summary of what was done, decided, or learned.
+        tags : list[str], optional
+            Additional tags for better retrieval. Defaults to [skill_name].
+        """
+        if self.verbose:
+            print(f"\n💾 [after_skill:{skill_name}] Storing memory: {summary[:60]}...")
+
+        self._store.write(skill=skill_name, content=summary, tags=tags or [skill_name])
+
+        if self.verbose:
+            print("   Memory stored successfully.")
+
+    def get_engineering_profile(self, limit: int = 20) -> list:
+        """
+        Returns all memories in the Engineering Profile (local mode only).
+        Useful for debugging and validation.
+        """
+        if self._mode == "local":
+            return [m.to_dict() for m in self._store._memories[-limit:]]
+        else:
+            return self._store.query(skill="*", query="engineering profile", limit=limit)

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,141 @@
+"""
+validate.py
+===========
+Automated validation script for the SkillMemoryBridge.
+Verifies that the bridge correctly stores and retrieves memories
+in both LOCAL PREVIEW and (optionally) LIVE MEMANTO modes.
+
+Run:
+    python validate.py              # local preview validation
+    MOORCHEH_API_KEY=... python validate.py  # live API validation
+"""
+
+import os
+import pathlib
+import sys
+
+# Force local for automated validation unless explicitly set to live
+if not os.environ.get("MOORCHEH_API_KEY"):
+    os.environ["LOCAL_PREVIEW"] = "true"
+
+from skill_memory_bridge import SkillMemoryBridge
+
+PASS = "✅ PASS"
+FAIL = "❌ FAIL"
+TEST_STORE = ".validate_test.jsonl"
+
+def run_test(name: str, fn) -> bool:
+    try:
+        fn()
+        print(f"  {PASS}: {name}")
+        return True
+    except AssertionError as e:
+        print(f"  {FAIL}: {name} — {e}")
+        return False
+    except Exception as e:
+        print(f"  {FAIL}: {name} — Unexpected error: {e}")
+        return False
+
+def cleanup():
+    pathlib.Path(TEST_STORE).unlink(missing_ok=True)
+
+def test_bridge_initializes():
+    cleanup()
+    bridge = SkillMemoryBridge(local_store_path=TEST_STORE, verbose=False)
+    assert bridge.mode in ("local", "live"), f"Unexpected mode: {bridge.mode}"
+    cleanup()
+
+def test_after_skill_stores_memory():
+    cleanup()
+    bridge = SkillMemoryBridge(local_store_path=TEST_STORE, verbose=False)
+    bridge.after_skill("tdd", "Used pytest fixtures for database tests", tags=["tdd", "testing"])
+    profile = bridge.get_engineering_profile()
+    assert len(profile) == 1, f"Expected 1 memory, got {len(profile)}"
+    assert "pytest" in profile[0]["content"]
+    cleanup()
+
+def test_before_skill_returns_empty_on_no_memories():
+    cleanup()
+    bridge = SkillMemoryBridge(local_store_path=TEST_STORE, verbose=False)
+    ctx = bridge.before_skill("tdd", "Add rate limiting")
+    assert ctx == "", f"Expected empty string, got: {ctx!r}"
+    cleanup()
+
+def test_before_skill_returns_relevant_memories():
+    cleanup()
+    bridge = SkillMemoryBridge(local_store_path=TEST_STORE, verbose=False)
+    bridge.after_skill("tdd", "Used Redis for rate limiting in auth service", tags=["tdd", "redis"])
+    bridge.after_skill("handoff", "Wrote handoff for payment service", tags=["handoff", "payments"])
+    ctx = bridge.before_skill("tdd", "Add Redis-based caching to the API")
+    assert "Redis" in ctx, f"Expected Redis memory to be surfaced, got: {ctx}"
+    cleanup()
+
+def test_cross_skill_memory_retrieval():
+    """Memories from one skill should surface when relevant to another skill."""
+    cleanup()
+    bridge = SkillMemoryBridge(local_store_path=TEST_STORE, verbose=False)
+    bridge.after_skill("tdd", "All database tests use a shared PostgreSQL fixture", tags=["tdd", "postgresql", "database"])
+    # A different skill asking about databases should find this
+    ctx = bridge.before_skill("grill-with-docs", "Document the database connection pooling setup")
+    assert "PostgreSQL" in ctx or "database" in ctx.lower(), \
+        f"Expected cross-skill memory retrieval, got: {ctx}"
+    cleanup()
+
+def test_multiple_memories_stored_and_retrieved():
+    cleanup()
+    bridge = SkillMemoryBridge(local_store_path=TEST_STORE, verbose=False)
+    for i in range(5):
+        bridge.after_skill("tdd", f"Test memory {i}: topic_{i}", tags=["tdd", f"topic_{i}"])
+    profile = bridge.get_engineering_profile()
+    assert len(profile) == 5, f"Expected 5 memories, got {len(profile)}"
+    cleanup()
+
+def test_tags_improve_retrieval():
+    cleanup()
+    bridge = SkillMemoryBridge(local_store_path=TEST_STORE, verbose=False)
+    bridge.after_skill("tdd", "Unrelated content about cooking recipes", tags=["tdd", "cooking"])
+    bridge.after_skill("tdd", "Auth service uses JWT tokens with 1h expiry", tags=["tdd", "auth", "jwt"])
+    ctx = bridge.before_skill("tdd", "Add JWT refresh token support to auth")
+    assert "JWT" in ctx, f"Expected JWT memory to be surfaced, got: {ctx}"
+    cleanup()
+
+
+def main():
+    print("=" * 55)
+    print("  SkillMemoryBridge — Validation Suite")
+    print("=" * 55)
+
+    mode = "LOCAL PREVIEW" if os.environ.get("LOCAL_PREVIEW") == "true" else "LIVE MEMANTO"
+    print(f"\nMode: {mode}\n")
+
+    tests = [
+        ("Bridge initializes correctly", test_bridge_initializes),
+        ("after_skill() stores memory", test_after_skill_stores_memory),
+        ("before_skill() returns empty when no memories", test_before_skill_returns_empty_on_no_memories),
+        ("before_skill() returns relevant memories", test_before_skill_returns_relevant_memories),
+        ("Cross-skill memory retrieval works", test_cross_skill_memory_retrieval),
+        ("Multiple memories stored and retrieved", test_multiple_memories_stored_and_retrieved),
+        ("Tags improve retrieval precision", test_tags_improve_retrieval),
+    ]
+
+    passed = 0
+    failed = 0
+    for name, fn in tests:
+        if run_test(name, fn):
+            passed += 1
+        else:
+            failed += 1
+
+    print(f"\n{'─' * 55}")
+    print(f"Results: {passed}/{len(tests)} passed")
+
+    if failed == 0:
+        print("✅ All tests passed! The bridge is working correctly.")
+        sys.exit(0)
+    else:
+        print(f"❌ {failed} test(s) failed.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -13,16 +13,33 @@ Run:
 import os
 import pathlib
 import sys
+import uuid
 
 # Force local for automated validation unless explicitly set to live
 if not os.environ.get("MOORCHEH_API_KEY"):
     os.environ["LOCAL_PREVIEW"] = "true"
+
+# When running against live Memanto, isolate all writes into a dedicated
+# test namespace so the suite never contaminates the user's real
+# Engineering Profile data. Each run uses a unique suffix so concurrent or
+# repeated runs cannot interfere with each other either.
+if os.environ.get("MOORCHEH_API_KEY") and os.environ.get("LOCAL_PREVIEW", "").lower() != "true":
+    # Allow the user to override with an explicit MEMANTO_TEST_NAMESPACE
+    # but otherwise always pick a fresh, scoped namespace.
+    if not os.environ.get("MEMANTO_TEST_NAMESPACE"):
+        os.environ["MEMANTO_TEST_NAMESPACE"] = (
+            f"validate-test-{uuid.uuid4().hex[:8]}"
+        )
+    # Force the bridge to use the test namespace regardless of any
+    # MEMANTO_NAMESPACE the user may have configured for normal use.
+    os.environ["MEMANTO_NAMESPACE"] = os.environ["MEMANTO_TEST_NAMESPACE"]
 
 from skill_memory_bridge import SkillMemoryBridge
 
 PASS = "✅ PASS"
 FAIL = "❌ FAIL"
 TEST_STORE = ".validate_test.jsonl"
+TEST_NAMESPACE = os.environ.get("MEMANTO_TEST_NAMESPACE")
 
 def run_test(name: str, fn) -> bool:
     try:
@@ -106,7 +123,10 @@ def main():
     print("=" * 55)
 
     mode = "LOCAL PREVIEW" if os.environ.get("LOCAL_PREVIEW") == "true" else "LIVE MEMANTO"
-    print(f"\nMode: {mode}\n")
+    print(f"\nMode: {mode}")
+    if TEST_NAMESPACE:
+        print(f"Live test namespace (isolated): {TEST_NAMESPACE}")
+    print()
 
     tests = [
         ("Bridge initializes correctly", test_bridge_initializes),


### PR DESCRIPTION
Adds examples/claudecode-skills-memanto — a lightweight Memanto memory bridge for mattpocock/skills-style developer workflows (Claude Code, /grill-with-docs, /tdd, /handoff, etc.).

Closes #508

## What's included

- skill_memory_bridge.py: Core SkillMemoryBridge class with before_skill() and after_skill() lifecycle hooks
- demo.py: Runnable 4-session demo showing cross-skill memory persistence
- validate.py: Automated validation suite (7 tests, all passing)
- README.md: Full documentation with architecture diagram, usage, and demo transcript
- requirements.txt + .env.example

## Two modes

- LOCAL PREVIEW (default): JSONL-backed mock store, no API key required
- LIVE MEMANTO: Real Memanto API via MOORCHEH_API_KEY

## Key differentiator

The bridge correctly handles cross-skill memory retrieval — in the demo, Redis architectural decisions from a /tdd session automatically surface during a later /handoff session on a different service, with no manual context injection required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an example integration that provides persistent memory for CLI skills with local preview and optional live Memanto API, injecting relevant memory before tasks and persisting learnings after.

* **Documentation**
  * Added usage docs and an environment example documenting API key, local preview flag, and optional namespace with quick-start instructions.

* **Demos & Tests**
  * Added a runnable demo showcasing multi-session memory flows and a validation script with automated pass/fail checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->