### PR TITLE
Add Claude Code skills Memanto bridge

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,67 @@
+# Claude Code Skills + Memanto
+
+This example shows how Memanto can act as a global memory companion for
+developer skills such as `/grill-with-docs`, `/tdd`, and `/handoff`.
+
+It adds two lifecycle hooks:
+
+- `before`: recalls relevant engineering memories and prints a concise context
+  block for the next skill invocation.
+- `after`: distills explicit `decision:`, `preference:`, `instruction:`,
+  `constraint:`, `context:`, and `artifact:` lines from the completed skill
+  transcript and stores them for future runs.
+
+The default backend is a local JSONL store so reviewers can validate the flow
+without private credentials or network access. Set `MEMANTO_SKILL_BACKEND=cli`
+and `MOORCHEH_API_KEY` to route memory through the installed `memanto` CLI.
+
+## Quick Validation
+
+```bash
+cd examples/claudecode-skills-memanto
+python validate.py
+python -m unittest test_skill_memory.py
+```
+
+## Manual Demo
+
+```bash
+cat > /tmp/skill-transcript.txt <<'EOF'
+decision: use a repository-local service layer for billing changes
+preference: keep React toolbars dense and keyboard-friendly
+instruction: run focused unit tests before broad integration tests
+EOF
+
+python skill_memory.py after \
+  --skill /grill-with-docs \
+  --transcript-file /tmp/skill-transcript.txt \
+  --cwd "$PWD"
+
+python skill_memory.py before \
+  --skill /tdd \
+  --prompt "write billing service tests for the React toolbar" \
+  --cwd "$PWD"
+```
+
+## Wrapper Generation
+
+Generate executable wrappers that run the memory hooks around the skill command:
+
+```bash
+python mattpocock_adapter.py --output-dir ./.memanto-skill-bin
+PATH="$PWD/.memanto-skill-bin:$PATH"
+```
+
+The generated wrappers preserve the original command arguments, tee the skill
+output to a temporary transcript, and then store durable engineering memories.
+
+## Live Memanto Mode
+
+```bash
+export MOORCHEH_API_KEY=...
+export MEMANTO_SKILL_BACKEND=cli
+python skill_memory.py before --skill /handoff --prompt "summarize auth refactor"
+```
+
+Live mode uses `memanto remember` and `memanto recall`. The local backend remains
+the default so PR reviewers can verify behavior without an API key.

--- a/examples/claudecode-skills-memanto/demo_transcript.md
+++ b/examples/claudecode-skills-memanto/demo_transcript.md
@@ -1,0 +1,22 @@
+# Demo Transcript
+
+Session A uses `/grill-with-docs` to settle architecture:
+
+```text
+decision: use a repository-local service layer for billing changes
+preference: keep React toolbars dense and keyboard-friendly
+instruction: run focused unit tests before broad integration tests
+```
+
+Session B starts `/tdd` with a different prompt:
+
+```text
+Relevant Memanto engineering memory for this skill run:
+- [decision] use a repository-local service layer for billing changes
+- [preference] keep React toolbars dense and keyboard-friendly
+- [instruction] run focused unit tests before broad integration tests
+Apply these constraints unless the user explicitly overrides them.
+```
+
+This removes the repeated instruction step between skills while keeping the
+memory records explicit, typed, and reviewable.

--- a/examples/claudecode-skills-memanto/mattpocock_adapter.py
+++ b/examples/claudecode-skills-memanto/mattpocock_adapter.py
@@ -1,0 +1,69 @@
+"""Generate wrappers that add Memanto memory to mattpocock-style skills."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+from pathlib import Path
+
+from skill_memory import SKILL_NAMES
+
+WRAPPER_TEMPLATE = """#!/usr/bin/env bash
+set -euo pipefail
+
+skill_name="{skill_name}"
+bridge_dir="{bridge_dir}"
+transcript="$(mktemp)"
+
+python "$bridge_dir/skill_memory.py" before \\
+  --skill "$skill_name" \\
+  --prompt "$*" \\
+  --cwd "$PWD"
+
+"{target_command}" "$@" 2>&1 | tee "$transcript"
+
+python "$bridge_dir/skill_memory.py" after \\
+  --skill "$skill_name" \\
+  --transcript-file "$transcript" \\
+  --cwd "$PWD"
+"""
+
+
+def render_wrapper(skill_name: str, target_command: str, bridge_dir: Path) -> str:
+    """Return a shell wrapper for one skill command."""
+
+    return WRAPPER_TEMPLATE.format(
+        skill_name=skill_name,
+        target_command=shlex.quote(target_command),
+        bridge_dir=shlex.quote(str(bridge_dir.resolve())),
+    )
+
+
+def install_wrappers(output_dir: Path, *, bridge_dir: Path) -> list[Path]:
+    """Create executable wrappers for the supported developer skills."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    created: list[Path] = []
+    for skill_name in SKILL_NAMES:
+        wrapper = output_dir / skill_name.removeprefix("/")
+        wrapper.write_text(
+            render_wrapper(skill_name, skill_name, bridge_dir),
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+        created.append(wrapper)
+    return created
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--bridge-dir", type=Path, default=Path(__file__).parent)
+    args = parser.parse_args()
+    for path in install_wrappers(args.output_dir, bridge_dir=args.bridge_dir):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,251 @@
+"""Cross-skill memory hooks for Claude Code-style developer skills.
+
+The module is intentionally dependency-free so maintainers can run and review
+the example without a Moorcheh API key. Set ``MEMANTO_SKILL_BACKEND=cli`` and
+``MOORCHEH_API_KEY`` to route writes and recalls through the installed
+``memanto`` command instead of the local JSONL preview backend.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+DEFAULT_STORE = Path(".memanto-skills/memories.jsonl")
+MEMORY_PREFIXES: tuple[tuple[str, str, float], ...] = (
+    ("decision:", "decision", 0.9),
+    ("preference:", "preference", 0.86),
+    ("instruction:", "instruction", 0.88),
+    ("constraint:", "instruction", 0.82),
+    ("context:", "context", 0.72),
+    ("artifact:", "artifact", 0.68),
+)
+SKILL_NAMES = ("/grill-with-docs", "/tdd", "/handoff")
+
+
+@dataclass(frozen=True)
+class Memory:
+    """A distilled engineering memory carried between skill executions."""
+
+    text: str
+    memory_type: str
+    source_skill: str
+    path: str
+    confidence: float
+    created_at: str
+
+
+class MemoryBackend(Protocol):
+    """Storage contract shared by the local preview and live Memanto backends."""
+
+    def remember(self, memory: Memory) -> None:
+        """Persist one memory."""
+
+    def recall(self, query: str, *, limit: int = 5) -> list[Memory]:
+        """Return memories relevant to a new skill invocation."""
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def normalize_text(value: str) -> str:
+    return " ".join(value.strip().split())
+
+
+def tokenize(value: str) -> set[str]:
+    return set(re.findall(r"[a-zA-Z0-9_./-]{3,}", value.lower()))
+
+
+class LocalJsonlBackend:
+    """Credential-free backend used for reviewer demos and unit tests."""
+
+    def __init__(self, store_path: Path = DEFAULT_STORE) -> None:
+        self.store_path = store_path
+
+    def remember(self, memory: Memory) -> None:
+        self.store_path.parent.mkdir(parents=True, exist_ok=True)
+        existing = {self._dedupe_key(item) for item in self._read_all()}
+        if self._dedupe_key(memory) in existing:
+            return
+        with self.store_path.open("a", encoding="utf-8") as file:
+            file.write(json.dumps(asdict(memory), sort_keys=True) + "\n")
+
+    def recall(self, query: str, *, limit: int = 5) -> list[Memory]:
+        query_terms = tokenize(query)
+        ranked: list[tuple[float, Memory]] = []
+        for memory in self._read_all():
+            haystack = " ".join(
+                [memory.text, memory.memory_type, memory.source_skill, memory.path]
+            )
+            overlap = len(query_terms & tokenize(haystack))
+            if overlap == 0:
+                continue
+            type_boost = (
+                0.35 if memory.memory_type in {"decision", "instruction"} else 0
+            )
+            ranked.append((overlap + type_boost + memory.confidence, memory))
+        ranked.sort(key=lambda item: item[0], reverse=True)
+        return [memory for _, memory in ranked[:limit]]
+
+    def _read_all(self) -> list[Memory]:
+        if not self.store_path.exists():
+            return []
+        memories: list[Memory] = []
+        with self.store_path.open(encoding="utf-8") as file:
+            for line in file:
+                if not line.strip():
+                    continue
+                memories.append(Memory(**json.loads(line)))
+        return memories
+
+    @staticmethod
+    def _dedupe_key(memory: Memory) -> tuple[str, str, str]:
+        return (
+            normalize_text(memory.text).lower(),
+            memory.memory_type,
+            memory.path,
+        )
+
+
+class MemantoCliBackend:
+    """Live backend that delegates to the installed ``memanto`` CLI."""
+
+    def __init__(self, command: str = "memanto") -> None:
+        self.command = command
+
+    def remember(self, memory: Memory) -> None:
+        payload = (
+            f"{memory.text}\n\n"
+            f"source_skill={memory.source_skill}; path={memory.path}; "
+            f"confidence={memory.confidence:.2f}"
+        )
+        subprocess.run(
+            [self.command, "remember", payload, "--type", memory.memory_type],
+            check=True,
+            text=True,
+        )
+
+    def recall(self, query: str, *, limit: int = 5) -> list[Memory]:
+        result = subprocess.run(
+            [self.command, "recall", query, "--limit", str(limit)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        text = normalize_text(result.stdout)
+        if not text:
+            return []
+        return [
+            Memory(
+                text=text,
+                memory_type="context",
+                source_skill="memanto recall",
+                path="",
+                confidence=0.75,
+                created_at=utc_now(),
+            )
+        ]
+
+
+class SkillMemoryBridge:
+    """Captures skill outputs and injects relevant memories before new runs."""
+
+    def __init__(self, backend: MemoryBackend) -> None:
+        self.backend = backend
+
+    def before_skill(self, skill: str, prompt: str, cwd: Path) -> str:
+        query = f"{skill} {cwd} {prompt}"
+        memories = self.backend.recall(query)
+        if not memories:
+            return ""
+        bullets = "\n".join(f"- [{item.memory_type}] {item.text}" for item in memories)
+        return (
+            "Relevant Memanto engineering memory for this skill run:\n"
+            f"{bullets}\n"
+            "Apply these constraints unless the user explicitly overrides them."
+        )
+
+    def after_skill(self, skill: str, transcript: str, cwd: Path) -> list[Memory]:
+        memories = distill_memories(transcript, source_skill=skill, cwd=cwd)
+        for memory in memories:
+            self.backend.remember(memory)
+        return memories
+
+
+def distill_memories(transcript: str, *, source_skill: str, cwd: Path) -> list[Memory]:
+    """Extract explicit durable engineering signals from a skill transcript."""
+
+    memories: list[Memory] = []
+    for raw_line in transcript.splitlines():
+        line = normalize_text(raw_line)
+        lowered = line.lower()
+        for prefix, memory_type, confidence in MEMORY_PREFIXES:
+            if lowered.startswith(prefix):
+                memories.append(
+                    Memory(
+                        text=line[len(prefix) :].strip(),
+                        memory_type=memory_type,
+                        source_skill=source_skill,
+                        path=str(cwd),
+                        confidence=confidence,
+                        created_at=utc_now(),
+                    )
+                )
+                break
+    return memories
+
+
+def build_backend() -> MemoryBackend:
+    backend = os.getenv("MEMANTO_SKILL_BACKEND", "local").lower()
+    if backend == "cli":
+        return MemantoCliBackend(os.getenv("MEMANTO_COMMAND", "memanto"))
+    return LocalJsonlBackend(Path(os.getenv("MEMANTO_SKILL_STORE", str(DEFAULT_STORE))))
+
+
+def print_injected_context(context: str) -> None:
+    if context:
+        print(context)
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    before = subparsers.add_parser("before", help="Recall and print memory context")
+    before.add_argument("--skill", required=True, choices=SKILL_NAMES)
+    before.add_argument("--prompt", default="")
+    before.add_argument("--cwd", type=Path, default=Path.cwd())
+
+    after = subparsers.add_parser("after", help="Distill and store skill transcript")
+    after.add_argument("--skill", required=True, choices=SKILL_NAMES)
+    after.add_argument("--transcript-file", type=Path, required=True)
+    after.add_argument("--cwd", type=Path, default=Path.cwd())
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    bridge = SkillMemoryBridge(build_backend())
+
+    if args.command == "before":
+        print_injected_context(bridge.before_skill(args.skill, args.prompt, args.cwd))
+        return 0
+
+    transcript = args.transcript_file.read_text(encoding="utf-8")
+    memories = bridge.after_skill(args.skill, transcript, args.cwd)
+    print(f"stored {len(memories)} memories")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from mattpocock_adapter import install_wrappers, render_wrapper
+from skill_memory import LocalJsonlBackend, SkillMemoryBridge, distill_memories
+
+
+class SkillMemoryTests(unittest.TestCase):
+    def test_distill_memories_extracts_explicit_signals(self) -> None:
+        memories = distill_memories(
+            "\n".join(
+                [
+                    "decision: keep adapters thin",
+                    "preference: prefer pytest fixtures",
+                    "debug noise without a durable prefix",
+                ]
+            ),
+            source_skill="/grill-with-docs",
+            cwd=Path("/repo"),
+        )
+
+        self.assertEqual(
+            [item.memory_type for item in memories],
+            ["decision", "preference"],
+        )
+        self.assertEqual(memories[0].text, "keep adapters thin")
+
+    def test_local_backend_deduplicates_and_recalls_by_relevance(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            backend = LocalJsonlBackend(Path(raw_tmp) / "memories.jsonl")
+            bridge = SkillMemoryBridge(backend)
+
+            transcript = "decision: use SQLAlchemy repository tests"
+            bridge.after_skill("/tdd", transcript, Path("/repo"))
+            bridge.after_skill("/tdd", transcript, Path("/repo"))
+
+            recalled = backend.recall("repository tests with SQLAlchemy")
+
+        self.assertEqual(len(recalled), 1)
+        self.assertEqual(recalled[0].text, "use SQLAlchemy repository tests")
+
+    def test_before_skill_formats_injected_context(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            backend = LocalJsonlBackend(Path(raw_tmp) / "memories.jsonl")
+            bridge = SkillMemoryBridge(backend)
+            bridge.after_skill(
+                "/handoff",
+                "instruction: preserve public API names during refactors",
+                Path("/repo"),
+            )
+
+            context = bridge.before_skill(
+                "/tdd", "refactor public API tests", Path("/repo")
+            )
+
+        self.assertIn("Relevant Memanto engineering memory", context)
+        self.assertIn("preserve public API names", context)
+
+    def test_adapter_generates_executable_wrappers(self) -> None:
+        script = render_wrapper("/tdd", "/usr/local/bin/tdd", Path("/bridge"))
+        self.assertIn('skill_name="/tdd"', script)
+        self.assertIn('bridge_dir="/bridge"', script)
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            paths = install_wrappers(Path(raw_tmp), bridge_dir=Path("/bridge"))
+            names = sorted(path.name for path in paths)
+            modes = [path.stat().st_mode & 0o111 for path in paths]
+
+        self.assertEqual(names, ["grill-with-docs", "handoff", "tdd"])
+        self.assertTrue(all(mode for mode in modes))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,45 @@
+"""Credential-free validation for the Claude Code skills Memanto example."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from mattpocock_adapter import install_wrappers
+from skill_memory import LocalJsonlBackend, SkillMemoryBridge
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        store = tmp / "memories.jsonl"
+        backend = LocalJsonlBackend(store)
+        bridge = SkillMemoryBridge(backend)
+
+        transcript = "\n".join(
+            [
+                "decision: use a repository-local service layer for billing",
+                "preference: keep React toolbars dense and keyboard-friendly",
+                "instruction: run focused unit tests before broad integration tests",
+            ]
+        )
+        stored = bridge.after_skill("/grill-with-docs", transcript, tmp / "repo")
+        assert len(stored) == 3
+
+        context = bridge.before_skill(
+            "/tdd",
+            "write billing service tests for React toolbar behavior",
+            tmp / "repo",
+        )
+        assert "repository-local service layer" in context
+        assert "focused unit tests" in context
+
+        wrappers = install_wrappers(tmp / "bin", bridge_dir=Path(__file__).parent)
+        assert {path.name for path in wrappers} == {"grill-with-docs", "tdd", "handoff"}
+
+    print("claudecode-skills-memanto validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
/claim #508

BountyHub bounty: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe

## Summary
Adds `examples/claudecode-skills-memanto`, a reviewer-safe implementation of the Memanto + mattpocock developer skills challenge.

Includes:
- credential-free local JSONL backend
- optional live Memanto CLI backend
- before/after hooks for `/grill-with-docs`, `/tdd`, and `/handoff`
- wrapper generation
- README, demo transcript, validator, and unit tests

## Showcase
In-repo showcase/demo transcript: `examples/claudecode-skills-memanto/demo_transcript.md`

I have not posted an external social showcase yet; per the issue discussion, technical review can proceed without one, while social engagement may add final judging points.

## Verification
- `python examples/claudecode-skills-memanto/validate.py`
- `python -m unittest examples/claudecode-skills-memanto/test_skill_memory.py`
- `python -m py_compile examples/claudecode-skills-memanto/skill_memory.py examples/claudecode-skills-memanto/mattpocock_adapter.py examples/claudecode-skills-memanto/validate.py examples/claudecode-skills-memanto/test_skill_memory.py`
- `uvx ruff check examples/claudecode-skills-memanto`
- `uvx ruff format --check examples/claudecode-skills-memanto`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Memanto global memory companion example with comprehensive usage guide and demo workflow

* **New Features**
  * Introduced skill memory persistence system for storing and recalling engineering decisions across sessions
  * Included wrapper generation and validation tools for memory-enabled skills

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->