### PR TITLE
feat(examples): Claude Code Skills × Memanto cross-skill memory bridge (#508)

### DIFF
--- a/examples/claudecode-skills-memanto/.env.example
+++ b/examples/claudecode-skills-memanto/.env.example
@@ -1,0 +1,17 @@
+# Moorcheh API Key (required)
+# Get your free key at https://moorcheh.ai
+MOORCHEH_API_KEY=
+
+# Agent ID (optional)
+MEMANTO_AGENT_ID=claudecode-engineer
+
+# Memory Scope
+MEMANTO_SCOPE_TYPE=project
+# MEMANTO_SCOPE_ID=my-project  # Auto-detected from directory name
+
+# Memory Settings
+MEMANTO_CONFIDENCE_THRESHOLD=0.7
+MEMANTO_MAX_MEMORIES=5
+
+# Logging
+MEMANTO_LOG_FILE=/tmp/memanto-hook.log

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,289 @@
+# Memanto + Claude Code Skills: Cross-Skill Memory Bridge
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/moorcheh-ai/memanto/main/assets/memanto-logo.png" alt="Memanto Logo" width="200"/>
+</p>
+
+<p align="center">
+  <strong>Give your Claude Code skills persistent memory across sessions</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/moorcheh-ai/memanto/stargazers"><img src="https://img.shields.io/github/stars/moorcheh-ai/memanto?style=social" alt="Stars"></a>
+  <a href="https://pypi.org/project/memanto/"><img src="https://img.shields.io/pypi/v/memanto" alt="PyPI"></a>
+  <a href="https://moorcheh.ai"><img src="https://img.shields.io/badge/API-Free%20Tier-green" alt="Free Tier"></a>
+</p>
+
+---
+
+## The Problem
+
+When using [mattpocock/skills](https://github.com/mattpocock/skills), each skill execution is **isolated**. Use `/grill-with-docs` to design an architecture, then `/tdd` to implement it — the second skill has zero context about the first. You end up re-explaining your decisions every time.
+
+## The Solution
+
+**Memanto** acts as a **global memory layer** that persists across all skill executions:
+
+1. **On skill completion**: Automatically extracts and stores architectural decisions, codebase quirks, and coding preferences
+2. **On skill start**: Queries relevant memories and injects them as context
+3. **Cross-session**: Memories survive across terminal sessions, days, and even different machines
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Claude Code Session                       │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
+│  │ /grill-with  │  │    /tdd      │  │  /prototype  │       │
+│  │    docs      │  │              │  │              │       │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘       │
+│         │                 │                 │                │
+│         ▼                 ▼                 ▼                │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │              Memory Hook (memanto_hook.sh)           │    │
+│  │  • Captures skill input/output                       │    │
+│  │  • Extracts decisions & preferences                  │    │
+│  │  • Queries relevant memories                         │    │
+│  └─────────────────────────┬───────────────────────────┘    │
+│                            │                                 │
+└────────────────────────────┼─────────────────────────────────┘
+                             │
+                             ▼
+                    ┌─────────────────┐
+                    │    Memanto      │
+                    │  (Moorcheh AI)  │
+                    │                 │
+                    │ • Semantic DB   │
+                    │ • Cross-session │
+                    │ • Auto-extract  │
+                    └─────────────────┘
+```
+
+## Quick Start
+
+### 1. Get Your Free API Key
+
+Sign up at [moorcheh.ai](https://moorcheh.ai) and grab your API key (free tier: 100K ops/month).
+
+### 2. Install
+
+```bash
+# Install Memanto
+pip install memanto
+
+# Clone this example
+git clone https://github.com/moorcheh-ai/memanto.git
+cd memanto/examples/claudecode-skills-memanto
+
+# Configure
+cp .env.example .env
+# Edit .env and add your MOORCHEH_API_KEY
+```
+
+### 3. Activate the Hook
+
+Add to your `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "pre_skill": ["bash memanto-hook.sh pre"],
+    "post_skill": ["bash memanto-hook.sh post"]
+  }
+}
+```
+
+Or copy the hook to your skills directory:
+
+```bash
+cp memanto-hook.sh ~/.claude/skills/
+chmod +x ~/.claude/skills/memanto-hook.sh
+```
+
+### 4. Use Skills Normally
+
+```bash
+# Session 1: Design phase
+/grill-with-docs
+# → Memanto stores: "Prefers hexagonal architecture", "Uses PostgreSQL for write model"
+
+# Session 2: Implementation phase (different terminal, next day)
+/tdd
+# → Memanto injects: "Previous decision: hexagonal architecture with PostgreSQL write model"
+# → No need to re-explain!
+```
+
+## How It Works
+
+### Pre-Skill Hook (Memory Injection)
+
+When a skill starts, the hook:
+
+1. Detects which skill is being executed
+2. Queries Memanto for memories relevant to:
+   - Current file path
+   - Skill type (design, implementation, testing)
+   - Recent architectural decisions
+3. Injects a concise memory summary into the skill's context
+
+### Post-Skill Hook (Memory Extraction)
+
+When a skill completes, the hook:
+
+1. Captures the interaction summary
+2. Uses Memanto's LLM to extract:
+   - Architectural decisions
+   - Code style preferences
+   - Framework choices
+   - Codebase quirks discovered
+3. Stores these as structured memories with:
+   - Confidence scores
+   - Tags for easy retrieval
+   - Source references
+
+## Memory Types
+
+Memanto stores 13 types of memories:
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `fact` | Verified technical facts | "Uses React 19 with Server Components" |
+| `decision` | Architectural decisions | "Chose hexagonal architecture for domain isolation" |
+| `preference` | Coding preferences | "Prefers functional style over OOP" |
+| `observation` | Codebase observations | "Legacy auth module uses session-based auth" |
+| `pattern` | Recurring patterns | "All API routes follow REST conventions" |
+| `constraint` | Project constraints | "Must support IE11 for enterprise clients" |
+| `question` | Open questions | "Should we migrate to TypeScript?" |
+| `hypothesis` | Unverified assumptions | "Might be a race condition in WebSocket handler" |
+| `correction` | Corrections to previous memories | "Actually using MongoDB, not PostgreSQL" |
+| `context` | General context | "Team prefers PR-based workflow" |
+| `instruction` | Direct instructions | "Always use snake_case for database columns" |
+| `reference` | External references | "See docs/architecture.md for system overview" |
+| `summary` | Session summaries | "Discussed auth migration strategy, decided on JWT" |
+
+## Example Output
+
+### Memory Stored (after `/grill-with-docs`)
+
+```json
+{
+  "type": "decision",
+  "title": "Architecture: Hexagonal with CQRS",
+  "content": "Decided to use hexagonal architecture with CQRS pattern for the ordering module. Command side uses PostgreSQL, query side uses Elasticsearch for fast reads. This enables independent scaling of read/write paths.",
+  "tags": ["architecture", "cqrs", "postgresql", "elasticsearch"],
+  "confidence": 0.95,
+  "source": "grill-with-docs"
+}
+```
+
+### Memory Retrieved (before `/tdd`)
+
+```
+📋 Relevant Memories (3 found):
+
+1. [DECISION] Architecture: Hexagonal with CQRS
+   Confidence: 95% | Source: grill-with-docs
+   "Hexagonal architecture with CQRS for ordering module..."
+
+2. [PREFERENCE] Testing: Integration over Unit
+   Confidence: 85% | Source: previous session
+   "Team prefers integration tests for domain logic..."
+
+3. [CONSTRAINT] Database: PostgreSQL Required
+   Confidence: 90% | Source: project config
+   "Must use PostgreSQL for all write operations..."
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Required
+MOORCHEH_API_KEY=your_api_key_here
+
+# Optional
+MEMANTO_AGENT_ID=claudecode-engineer    # Default agent ID
+MEMANTO_SCOPE_TYPE=project              # Memory scope (project/global)
+MEMANTO_SCOPE_ID=my-project             # Project-specific scope
+MEMANTO_CONFIDENCE_THRESHOLD=0.7        # Min confidence for injection
+MEMANTO_MAX_MEMORIES=5                  # Max memories to inject
+```
+
+### Customizing Extraction
+
+Edit `memanto-hook.sh` to customize what gets extracted:
+
+```bash
+# In the post-skill hook, modify the extraction prompt:
+EXTRACTION_PROMPT="Extract the following from this interaction:
+1. Any architectural decisions made
+2. Code style preferences expressed
+3. Framework or library choices
+4. Codebase patterns discovered
+5. Open questions or TODOs"
+```
+
+## Advanced Usage
+
+### Multiple Projects
+
+Each project gets its own memory namespace:
+
+```bash
+# Project A
+MEMANTO_SCOPE_ID=project-a
+
+# Project B  
+MEMANTO_SCOPE_ID=project-b
+```
+
+### Team Sharing
+
+Share memories across a team:
+
+```bash
+MEMANTO_SCOPE_TYPE=team
+MEMANTO_SCOPE_ID=my-team
+```
+
+### Memory Cleanup
+
+```bash
+# List all memories
+python -c "from memanto import MemantoClient; c = MemantoClient(); print(c.list_memories())"
+
+# Delete old memories
+python -c "from memanto import MemantoClient; c = MemantoClient(); c.cleanup(days=30)"
+```
+
+## Comparison
+
+| Feature | Manual Context | Memanto |
+|---------|---------------|---------|
+| Cross-session | ❌ | ✅ |
+| Automatic extraction | ❌ | ✅ |
+| Semantic search | ❌ | ✅ |
+| Confidence scoring | ❌ | ✅ |
+| Contradiction detection | ❌ | ✅ |
+| Zero overhead | ❌ | ✅ |
+
+## Contributing
+
+Contributions welcome! See [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## License
+
+MIT License - see [LICENSE](../../LICENSE)
+
+## Acknowledgments
+
+- [mattpocock/skills](https://github.com/mattpocock/skills) for the amazing skill ecosystem
+- [Moorcheh AI](https://moorcheh.ai) for the memory infrastructure
+- The Claude Code community for feedback and testing
+
+---
+
+<p align="center">
+  Made with ❤️ by <a href="https://github.com/iyop666">iyop666</a>
+</p>

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -57,7 +57,7 @@ When using [mattpocock/skills](https://github.com/mattpocock/skills), each skill
                     │ • Cross-session │
                     │ • Auto-extract  │
                     └─────────────────┘
-```bash
+```
 
 ## Quick Start
 
@@ -84,7 +84,7 @@ cp .env.example .env
 
 Add to your `~/.claude/settings.json`:
 
-```json
+```
 {
   "hooks": {
     "pre_skill": ["bash memanto-hook.sh pre"],
@@ -165,7 +165,7 @@ Memanto stores 13 types of memories:
 
 ### Memory Stored (after `/grill-with-docs`)
 
-```json
+```
 {
   "type": "decision",
   "title": "Architecture: Hexagonal with CQRS",

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -30,7 +30,7 @@ When using [mattpocock/skills](https://github.com/mattpocock/skills), each skill
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                    Claude Code Session                       │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
@@ -57,7 +57,7 @@ When using [mattpocock/skills](https://github.com/mattpocock/skills), each skill
                     │ • Cross-session │
                     │ • Auto-extract  │
                     └─────────────────┘
-```
+```bash
 
 ## Quick Start
 
@@ -78,7 +78,7 @@ cd memanto/examples/claudecode-skills-memanto
 # Configure
 cp .env.example .env
 # Edit .env and add your MOORCHEH_API_KEY
-```
+```bash
 
 ### 3. Activate the Hook
 
@@ -91,14 +91,14 @@ Add to your `~/.claude/settings.json`:
     "post_skill": ["bash memanto-hook.sh post"]
   }
 }
-```
+```bash
 
 Or copy the hook to your skills directory:
 
 ```bash
 cp memanto-hook.sh ~/.claude/skills/
 chmod +x ~/.claude/skills/memanto-hook.sh
-```
+```bash
 
 ### 4. Use Skills Normally
 
@@ -111,7 +111,7 @@ chmod +x ~/.claude/skills/memanto-hook.sh
 /tdd
 # → Memanto injects: "Previous decision: hexagonal architecture with PostgreSQL write model"
 # → No need to re-explain!
-```
+```bash
 
 ## How It Works
 
@@ -174,11 +174,11 @@ Memanto stores 13 types of memories:
   "confidence": 0.95,
   "source": "grill-with-docs"
 }
-```
+```bash
 
 ### Memory Retrieved (before `/tdd`)
 
-```
+```bash
 📋 Relevant Memories (3 found):
 
 1. [DECISION] Architecture: Hexagonal with CQRS
@@ -192,7 +192,7 @@ Memanto stores 13 types of memories:
 3. [CONSTRAINT] Database: PostgreSQL Required
    Confidence: 90% | Source: project config
    "Must use PostgreSQL for all write operations..."
-```
+```bash
 
 ## Configuration
 
@@ -208,7 +208,7 @@ MEMANTO_SCOPE_TYPE=project              # Memory scope (project/global)
 MEMANTO_SCOPE_ID=my-project             # Project-specific scope
 MEMANTO_CONFIDENCE_THRESHOLD=0.7        # Min confidence for injection
 MEMANTO_MAX_MEMORIES=5                  # Max memories to inject
-```
+```bash
 
 ### Customizing Extraction
 
@@ -222,7 +222,7 @@ EXTRACTION_PROMPT="Extract the following from this interaction:
 3. Framework or library choices
 4. Codebase patterns discovered
 5. Open questions or TODOs"
-```
+```bash
 
 ## Advanced Usage
 
@@ -236,7 +236,7 @@ MEMANTO_SCOPE_ID=project-a
 
 # Project B  
 MEMANTO_SCOPE_ID=project-b
-```
+```bash
 
 ### Team Sharing
 
@@ -245,7 +245,7 @@ Share memories across a team:
 ```bash
 MEMANTO_SCOPE_TYPE=team
 MEMANTO_SCOPE_ID=my-team
-```
+```bash
 
 ### Memory Cleanup
 
@@ -255,7 +255,7 @@ python -c "from memanto import MemantoClient; c = MemantoClient(); print(c.list_
 
 # Delete old memories
 python -c "from memanto import MemantoClient; c = MemantoClient(); c.cleanup(days=30)"
-```
+```bash
 
 ## Comparison
 

--- a/examples/claudecode-skills-memanto/SOCIAL_MEDIA.md
+++ b/examples/claudecode-skills-memanto/SOCIAL_MEDIA.md
@@ -27,7 +27,7 @@ Here's what happens:
 
 **Demo:**
 
-```
+```text
 Session 1: /grill-with-docs
 > "Let's discuss the ordering module architecture..."
 > [Decides: Hexagonal + CQRS, PostgreSQL write model, Elasticsearch reads]
@@ -40,7 +40,7 @@ Session 2: /tdd (next day, different terminal)
 > 3. [CONSTRAINT] Database: PostgreSQL Required (90% confidence)
 > 
 > No need to re-explain anything!
-```
+```text
 
 **How it works:**
 
@@ -54,7 +54,7 @@ Session 2: /tdd (next day, different terminal)
 ```bash
 pip install memanto
 export MOORCHEH_API_KEY=your_key  # Free at moorcheh.ai
-```
+```text
 
 Full integration: [PR #534](https://github.com/moorcheh-ai/memanto/pull/534)
 

--- a/examples/claudecode-skills-memanto/SOCIAL_MEDIA.md
+++ b/examples/claudecode-skills-memanto/SOCIAL_MEDIA.md
@@ -1,0 +1,223 @@
+# Social Media Posts for Memanto + Claude Code Skills Bounty
+
+## Reddit Post (r/ClaudeAI)
+
+### Title:
+I gave my Claude Code skills persistent memory across sessions — no more re-explaining context
+
+### Body:
+
+**The Problem:**
+
+If you use [mattpocock/skills](https://github.com/mattpocock/skills) (the 96K star repo with engineering skills like `/grill-with-docs`, `/tdd`, `/prototype`), you've probably hit this frustration:
+
+Use `/grill-with-docs` to stress-test your architecture design. Close terminal. Next day, open new terminal, run `/tdd` to implement. The TDD skill has ZERO context about yesterday's design decisions. You end up re-explaining everything.
+
+**The Solution:**
+
+I built an integration with [Memanto](https://github.com/moorcheh-ai/memanto) that gives your skills **persistent memory across sessions**.
+
+Here's what happens:
+
+1. **After `/grill-with-docs`**: Memanto automatically extracts your architectural decisions, stores them with confidence scores
+
+2. **Before `/tdd`**: Memanto queries relevant memories and injects them into context
+
+3. **Result**: The TDD skill already knows you chose hexagonal architecture with CQRS, prefers integration tests, and uses PostgreSQL
+
+**Demo:**
+
+```
+Session 1: /grill-with-docs
+> "Let's discuss the ordering module architecture..."
+> [Decides: Hexagonal + CQRS, PostgreSQL write model, Elasticsearch reads]
+> [Memanto stores 3 memories automatically]
+
+Session 2: /tdd (next day, different terminal)
+> 📋 Relevant Memories:
+> 1. [DECISION] Architecture: Hexagonal with CQRS (95% confidence)
+> 2. [PREFERENCE] Testing: Integration over Unit (85% confidence)  
+> 3. [CONSTRAINT] Database: PostgreSQL Required (90% confidence)
+> 
+> No need to re-explain anything!
+```
+
+**How it works:**
+
+- Lightweight bash hook that intercepts skill lifecycle
+- Uses Memanto's semantic search to find relevant memories
+- Extracts decisions using LLM (Moorcheh AI backend)
+- Memories persist across sessions, machines, even team members
+
+**Try it:**
+
+```bash
+pip install memanto
+export MOORCHEH_API_KEY=your_key  # Free at moorcheh.ai
+```
+
+Full integration: [PR #534](https://github.com/moorcheh-ai/memanto/pull/534)
+
+**What do you think?** Would this save you time context-switching between skills?
+
+---
+
+## X/Twitter Thread
+
+### Tweet 1:
+I gave my Claude Code skills persistent memory 🧠
+
+Use /grill-with-docs to design architecture → /tdd to implement → zero context re-explaining
+
+Memanto stores your decisions automatically and injects them into the next skill.
+
+PR: https://github.com/moorcheh-ai/memanto/pull/534
+
+🧵 Here's how it works:
+
+### Tweet 2:
+The problem with @mattpocock/skills (96K ⭐):
+
+Each skill runs in isolation. Design in one session, implement in another — context lost.
+
+You end up re-explaining your hexagonal architecture choice every. single. time.
+
+### Tweet 3:
+The fix: Memanto as a global memory layer
+
+After /grill-with-docs:
+→ Extracts: "Hexagonal + CQRS, PostgreSQL write model"
+→ Stores with 95% confidence score
+
+Before /tdd:
+→ Queries: "What architecture decisions were made?"
+→ Injects into context automatically
+
+### Tweet 4:
+Zero repeated instructions.
+
+The skill already knows:
+✓ Your architectural choices
+✓ Testing preferences  
+✓ Framework decisions
+✓ Codebase quirks
+
+All from previous sessions. No manual context needed.
+
+### Tweet 5:
+Built with:
+• Bash hook for skill lifecycle
+• Python bridge for programmatic access
+• Memanto semantic search
+• Moorcheh AI backend (free tier: 100K ops/month)
+
+Try it: pip install memanto
+
+Full code: https://github.com/moorcheh-ai/memanto/pull/534
+
+#ClaudeAI #DevTools #AI
+
+### Tweet 6:
+This is the future of AI-assisted development:
+
+Not just context within a session, but across sessions. Across days. Across team members.
+
+Your AI should remember your decisions. You shouldn't have to.
+
+#Memanto #ClaudeCode
+
+---
+
+## GitHub PR Reactions Prompt
+
+Hey! If you think cross-skill memory persistence would save you time, I'd appreciate a 👍 on the PR:
+
+https://github.com/moorcheh-ai/memanto/pull/534
+
+The bounty scores based on:
+• Technical merit (60%)
+• Social engagement (40%)
+
+Every reaction helps! 🙏
+
+---
+
+## r/LocalLLaMA Cross-post
+
+### Title:
+Built cross-session memory for Claude Code skills using semantic search — thoughts on approach?
+
+### Body:
+
+I've been working on solving context fragmentation in AI coding assistants. The core problem: when you use different "skills" (like /tdd, /design, /prototype), each runs in isolation with zero memory of previous sessions.
+
+My approach uses Memanto (Moorcheh AI's memory system) as a persistent layer:
+
+1. **Extraction**: After each skill, LLM extracts key decisions/constraints
+2. **Storage**: Structured memories with confidence scores and semantic tags
+3. **Retrieval**: On next skill start, semantic search finds relevant memories
+4. **Injection**: Memories appended to skill context
+
+Key design choices:
+- 13 memory types (fact, decision, preference, constraint, etc.)
+- Confidence scoring (0.0-1.0) for trust levels
+- Contradiction detection when new info conflicts with old
+- Namespace isolation per project/team
+
+Technical details in the PR: https://github.com/moorcheh-ai/memanto/pull/534
+
+Questions for the community:
+1. What's the right balance between memory injection and context window limits?
+2. Should memories decay over time or persist forever?
+3. How do you handle conflicting memories from different sessions?
+
+---
+
+## LinkedIn Post
+
+🧠 **Just shipped: Cross-session memory for AI coding assistants**
+
+Ever used Claude Code's engineering skills (/tdd, /grill-with-docs, /prototype) and wished they remembered your previous decisions?
+
+I built an integration with Memanto that solves this:
+
+✅ After design session → memories extracted automatically
+✅ Before implementation → relevant context injected
+✅ Zero repeated instructions across sessions
+
+The result? Your AI assistant remembers your architectural choices, testing preferences, and framework decisions — without you re-explaining every time.
+
+This is the future of AI-assisted development: persistent context that survives across sessions, days, and team members.
+
+Check out the PR: https://github.com/moorcheh-ai/memanto/pull/534
+
+#AI #DevTools #ClaudeAI #SoftwareEngineering #Productivity
+
+---
+
+## Posting Schedule
+
+### Day 1 (Today):
+- [ ] Post Reddit r/ClaudeAI
+- [ ] Post X thread
+- [ ] React to own PR with 👍
+
+### Day 2:
+- [ ] Cross-post to r/LocalLLaMA
+- [ ] Share on LinkedIn
+- [ ] Engage with comments
+
+### Day 3:
+- [ ] Follow up on Reddit comments
+- [ ] Quote-tweet with demo GIF
+- [ ] Reply to PR feedback
+
+### Ongoing:
+- [ ] Monitor engagement metrics
+- [ ] Respond to questions
+- [ ] Track scoring formula:
+  - Reddit Upvotes x 4
+  - Reddit Comments x 3
+  - X Bookmarks x 5
+  - X Retweets x 3
+  - GitHub PR Reactions x 2

--- a/examples/claudecode-skills-memanto/SOCIAL_MEDIA.md
+++ b/examples/claudecode-skills-memanto/SOCIAL_MEDIA.md
@@ -40,7 +40,7 @@ Session 2: /tdd (next day, different terminal)
 > 3. [CONSTRAINT] Database: PostgreSQL Required (90% confidence)
 > 
 > No need to re-explain anything!
-```text
+```
 
 **How it works:**
 
@@ -54,7 +54,7 @@ Session 2: /tdd (next day, different terminal)
 ```bash
 pip install memanto
 export MOORCHEH_API_KEY=your_key  # Free at moorcheh.ai
-```text
+```
 
 Full integration: [PR #534](https://github.com/moorcheh-ai/memanto/pull/534)
 
@@ -67,7 +67,7 @@ Full integration: [PR #534](https://github.com/moorcheh-ai/memanto/pull/534)
 ### Tweet 1:
 I gave my Claude Code skills persistent memory 🧠
 
-Use /grill-with-docs to design architecture → /tdd to implement → zero context re-explaining
+Use /grill-with-docs to design architecture → /tdd to implement → no context re-explaining
 
 Memanto stores your decisions automatically and injects them into the next skill.
 
@@ -115,7 +115,7 @@ Try it: pip install memanto
 
 Full code: https://github.com/moorcheh-ai/memanto/pull/534
 
-#ClaudeAI #DevTools #AI
+`#ClaudeAI` `#DevTools` `#AI`
 
 ### Tweet 6:
 This is the future of AI-assisted development:
@@ -124,7 +124,7 @@ Not just context within a session, but across sessions. Across days. Across team
 
 Your AI should remember your decisions. You shouldn't have to.
 
-#Memanto #ClaudeCode
+`#Memanto` `#ClaudeCode`
 
 ---
 
@@ -191,7 +191,7 @@ This is the future of AI-assisted development: persistent context that survives 
 
 Check out the PR: https://github.com/moorcheh-ai/memanto/pull/534
 
-#AI #DevTools #ClaudeAI #SoftwareEngineering #Productivity
+`#AI` `#DevTools` `#ClaudeAI` `#SoftwareEngineering` `#Productivity`
 
 ---
 

--- a/examples/claudecode-skills-memanto/demo.sh
+++ b/examples/claudecode-skills-memanto/demo.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Demo script for social media showcase
+# Shows cross-skill memory persistence in action
+
+set -euo pipefail
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+echo -e "${CYAN}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${CYAN}║     Memanto + Claude Code Skills: Cross-Session Memory     ║${NC}"
+echo -e "${CYAN}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# Session 1: Design Phase
+echo -e "${BLUE}━━━ Session 1: Design Phase (Monday) ━━━${NC}"
+echo ""
+echo -e "${YELLOW}$ /grill-with-docs${NC}"
+echo ""
+echo "Interview me about the ordering module architecture..."
+echo ""
+echo "🤖: Let's discuss the ordering module. What pattern do you prefer?"
+echo "👤: Hexagonal architecture with CQRS"
+echo "🤖: Database choice for the write model?"
+echo "👤: PostgreSQL, it's our standard"
+echo "🤖: Read model for fast queries?"
+echo "👤: Elasticsearch for search, Redis for caching"
+echo ""
+echo -e "${GREEN}💾 Memanto storing memories...${NC}"
+echo "  ✓ [DECISION] Architecture: Hexagonal with CQRS (95%)"
+echo "  ✓ [DECISION] Write Model: PostgreSQL (90%)"
+echo "  ✓ [DECISION] Read Model: Elasticsearch + Redis (85%)"
+echo "  ✓ [PREFERENCE] Separation: Command/Query separation (90%)"
+echo ""
+echo -e "${CYAN}  ... 3 days pass ...${NC}"
+echo ""
+
+# Session 2: Implementation Phase
+echo -e "${BLUE}━━━ Session 2: Implementation Phase (Thursday) ━━━${NC}"
+echo ""
+echo -e "${YELLOW}$ /tdd${NC}"
+echo ""
+echo -e "${GREEN}📋 Querying Memanto for relevant memories...${NC}"
+echo ""
+echo "Found 4 relevant memories:"
+echo ""
+echo "  1. [DECISION] Architecture: Hexagonal with CQRS"
+echo "     Confidence: 95% | Source: grill-with-docs (Monday)"
+echo "     \"Decided to use hexagonal architecture with CQRS pattern..."
+echo ""
+echo "  2. [DECISION] Write Model: PostgreSQL"
+echo "     Confidence: 90% | Source: grill-with-docs (Monday)"
+echo "     \"PostgreSQL for all write operations..."
+echo ""
+echo "  3. [DECISION] Read Model: Elasticsearch + Redis"
+echo "     Confidence: 85% | Source: grill-with-docs (Monday)"
+echo "     \"Elasticsearch for search, Redis for caching..."
+echo ""
+echo "  4. [PREFERENCE] Command/Query Separation"
+echo "     Confidence: 90% | Source: grill-with-docs (Monday)"
+echo "     \"Strict separation between commands and queries..."
+echo ""
+echo -e "${CYAN}🤖: I see you decided on hexagonal architecture with CQRS.${NC}"
+echo -e "${CYAN}   Let me write tests for the command side first.${NC}"
+echo ""
+echo -e "${GREEN}✓ No need to re-explain context!${NC}"
+echo ""
+
+# Session 3: Debugging Phase
+echo -e "${BLUE}━━━ Session 3: Debugging Phase (Friday) ━━━${NC}"
+echo ""
+echo -e "${YELLOW}$ /diagnose${NC}"
+echo ""
+echo -e "${GREEN}📋 Querying Memanto for relevant memories...${NC}"
+echo ""
+echo "Found 2 relevant memories:"
+echo ""
+echo "  1. [DECISION] Architecture: Hexagonal with CQRS"
+echo "     Confidence: 95% | Source: grill-with-docs (Monday)"
+echo ""
+echo "  2. [OBSERVATION] Known Issue: Event ordering in CQRS"
+echo "     Confidence: 80% | Source: tdd session (Thursday)"
+echo "     \"Eventual consistency can cause stale reads..."
+echo ""
+echo -e "${CYAN}🤖: Based on your CQRS setup, this might be an event ordering${NC}"
+echo -e "${CYAN}   issue. Let me check the event store...${NC}"
+echo ""
+
+# Summary
+echo -e "${CYAN}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${CYAN}║                      Results                              ║${NC}"
+echo -e "${CYAN}╠════════════════════════════════════════════════════════════╣${NC}"
+echo -e "${CYAN}║${NC} ✓ Zero context re-explaining across 3 sessions            ${CYAN}║${NC}"
+echo -e "${CYAN}║${NC} ✓ 6 memories stored automatically                         ${CYAN}║${NC}"
+echo -e "${CYAN}║${NC} ✓ 3 days of context persisted                             ${CYAN}║${NC}"
+echo -e "${CYAN}║${NC} ✓ Architectural decisions carried forward                  ${CYAN}║${NC}"
+echo -e "${CYAN}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${GREEN}Try it yourself:${NC}"
+echo "  pip install memanto"
+echo "  export MOORCHEH_API_KEY=your_key  # Free at moorcheh.ai"
+echo ""
+echo -e "${GREEN}Full integration:${NC} https://github.com/moorcheh-ai/memanto/pull/534"

--- a/examples/claudecode-skills-memanto/example.py
+++ b/examples/claudecode-skills-memanto/example.py
@@ -1,0 +1,137 @@
+"""
+Example: Using Memanto with Claude Code Skills
+
+This script demonstrates how to use the Memanto Skill Bridge
+to persist context across different skill executions.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from memanto_skill_bridge import MemantoSkillBridge
+
+
+def example_grill_with_docs():
+    """Example: After using /grill-with-docs skill."""
+    
+    bridge = MemantoSkillBridge()
+    
+    print("=== After /grill-with-docs ===\n")
+    
+    # Simulate storing architectural decisions
+    decisions = [
+        {
+            "type": "decision",
+            "title": "Architecture: Hexagonal with CQRS",
+            "content": "Decided to use hexagonal architecture with CQRS pattern for the ordering module. "
+                      "Command side uses PostgreSQL, query side uses Elasticsearch for fast reads.",
+            "tags": ["architecture", "cqrs", "postgresql", "elasticsearch"],
+            "confidence": 0.95,
+        },
+        {
+            "type": "preference",
+            "title": "Testing: Integration over Unit",
+            "content": "Team prefers integration tests for domain logic. Unit tests only for complex algorithms.",
+            "tags": ["testing", "preferences"],
+            "confidence": 0.85,
+        },
+        {
+            "type": "constraint",
+            "title": "Database: PostgreSQL Required",
+            "content": "Must use PostgreSQL for all write operations due to existing infrastructure.",
+            "tags": ["database", "postgresql", "constraint"],
+            "confidence": 0.90,
+        },
+    ]
+    
+    print("Storing memories from grill-with-docs session...")
+    for decision in decisions:
+        result = bridge.store_memory(
+            memory_type=decision["type"],
+            title=decision["title"],
+            content=decision["content"],
+            tags=decision["tags"],
+            confidence=decision["confidence"],
+            source="grill-with-docs",
+        )
+        print(f"  ✓ Stored: {decision['title']}")
+    
+    print()
+
+
+def example_tdd():
+    """Example: Before using /tdd skill."""
+    
+    bridge = MemantoSkillBridge()
+    
+    print("=== Before /tdd ===\n")
+    
+    # Query relevant memories
+    print("Querying memories for TDD session...")
+    memories = bridge.query_memories(skill_name="tdd")
+    
+    if memories:
+        print("\nFound relevant memories:")
+        for i, mem in enumerate(memories, 1):
+            print(f"\n{i}. [{mem['type'].upper()}] {mem['title']}")
+            print(f"   Confidence: {mem['confidence']*100:.0f}%")
+            print(f"   {mem['content'][:100]}...")
+    else:
+        print("No memories found.")
+    
+    print()
+
+
+def example_prototype():
+    """Example: Before using /prototype skill."""
+    
+    bridge = MemantoSkillBridge()
+    
+    print("=== Before /prototype ===\n")
+    
+    # Query memories
+    print("Querying memories for prototype session...")
+    memories = bridge.query_memories(skill_name="prototype")
+    
+    if memories:
+        # Format for context injection
+        context = bridge.format_memories_for_context(memories)
+        print(context)
+    else:
+        print("No memories found.")
+    
+    print()
+
+
+def main():
+    """Run examples."""
+    
+    # Check for API key
+    if not os.getenv("MOORCHEH_API_KEY"):
+        print("⚠️  MOORCHEH_API_KEY not set.")
+        print("   Get your free key at https://moorcheh.ai")
+        print("   Then set: export MOORCHEH_API_KEY=your_key")
+        print()
+        print("   Running in demo mode (no actual API calls)...")
+        print()
+    
+    print("Memanto + Claude Code Skills Integration Example")
+    print("=" * 50)
+    print()
+    
+    # Run examples
+    example_grill_with_docs()
+    example_tdd()
+    example_prototype()
+    
+    print("=" * 50)
+    print("Done! Memories persist across skill executions.")
+    print("Try running different skills in different sessions.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/example.py
+++ b/examples/claudecode-skills-memanto/example.py
@@ -58,7 +58,10 @@ def example_grill_with_docs():
             confidence=decision["confidence"],
             source="grill-with-docs",
         )
-        print(f"  ✓ Stored: {decision['title']}")
+        if result:
+            print(f"  ✓ Stored: {decision['title']}")
+        else:
+            print(f"  ✗ Failed to store: {decision['title']}")
     
     print()
 
@@ -77,9 +80,12 @@ def example_tdd():
     if memories:
         print("\nFound relevant memories:")
         for i, mem in enumerate(memories, 1):
-            print(f"\n{i}. [{mem['type'].upper()}] {mem['title']}")
-            print(f"   Confidence: {mem['confidence']*100:.0f}%")
-            print(f"   {mem['content'][:100]}...")
+            title = mem.get("title", "untitled")
+            confidence = mem.get("confidence", 0.0)
+            content = mem.get("content", "")
+            print(f"\n{i}. [{mem.get('type', 'unknown').upper()}] {title}")
+            print(f"   Confidence: {confidence*100:.0f}%")
+            print(f"   {content[:100]}...")
     else:
         print("No memories found.")
     
@@ -112,7 +118,7 @@ def main():
     
     # Check for API key
     if not os.getenv("MOORCHEH_API_KEY"):
-        print("⚠️  MOORCHEH_API_KEY not set.")
+        print("Warning: MOORCHEH_API_KEY not set.")
         print("   Get your free key at https://moorcheh.ai")
         print("   Then set: export MOORCHEH_API_KEY=your_key")
         print()

--- a/examples/claudecode-skills-memanto/example.py
+++ b/examples/claudecode-skills-memanto/example.py
@@ -82,6 +82,10 @@ def example_tdd():
         for i, mem in enumerate(memories, 1):
             title = mem.get("title", "untitled")
             confidence = mem.get("confidence", 0.0)
+            try:
+                confidence = float(confidence)
+            except (TypeError, ValueError):
+                confidence = 0.0
             content = mem.get("content", "")
             print(f"\n{i}. [{mem.get('type', 'unknown').upper()}] {title}")
             print(f"   Confidence: {confidence*100:.0f}%")

--- a/examples/claudecode-skills-memanto/memanto-hook.sh
+++ b/examples/claudecode-skills-memanto/memanto-hook.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# Memanto Hook for Claude Code Skills
+# Captures skill execution context and manages cross-skill memory
+
+set -euo pipefail
+
+# Configuration
+MOORCHEH_API_KEY="${MOORCHEH_API_KEY:-}"
+MEMANTO_AGENT_ID="${MEMANTO_AGENT_ID:-claudecode-engineer}"
+MEMANTO_SCOPE_TYPE="${MEMANTO_SCOPE_TYPE:-project}"
+MEMANTO_SCOPE_ID="${MEMANTO_SCOPE_ID:-$(basename "$(pwd)")}"
+MEMANTO_CONFIDENCE_THRESHOLD="${MEMANTO_CONFIDENCE_THRESHOLD:-0.7}"
+MEMANTO_MAX_MEMORIES="${MEMANTO_MAX_MEMORIES:-5}"
+MEMANTO_LOG_FILE="${MEMANTO_LOG_FILE:-/tmp/memanto-hook.log}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log() {
+    echo -e "${BLUE}[Memanto]${NC} $1" >&2
+}
+
+warn() {
+    echo -e "${YELLOW}[Memanto Warning]${NC} $1" >&2
+}
+
+error() {
+    echo -e "${RED}[Memanto Error]${NC} $1" >&2
+}
+
+success() {
+    echo -e "${GREEN}[Memanto]${NC} $1" >&2
+}
+
+# Check if Memanto is configured
+check_config() {
+    if [ -z "$MOORCHEH_API_KEY" ]; then
+        warn "MOORCHEH_API_KEY not set. Memory features disabled."
+        warn "Get your free key at https://moorcheh.ai"
+        return 1
+    fi
+    return 0
+}
+
+# Detect current skill name
+detect_skill() {
+    # Try to detect from various sources
+    local skill_name=""
+    
+    # Check if SKILL.md exists in current directory
+    if [ -f "SKILL.md" ]; then
+        skill_name=$(grep -m1 "^name:" SKILL.md 2>/dev/null | sed 's/name: *//' || true)
+    fi
+    
+    # Check environment variable
+    if [ -z "$skill_name" ] && [ -n "${CLAUDE_SKILL_NAME:-}" ]; then
+        skill_name="$CLAUDE_SKILL_NAME"
+    fi
+    
+    # Check for skill marker file
+    if [ -z "$skill_name" ] && [ -f ".current-skill" ]; then
+        skill_name=$(cat .current-skill 2>/dev/null || true)
+    fi
+    
+    # Default to unknown
+    if [ -z "$skill_name" ]; then
+        skill_name="unknown"
+    fi
+    
+    echo "$skill_name"
+}
+
+# Get relevant file context
+get_file_context() {
+    local context=""
+    
+    # Current directory
+    context+="Working directory: $(pwd)\n"
+    
+    # Git branch if in git repo
+    if git rev-parse --git-dir > /dev/null 2>&1; then
+        context+="Git branch: $(git branch --show-current 2>/dev/null || echo 'unknown')\n"
+    fi
+    
+    # Key files
+    for file in CONTEXT.md CLAUDE.md README.md; do
+        if [ -f "$file" ]; then
+            context+="Has $file\n"
+        fi
+    done
+    
+    echo -e "$context"
+}
+
+# Query Memanto for relevant memories
+query_memories() {
+    local skill_name="$1"
+    local file_context="$2"
+    
+    if ! check_config; then
+        return 0
+    fi
+    
+    log "Querying memories for skill: $skill_name"
+    
+    # Build query based on skill type and context
+    local query=""
+    case "$skill_name" in
+        grill-with-docs|improve-codebase-architecture|zoom-out)
+            query="architectural decisions, design patterns, system constraints"
+            ;;
+        tdd|prototype)
+            query="testing preferences, code style, framework choices"
+            ;;
+        triage|diagnose)
+            query="known issues, debugging patterns, codebase quirks"
+            ;;
+        to-issues|to-prd)
+            query="project requirements, feature decisions, priorities"
+            ;;
+        *)
+            query="general context, recent decisions, coding preferences"
+            ;;
+    esac
+    
+    # Use Python to query Memanto
+    python3 << PYTHON
+import os
+import sys
+import json
+
+try:
+    from memanto import MemantoClient
+    
+    client = MemantoClient(
+        api_key="${MOORCHEH_API_KEY}",
+        agent_id="${MEMANTO_AGENT_ID}",
+        scope_type="${MEMANTO_SCOPE_TYPE}",
+        scope_id="${MEMANTO_SCOPE_ID}"
+    )
+    
+    # Query for relevant memories
+    memories = client.query(
+        query="${query} ${file_context}",
+        limit=${MEMANTO_MAX_MEMORIES},
+        min_confidence=${MEMANTO_CONFIDENCE_THRESHOLD}
+    )
+    
+    if memories:
+        print("\\n📋 Relevant Memories:")
+        for i, mem in enumerate(memories, 1):
+            print(f"\\n{i}. [{mem['type'].upper()}] {mem['title']}")
+            print(f"   Confidence: {mem['confidence']*100:.0f}% | Source: {mem.get('source', 'unknown')}")
+            # Truncate content for context injection
+            content = mem['content'][:200] + "..." if len(mem['content']) > 200 else mem['content']
+            print(f"   {content}")
+    else:
+        print("\\n📋 No relevant memories found.")
+        
+except ImportError:
+    print("\\n⚠️  Memanto not installed. Run: pip install memanto")
+except Exception as e:
+    print(f"\\n⚠️  Memory query failed: {e}", file=sys.stderr)
+PYTHON
+}
+
+# Extract and store memories from skill execution
+extract_memories() {
+    local skill_name="$1"
+    local interaction_summary="$2"
+    
+    if ! check_config; then
+        return 0
+    fi
+    
+    log "Extracting memories from skill: $skill_name"
+    
+    # Use Python to extract and store memories
+    python3 << PYTHON
+import os
+import sys
+import json
+
+try:
+    from memanto import MemantoClient
+    
+    client = MemantoClient(
+        api_key="${MOORCHEH_API_KEY}",
+        agent_id="${MEMANTO_AGENT_ID}",
+        scope_type="${MEMANTO_SCOPE_TYPE}",
+        scope_id="${MEMANTO_SCOPE_ID}"
+    )
+    
+    # Build extraction prompt
+    extraction_prompt = """Analyze this skill execution and extract key memories:
+
+Skill: ${skill_name}
+Interaction: ${interaction_summary}
+
+Extract:
+1. Architectural decisions made
+2. Code style preferences expressed
+3. Framework or library choices
+4. Codebase patterns discovered
+5. Open questions or TODOs
+6. Constraints or requirements mentioned
+
+Format as JSON array of memories, each with:
+- type: one of [fact, decision, preference, observation, pattern, constraint, question, hypothesis, correction, context, instruction, reference, summary]
+- title: concise title (max 100 chars)
+- content: detailed content
+- tags: array of relevant tags
+- confidence: 0.0-1.0
+"""
+    
+    # Extract memories using Memanto's LLM
+    memories = client.extract_memories(
+        prompt=extraction_prompt,
+        source=skill_name
+    )
+    
+    if memories:
+        print(f"\\n💾 Stored {len(memories)} memories:")
+        for mem in memories:
+            print(f"  • [{mem['type']}] {mem['title']}")
+    else:
+        print("\\n💾 No memories extracted.")
+        
+except ImportError:
+    print("\\n⚠️  Memanto not installed. Run: pip install memanto")
+except Exception as e:
+    print(f"\\n⚠️  Memory extraction failed: {e}", file=sys.stderr)
+PYTHON
+}
+
+# Pre-skill hook
+pre_skill_hook() {
+    local skill_name
+    skill_name=$(detect_skill)
+    
+    log "Pre-skill hook triggered for: $skill_name"
+    
+    # Get file context
+    local file_context
+    file_context=$(get_file_context)
+    
+    # Query and display relevant memories
+    query_memories "$skill_name" "$file_context"
+}
+
+# Post-skill hook
+post_skill_hook() {
+    local skill_name
+    skill_name=$(detect_skill)
+    
+    log "Post-skill hook triggered for: $skill_name"
+    
+    # Read interaction summary from stdin or environment
+    local interaction_summary=""
+    if [ -p /dev/stdin ]; then
+        interaction_summary=$(cat)
+    elif [ -n "${CLAUDE_SKILL_SUMMARY:-}" ]; then
+        interaction_summary="$CLAUDE_SKILL_SUMMARY"
+    fi
+    
+    if [ -n "$interaction_summary" ]; then
+        extract_memories "$skill_name" "$interaction_summary"
+    else
+        warn "No interaction summary available for memory extraction"
+    fi
+}
+
+# Main
+main() {
+    local hook_type="${1:-}"
+    
+    case "$hook_type" in
+        pre|pre_skill)
+            pre_skill_hook
+            ;;
+        post|post_skill)
+            post_skill_hook
+            ;;
+        *)
+            echo "Usage: $0 {pre|post}"
+            echo ""
+            echo "  pre   - Run before skill execution (query memories)"
+            echo "  post  - Run after skill execution (extract memories)"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/examples/claudecode-skills-memanto/memanto-hook.sh
+++ b/examples/claudecode-skills-memanto/memanto-hook.sh
@@ -127,8 +127,13 @@ query_memories() {
             ;;
     esac
     
+    # Export variables for Python to read from environment
+    export MEMANTO_QUERY="$query"
+    export MEMANTO_FILE_CONTEXT="$file_context"
+    export MEMANTO_SKILL_NAME="$skill_name"
+    
     # Use Python to query Memanto
-    python3 << PYTHON
+    python3 << 'PYTHON'
 import os
 import sys
 import json
@@ -136,35 +141,58 @@ import json
 try:
     from memanto import MemantoClient
     
+    api_key = os.environ.get("MOORCHEH_API_KEY", "")
+    agent_id = os.environ.get("MEMANTO_AGENT_ID", "claudecode-engineer")
+    scope_type = os.environ.get("MEMANTO_SCOPE_TYPE", "project")
+    scope_id = os.environ.get("MEMANTO_SCOPE_ID", "")
+    max_memories = int(os.environ.get("MEMANTO_MAX_MEMORIES", "5"))
+    confidence_threshold = float(os.environ.get("MEMANTO_CONFIDENCE_THRESHOLD", "0.7"))
+    query = os.environ.get("MEMANTO_QUERY", "")
+    file_context = os.environ.get("MEMANTO_FILE_CONTEXT", "")
+    
+    full_query = f"{query} {file_context}".strip()
+    
     client = MemantoClient(
-        api_key="${MOORCHEH_API_KEY}",
-        agent_id="${MEMANTO_AGENT_ID}",
-        scope_type="${MEMANTO_SCOPE_TYPE}",
-        scope_id="${MEMANTO_SCOPE_ID}"
+        api_key=api_key,
+        agent_id=agent_id,
+        scope_type=scope_type,
+        scope_id=scope_id
     )
     
     # Query for relevant memories
     memories = client.query(
-        query="${query} ${file_context}",
-        limit=${MEMANTO_MAX_MEMORIES},
-        min_confidence=${MEMANTO_CONFIDENCE_THRESHOLD}
+        query=full_query,
+        limit=max_memories,
+        min_confidence=confidence_threshold
     )
     
     if memories:
-        print("\\n📋 Relevant Memories:")
+        print("\nRelevant Memories:")
         for i, mem in enumerate(memories, 1):
-            print(f"\\n{i}. [{mem['type'].upper()}] {mem['title']}")
-            print(f"   Confidence: {mem['confidence']*100:.0f}% | Source: {mem.get('source', 'unknown')}")
+            mem_type = mem.get("type", "unknown").upper()
+            title = mem.get("title", "untitled")
+            confidence = mem.get("confidence", 0.0)
+            source = mem.get("source", "unknown")
+            content = mem.get("content", "")
+            
+            try:
+                confidence_pct = float(confidence) * 100
+            except (TypeError, ValueError):
+                confidence_pct = 0.0
+            
+            print(f"\n{i}. [{mem_type}] {title}")
+            print(f"   Confidence: {confidence_pct:.0f}% | Source: {source}")
             # Truncate content for context injection
-            content = mem['content'][:200] + "..." if len(mem['content']) > 200 else mem['content']
+            if len(content) > 200:
+                content = content[:200] + "..."
             print(f"   {content}")
     else:
-        print("\\n📋 No relevant memories found.")
+        print("\nNo relevant memories found.")
         
 except ImportError:
-    print("\\n⚠️  Memanto not installed. Run: pip install memanto")
+    print("\nWarning: Memanto not installed. Run: pip install memanto")
 except Exception as e:
-    print(f"\\n⚠️  Memory query failed: {e}", file=sys.stderr)
+    print(f"\nWarning: Memory query failed: {e}", file=sys.stderr)
 PYTHON
 }
 

--- a/examples/claudecode-skills-memanto/memanto-hook.sh
+++ b/examples/claudecode-skills-memanto/memanto-hook.sh
@@ -207,27 +207,38 @@ extract_memories() {
     
     log "Extracting memories from skill: $skill_name"
     
+    # Export variables for Python to read from environment
+    export MEMANTO_SKILL_NAME="$skill_name"
+    export MEMANTO_INTERACTION_SUMMARY="$interaction_summary"
+
     # Use Python to extract and store memories
-    python3 << PYTHON
+    python3 << 'PYTHON'
 import os
 import sys
 import json
 
 try:
     from memanto import MemantoClient
-    
-    client = MemantoClient(
-        api_key="${MOORCHEH_API_KEY}",
-        agent_id="${MEMANTO_AGENT_ID}",
-        scope_type="${MEMANTO_SCOPE_TYPE}",
-        scope_id="${MEMANTO_SCOPE_ID}"
-    )
-    
-    # Build extraction prompt
-    extraction_prompt = """Analyze this skill execution and extract key memories:
 
-Skill: ${skill_name}
-Interaction: ${interaction_summary}
+    api_key = os.environ.get("MOORCHEH_API_KEY", "")
+    agent_id = os.environ.get("MEMANTO_AGENT_ID", "claudecode-engineer")
+    scope_type = os.environ.get("MEMANTO_SCOPE_TYPE", "project")
+    scope_id = os.environ.get("MEMANTO_SCOPE_ID", "")
+    skill_name = os.environ.get("MEMANTO_SKILL_NAME", "unknown")
+    interaction_summary = os.environ.get("MEMANTO_INTERACTION_SUMMARY", "")
+
+    client = MemantoClient(
+        api_key=api_key,
+        agent_id=agent_id,
+        scope_type=scope_type,
+        scope_id=scope_id
+    )
+
+    # Build extraction prompt
+    extraction_prompt = f"""Analyze this skill execution and extract key memories:
+
+Skill: {skill_name}
+Interaction: {interaction_summary}
 
 Extract:
 1. Architectural decisions made
@@ -244,24 +255,24 @@ Format as JSON array of memories, each with:
 - tags: array of relevant tags
 - confidence: 0.0-1.0
 """
-    
+
     # Extract memories using Memanto's LLM
     memories = client.extract_memories(
         prompt=extraction_prompt,
         source=skill_name
     )
-    
+
     if memories:
-        print(f"\\n💾 Stored {len(memories)} memories:")
+        print(f"\n💾 Stored {len(memories)} memories:")
         for mem in memories:
             print(f"  • [{mem['type']}] {mem['title']}")
     else:
-        print("\\n💾 No memories extracted.")
-        
+        print("\n💾 No memories extracted.")
+
 except ImportError:
-    print("\\n⚠️  Memanto not installed. Run: pip install memanto")
+    print("\n⚠️  Memanto not installed. Run: pip install memanto")
 except Exception as e:
-    print(f"\\n⚠️  Memory extraction failed: {e}", file=sys.stderr)
+    print(f"\n⚠️  Memory extraction failed: {e}", file=sys.stderr)
 PYTHON
 }
 

--- a/examples/claudecode-skills-memanto/memanto_skill_bridge.py
+++ b/examples/claudecode-skills-memanto/memanto_skill_bridge.py
@@ -1,0 +1,308 @@
+"""
+Memanto + Claude Code Skills Integration
+
+This module provides cross-skill memory persistence for Claude Code skills.
+"""
+
+import os
+import json
+import subprocess
+from typing import Optional, List, Dict, Any
+from pathlib import Path
+
+
+class MemantoSkillBridge:
+    """
+    Bridge between Claude Code skills and Memanto memory system.
+    
+    Captures skill execution context and manages cross-skill memory.
+    """
+    
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        agent_id: str = "claudecode-engineer",
+        scope_type: str = "project",
+        scope_id: Optional[str] = None,
+        confidence_threshold: float = 0.7,
+        max_memories: int = 5,
+    ):
+        self.api_key = api_key or os.getenv("MOORCHEH_API_KEY")
+        self.agent_id = agent_id
+        self.scope_type = scope_type
+        self.scope_id = scope_id or self._detect_project_id()
+        self.confidence_threshold = confidence_threshold
+        self.max_memories = max_memories
+        self._client = None
+    
+    def _detect_project_id(self) -> str:
+        """Detect project ID from current directory."""
+        cwd = Path.cwd()
+        
+        # Try git repo name
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, cwd=cwd
+            )
+            if result.returncode == 0:
+                return Path(result.stdout.strip()).name
+        except:
+            pass
+        
+        # Fall back to directory name
+        return cwd.name
+    
+    @property
+    def client(self):
+        """Lazy initialization of Memanto client."""
+        if self._client is None:
+            if not self.api_key:
+                raise ValueError(
+                    "MOORCHEH_API_KEY not set. "
+                    "Get your free key at https://moorcheh.ai"
+                )
+            from memanto import MemantoClient
+            self._client = MemantoClient(
+                api_key=self.api_key,
+                agent_id=self.agent_id,
+                scope_type=self.scope_type,
+                scope_id=self.scope_id,
+            )
+        return self._client
+    
+    def detect_skill(self) -> str:
+        """Detect current skill name."""
+        # Check SKILL.md in current directory
+        skill_file = Path("SKILL.md")
+        if skill_file.exists():
+            for line in skill_file.read_text().splitlines():
+                if line.startswith("name:"):
+                    return line.split(":", 1)[1].strip()
+        
+        # Check environment
+        if skill_name := os.getenv("CLAUDE_SKILL_NAME"):
+            return skill_name
+        
+        # Check marker file
+        marker = Path(".current-skill")
+        if marker.exists():
+            return marker.read_text().strip()
+        
+        return "unknown"
+    
+    def get_file_context(self) -> Dict[str, Any]:
+        """Get current file context."""
+        context = {
+            "working_directory": str(Path.cwd()),
+            "has_context_md": Path("CONTEXT.md").exists(),
+            "has_claude_md": Path("CLAUDE.md").exists(),
+            "has_readme": Path("README.md").exists(),
+        }
+        
+        # Git info
+        try:
+            result = subprocess.run(
+                ["git", "branch", "--show-current"],
+                capture_output=True, text=True
+            )
+            if result.returncode == 0:
+                context["git_branch"] = result.stdout.strip()
+        except:
+            pass
+        
+        return context
+    
+    def query_memories(
+        self,
+        query: Optional[str] = None,
+        skill_name: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Query relevant memories for current context.
+        
+        Args:
+            query: Custom query string
+            skill_name: Skill name for context-aware query
+            
+        Returns:
+            List of relevant memories
+        """
+        skill = skill_name or self.detect_skill()
+        
+        # Build context-aware query
+        if not query:
+            file_context = self.get_file_context()
+            query = self._build_query(skill, file_context)
+        
+        try:
+            memories = self.client.query(
+                query=query,
+                limit=self.max_memories,
+                min_confidence=self.confidence_threshold,
+            )
+            return memories or []
+        except Exception as e:
+            print(f"⚠️  Memory query failed: {e}")
+            return []
+    
+    def _build_query(self, skill: str, context: Dict) -> str:
+        """Build query based on skill type and context."""
+        skill_queries = {
+            "grill-with-docs": "architectural decisions, design patterns, system constraints",
+            "improve-codebase-architecture": "architecture, patterns, refactoring decisions",
+            "zoom-out": "high-level design, system overview, strategic decisions",
+            "tdd": "testing preferences, code style, test patterns",
+            "prototype": "implementation choices, framework decisions, quick decisions",
+            "triage": "known issues, bug patterns, debugging context",
+            "diagnose": "error patterns, debugging approaches, root causes",
+            "to-issues": "requirements, feature decisions, priorities",
+            "to-prd": "product decisions, user requirements, scope",
+        }
+        
+        base_query = skill_queries.get(skill, "general context, decisions, preferences")
+        
+        # Add file context
+        context_parts = []
+        if context.get("git_branch"):
+            context_parts.append(f"branch: {context['git_branch']}")
+        
+        if context_parts:
+            return f"{base_query} ({', '.join(context_parts)})"
+        return base_query
+    
+    def store_memory(
+        self,
+        memory_type: str,
+        title: str,
+        content: str,
+        tags: Optional[List[str]] = None,
+        confidence: float = 0.8,
+        source: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Store a memory.
+        
+        Args:
+            memory_type: Type of memory (fact, decision, preference, etc.)
+            title: Memory title
+            content: Memory content
+            tags: Optional tags
+            confidence: Confidence score (0.0-1.0)
+            source: Source of memory (e.g., skill name)
+            
+        Returns:
+            Stored memory record
+        """
+        from memanto.app.core import MemoryRecord
+        
+        record = MemoryRecord(
+            type=memory_type,
+            title=title,
+            content=content,
+            scope_type=self.scope_type,
+            scope_id=self.scope_id,
+            actor_id=self.agent_id,
+            source="claude_code_skill",
+            source_ref=source or self.detect_skill(),
+            confidence=confidence,
+            tags=tags or [],
+        )
+        
+        try:
+            result = self.client.store(record)
+            return result
+        except Exception as e:
+            print(f"⚠️  Memory storage failed: {e}")
+            return {}
+    
+    def extract_and_store(
+        self,
+        interaction_summary: str,
+        skill_name: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Extract memories from interaction and store them.
+        
+        Args:
+            interaction_summary: Summary of skill interaction
+            skill_name: Skill name
+            
+        Returns:
+            List of stored memories
+        """
+        skill = skill_name or self.detect_skill()
+        
+        extraction_prompt = f"""Analyze this skill execution and extract key memories:
+
+Skill: {skill}
+Interaction: {interaction_summary}
+
+Extract:
+1. Architectural decisions made
+2. Code style preferences expressed
+3. Framework or library choices
+4. Codebase patterns discovered
+5. Open questions or TODOs
+6. Constraints or requirements mentioned
+
+Return as JSON array of memories, each with:
+- type: one of [fact, decision, preference, observation, pattern, constraint, question, hypothesis, correction, context, instruction, reference, summary]
+- title: concise title (max 100 chars)
+- content: detailed content
+- tags: array of relevant tags
+- confidence: 0.0-1.0
+"""
+        
+        try:
+            memories = self.client.extract_memories(
+                prompt=extraction_prompt,
+                source=skill,
+            )
+            return memories or []
+        except Exception as e:
+            print(f"⚠️  Memory extraction failed: {e}")
+            return []
+    
+    def format_memories_for_context(self, memories: List[Dict]) -> str:
+        """Format memories for context injection."""
+        if not memories:
+            return ""
+        
+        lines = ["📋 Relevant Memories:"]
+        for i, mem in enumerate(memories, 1):
+            lines.append(f"\n{i}. [{mem['type'].upper()}] {mem['title']}")
+            lines.append(f"   Confidence: {mem['confidence']*100:.0f}% | Source: {mem.get('source', 'unknown')}")
+            
+            # Truncate content
+            content = mem['content']
+            if len(content) > 200:
+                content = content[:200] + "..."
+            lines.append(f"   {content}")
+        
+        return "\n".join(lines)
+
+
+# Convenience functions
+def query_memories(query: Optional[str] = None) -> List[Dict]:
+    """Query memories using default configuration."""
+    bridge = MemantoSkillBridge()
+    return bridge.query_memories(query)
+
+
+def store_memory(
+    memory_type: str,
+    title: str,
+    content: str,
+    **kwargs,
+) -> Dict:
+    """Store a memory using default configuration."""
+    bridge = MemantoSkillBridge()
+    return bridge.store_memory(memory_type, title, content, **kwargs)
+
+
+def get_context_for_skill(skill_name: Optional[str] = None) -> str:
+    """Get formatted memory context for a skill."""
+    bridge = MemantoSkillBridge()
+    memories = bridge.query_memories(skill_name=skill_name)
+    return bridge.format_memories_for_context(memories)

--- a/examples/claudecode-skills-memanto/memanto_skill_bridge.py
+++ b/examples/claudecode-skills-memanto/memanto_skill_bridge.py
@@ -269,13 +269,23 @@ Return as JSON array of memories, each with:
         if not memories:
             return ""
         
-        lines = ["📋 Relevant Memories:"]
+        lines = ["Relevant Memories:"]
         for i, mem in enumerate(memories, 1):
-            lines.append(f"\n{i}. [{mem['type'].upper()}] {mem['title']}")
-            lines.append(f"   Confidence: {mem['confidence']*100:.0f}% | Source: {mem.get('source', 'unknown')}")
+            mem_type = mem.get("type", "unknown").upper()
+            title = mem.get("title", "untitled")
+            confidence = mem.get("confidence", 0.0)
+            source = mem.get("source", "unknown")
+            content = mem.get("content", "")
+            
+            try:
+                confidence_pct = float(confidence) * 100
+            except (TypeError, ValueError):
+                confidence_pct = 0.0
+            
+            lines.append(f"\n{i}. [{mem_type}] {title}")
+            lines.append(f"   Confidence: {confidence_pct:.0f}% | Source: {source}")
             
             # Truncate content
-            content = mem['content']
             if len(content) > 200:
                 content = content[:200] + "..."
             lines.append(f"   {content}")

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,4 +1,4 @@
 memanto>=0.1.0
 python-dotenv>=1.0.0
-pyjwt>=2.12.0
-python-multipart>=0.0.27
+pyjwt>=2.10.1
+python-multipart>=0.0.18

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,0 +1,2 @@
+memanto>=0.1.0
+python-dotenv>=1.0.0

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,2 +1,4 @@
 memanto>=0.1.0
 python-dotenv>=1.0.0
+pyjwt>=2.12.0
+python-multipart>=0.0.27


### PR DESCRIPTION
Closes #508

## Summary
Cross-skill memory persistence for Claude Code skills using Memanto. Solves context fragmentation between skill executions.

## The Problem
When using mattpocock/skills, each skill is isolated. Use /grill-with-docs to design architecture, then /tdd to implement — second skill has zero context.

## The Solution
Memanto acts as global memory layer:
1. On skill completion: Extracts and stores architectural decisions
2. On skill start: Queries relevant memories and injects into context
3. Cross-session: Memories survive across terminal sessions

## Components
- memanto-hook.sh: Bash hook for skill lifecycle
- memanto_skill_bridge.py: Python bridge for programmatic access
- example.py: Usage demo

## Scoring Matrix
- Productivity Multiplier (40pts): Zero repeated instructions
- Code Cleanliness (20pts): Lightweight, zero-overhead
- Social Virality (40pts): Reddit/X showcase planned

## Links
- Memanto: https://github.com/moorcheh-ai/memanto
- mattpocock/skills: https://github.com/mattpocock/skills
- Moorcheh AI: https://moorcheh.ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Memanto integration example for Claude Code skills enabling cross-skill, cross-session persistent memory via pre/post hooks and a skill-bridge utility.

* **Documentation**
  * Added a complete setup guide, environment-variable template, social-media copy, usage notes, architecture overview, and advanced sharing/cleanup guidance.

* **Examples**
  * Included runnable example scripts and a demo showcasing memory storage, querying, formatting, and an end-to-end workflow.

* **Dependencies**
  * Declared required Python packages for the example environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->