### PR TITLE
Add Claude Code skills Memanto hook example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,88 @@
+# Claude Code Skills + Memanto
+
+This example shows Memanto acting as a global engineering memory layer for
+Claude Code or `mattpocock/skills`-style command workflows.
+
+The important distinction is that this uses Claude Code hook events directly:
+
+- `Stop` distills durable engineering memory from a completed skill session.
+- `UserPromptSubmit` and `UserPromptExpansion` recall relevant decisions and
+  inject them through `hookSpecificOutput.additionalContext`.
+- A credential-free JSONL backend is the default so maintainers can review the
+  behavior without private API keys.
+- Optional live Memanto sync is available with `MEMANTO_SYNC=1` and
+  `MOORCHEH_API_KEY`.
+
+## Quick Validation
+
+```bash
+cd examples/claudecode-skills-memanto
+python3 validate.py
+python3 -m unittest test_claude_skill_memory.py
+python3 -m py_compile claude_skill_memory.py validate.py test_claude_skill_memory.py
+```
+
+Expected:
+
+```text
+credential-free Claude Code hook validation passed
+..
+OK
+```
+
+## Hook Configuration
+
+Copy `settings.example.json` into your Claude Code settings and adjust the path
+to this repository if needed. The hook command reads the JSON hook payload from
+stdin and writes a Claude-compatible JSON response to stdout.
+
+## Live Memanto Mode
+
+Local JSONL mode is always used for deterministic review. To also mirror
+distilled memories into Memanto:
+
+```bash
+export MEMANTO_SYNC=1
+export MOORCHEH_API_KEY="..."
+export MEMANTO_AGENT_ID="claude-code-skills"
+```
+
+The hook creates or reuses the configured agent, activates a session, then
+stores typed `decision`, `preference`, `instruction`, and `context` memories via
+`SdkClient.remember`.
+
+## Demo Transcript
+
+Session A, `/grill-with-docs` finishes:
+
+```text
+Decision: use Redis streams for billing retries.
+Prefer pytest fixtures over mutable module globals.
+Never commit generated SDK clients.
+```
+
+`Stop` stores three durable memories.
+
+Session B, a fresh `/tdd` run starts:
+
+```text
+Use /tdd to add billing retry tests.
+```
+
+`UserPromptSubmit` injects:
+
+```text
+Memanto engineering memory for this skill run:
+- [decision] Decision: use Redis streams for billing retries.
+- [preference] Prefer pytest fixtures over mutable module globals.
+- [instruction] Never commit generated SDK clients.
+```
+
+That is the bounty's productivity goal in miniature: the later skill receives
+the earlier architectural choices without manual context shoving.
+
+## Safety
+
+The distiller redacts common API-key, token, secret, and password forms before
+anything is stored. Local mode stores only in the configured JSONL file. Live
+Memanto mode is opt-in.

--- a/examples/claudecode-skills-memanto/claude_skill_memory.py
+++ b/examples/claudecode-skills-memanto/claude_skill_memory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import re
 import sys
@@ -25,6 +26,8 @@ MEMORY_PATTERNS = [
     ("instruction", re.compile(r"(?im)^\s*(?:always|never|avoid|must)\s+(.+)$")),
     ("context", re.compile(r"(?im)^\s*(?:in this repo|convention:|note:)\s+(.+)$")),
 ]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -54,7 +57,7 @@ def distill_memories(
 
     for kind, pattern in MEMORY_PATTERNS:
         for match in pattern.finditer(redacted):
-            text = match.group(0).strip()
+            text = match.group(1).strip()
             if not text.endswith("."):
                 text += "."
             key = (kind, text.lower())
@@ -82,8 +85,15 @@ def load_records(store_path: str | Path) -> list[MemoryRecord]:
     for line in path.read_text().splitlines():
         if not line.strip():
             continue
-        data = json.loads(line)
-        records.append(MemoryRecord(**data))
+        try:
+            data = json.loads(line)
+            records.append(MemoryRecord(**data))
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Skipping malformed memory record in %s: %s",
+                path,
+                exc,
+            )
     return records
 
 
@@ -126,8 +136,16 @@ def sync_records_to_memanto(records: list[MemoryRecord]) -> int:
             pattern="hook",
             description="Claude Code developer skills engineering memory",
         )
-    except Exception:
-        pass
+    except Exception as exc:
+        message = str(exc).lower()
+        if "already" not in message and "exist" not in message and "409" not in message:
+            logger.warning(
+                "Memanto agent creation failed for %s with %s: %s",
+                agent_id,
+                type(exc).__name__,
+                exc,
+            )
+            raise
     client.activate_agent(agent_id, duration_hours=8)
 
     synced = 0
@@ -166,14 +184,12 @@ def recall_context(
     cwd = str(event.get("cwd") or "")
     tool_input = event.get("tool_input") or {}
     path_hint = str(tool_input.get("file_path") or tool_input.get("path") or "")
-    ranked = sorted(
-        load_records(store_path),
-        key=lambda record: score_record(record, prompt, cwd, path_hint),
-        reverse=True,
-    )
-    selected = [
-        record for record in ranked if score_record(record, prompt, cwd, path_hint) > 0
-    ][:limit]
+    scored = [
+        (score_record(record, prompt, cwd, path_hint), record)
+        for record in load_records(store_path)
+    ]
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    selected = [record for score, record in scored if score > 0][:limit]
 
     if not selected:
         return ""

--- a/examples/claudecode-skills-memanto/claude_skill_memory.py
+++ b/examples/claudecode-skills-memanto/claude_skill_memory.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class MemoryRecord:
+    """One distilled engineering memory captured from a Claude Code hook run."""
+
     kind: str
     text: str
     cwd: str
@@ -41,6 +43,8 @@ class MemoryRecord:
 
 
 def redact_secrets(text: str) -> str:
+    """Replace common API keys and tokens before storing transcript-derived text."""
+
     redacted = text
     for pattern in SECRET_PATTERNS:
         redacted = pattern.sub("[REDACTED]", redacted)
@@ -50,6 +54,8 @@ def redact_secrets(text: str) -> str:
 def distill_memories(
     transcript: str, cwd: str, skill: str = "unknown"
 ) -> list[MemoryRecord]:
+    """Extract durable decisions, preferences, instructions, and context notes."""
+
     redacted = redact_secrets(transcript)
     memories: list[MemoryRecord] = []
     seen: set[tuple[str, str]] = set()
@@ -77,6 +83,8 @@ def distill_memories(
 
 
 def load_records(store_path: str | Path) -> list[MemoryRecord]:
+    """Read valid JSONL memory records while skipping malformed local entries."""
+
     path = Path(store_path)
     if not path.exists():
         return []
@@ -98,6 +106,8 @@ def load_records(store_path: str | Path) -> list[MemoryRecord]:
 
 
 def append_records(store_path: str | Path, records: list[MemoryRecord]) -> None:
+    """Append new memory records to the JSONL store without duplicating entries."""
+
     path = Path(store_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     existing = {
@@ -165,6 +175,8 @@ def sync_records_to_memanto(records: list[MemoryRecord]) -> int:
 
 
 def score_record(record: MemoryRecord, prompt: str, cwd: str, path_hint: str) -> int:
+    """Score whether a stored memory is relevant to the current prompt event."""
+
     haystack = f"{prompt} {path_hint}".lower()
     score = 0
     if record.cwd == cwd:
@@ -180,6 +192,8 @@ def score_record(record: MemoryRecord, prompt: str, cwd: str, path_hint: str) ->
 def recall_context(
     event: dict[str, Any], store_path: str | Path, limit: int = 6
 ) -> str:
+    """Render the most relevant stored memories as Claude Code hook context."""
+
     prompt = str(event.get("prompt") or event.get("user_prompt") or "")
     cwd = str(event.get("cwd") or "")
     tool_input = event.get("tool_input") or {}
@@ -202,6 +216,8 @@ def recall_context(
 
 
 def handle_hook_event(event: dict[str, Any], store_path: str | Path) -> dict[str, Any]:
+    """Route Claude Code hook events to memory storage or context injection."""
+
     name = event.get("hook_event_name") or event.get("event")
     cwd = str(event.get("cwd") or "")
     skill = str(event.get("skill") or event.get("command") or "unknown")
@@ -231,6 +247,8 @@ def handle_hook_event(event: dict[str, Any], store_path: str | Path) -> dict[str
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the hook handler from stdin or an event JSON file."""
+
     parser = argparse.ArgumentParser(description="Claude Code skills Memanto hook demo")
     parser.add_argument("--store", default=".claude-memanto-memory.jsonl")
     parser.add_argument(

--- a/examples/claudecode-skills-memanto/claude_skill_memory.py
+++ b/examples/claudecode-skills-memanto/claude_skill_memory.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SECRET_PATTERNS = [
+    re.compile(r"(?i)(api[_-]?key|token|secret|password)\s*=\s*['\"]?[^'\"\s]+"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"),
+]
+
+MEMORY_PATTERNS = [
+    (
+        "decision",
+        re.compile(r"(?im)^\s*(?:decision:|we decided to|decided to|use)\s+(.+)$"),
+    ),
+    ("preference", re.compile(r"(?im)^\s*(?:prefer|preference:)\s+(.+)$")),
+    ("instruction", re.compile(r"(?im)^\s*(?:always|never|avoid|must)\s+(.+)$")),
+    ("context", re.compile(r"(?im)^\s*(?:in this repo|convention:|note:)\s+(.+)$")),
+]
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    kind: str
+    text: str
+    cwd: str
+    skill: str
+    created_at: str
+    source: str = "claude-code-hook"
+
+
+def redact_secrets(text: str) -> str:
+    redacted = text
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted
+
+
+def distill_memories(
+    transcript: str, cwd: str, skill: str = "unknown"
+) -> list[MemoryRecord]:
+    redacted = redact_secrets(transcript)
+    memories: list[MemoryRecord] = []
+    seen: set[tuple[str, str]] = set()
+    now = datetime.now(UTC).isoformat()
+
+    for kind, pattern in MEMORY_PATTERNS:
+        for match in pattern.finditer(redacted):
+            text = match.group(0).strip()
+            if not text.endswith("."):
+                text += "."
+            key = (kind, text.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            memories.append(
+                MemoryRecord(
+                    kind=kind,
+                    text=text,
+                    cwd=cwd,
+                    skill=skill,
+                    created_at=now,
+                )
+            )
+    return memories
+
+
+def load_records(store_path: str | Path) -> list[MemoryRecord]:
+    path = Path(store_path)
+    if not path.exists():
+        return []
+
+    records = []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        data = json.loads(line)
+        records.append(MemoryRecord(**data))
+    return records
+
+
+def append_records(store_path: str | Path, records: list[MemoryRecord]) -> None:
+    path = Path(store_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = {
+        (record.kind, record.text.lower(), record.cwd) for record in load_records(path)
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        for record in records:
+            key = (record.kind, record.text.lower(), record.cwd)
+            if key in existing:
+                continue
+            handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+            existing.add(key)
+
+
+def sync_records_to_memanto(records: list[MemoryRecord]) -> int:
+    """Optionally mirror local hook memories into real Memanto.
+
+    The example is reviewer-safe by default: it always works with local JSONL
+    storage and only touches the network when MEMANTO_SYNC=1 and a Moorcheh key
+    are present.
+    """
+    if os.environ.get("MEMANTO_SYNC") != "1":
+        return 0
+
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        return 0
+
+    from memanto.cli.client.sdk_client import SdkClient
+
+    agent_id = os.environ.get("MEMANTO_AGENT_ID", "claude-code-skills")
+    client = SdkClient(api_key=api_key)
+    try:
+        client.create_agent(
+            agent_id=agent_id,
+            pattern="hook",
+            description="Claude Code developer skills engineering memory",
+        )
+    except Exception:
+        pass
+    client.activate_agent(agent_id, duration_hours=8)
+
+    synced = 0
+    for record in records:
+        client.remember(
+            agent_id=agent_id,
+            memory_type=record.kind,
+            title=record.text[:100],
+            content=record.text,
+            confidence=0.9,
+            tags=["claude-code", "skills", record.skill],
+            source=record.source,
+            provenance=f"cwd:{record.cwd}",
+        )
+        synced += 1
+    return synced
+
+
+def score_record(record: MemoryRecord, prompt: str, cwd: str, path_hint: str) -> int:
+    haystack = f"{prompt} {path_hint}".lower()
+    score = 0
+    if record.cwd == cwd:
+        score += 3
+    if record.kind in {"decision", "instruction", "preference"}:
+        score += 2
+    for token in re.findall(r"[a-zA-Z0-9_/-]{4,}", record.text.lower()):
+        if token in haystack:
+            score += 1
+    return score
+
+
+def recall_context(
+    event: dict[str, Any], store_path: str | Path, limit: int = 6
+) -> str:
+    prompt = str(event.get("prompt") or event.get("user_prompt") or "")
+    cwd = str(event.get("cwd") or "")
+    tool_input = event.get("tool_input") or {}
+    path_hint = str(tool_input.get("file_path") or tool_input.get("path") or "")
+    ranked = sorted(
+        load_records(store_path),
+        key=lambda record: score_record(record, prompt, cwd, path_hint),
+        reverse=True,
+    )
+    selected = [
+        record for record in ranked if score_record(record, prompt, cwd, path_hint) > 0
+    ][:limit]
+
+    if not selected:
+        return ""
+
+    lines = [
+        "Memanto engineering memory for this skill run:",
+        *[f"- [{record.kind}] {record.text}" for record in selected],
+    ]
+    return "\n".join(lines)
+
+
+def handle_hook_event(event: dict[str, Any], store_path: str | Path) -> dict[str, Any]:
+    name = event.get("hook_event_name") or event.get("event")
+    cwd = str(event.get("cwd") or "")
+    skill = str(event.get("skill") or event.get("command") or "unknown")
+
+    if name == "Stop":
+        transcript = str(event.get("transcript") or event.get("conversation") or "")
+        memories = distill_memories(transcript, cwd=cwd, skill=skill)
+        append_records(store_path, memories)
+        synced = sync_records_to_memanto(memories)
+        return {
+            "stored": len(memories),
+            "syncedToMemanto": synced,
+            "suppressOutput": False,
+        }
+
+    if name in {"UserPromptSubmit", "UserPromptExpansion", "SessionStart"}:
+        context = recall_context(event, store_path)
+        return {
+            "suppressOutput": False,
+            "hookSpecificOutput": {
+                "hookEventName": name,
+                "additionalContext": context,
+            },
+        }
+
+    return {"suppressOutput": False}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Claude Code skills Memanto hook demo")
+    parser.add_argument("--store", default=".claude-memanto-memory.jsonl")
+    parser.add_argument(
+        "--event-file",
+        help="Read a Claude Code hook event JSON file. Defaults to stdin.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.event_file:
+        event = json.loads(Path(args.event_file).read_text())
+    else:
+        event = json.loads(sys.stdin.read())
+    print(json.dumps(handle_hook_event(event, args.store), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/settings.example.json
+++ b/examples/claudecode-skills-memanto/settings.example.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python examples/claudecode-skills-memanto/claude_skill_memory.py --store .claude-memanto-memory.jsonl"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python examples/claudecode-skills-memanto/claude_skill_memory.py --store .claude-memanto-memory.jsonl"
+          }
+        ]
+      }
+    ],
+    "UserPromptExpansion": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python examples/claudecode-skills-memanto/claude_skill_memory.py --store .claude-memanto-memory.jsonl"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/claudecode-skills-memanto/test_claude_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_claude_skill_memory.py
@@ -1,0 +1,64 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from claude_skill_memory import handle_hook_event
+
+
+class ClaudeSkillMemoryHookTests(unittest.TestCase):
+    def test_stop_event_distills_and_redacts_durable_engineering_memory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = Path(tmpdir) / "memory.jsonl"
+            event = {
+                "hook_event_name": "Stop",
+                "cwd": "/repo",
+                "transcript": (
+                    "We decided to use server-side validation for checkout forms.\n"
+                    "Always keep generated API clients out of source control.\n"
+                    "OPENAI_API_KEY=sk-secret-should-not-leak\n"
+                ),
+            }
+
+            result = handle_hook_event(event, store)
+
+            self.assertEqual(result["stored"], 2)
+            records = [json.loads(line) for line in store.read_text().splitlines()]
+            self.assertEqual(
+                [record["kind"] for record in records], ["decision", "instruction"]
+            )
+            serialized = json.dumps(records)
+            self.assertIn("server-side validation", serialized)
+            self.assertIn("generated API clients", serialized)
+            self.assertNotIn("sk-secret-should-not-leak", serialized)
+
+    def test_user_prompt_submit_returns_claude_additional_context_from_memories(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = Path(tmpdir) / "memory.jsonl"
+            stop_event = {
+                "hook_event_name": "Stop",
+                "cwd": "/repo",
+                "transcript": (
+                    "Decision: use Redis for retry queues in billing workers.\n"
+                    "Prefer pytest fixtures over shared mutable globals.\n"
+                ),
+            }
+            handle_hook_event(stop_event, store)
+
+            prompt_event = {
+                "hook_event_name": "UserPromptSubmit",
+                "cwd": "/repo",
+                "prompt": "Use /tdd to add retry queue tests for billing",
+                "tool_input": {"file_path": "tests/test_billing_retries.py"},
+            }
+            result = handle_hook_event(prompt_event, store)
+
+            self.assertFalse(result["suppressOutput"])
+            additional_context = result["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("Memanto engineering memory", additional_context)
+            self.assertIn("Redis", additional_context)
+            self.assertIn("pytest fixtures", additional_context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from claude_skill_memory import handle_hook_event
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = Path(tmpdir) / "memory.jsonl"
+        stored = handle_hook_event(
+            {
+                "hook_event_name": "Stop",
+                "cwd": "/workspace/shop",
+                "skill": "grill-with-docs",
+                "transcript": (
+                    "Decision: use Redis streams for billing retries.\n"
+                    "Prefer pytest fixtures over mutable module globals.\n"
+                    "Never commit generated SDK clients.\n"
+                ),
+            },
+            store,
+        )
+        recalled = handle_hook_event(
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "cwd": "/workspace/shop",
+                "prompt": "Use /tdd to add billing retry tests",
+                "tool_input": {"file_path": "tests/test_billing_retries.py"},
+            },
+            store,
+        )
+        context = recalled["hookSpecificOutput"]["additionalContext"]
+        assert stored["stored"] == 3
+        assert "Redis streams" in context
+        assert "pytest fixtures" in context
+        assert "generated SDK clients" in context
+    print("credential-free Claude Code hook validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -6,6 +6,11 @@ from pathlib import Path
 from claude_skill_memory import handle_hook_event
 
 
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as tmpdir:
         store = Path(tmpdir) / "memory.jsonl"
@@ -32,10 +37,16 @@ def main() -> int:
             store,
         )
         context = recalled["hookSpecificOutput"]["additionalContext"]
-        assert stored["stored"] == 3
-        assert "Redis streams" in context
-        assert "pytest fixtures" in context
-        assert "generated SDK clients" in context
+        require(
+            stored.get("stored") == 3,
+            f"expected 3 stored memories, got {stored.get('stored')}",
+        )
+        for expected in (
+            "Redis streams",
+            "pytest fixtures",
+            "generated SDK clients",
+        ):
+            require(expected in context, f"missing recalled context: {expected}")
     print("credential-free Claude Code hook validation passed")
     return 0
 

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -7,11 +7,15 @@ from claude_skill_memory import handle_hook_event
 
 
 def require(condition: bool, message: str) -> None:
+    """Raise a clear validation error when an expected condition is false."""
+
     if not condition:
         raise RuntimeError(message)
 
 
 def main() -> int:
+    """Exercise the credential-free hook flow end to end."""
+
     with tempfile.TemporaryDirectory() as tmpdir:
         store = Path(tmpdir) / "memory.jsonl"
         stored = handle_hook_event(


### PR DESCRIPTION
/claim #508

## Summary

Adds `examples/claudecode-skills-memanto`, a focused Claude Code hook example for using Memanto as a global active memory companion across `mattpocock/skills`-style developer workflows.

This implementation is intentionally hook-first rather than wrapper-first:

- `Stop` distills completed skill transcripts into durable engineering memories.
- `UserPromptSubmit` and `UserPromptExpansion` return Claude-compatible `hookSpecificOutput.additionalContext`, so later skill runs receive relevant remembered decisions without manual context shoving.
- Local JSONL mode is the default, giving maintainers a credential-free review path.
- Optional live Memanto mirroring is available with `MEMANTO_SYNC=1`, `MOORCHEH_API_KEY`, and `MEMANTO_AGENT_ID`.
- The distiller redacts common API key, token, secret, and password forms before storage.

## Bounty Mapping

BountyHub issue: moorcheh-ai/memanto#508
BountyHub page: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe

This PR targets the bounty requirements:

- Global memory hook: `claude_skill_memory.py` handles Claude Code hook payloads directly.
- Active extraction: `Stop` distills durable `decision`, `preference`, `instruction`, and `context` memories.
- Dynamic injection: prompt-start hooks inject remembered engineering context through `additionalContext`.
- Productivity proof: the validator stores `/grill-with-docs` decisions and recalls them for a later `/tdd` task.

## Verification

```text
python3 -m unittest test_claude_skill_memory.py
# Ran 2 tests in 0.006s
# OK

python3 validate.py
# credential-free Claude Code hook validation passed

python3 -m py_compile claude_skill_memory.py validate.py test_claude_skill_memory.py
# passed

uvx ruff check examples/claudecode-skills-memanto
# All checks passed!

uvx ruff format --check examples/claudecode-skills-memanto
# 3 files already formatted

git diff --check
# passed
```

No API keys, private payout details, or hidden prompts are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code skills example demonstrating persistent local memory with optional live Memanto sync and a CLI to process hook events; example includes hook configurations for Stop, UserPromptSubmit, and UserPromptExpansion.

* **Documentation**
  * Added a README detailing hook usage, credential-free defaults, enabling live sync, validation commands, expected output, demo transcript, and safety/redaction behavior.

* **Tests**
  * Added unit tests and an end-to-end validation script verifying memory distillation, recall behavior, and secret redaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->