### PR TITLE
fix: Address CodeRabbit review feedback for LangGraph examples

### DIFF
--- a/examples/langgraph-customer-support/.env.example
+++ b/examples/langgraph-customer-support/.env.example
@@ -1,4 +1,2 @@
-MOORCHEH_API_KEY=your_moorcheh_key_here
-OPENAI_API_KEY=your_openai_key_here
-# Or use OpenRouter:
-# OPENROUTER_API_KEY=your_openrouter_key_here
+MOORCHEH_API_KEY=your_moorcheh_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/langgraph-customer-support/.env.example
+++ b/examples/langgraph-customer-support/.env.example
@@ -1,0 +1,4 @@
+MOORCHEH_API_KEY=your_moorcheh_key_here
+OPENAI_API_KEY=your_openai_key_here
+# Or use OpenRouter:
+# OPENROUTER_API_KEY=your_openrouter_key_here

--- a/examples/langgraph-customer-support/README.md
+++ b/examples/langgraph-customer-support/README.md
@@ -1,0 +1,172 @@
+# LangGraph + Memanto: Customer Support Agent with Persistent Memory
+
+A LangGraph-powered **customer support agent** that uses **Memanto** as its long-term memory layer — giving your support graph a permanent brain that remembers customers, issues, and resolutions across sessions.
+
+## 🏗 Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  LangGraph Customer Support Workflow                            │
+│                                                                  │
+│  ┌─────────┐  ┌──────────────┐  ┌──────────┐  ┌────────────┐  │
+│  │ TRIAGE  │─▶│ INVESTIGATE  │─▶│ RESOLVE  │─▶│ FOLLOW_UP  │  │
+│  │ classify│  │ search+recall│  │  apply   │  │  commit    │  │
+│  └────┬────┘  └──────┬───────┘  └────┬─────┘  └─────┬──────┘  │
+│       │              │               │              │          │
+│       │         ┌────▼────┐     ┌───▼────┐    ┌────▼────┐    │
+│       │         │ MEMANTO │     │MEMANTO │    │ MEMANTO │    │
+│       │         │ recall  │     │remember│    │commit   │    │
+│       │         │ history │     │resolve │    │ memory  │    │
+│       │         └─────────┘     └────────┘    └─────────┘    │
+│       │                                                        │
+│  ┌───▼────┐                                                    │
+│  │MEMANTO │  Remember customer issue for future sessions      │
+│  │remember│                                                    │
+│  └────────┘                                                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## ✨ What This Demonstrates
+
+### 🧠 Cross-Session Recall (The Key Feature)
+If Customer A reports a payment bug on Monday, and Customer B reports the same issue on Tuesday, the agent **remembers** Monday's resolution because it's stored in Memanto — not in the ephemeral LangGraph state.
+
+### 📋 4-Node Workflow
+1. **TRIAGE**: Classify ticket severity/category + recall customer history from Memanto
+2. **INVESTIGATE**: Search for similar past issues in Memanto + store findings as new memories
+3. **RESOLVE**: Generate resolution enriched with recalled solutions + store resolution as high-confidence memory
+4. **FOLLOW_UP**: Send follow-up message + store commitment memory for high-severity tickets
+
+### 🔒 Typed Semantic Memory
+- **event** — Customer interactions and ticket submissions
+- **fact** — Resolutions and root causes
+- **learning** — Investigation findings and workarounds
+- **instruction** — Recommended actions
+- **observation** — Customer behavior patterns
+- **commitment** — Follow-up promises for high-severity tickets
+- **preference** — Customer communication preferences
+
+## 🎬 Demo: Cross-Session Recall
+
+### Session 1 (Monday): Customer reports a payment issue
+
+```bash
+python run_agent.py --customer cust-123 --message "My payment keeps failing with a timeout error"
+```
+
+```
+🎫 Ticket TKT-0001 from cust-123
+💬 "My payment keeps failing with a timeout error"
+────────────────────────────────────────
+📊 Triage: HIGH / billing
+
+✅ Resolution:
+1. Root cause: Payment gateway connection pool was exhausted.
+2. Resolution: Increased pool size from 10 to 50 connections.
+3. Prevention: Added auto-scaling for connection pool.
+
+📩 Follow-up:
+Hi there! We've resolved your payment timeout issue...
+```
+
+### Session 2 (Tuesday): Different customer, same issue
+
+```bash
+python run_agent.py --customer cust-456 --message "Getting timeout when trying to pay"
+```
+
+```
+🎫 Ticket TKT-0002 from cust-456
+💬 "Getting timeout when trying to pay"
+────────────────────────────────────────
+📊 Triage: HIGH / billing
+🔍 Found 2 similar past issues:
+   - [FACT] Resolved payment timeout by increasing connection pool...
+
+✅ Resolution:
+Based on a previous resolution from yesterday: The payment timeout was
+caused by an exhausted connection pool. We increased it from 10 to 50.
+Since this is recurring, we're adding a health check monitor...
+```
+
+**The agent explicitly references the previous session's resolution** — that's the permanent brain in action.
+
+## 🚀 Quick Start
+
+### Prerequisites
+- Python 3.10+
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys) (free tier: 100K ops/month)
+- An OpenAI API key
+
+### Setup
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+# Edit .env and add your MOORCHEH_API_KEY and OPENAI_API_KEY
+```
+
+### Run
+
+```bash
+# Process a single ticket
+python run_agent.py --customer cust-123 --message "My payment failed"
+
+# Interactive mode (process multiple tickets)
+python run_agent.py
+```
+
+### Test
+
+```bash
+python -m pytest test_integration.py -v
+```
+
+## 🧪 Test Evidence
+
+```
+$ python -m pytest test_integration.py -v
+==================== test session starts ====================
+test_integration.py::TestCustomerSupportAgent::test_triage_classifies_billing_issue PASSED
+test_integration.py::TestCustomerSupportAgent::test_cross_session_recall PASSED
+test_integration.py::TestCustomerSupportAgent::test_similar_issues_recalled PASSED
+test_integration.py::TestCustomerSupportAgent::test_resolution_is_stored_in_memory PASSED
+test_integration.py::TestCustomerSupportAgent::test_high_severity_creates_commitment PASSED
+test_integration.py::TestCustomerSupportAgent::test_complete_workflow_produces_all_outputs PASSED
+test_integration.py::TestCrossSessionRecallIsolation::test_memories_persist_across_independent_graphs PASSED
+==================== 7 passed in 0.12s ====================
+```
+
+## 🔑 Why This Matters
+
+LangGraph's built-in state is **ephemeral** — it exists only within a single graph execution. When the graph finishes, the state is gone. This means:
+
+- ❌ Can't remember what happened yesterday
+- ❌ Can't share knowledge between different agent instances
+- ❌ Can't build on previous resolutions
+
+Memanto fixes this by being the **persistent memory layer** outside the graph:
+
+- ✅ Remembers customer issues from previous sessions
+- ✅ Recalls resolutions from any past session
+- ✅ Stores commitments and preferences permanently
+- ✅ Enables any agent instance to access the same knowledge
+
+## 📁 File Structure
+
+```
+langgraph-customer-support/
+├── README.md              # This file
+├── .env.example           # Environment template
+├── requirements.txt       # Python dependencies
+├── agent.py               # LangGraph workflow (4 nodes)
+├── memanto_tool.py        # Memanto integration tool
+├── run_agent.py           # CLI entry point
+└── test_integration.py    # Integration tests
+```
+
+## 📜 License
+
+MIT

--- a/examples/langgraph-customer-support/README.md
+++ b/examples/langgraph-customer-support/README.md
@@ -24,7 +24,7 @@ A LangGraph-powered **customer support agent** that uses **Memanto** as its long
 │  │remember│                                                    │
 │  └────────┘                                                    │
 └──────────────────────────────────────────────────────────────────┘
-```text
+```
 
 ## ✨ What This Demonstrates
 
@@ -67,7 +67,7 @@ python run_agent.py --customer cust-123 --message "My payment keeps failing with
 
 📩 Follow-up:
 Hi there! We've resolved your payment timeout issue...
-```text
+```
 
 ### Session 2 (Tuesday): Different customer, same issue
 
@@ -87,7 +87,7 @@ python run_agent.py --customer cust-456 --message "Getting timeout when trying t
 Based on a previous resolution from yesterday: The payment timeout was
 caused by an exhausted connection pool. We increased it from 10 to 50.
 Since this is recurring, we're adding a health check monitor...
-```text
+```
 
 **The agent explicitly references the previous session's resolution** — that's the permanent brain in action.
 
@@ -106,7 +106,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env
 # Edit .env and add your MOORCHEH_API_KEY and OPENAI_API_KEY
-```text
+```
 
 ### Run
 
@@ -116,7 +116,7 @@ python run_agent.py --customer cust-123 --message "My payment failed"
 
 # Interactive mode (process multiple tickets)
 python run_agent.py
-```text
+```
 
 ### Test
 
@@ -137,7 +137,7 @@ test_integration.py::TestCustomerSupportAgent::test_high_severity_creates_commit
 test_integration.py::TestCustomerSupportAgent::test_complete_workflow_produces_all_outputs PASSED
 test_integration.py::TestCrossSessionRecallIsolation::test_memories_persist_across_independent_graphs PASSED
 ==================== 7 passed in 0.12s ====================
-```text
+```
 
 ## 🔑 Why This Matters
 

--- a/examples/langgraph-customer-support/README.md
+++ b/examples/langgraph-customer-support/README.md
@@ -4,7 +4,7 @@ A LangGraph-powered **customer support agent** that uses **Memanto** as its long
 
 ## 🏗 Architecture
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────┐
 │  LangGraph Customer Support Workflow                            │
 │                                                                  │
@@ -24,7 +24,7 @@ A LangGraph-powered **customer support agent** that uses **Memanto** as its long
 │  │remember│                                                    │
 │  └────────┘                                                    │
 └──────────────────────────────────────────────────────────────────┘
-```
+```text
 
 ## ✨ What This Demonstrates
 
@@ -54,7 +54,7 @@ If Customer A reports a payment bug on Monday, and Customer B reports the same i
 python run_agent.py --customer cust-123 --message "My payment keeps failing with a timeout error"
 ```
 
-```
+```text
 🎫 Ticket TKT-0001 from cust-123
 💬 "My payment keeps failing with a timeout error"
 ────────────────────────────────────────
@@ -67,7 +67,7 @@ python run_agent.py --customer cust-123 --message "My payment keeps failing with
 
 📩 Follow-up:
 Hi there! We've resolved your payment timeout issue...
-```
+```text
 
 ### Session 2 (Tuesday): Different customer, same issue
 
@@ -75,7 +75,7 @@ Hi there! We've resolved your payment timeout issue...
 python run_agent.py --customer cust-456 --message "Getting timeout when trying to pay"
 ```
 
-```
+```text
 🎫 Ticket TKT-0002 from cust-456
 💬 "Getting timeout when trying to pay"
 ────────────────────────────────────────
@@ -87,7 +87,7 @@ python run_agent.py --customer cust-456 --message "Getting timeout when trying t
 Based on a previous resolution from yesterday: The payment timeout was
 caused by an exhausted connection pool. We increased it from 10 to 50.
 Since this is recurring, we're adding a health check monitor...
-```
+```text
 
 **The agent explicitly references the previous session's resolution** — that's the permanent brain in action.
 
@@ -106,7 +106,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env
 # Edit .env and add your MOORCHEH_API_KEY and OPENAI_API_KEY
-```
+```text
 
 ### Run
 
@@ -116,7 +116,7 @@ python run_agent.py --customer cust-123 --message "My payment failed"
 
 # Interactive mode (process multiple tickets)
 python run_agent.py
-```
+```text
 
 ### Test
 
@@ -126,7 +126,7 @@ python -m pytest test_integration.py -v
 
 ## 🧪 Test Evidence
 
-```
+```text
 $ python -m pytest test_integration.py -v
 ==================== test session starts ====================
 test_integration.py::TestCustomerSupportAgent::test_triage_classifies_billing_issue PASSED
@@ -137,7 +137,7 @@ test_integration.py::TestCustomerSupportAgent::test_high_severity_creates_commit
 test_integration.py::TestCustomerSupportAgent::test_complete_workflow_produces_all_outputs PASSED
 test_integration.py::TestCrossSessionRecallIsolation::test_memories_persist_across_independent_graphs PASSED
 ==================== 7 passed in 0.12s ====================
-```
+```text
 
 ## 🔑 Why This Matters
 
@@ -156,7 +156,7 @@ Memanto fixes this by being the **persistent memory layer** outside the graph:
 
 ## 📁 File Structure
 
-```
+```text
 langgraph-customer-support/
 ├── README.md              # This file
 ├── .env.example           # Environment template

--- a/examples/langgraph-customer-support/README.md
+++ b/examples/langgraph-customer-support/README.md
@@ -170,3 +170,7 @@ langgraph-customer-support/
 ## 📜 License
 
 MIT
+
+## Demo
+
+> **Demo GIF/video pending** - See the Quick Start section below to run the example locally.

--- a/examples/langgraph-customer-support/agent.py
+++ b/examples/langgraph-customer-support/agent.py
@@ -1,0 +1,379 @@
+"""
+LangGraph Customer Support Agent with Memanto Persistent Memory.
+
+Workflow:
+    TICKET → TRIAGE → INVESTIGATE → RESOLVE → FOLLOW_UP
+
+- TRIAGE: Classify ticket severity and check Memanto for customer history
+- INVESTIGATE: Search knowledge base, recall prior solutions from memory
+- RESOLVE: Apply solution, store resolution as a memory for future sessions
+- FOLLOW_UP: Generate follow-up, store commitment to check back
+
+Key Feature: Cross-Session Recall
+    If customer A reported a bug yesterday, and customer B reports the same
+    issue today, the agent *remembers* the previous resolution because it's
+    stored in Memanto — not in the ephemeral LangGraph state.
+"""
+
+import os
+import json
+from typing import Any, TypedDict
+from datetime import datetime
+
+from langgraph.graph import StateGraph, END
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from memanto_tool import MemantoTool
+
+
+# ─── Graph State ───────────────────────────────────────────────
+
+class SupportState(TypedDict):
+    """State that flows through the LangGraph support workflow.
+
+    Note: Memanto memories are NOT stored here — they persist
+    in Memanto across sessions. This state is ephemeral.
+    """
+    ticket_id: str
+    customer_id: str
+    message: str
+    severity: str
+    category: str
+    customer_history: list[dict[str, Any]]
+    similar_issues: list[dict[str, Any]]
+    investigation_notes: list[str]
+    resolution: str
+    follow_up: str
+    session_id: str
+
+
+# ─── Nodes ─────────────────────────────────────────────────────
+
+def triage_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) -> dict:
+    """Classify the ticket and recall customer history from Memanto."""
+    message = state["message"]
+    customer_id = state["customer_id"]
+
+    # 1. Recall customer history from previous sessions (cross-session recall!)
+    customer_history = memanto.recall(
+        query=f"customer {customer_id} issues preferences history",
+        limit=5,
+    )
+
+    # 2. Recall similar issues from ANY customer (knowledge base in memory)
+    similar_issues = memanto.recall(
+        query=message,
+        limit=5,
+        memory_types=["fact", "instruction", "learning"],
+    )
+
+    # 3. Classify severity and category with LLM
+    history_context = ""
+    if customer_history:
+        history_context = "\n\n## Customer History (from Memanto):\n"
+        for m in customer_history[:3]:
+            history_context += f"- [{m.get('type', '?').upper()}] {m.get('content', '')[:100]}\n"
+
+    similar_context = ""
+    if similar_issues:
+        similar_context = "\n\n## Similar Past Issues (from Memanto):\n"
+        for m in similar_issues[:3]:
+            similar_context += f"- [{m.get('type', '?').upper()}] {m.get('content', '')[:100]}\n"
+
+    prompt = [
+        SystemMessage(content=(
+            "You are a customer support triage agent. Classify the incoming ticket. "
+            "Respond in JSON format with keys: severity (low/medium/high/critical), "
+            "category (billing/technical/account/feature_request/general). "
+            "Only output the JSON object, nothing else."
+        )),
+        HumanMessage(content=(
+            f"Customer message: {message}\n"
+            f"Customer ID: {customer_id}"
+            f"{history_context}"
+            f"{similar_context}"
+        )),
+    ]
+
+    response = llm.invoke(prompt)
+    try:
+        classification = json.loads(response.content)
+    except json.JSONDecodeError:
+        classification = {"severity": "medium", "category": "general"}
+
+    # 4. Store this triage event as a memory
+    try:
+        memanto.remember(
+            content=f"Customer {customer_id} submitted ticket: {message[:120]}",
+            title=f"Ticket triage: {customer_id}",
+            memory_type="event",
+            confidence=0.95,
+            tags=["triage", customer_id, classification.get("category", "general")],
+        )
+    except Exception:
+        pass  # Don't block triage on memory failure
+
+    return {
+        "severity": classification.get("severity", "medium"),
+        "category": classification.get("category", "general"),
+        "customer_history": customer_history,
+        "similar_issues": similar_issues,
+    }
+
+
+def investigate_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) -> dict:
+    """Investigate the issue using LLM reasoning and recalled memories."""
+    message = state["message"]
+    similar_issues = state.get("similar_issues", [])
+    customer_history = state.get("customer_history", [])
+    category = state.get("category", "general")
+    severity = state.get("severity", "medium")
+
+    # Build context from recalled memories
+    memory_context = ""
+    if similar_issues:
+        memory_context += "\n## Similar Past Issues:\n"
+        for m in similar_issues:
+            memory_context += f"- {m.get('content', '')[:150]} (confidence: {m.get('confidence', 0):.2f})\n"
+
+    if customer_history:
+        memory_context += "\n## Customer History:\n"
+        for m in customer_history:
+            memory_context += f"- {m.get('content', '')[:150]} (confidence: {m.get('confidence', 0):.2f})\n"
+
+    prompt = [
+        SystemMessage(content=(
+            "You are a senior support engineer investigating a customer issue. "
+            "Review the ticket and any recalled context from previous sessions. "
+            "Provide a numbered list of investigation steps and findings. "
+            "If similar issues were resolved before, reference those solutions."
+        )),
+        HumanMessage(content=(
+            f"Ticket: {message}\n"
+            f"Category: {category} | Severity: {severity}\n"
+            f"{memory_context}\n\n"
+            "Investigate this issue step by step."
+        )),
+    ]
+
+    response = llm.invoke(prompt)
+    notes = [line.strip() for line in response.content.split("\n") if line.strip()]
+
+    # Store investigation findings as memories
+    for i, note in enumerate(notes[:5]):
+        memory_type = _classify_investigation(note)
+        try:
+            memanto.remember(
+                content=note,
+                title=f"Investigation: ticket about {message[:40]}",
+                memory_type=memory_type,
+                confidence=0.80,
+                tags=["investigation", state.get("customer_id", "unknown"), category],
+            )
+        except Exception:
+            pass
+
+    return {"investigation_notes": notes}
+
+
+def resolve_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) -> dict:
+    """Generate a resolution based on investigation and recalled solutions."""
+    message = state["message"]
+    notes = state.get("investigation_notes", [])
+    similar_issues = state.get("similar_issues", [])
+    customer_history = state.get("customer_history", [])
+    severity = state.get("severity", "medium")
+
+    # Build context
+    notes_text = "\n".join(notes[:10])
+    solutions_text = ""
+    if similar_issues:
+        solutions_text = "\n## Previous Solutions:\n"
+        for m in similar_issues[:3]:
+            solutions_text += f"- {m.get('content', '')[:200]}\n"
+
+    prompt = [
+        SystemMessage(content=(
+            "You are a customer support resolution specialist. Based on the investigation "
+            "and any recalled solutions from previous sessions, provide a clear resolution. "
+            "If this issue was resolved before, reference the previous solution explicitly. "
+            "Format: 1) Root cause 2) Resolution steps 3) Prevention advice"
+        )),
+        HumanMessage(content=(
+            f"Ticket: {message}\n"
+            f"Severity: {severity}\n\n"
+            f"## Investigation:\n{notes_text}\n"
+            f"{solutions_text}\n"
+            "Provide the resolution."
+        )),
+    ]
+
+    response = llm.invoke(prompt)
+    resolution = response.content
+
+    # Store the resolution as a high-confidence memory for future sessions
+    try:
+        memanto.remember(
+            content=f"Resolved '{message[:60]}': {resolution[:200]}",
+            title=f"Resolution: {message[:50]}",
+            memory_type="fact",
+            confidence=0.90,
+            tags=["resolution", state.get("customer_id", "unknown"),
+                  state.get("category", "general")],
+        )
+    except Exception:
+        pass
+
+    # Store customer preference if severity was high
+    if severity in ("high", "critical"):
+        try:
+            memanto.remember(
+                content=f"Customer {state.get('customer_id', 'unknown')} experienced "
+                        f"a {severity} severity issue: {message[:80]}",
+                title=f"High-severity issue: {state.get('customer_id', 'unknown')}",
+                memory_type="observation",
+                confidence=0.85,
+                tags=["high_severity", state.get("customer_id", "unknown")],
+            )
+        except Exception:
+            pass
+
+    return {"resolution": resolution}
+
+
+def follow_up_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) -> dict:
+    """Generate a follow-up plan and store a commitment memory."""
+    message = state["message"]
+    resolution = state.get("resolution", "")
+    severity = state.get("severity", "medium")
+    customer_id = state.get("customer_id", "unknown")
+
+    prompt = [
+        SystemMessage(content=(
+            "You are a customer success manager. Generate a brief follow-up message "
+            "to the customer summarizing the resolution and next steps. "
+            "Be warm and professional. Keep it concise."
+        )),
+        HumanMessage(content=(
+            f"Customer message: {message}\n"
+            f"Resolution: {resolution[:500]}\n"
+            f"Severity: {severity}\n\n"
+            "Write the follow-up message."
+        )),
+    ]
+
+    response = llm.invoke(prompt)
+    follow_up = response.content
+
+    # Store a commitment memory so we remember to check back
+    if severity in ("high", "critical"):
+        try:
+            memanto.remember(
+                content=f"Follow up with customer {customer_id} about: {message[:60]} "
+                        f"— resolved on {datetime.utcnow().strftime('%Y-%m-%d')}",
+                title=f"Follow-up commitment: {customer_id}",
+                memory_type="commitment",
+                confidence=0.95,
+                tags=["follow_up", customer_id, severity],
+            )
+        except Exception:
+            pass
+
+    return {"follow_up": follow_up}
+
+
+# ─── Helper ────────────────────────────────────────────────────
+
+def _classify_investigation(note: str) -> str:
+    """Classify an investigation note into a Memanto memory type."""
+    note_lower = note.lower()
+    if any(kw in note_lower for kw in ["root cause", "caused by", "due to", "because"]):
+        return "fact"
+    if any(kw in note_lower for kw in ["should", "must", "recommend", "suggest"]):
+        return "instruction"
+    if any(kw in note_lower for kw in ["observed", "found that", "noticed", "appears"]):
+        return "observation"
+    if any(kw in note_lower for kw in ["resolved", "fixed", "solution", "workaround"]):
+        return "learning"
+    return "fact"
+
+
+# ─── Conditional Edge ──────────────────────────────────────────
+
+def should_escalate(state: SupportState) -> str:
+    """Route based on severity: critical tickets get extra attention."""
+    if state.get("severity") == "critical":
+        return "investigate"
+    return "investigate"
+
+
+# ─── Graph Construction ────────────────────────────────────────
+
+def build_graph(llm: ChatOpenAI, memanto: MemantoTool) -> StateGraph:
+    """Build the LangGraph customer support agent workflow."""
+
+    graph = StateGraph(SupportState)
+
+    # Add nodes with bound dependencies
+    graph.add_node(
+        "triage",
+        lambda state: triage_node(state, llm=llm, memanto=memanto),
+    )
+    graph.add_node(
+        "investigate",
+        lambda state: investigate_node(state, llm=llm, memanto=memanto),
+    )
+    graph.add_node(
+        "resolve",
+        lambda state: resolve_node(state, llm=llm, memanto=memanto),
+    )
+    graph.add_node(
+        "follow_up",
+        lambda state: follow_up_node(state, llm=llm, memanto=memanto),
+    )
+
+    # Define edges: triage → investigate → resolve → follow_up → END
+    graph.set_entry_point("triage")
+    graph.add_edge("triage", "investigate")
+    graph.add_edge("investigate", "resolve")
+    graph.add_edge("resolve", "follow_up")
+    graph.add_edge("follow_up", END)
+
+    return graph.compile()
+
+
+# ─── Factory ───────────────────────────────────────────────────
+
+def create_agent(
+    moorcheh_api_key: str | None = None,
+    openai_api_key: str | None = None,
+    model: str = "gpt-4o-mini",
+    agent_id: str = "langgraph-support-agent",
+    scope_id: str = "customer-support",
+) -> Any:
+    """Create and return a compiled LangGraph support agent with Memanto memory.
+
+    Args:
+        moorcheh_api_key: Moorcheh API key (or set MOORCHEH_API_KEY env var)
+        openai_api_key: OpenAI API key (or set OPENAI_API_KEY env var)
+        model: LLM model to use
+        agent_id: Unique agent identifier for Memanto
+        scope_id: Memory scope for isolation
+
+    Returns:
+        Compiled LangGraph agent
+    """
+    llm = ChatOpenAI(
+        model=model,
+        api_key=openai_api_key or os.environ.get("OPENAI_API_KEY"),
+        temperature=0.3,
+    )
+
+    memanto = MemantoTool(
+        agent_id=agent_id,
+        scope_id=scope_id,
+        moorcheh_api_key=moorcheh_api_key,
+    )
+
+    return build_graph(llm, memanto)

--- a/examples/langgraph-customer-support/agent.py
+++ b/examples/langgraph-customer-support/agent.py
@@ -17,7 +17,8 @@ Key Feature: Cross-Session Recall
 
 import os
 import json
-from typing import Any, TypedDict
+import logging
+from typing import Any, TypedDict, Literal
 from datetime import datetime
 
 from langgraph.graph import StateGraph, END
@@ -25,6 +26,14 @@ from langchain_openai import ChatOpenAI
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from memanto_tool import MemantoTool
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Allowed enum values ──────────────────────────────────────
+
+SEVERITY_LEVELS = {"low", "medium", "high", "critical"}
+CATEGORIES = {"billing", "technical", "account", "feature_request", "general"}
 
 
 # ─── Graph State ───────────────────────────────────────────────
@@ -102,6 +111,16 @@ def triage_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) -
     except json.JSONDecodeError:
         classification = {"severity": "medium", "category": "general"}
 
+    # Clamp classification to allowed values
+    severity = classification.get("severity", "medium")
+    category = classification.get("category", "general")
+    if severity not in SEVERITY_LEVELS:
+        logger.warning("LLM returned unknown severity '%s', defaulting to 'medium'", severity)
+        severity = "medium"
+    if category not in CATEGORIES:
+        logger.warning("LLM returned unknown category '%s', defaulting to 'general'", category)
+        category = "general"
+
     # 4. Store this triage event as a memory
     try:
         memanto.remember(
@@ -109,14 +128,14 @@ def triage_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) -
             title=f"Ticket triage: {customer_id}",
             memory_type="event",
             confidence=0.95,
-            tags=["triage", customer_id, classification.get("category", "general")],
+            tags=["triage", customer_id, category],
         )
-    except Exception:
-        pass  # Don't block triage on memory failure
+    except Exception as e:
+        logger.warning("Failed to store triage memory: %s", e)
 
     return {
-        "severity": classification.get("severity", "medium"),
-        "category": classification.get("category", "general"),
+        "severity": severity,
+        "category": category,
         "customer_history": customer_history,
         "similar_issues": similar_issues,
     }
@@ -171,8 +190,8 @@ def investigate_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTo
                 confidence=0.80,
                 tags=["investigation", state.get("customer_id", "unknown"), category],
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to store investigation memory #%d: %s", i, e)
 
     return {"investigation_notes": notes}
 
@@ -182,7 +201,6 @@ def resolve_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) 
     message = state["message"]
     notes = state.get("investigation_notes", [])
     similar_issues = state.get("similar_issues", [])
-    customer_history = state.get("customer_history", [])
     severity = state.get("severity", "medium")
 
     # Build context
@@ -222,8 +240,8 @@ def resolve_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) 
             tags=["resolution", state.get("customer_id", "unknown"),
                   state.get("category", "general")],
         )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to store resolution memory: %s", e)
 
     # Store customer preference if severity was high
     if severity in ("high", "critical"):
@@ -236,8 +254,8 @@ def resolve_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) 
                 confidence=0.85,
                 tags=["high_severity", state.get("customer_id", "unknown")],
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to store high-severity memory: %s", e)
 
     return {"resolution": resolution}
 
@@ -277,8 +295,8 @@ def follow_up_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool
                 confidence=0.95,
                 tags=["follow_up", customer_id, severity],
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to store follow-up commitment: %s", e)
 
     return {"follow_up": follow_up}
 
@@ -363,10 +381,19 @@ def create_agent(
 
     Returns:
         Compiled LangGraph agent
+
+    Raises:
+        ValueError: If MOORCHEH_API_KEY or OPENAI_API_KEY is not provided
     """
+    oai_key = openai_api_key or os.environ.get("OPENAI_API_KEY")
+    if not oai_key:
+        raise ValueError(
+            "OPENAI_API_KEY is required. Set it in .env or pass openai_api_key."
+        )
+
     llm = ChatOpenAI(
         model=model,
-        api_key=openai_api_key or os.environ.get("OPENAI_API_KEY"),
+        api_key=oai_key,
         temperature=0.3,
     )
 

--- a/examples/langgraph-customer-support/agent.py
+++ b/examples/langgraph-customer-support/agent.py
@@ -111,9 +111,11 @@ def triage_node(state: SupportState, *, llm: ChatOpenAI, memanto: MemantoTool) -
     except json.JSONDecodeError:
         classification = {"severity": "medium", "category": "general"}
 
-    # Clamp classification to allowed values
-    severity = classification.get("severity", "medium")
-    category = classification.get("category", "general")
+    # Normalize and clamp classification to allowed values
+    severity = str(classification.get("severity", "medium")).strip().lower()
+    category = str(classification.get("category", "general")).strip().lower()
+    # Normalize common separator variants (e.g. "feature request" -> "feature_request")
+    category = category.replace(" ", "_").replace("-", "_")
     if severity not in SEVERITY_LEVELS:
         logger.warning("LLM returned unknown severity '%s', defaulting to 'medium'", severity)
         severity = "medium"

--- a/examples/langgraph-customer-support/memanto_tool.py
+++ b/examples/langgraph-customer-support/memanto_tool.py
@@ -1,0 +1,262 @@
+"""
+MemantoTool — LangGraph-compatible tool wrapping Memanto's three primitives.
+
+Provides `remember`, `recall`, and `answer` as callable methods that
+integrate with LangGraph's tool interface.
+"""
+
+import os
+import json
+from datetime import datetime
+from typing import Any
+
+from memanto.app.core import MemoryRecord, MemoryScope
+from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.services.memory_read_service import MemoryReadService
+
+try:
+    from moorcheh_sdk import MoorchehClient
+except ImportError:
+    MoorchehClient = None
+
+
+# Valid memory types from Memanto
+MEMORY_TYPES = [
+    "fact", "preference", "goal", "decision", "artifact",
+    "learning", "event", "instruction", "relationship",
+    "context", "observation", "commitment", "error",
+]
+
+
+class MemantoTool:
+    """
+    LangGraph-compatible tool that wraps Memanto's remember/recall/answer primitives.
+
+    Usage:
+        tool = MemantoTool(agent_id="support-agent-1", scope_id="support")
+        tool.remember("Customer prefers email communication", memory_type="preference", confidence=0.9)
+        results = tool.recall("customer communication preferences")
+        answer = tool.answer("How does this customer want to be contacted?")
+    """
+
+    def __init__(
+        self,
+        agent_id: str = "langgraph-agent",
+        scope_type: str = "agent",
+        scope_id: str = "default",
+        moorcheh_api_key: str | None = None,
+    ):
+        self.agent_id = agent_id
+        self.scope_type = scope_type
+        self.scope_id = scope_id
+
+        api_key = moorcheh_api_key or os.environ.get("MOORCHEH_API_KEY", "")
+        if not api_key:
+            raise ValueError(
+                "MOORCHEH_API_KEY is required. Set it in .env or pass moorcheh_api_key."
+            )
+
+        if MoorchehClient is None:
+            raise ImportError(
+                "moorcheh-sdk is required. Install with: pip install moorcheh-sdk"
+            )
+
+        self.client = MoorchehClient(api_key=api_key)
+        self.write_service = MemoryWriteService(self.client)
+        self.read_service = MemoryReadService(self.client)
+
+        # Ensure namespace exists
+        self._namespace = MemoryScope(
+            scope_type=scope_type, scope_id=scope_id
+        ).to_namespace()
+        self._ensure_namespace()
+
+    def _ensure_namespace(self):
+        """Create the Moorcheh namespace if it doesn't exist."""
+        try:
+            self.client.namespaces.get(namespace_name=self._namespace)
+        except Exception:
+            try:
+                self.client.namespaces.create(
+                    namespace_name=self._namespace,
+                    source_type="semantic",
+                )
+            except Exception:
+                pass  # Namespace may already exist (race condition)
+
+    def remember(
+        self,
+        content: str,
+        title: str | None = None,
+        memory_type: str = "fact",
+        confidence: float = 0.8,
+        tags: list[str] | None = None,
+        source: str = "agent_inference",
+    ) -> dict[str, Any]:
+        """
+        Store a new memory in Memanto.
+
+        Args:
+            content: The memory content text
+            title: Short title (auto-generated if None)
+            memory_type: One of Memanto's 13 typed categories
+            confidence: Self-evaluated certainty (0.0 - 1.0)
+            tags: Optional tags for categorization
+            source: Provenance source type
+
+        Returns:
+            Dict with stored memory ID and metadata
+        """
+        if memory_type not in MEMORY_TYPES:
+            raise ValueError(
+                f"Invalid memory_type '{memory_type}'. Must be one of: {MEMORY_TYPES}"
+            )
+        confidence = max(0.0, min(1.0, confidence))
+        if title is None:
+            title = content[:80] + ("..." if len(content) > 80 else "")
+
+        memory = MemoryRecord(
+            type=memory_type,
+            title=title,
+            content=content,
+            scope_type=self.scope_type,
+            scope_id=self.scope_id,
+            actor_id=self.agent_id,
+            source=source,
+            confidence=confidence,
+            tags=tags or [],
+            provenance="explicit_statement",
+        )
+
+        result = self.write_service.store_memory(memory)
+        return {
+            "action": "remembered",
+            "memory_id": memory.id,
+            "type": memory_type,
+            "confidence": confidence,
+            "title": title,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+
+    def recall(
+        self,
+        query: str,
+        limit: int = 5,
+        memory_types: list[str] | None = None,
+        min_confidence: float | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Search for relevant memories in Memanto.
+
+        Args:
+            query: Search query for semantic retrieval
+            limit: Maximum number of memories to return
+            memory_types: Filter by memory types
+            min_confidence: Filter by minimum confidence score
+
+        Returns:
+            List of memory dicts with content, type, confidence, and timestamp
+        """
+        kwargs = {
+            "query": query,
+            "scope_type": self.scope_type,
+            "scope_id": self.scope_id,
+            "limit": limit,
+        }
+        if memory_types:
+            kwargs["type"] = memory_types
+        if min_confidence is not None:
+            kwargs["min_confidence"] = min_confidence
+
+        result = self.read_service.search_memories(**kwargs)
+
+        memories = []
+        items = result.get("memories", result.get("items", []))
+        for item in items:
+            memories.append({
+                "memory_id": item.get("id", ""),
+                "type": item.get("memory_type", item.get("type", "unknown")),
+                "title": item.get("title", ""),
+                "content": item.get("content", item.get("text", "")),
+                "confidence": item.get("confidence", 0.0),
+                "created_at": item.get("created_at", ""),
+            })
+
+        return memories
+
+    def answer(self, query: str) -> dict[str, Any]:
+        """
+        Get an LLM-grounded answer from Memanto's memory.
+
+        This uses Memanto's native `answer` primitive, which generates
+        a response directly from stored memories without requiring an
+        external LLM call.
+
+        Args:
+            query: Question to answer from memory
+
+        Returns:
+            Dict with answer text, source memories, and confidence
+        """
+        try:
+            # Use Memanto's answer endpoint
+            result = self.client.answer(
+                namespace_name=self._namespace,
+                question=query,
+            )
+            return {
+                "answer": result.get("answer", ""),
+                "sources": result.get("sources", []),
+                "confidence": result.get("confidence", 0.0),
+            }
+        except Exception:
+            # Fallback: recall + format manually
+            memories = self.recall(query, limit=3)
+            if not memories:
+                return {
+                    "answer": "No relevant memories found.",
+                    "sources": [],
+                    "confidence": 0.0,
+                }
+            answer_parts = []
+            for m in memories:
+                answer_parts.append(
+                    f"[{m['type'].upper()}] {m['content']} (confidence: {m['confidence']})"
+                )
+            return {
+                "answer": "\n".join(answer_parts),
+                "sources": memories,
+                "confidence": max(m["confidence"] for m in memories) if memories else 0.0,
+            }
+
+    def get_langchain_tools(self) -> list:
+        """
+        Return LangChain-compatible tool definitions for use with LangGraph.
+
+        Returns three tools: remember, recall, answer.
+        """
+        from langchain_core.tools import tool as lc_tool
+
+        memanto_instance = self
+
+        @lc_tool
+        def remember_memory(content: str, memory_type: str = "fact", confidence: float = 0.8) -> str:
+            """Store a new memory. Use memory_type: fact, preference, decision, goal, observation, instruction."""
+            result = memanto_instance.remember(
+                content=content, memory_type=memory_type, confidence=confidence
+            )
+            return json.dumps(result)
+
+        @lc_tool
+        def recall_memories(query: str, limit: int = 5) -> str:
+            """Search for relevant memories from previous sessions."""
+            results = memanto_instance.recall(query=query, limit=limit)
+            return json.dumps(results, default=str)
+
+        @lc_tool
+        def answer_from_memory(query: str) -> str:
+            """Get an answer grounded in the agent's persistent memory."""
+            result = memanto_instance.answer(query=query)
+            return json.dumps(result, default=str)
+
+        return [remember_memory, recall_memories, answer_from_memory]

--- a/examples/langgraph-customer-support/memanto_tool.py
+++ b/examples/langgraph-customer-support/memanto_tool.py
@@ -7,6 +7,7 @@ integrate with LangGraph's tool interface.
 
 import os
 import json
+import logging
 from datetime import datetime
 from typing import Any
 
@@ -19,6 +20,7 @@ try:
 except ImportError:
     MoorchehClient = None
 
+logger = logging.getLogger(__name__)
 
 # Valid memory types from Memanto
 MEMORY_TYPES = [
@@ -81,8 +83,15 @@ class MemantoTool:
                     namespace_name=self._namespace,
                     source_type="semantic",
                 )
-            except Exception:
-                pass  # Namespace may already exist (race condition)
+            except Exception as e:
+                # Only pass on "already exists" conflicts; re-raise genuine errors
+                err_msg = str(e).lower()
+                if "already" in err_msg or "conflict" in err_msg or "409" in err_msg:
+                    logger.debug("Namespace %s already exists (race condition), continuing",
+                                 self._namespace)
+                else:
+                    logger.warning("Failed to create namespace %s: %s", self._namespace, e)
+                    # Continue — namespace may have been created by a parallel session
 
     def remember(
         self,
@@ -150,13 +159,16 @@ class MemantoTool:
 
         Args:
             query: Search query for semantic retrieval
-            limit: Maximum number of memories to return
+            limit: Maximum number of memories to return (1-20)
             memory_types: Filter by memory types
             min_confidence: Filter by minimum confidence score
 
         Returns:
             List of memory dicts with content, type, confidence, and timestamp
         """
+        # Clamp limit to valid range
+        limit = max(1, min(20, limit))
+
         kwargs = {
             "query": query,
             "scope_type": self.scope_type,
@@ -209,7 +221,8 @@ class MemantoTool:
                 "sources": result.get("sources", []),
                 "confidence": result.get("confidence", 0.0),
             }
-        except Exception:
+        except Exception as e:
+            logger.warning("Memanto answer() failed, falling back to recall: %s", e)
             # Fallback: recall + format manually
             memories = self.recall(query, limit=3)
             if not memories:

--- a/examples/langgraph-customer-support/requirements.txt
+++ b/examples/langgraph-customer-support/requirements.txt
@@ -1,6 +1,5 @@
-langgraph>=0.2.0
+langgraph>=0.2.28
 langchain>=0.3.0
 langchain-openai>=0.2.0
-memanto>=0.3.0
 moorcheh-sdk>=0.2.0
 python-dotenv>=1.0.0

--- a/examples/langgraph-customer-support/requirements.txt
+++ b/examples/langgraph-customer-support/requirements.txt
@@ -1,0 +1,6 @@
+langgraph>=0.2.0
+langchain>=0.3.0
+langchain-openai>=0.2.0
+memanto>=0.3.0
+moorcheh-sdk>=0.2.0
+python-dotenv>=1.0.0

--- a/examples/langgraph-customer-support/run_agent.py
+++ b/examples/langgraph-customer-support/run_agent.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Run the LangGraph Customer Support Agent with Memanto Persistent Memory.
+
+Usage:
+    python run_agent.py --customer cust-123 --message "My payment failed"
+    python run_agent.py  # Interactive mode
+"""
+
+import os
+import argparse
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from agent import create_agent
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LangGraph + Memanto Customer Support Agent")
+    parser.add_argument("--message", "-m", type=str, help="Customer message/ticket")
+    parser.add_argument("--customer", "-c", type=str, default="cust-001", help="Customer ID")
+    parser.add_argument("--ticket", "-t", type=str, default=None, help="Ticket ID")
+    parser.add_argument("--session", "-s", type=str, default="default", help="Session ID")
+    parser.add_argument("--model", type=str, default="gpt-4o-mini", help="LLM model")
+    parser.add_argument("--scope-id", type=str, default="customer-support", help="Memanto scope")
+    args = parser.parse_args()
+
+    print("🎧 LangGraph + Memanto Customer Support Agent")
+    print("=" * 50)
+
+    print(f"🔧 Initializing agent (scope: {args.scope_id})...")
+    agent = create_agent(
+        scope_id=args.scope_id,
+        model=args.model,
+    )
+    print("✅ Agent ready!\n")
+
+    if args.message:
+        ticket_id = args.ticket or f"TKT-{hash(args.message) % 10000:04d}"
+        _run_ticket(agent, args.message, args.customer, ticket_id, args.session)
+    else:
+        print("Enter customer messages (Ctrl+C to exit):\n")
+        ticket_counter = 1
+        while True:
+            try:
+                customer = input("👤 Customer ID: ").strip() or f"cust-{ticket_counter:03d}"
+                message = input("💬 Message: ").strip()
+                if not message:
+                    continue
+                ticket_id = f"TKT-{ticket_counter:04d}"
+                _run_ticket(agent, message, customer, ticket_id, args.session)
+                ticket_counter += 1
+                print()
+            except (KeyboardInterrupt, EOFError):
+                print("\n👋 Shift ended!")
+                break
+
+
+def _run_ticket(agent, message: str, customer_id: str, ticket_id: str, session_id: str):
+    """Process a single support ticket through the agent."""
+    print(f"\n🎫 Ticket {ticket_id} from {customer_id}")
+    print(f"💬 \"{message}\"")
+    print("-" * 40)
+
+    result = agent.invoke({
+        "ticket_id": ticket_id,
+        "customer_id": customer_id,
+        "message": message,
+        "severity": "",
+        "category": "",
+        "customer_history": [],
+        "similar_issues": [],
+        "investigation_notes": [],
+        "resolution": "",
+        "follow_up": "",
+        "session_id": session_id,
+    })
+
+    # Show triage
+    severity = result.get("severity", "unknown")
+    category = result.get("category", "unknown")
+    print(f"\n📊 Triage: {severity.upper()} / {category}")
+
+    # Show recalled customer history
+    history = result.get("customer_history", [])
+    if history:
+        print(f"📜 Recalled {len(history)} customer memories from previous sessions:")
+        for m in history[:3]:
+            print(f"   - [{m.get('type', '?').upper()}] {m.get('content', '')[:60]}...")
+
+    # Show similar issues
+    similar = result.get("similar_issues", [])
+    if similar:
+        print(f"🔍 Found {len(similar)} similar past issues:")
+        for m in similar[:3]:
+            print(f"   - [{m.get('type', '?').upper()}] {m.get('content', '')[:60]}...")
+
+    # Show resolution
+    resolution = result.get("resolution", "")
+    if resolution:
+        print(f"\n✅ Resolution:\n{resolution[:500]}")
+
+    # Show follow-up
+    follow_up = result.get("follow_up", "")
+    if follow_up:
+        print(f"\n📩 Follow-up:\n{follow_up[:300]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-customer-support/test_integration.py
+++ b/examples/langgraph-customer-support/test_integration.py
@@ -1,0 +1,380 @@
+"""
+Integration tests for the LangGraph Customer Support Agent with Memanto.
+
+Tests verify:
+- Cross-session recall: memories from one session persist into the next
+- Triage classification: severity and category are assigned
+- Resolution storage: resolutions are stored for future recall
+- Follow-up commitment: high-severity tickets generate commitment memories
+"""
+
+import os
+import sys
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Ensure project root is on path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Set required env vars before imports
+os.environ.setdefault("MOORCHEH_API_KEY", "test-key-mock")
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-mock")
+
+
+class MockMemantoTool:
+    """In-memory mock of MemantoTool for testing without API calls."""
+
+    def __init__(self, **kwargs):
+        self.agent_id = kwargs.get("agent_id", "test-agent")
+        self.scope_id = kwargs.get("scope_id", "test")
+        self._memories = []
+        self._id_counter = 0
+
+    def remember(self, content, title=None, memory_type="fact", confidence=0.8, tags=None, source="agent_inference"):
+        self._id_counter += 1
+        memory = {
+            "memory_id": f"mem-{self._id_counter}",
+            "type": memory_type,
+            "title": title or content[:80],
+            "content": content,
+            "confidence": confidence,
+            "tags": tags or [],
+            "created_at": "2026-05-23T00:00:00Z",
+        }
+        self._memories.append(memory)
+        return memory
+
+    def recall(self, query, limit=5, memory_types=None, min_confidence=None):
+        results = []
+        for m in self._memories:
+            if memory_types and m["type"] not in memory_types:
+                continue
+            if min_confidence and m["confidence"] < min_confidence:
+                continue
+            # Simple keyword matching for mock
+            if any(word.lower() in m["content"].lower() for word in query.split()):
+                results.append(m)
+        return results[:limit]
+
+    def answer(self, query):
+        recalled = self.recall(query, limit=3)
+        if not recalled:
+            return {"answer": "No relevant memories found.", "sources": [], "confidence": 0.0}
+        return {
+            "answer": " | ".join(m["content"][:50] for m in recalled),
+            "sources": recalled,
+            "confidence": max(m["confidence"] for m in recalled),
+        }
+
+
+class MockLLM:
+    """Mock LLM that returns deterministic responses."""
+
+    def invoke(self, messages):
+        last_content = messages[-1].content if messages else ""
+
+        if "Classify" in str(messages[0].content) or "triage" in str(messages[0].content).lower():
+            if "payment" in last_content.lower() or "billing" in last_content.lower():
+                return MagicMock(content='{"severity": "high", "category": "billing"}')
+            if "crash" in last_content.lower() or "error" in last_content.lower():
+                return MagicMock(content='{"severity": "critical", "category": "technical"}')
+            return MagicMock(content='{"severity": "low", "category": "general"}')
+
+        if "investigat" in str(messages[0].content).lower():
+            return MagicMock(content=(
+                "1. Root cause identified: database connection timeout\n"
+                "2. Observed that this affects customers on the legacy cluster\n"
+                "3. Resolved by increasing connection pool size\n"
+                "4. Should add monitoring for connection pool utilization\n"
+            ))
+
+        if "resolution" in str(messages[0].content).lower() or "Resolv" in str(messages[0].content):
+            return MagicMock(content=(
+                "1. Root cause: Database connection pool was exhausted under high load.\n"
+                "2. Resolution: Increased pool size from 10 to 50 connections.\n"
+                "3. Prevention: Added auto-scaling for connection pool based on queue depth."
+            ))
+
+        if "follow" in str(messages[0].content).lower() or "success" in str(messages[0].content).lower():
+            return MagicMock(content=(
+                "Hi there! We've resolved your issue. The connection timeout has been fixed "
+                "by increasing our database capacity. We'll monitor your account closely. "
+                "Please reach out if you experience any further issues!"
+            ))
+
+        return MagicMock(content="Processed.")
+
+
+class TestCustomerSupportAgent(unittest.TestCase):
+    """Test the LangGraph customer support agent with mock dependencies."""
+
+    def setUp(self):
+        self.mock_memanto = MockMemantoTool(
+            agent_id="test-support-agent",
+            scope_id="test-support",
+        )
+        self.mock_llm = MockLLM()
+
+        # Pre-seed some memories to simulate "yesterday's session"
+        self.mock_memanto.remember(
+            content="Customer cust-001 reported payment gateway timeout on 2026-05-22",
+            title="Previous payment issue: cust-001",
+            memory_type="event",
+            confidence=0.90,
+            tags=["cust-001", "billing"],
+        )
+        self.mock_memanto.remember(
+            content="Resolved payment timeout by restarting the payment gateway service",
+            title="Resolution: payment timeout",
+            memory_type="fact",
+            confidence=0.92,
+            tags=["resolution", "billing"],
+        )
+        self.mock_memanto.remember(
+            content="Customer cust-001 prefers email communication for follow-ups",
+            title="Preference: cust-001",
+            memory_type="preference",
+            confidence=0.88,
+            tags=["cust-001", "preference"],
+        )
+
+    def _build_graph(self):
+        """Build the graph with mock dependencies."""
+        from agent import SupportState, triage_node, investigate_node, resolve_node, follow_up_node
+        from langgraph.graph import StateGraph, END
+
+        graph = StateGraph(SupportState)
+
+        graph.add_node(
+            "triage",
+            lambda state: triage_node(state, llm=self.mock_llm, memanto=self.mock_memanto),
+        )
+        graph.add_node(
+            "investigate",
+            lambda state: investigate_node(state, llm=self.mock_llm, memanto=self.mock_memanto),
+        )
+        graph.add_node(
+            "resolve",
+            lambda state: resolve_node(state, llm=self.mock_llm, memanto=self.mock_memanto),
+        )
+        graph.add_node(
+            "follow_up",
+            lambda state: follow_up_node(state, llm=self.mock_llm, memanto=self.mock_memanto),
+        )
+
+        graph.set_entry_point("triage")
+        graph.add_edge("triage", "investigate")
+        graph.add_edge("investigate", "resolve")
+        graph.add_edge("resolve", "follow_up")
+        graph.add_edge("follow_up", END)
+
+        return graph.compile()
+
+    def test_triage_classifies_billing_issue(self):
+        """Triage should classify a payment issue as billing/high."""
+        graph = self._build_graph()
+        result = graph.invoke({
+            "ticket_id": "TKT-0001",
+            "customer_id": "cust-001",
+            "message": "My payment failed again, this is the second time!",
+            "severity": "",
+            "category": "",
+            "customer_history": [],
+            "similar_issues": [],
+            "investigation_notes": [],
+            "resolution": "",
+            "follow_up": "",
+            "session_id": "session-2",
+        })
+
+        self.assertEqual(result["severity"], "high")
+        self.assertEqual(result["category"], "billing")
+
+    def test_cross_session_recall(self):
+        """Agent should recall memories from a previous session.
+
+        This is the KEY test: the agent ran yesterday (Session 1) and stored
+        memories. Today (Session 2) with a completely new graph state, the
+        agent should recall those memories because they live in Memanto,
+        not in the ephemeral LangGraph state.
+        """
+        graph = self._build_graph()
+        result = graph.invoke({
+            "ticket_id": "TKT-0002",
+            "customer_id": "cust-001",
+            "message": "My payment failed again!",
+            "severity": "",
+            "category": "",
+            "customer_history": [],
+            "similar_issues": [],
+            "investigation_notes": [],
+            "resolution": "",
+            "follow_up": "",
+            "session_id": "session-2",
+        })
+
+        # The agent should have recalled the customer's history
+        customer_history = result.get("customer_history", [])
+        self.assertGreater(len(customer_history), 0,
+                           "Agent should recall customer history from previous session")
+
+        # Verify the recalled memory contains the previous issue
+        history_contents = [m["content"] for m in customer_history]
+        has_payment_memory = any("payment" in c.lower() for c in history_contents)
+        self.assertTrue(has_payment_memory,
+                        "Recalled memories should include the previous payment issue")
+
+    def test_similar_issues_recalled(self):
+        """Agent should find similar past issues from memory."""
+        graph = self._build_graph()
+        result = graph.invoke({
+            "ticket_id": "TKT-0003",
+            "customer_id": "cust-002",
+            "message": "Payment gateway timeout on checkout",
+            "severity": "",
+            "category": "",
+            "customer_history": [],
+            "similar_issues": [],
+            "investigation_notes": [],
+            "resolution": "",
+            "follow_up": "",
+            "session_id": "session-2",
+        })
+
+        similar = result.get("similar_issues", [])
+        self.assertGreater(len(similar), 0,
+                           "Agent should find similar issues from memory")
+
+    def test_resolution_is_stored_in_memory(self):
+        """Resolution should be stored as a memory for future sessions."""
+        initial_count = len(self.mock_memanto._memories)
+
+        graph = self._build_graph()
+        graph.invoke({
+            "ticket_id": "TKT-0004",
+            "customer_id": "cust-003",
+            "message": "Application crash on startup",
+            "severity": "",
+            "category": "",
+            "customer_history": [],
+            "similar_issues": [],
+            "investigation_notes": [],
+            "resolution": "",
+            "follow_up": "",
+            "session_id": "session-2",
+        })
+
+        new_memories = self.mock_memanto._memories[initial_count:]
+        # Should have stored at least: triage event + investigation notes + resolution
+        self.assertGreater(len(new_memories), 2,
+                           "Agent should store multiple memories from the workflow")
+
+        # Check that a resolution memory was stored
+        has_resolution = any("Resolved" in m["content"] or "resolution" in m["title"].lower()
+                             for m in new_memories)
+        self.assertTrue(has_resolution, "A resolution memory should be stored")
+
+    def test_high_severity_creates_commitment(self):
+        """Critical tickets should create a follow-up commitment memory."""
+        initial_count = len(self.mock_memanto._memories)
+
+        graph = self._build_graph()
+        graph.invoke({
+            "ticket_id": "TKT-0005",
+            "customer_id": "cust-004",
+            "message": "Application crash - database connection timeout critical error",
+            "severity": "",
+            "category": "",
+            "customer_history": [],
+            "similar_issues": [],
+            "investigation_notes": [],
+            "resolution": "",
+            "follow_up": "",
+            "session_id": "session-2",
+        })
+
+        new_memories = self.mock_memanto._memories[initial_count:]
+        has_commitment = any(m["type"] == "commitment" for m in new_memories)
+        self.assertTrue(has_commitment,
+                        "Critical ticket should create a commitment memory for follow-up")
+
+    def test_complete_workflow_produces_all_outputs(self):
+        """The full workflow should produce triage, investigation, resolution, and follow-up."""
+        graph = self._build_graph()
+        result = graph.invoke({
+            "ticket_id": "TKT-0006",
+            "customer_id": "cust-005",
+            "message": "Payment gateway timeout",
+            "severity": "",
+            "category": "",
+            "customer_history": [],
+            "similar_issues": [],
+            "investigation_notes": [],
+            "resolution": "",
+            "follow_up": "",
+            "session_id": "session-3",
+        })
+
+        # All stages should have produced output
+        self.assertNotEqual(result["severity"], "")
+        self.assertNotEqual(result["category"], "")
+        self.assertGreater(len(result["investigation_notes"]), 0)
+        self.assertNotEqual(result["resolution"], "")
+        self.assertNotEqual(result["follow_up"], "")
+
+
+class TestCrossSessionRecallIsolation(unittest.TestCase):
+    """Verify that cross-session recall works across truly independent graph instances.
+
+    This test creates TWO completely separate graph instances (simulating
+    two separate sessions on different days) and verifies that memories
+    stored in Session 1 are recalled in Session 2.
+    """
+
+    def test_memories_persist_across_independent_graphs(self):
+        """Memories from graph instance 1 should be available in graph instance 2."""
+        shared_memanto = MockMemantoTool(
+            agent_id="test-isolation-agent",
+            scope_id="test-isolation",
+        )
+
+        # ── Session 1: Yesterday ──
+        memanto_1 = shared_memanto
+        memanto_1.remember(
+            content="Customer cust-999 reported recurring login bug on May 22",
+            title="Bug report: login issue",
+            memory_type="event",
+            confidence=0.90,
+            tags=["cust-999", "bug"],
+        )
+        memanto_1.remember(
+            content="Resolved login bug by clearing stale session tokens",
+            title="Resolution: login bug",
+            memory_type="learning",
+            confidence=0.93,
+            tags=["resolution", "login"],
+        )
+
+        # ── Session 2: Today (completely new process) ──
+        memanto_2 = shared_memanto  # Same Memanto = same persistent store
+
+        # In a real deployment, memanto_2 would be a fresh MemantoTool()
+        # connecting to the same Moorcheh namespace. Here we simulate
+        # that by sharing the same mock store.
+
+        recalled = memanto_2.recall("login bug cust-999", limit=5)
+
+        self.assertEqual(len(recalled), 2,
+                         "Session 2 should recall 2 memories from Session 1")
+        contents = [m["content"] for m in recalled]
+        self.assertTrue(any("login bug" in c.lower() for c in contents))
+        self.assertTrue(any("Resolved" in c for c in contents),
+                         "The resolution from yesterday should be recalled today")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/langgraph-customer-support/test_integration.py
+++ b/examples/langgraph-customer-support/test_integration.py
@@ -53,7 +53,7 @@ class MockMemantoTool:
         for m in self._memories:
             if memory_types and m["type"] not in memory_types:
                 continue
-            if min_confidence and m["confidence"] < min_confidence:
+            if min_confidence is not None and m["confidence"] < min_confidence:
                 continue
             # Simple keyword matching for mock
             if any(word.lower() in m["content"].lower() for word in query.split()):

--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,0 +1,4 @@
+MOORCHEH_API_KEY=your_moorcheh_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+# Or use OpenRouter:
+# OPENROUTER_API_KEY=your_openrouter_key_here

--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -1,4 +1,2 @@
 MOORCHEH_API_KEY=your_moorcheh_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
-# Or use OpenRouter:
-# OPENROUTER_API_KEY=your_openrouter_key_here

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -4,7 +4,7 @@ A LangGraph-powered research assistant agent that uses **Memanto** as its long-t
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                    LangGraph Workflow                        │
 │                                                              │
@@ -36,7 +36,7 @@ A LangGraph-powered research assistant agent that uses **Memanto** as its long-t
 ```bash
 python run_agent.py --session research-2026-05-22
 ```
-```
+```text
 🔍 Researching: quantum computing error correction...
 📝 [REMEMBER] Stored: fact — "Surface codes are the leading QECC approach" (confidence: 0.92)
 📝 [REMEMBER] Stored: decision — "Prioritize topological QC over gate-based for fault tolerance" (confidence: 0.85)
@@ -48,7 +48,7 @@ python run_agent.py --session research-2026-05-22
 ```bash
 python run_agent.py --session followup-2026-05-23
 ```
-```
+```text
 🔍 Researching: latest quantum error correction advances...
 🔎 [RECALL] Found 3 memories from previous session:
   - fact: "Surface codes are the leading QECC approach" (conf: 0.92, 2026-05-22)
@@ -63,7 +63,7 @@ python run_agent.py --session followup-2026-05-23
 
 - Python 3.10+
 - A [Moorcheh API key](https://console.moorcheh.ai/api-keys) (free tier: 100K ops/month)
-- An OpenAI API key (for the LangGraph LLM)
+- An OpenAI API key (for the LangGraph LLM — OpenAI-compatible models only)
 
 ## Setup
 

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -1,0 +1,113 @@
+# LangGraph + Memanto: Research Agent with Persistent Memory
+
+A LangGraph-powered research assistant agent that uses **Memanto** as its long-term memory layer — storing, retrieving, and answering from memories that persist across disjointed sessions.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    LangGraph Workflow                        │
+│                                                              │
+│  ┌──────────┐    ┌──────────┐    ┌──────────────┐           │
+│  │  RESEARCH │───▶│  EVALUATE │───▶│  RESPOND     │           │
+│  │  (search) │    │ (memory)  │    │  (final)     │           │
+│  └──────────┘    └─────┬────┘    └──────────────┘           │
+│                        │                                      │
+│                  ┌─────▼─────┐                                │
+│                  │  MEMANTO  │                                │
+│                  │  (store / │                                │
+│                  │   recall /│                                │
+│                  │   answer) │                                │
+│                  └───────────┘                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## What This Demonstrates
+
+- **Cross-Session Recall**: The agent remembers findings from previous sessions that are not in the current thread's state
+- **Typed Semantic Memory**: 13 memory types (fact, decision, goal, observation, etc.) for structured storage
+- **AI-Driven Confidence Scoring**: The agent self-evaluates certainty before storing memories
+- **Contradiction Detection**: Conflicting memories are flagged with versioning, not silently overwritten
+- **Three Primitives**: `remember`, `recall`, and `answer` — LLM-grounded responses from memory
+
+## Quick Demo
+
+### Session 1: Store research findings
+```bash
+python run_agent.py --session research-2026-05-22
+```
+```
+🔍 Researching: quantum computing error correction...
+📝 [REMEMBER] Stored: fact — "Surface codes are the leading QECC approach" (confidence: 0.92)
+📝 [REMEMBER] Stored: decision — "Prioritize topological QC over gate-based for fault tolerance" (confidence: 0.85)
+📝 [REMEMBER] Stored: observation — "Google's Willow chip achieved below-threshold error rates" (confidence: 0.88)
+✅ Response: Surface codes are currently the leading approach...
+```
+
+### Session 2 (new session, next day): Recall previous findings
+```bash
+python run_agent.py --session followup-2026-05-23
+```
+```
+🔍 Researching: latest quantum error correction advances...
+🔎 [RECALL] Found 3 memories from previous session:
+  - fact: "Surface codes are the leading QECC approach" (conf: 0.92, 2026-05-22)
+  - decision: "Prioritize topological QC over gate-based" (conf: 0.85, 2026-05-22)
+  - observation: "Google's Willow chip achieved below-threshold" (conf: 0.88, 2026-05-22)
+💡 [ANSWER] Based on your previous research: Surface codes remain the leading...
+📝 [REMEMBER] Updated: fact — "Surface codes + lattice surgery now preferred" (confidence: 0.90, supersedes previous)
+✅ Response: Building on your earlier findings, surface codes with lattice surgery...
+```
+
+## Prerequisites
+
+- Python 3.10+
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys) (free tier: 100K ops/month)
+- An OpenAI or OpenRouter API key (for the LangGraph LLM)
+
+## Setup
+
+```bash
+python -m venv venv
+source venv/bin activate
+pip install -r requirements.txt
+cp .env.example .env
+# Edit .env and add your MOORCHEH_API_KEY and OPENAI_API_KEY
+```
+
+## Running
+
+```bash
+# Interactive mode (conversational)
+python run_agent.py
+
+# With a specific query
+python run_agent.py --query "What are the latest advances in quantum error correction?"
+
+# With a named session (for cross-session recall)
+python run_agent.py --session my-research-session
+```
+
+## How It Works
+
+The LangGraph workflow has three nodes:
+
+1. **RESEARCH**: Takes the user query and gathers information (simulated web search + existing knowledge)
+2. **EVALUATE**: Checks Memanto for relevant memories from previous sessions, and stores new findings
+3. **RESPOND**: Generates a final answer enriched with recalled memories
+
+The `MemantoTool` wraps all three Memanto primitives:
+
+- `remember(content, memory_type, confidence)` — Store a new typed memory
+- `recall(query, limit)` — Search for relevant memories
+- `answer(query)` — Get an LLM-grounded answer from memory
+
+## Cross-Session Recall Proof
+
+The key feature: memories persist in Memanto's semantic database, not in LangGraph state. This means:
+
+1. Run the agent in Session A → memories are stored
+2. Start a completely new Session B with a different graph state
+3. The agent **recalls** Session A's memories because they live in Memanto, not in the ephemeral graph
+
+This is the "permanent brain" for your graph — the one thing LangGraph's built-in state management can't do alone.

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -63,13 +63,13 @@ python run_agent.py --session followup-2026-05-23
 
 - Python 3.10+
 - A [Moorcheh API key](https://console.moorcheh.ai/api-keys) (free tier: 100K ops/month)
-- An OpenAI or OpenRouter API key (for the LangGraph LLM)
+- An OpenAI API key (for the LangGraph LLM)
 
 ## Setup
 
 ```bash
 python -m venv venv
-source venv/bin activate
+source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env
 # Edit .env and add your MOORCHEH_API_KEY and OPENAI_API_KEY

--- a/examples/langgraph-memanto/agent.py
+++ b/examples/langgraph-memanto/agent.py
@@ -191,16 +191,25 @@ def create_agent(
     Args:
         moorcheh_api_key: Moorcheh API key (or set MOORCHEH_API_KEY env var)
         openai_api_key: OpenAI API key (or set OPENAI_API_KEY env var)
-        model: LLM model to use
+        model: LLM model to use (OpenAI-compatible models only)
         agent_id: Unique agent identifier for Memanto
         scope_id: Memory scope for isolation
 
     Returns:
         Compiled LangGraph agent
+
+    Raises:
+        ValueError: If MOORCHEH_API_KEY or OPENAI_API_KEY is not provided
     """
+    oai_key = openai_api_key or os.environ.get("OPENAI_API_KEY")
+    if not oai_key:
+        raise ValueError(
+            "OPENAI_API_KEY is required. Set it in .env or pass openai_api_key."
+        )
+
     llm = ChatOpenAI(
         model=model,
-        api_key=openai_api_key or os.environ.get("OPENAI_API_KEY"),
+        api_key=oai_key,
         temperature=0.3,
     )
 

--- a/examples/langgraph-memanto/agent.py
+++ b/examples/langgraph-memanto/agent.py
@@ -1,0 +1,207 @@
+"""
+LangGraph Research Agent with Memanto Persistent Memory.
+
+Workflow:
+  QUERY → RESEARCH → EVALUATE → RESPOND
+
+- RESEARCH: Simulates information gathering (web search + knowledge)
+- EVALUATE: Checks Memanto for prior memories, stores new findings
+- RESPOND: Generates final answer enriched with recalled context
+"""
+
+import os
+import json
+from typing import Any, TypedDict, Annotated
+from datetime import datetime
+
+from langgraph.graph import StateGraph, END
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from memanto_tool import MemantoTool
+
+
+# ─── Graph State ───────────────────────────────────────────────
+
+class AgentState(TypedDict):
+    """State that flows through the LangGraph workflow.
+
+    Note: Memanto memories are NOT stored here — they persist
+    in Memanto across sessions. This state is ephemeral.
+    """
+    query: str
+    session_id: str
+    research_notes: list[str]
+    recalled_memories: list[dict[str, Any]]
+    new_memories: list[dict[str, Any]]
+    final_answer: str
+
+
+# ─── Nodes ─────────────────────────────────────────────────────
+
+def research_node(state: AgentState, *, llm: ChatOpenAI) -> dict:
+    """Gather information on the query using the LLM as a research assistant."""
+    query = state["query"]
+
+    prompt = [
+        SystemMessage(content=(
+            "You are a research assistant. Given a query, provide detailed findings "
+            "as a numbered list of key facts, observations, and decisions. "
+            "Be thorough and specific. Include sources where possible."
+        )),
+        HumanMessage(content=f"Research this topic: {query}"),
+    ]
+
+    response = llm.invoke(prompt)
+    notes = [line.strip() for line in response.content.split("\n") if line.strip()]
+
+    return {"research_notes": notes}
+
+
+def evaluate_node(state: AgentState, *, memanto: MemantoTool) -> dict:
+    """Check Memanto for prior memories and store new findings."""
+    query = state["query"]
+    notes = state.get("research_notes", [])
+
+    # 1. Recall relevant memories from previous sessions
+    recalled = memanto.recall(query=query, limit=5)
+
+    # 2. Store new findings as typed memories
+    new_memories = []
+    for i, note in enumerate(notes[:5]):  # Store top 5 findings
+        # Determine memory type based on content
+        memory_type = _classify_note(note)
+        confidence = 0.85 + (0.05 * (len(note) > 100))  # Longer notes get slightly higher confidence
+        confidence = min(confidence, 0.95)
+
+        try:
+            result = memanto.remember(
+                content=note,
+                title=f"Research finding: {query[:40]}...",
+                memory_type=memory_type,
+                confidence=confidence,
+                tags=["research", state.get("session_id", "default")],
+            )
+            new_memories.append(result)
+        except Exception as e:
+            new_memories.append({"error": str(e), "note": note[:50]})
+
+    return {
+        "recalled_memories": recalled,
+        "new_memories": new_memories,
+    }
+
+
+def respond_node(state: AgentState, *, llm: ChatOpenAI) -> dict:
+    """Generate a final answer enriched with recalled memories."""
+    query = state["query"]
+    notes = state.get("research_notes", [])
+    recalled = state.get("recalled_memories", [])
+
+    # Build context from recalled memories
+    memory_context = ""
+    if recalled:
+        memory_context = "\n\n## Prior Knowledge (from Memanto memory):\n"
+        for m in recalled[:5]:
+            memory_context += (
+                f"- [{m.get('type', 'unknown').upper()}] {m.get('content', '')} "
+                f"(confidence: {m.get('confidence', 0):.2f})\n"
+            )
+
+    prompt = [
+        SystemMessage(content=(
+            "You are a knowledgeable research assistant with persistent memory. "
+            "Synthesize the research notes and any prior knowledge into a comprehensive answer. "
+            "If prior knowledge is available, explicitly reference it to show continuity "
+            "across sessions."
+        )),
+        HumanMessage(content=(
+            f"Query: {query}\n\n"
+            f"## Research Notes:\n" + "\n".join(notes[:10]) + "\n"
+            f"{memory_context}\n\n"
+            "Please provide a comprehensive answer that incorporates both the new research "
+            "and any prior knowledge. Make it clear when you're referencing information "
+            "from previous sessions."
+        )),
+    ]
+
+    response = llm.invoke(prompt)
+
+    return {"final_answer": response.content}
+
+
+# ─── Helper ────────────────────────────────────────────────────
+
+def _classify_note(note: str) -> str:
+    """Classify a research note into a Memanto memory type."""
+    note_lower = note.lower()
+
+    if any(kw in note_lower for kw in ["decided", "chose", "selected", "prefer", "recommend"]):
+        return "decision"
+    if any(kw in note_lower for kw in ["goal", "objective", "aim", "target"]):
+        return "goal"
+    if any(kw in note_lower for kw in ["should", "must", "always", "never", "rule"]):
+        return "instruction"
+    if any(kw in note_lower for kw in ["observed", "noticed", "found that", "discovered"]):
+        return "observation"
+    if any(kw in note_lower for kw in ["plan", "strategy", "approach", "method"]):
+        return "goal"
+    # Default to fact
+    return "fact"
+
+
+# ─── Graph Construction ────────────────────────────────────────
+
+def build_graph(llm: ChatOpenAI, memanto: MemantoTool) -> StateGraph:
+    """Build the LangGraph research agent workflow."""
+
+    graph = StateGraph(AgentState)
+
+    # Add nodes with bound dependencies
+    graph.add_node("research", lambda state: research_node(state, llm=llm))
+    graph.add_node("evaluate", lambda state: evaluate_node(state, memanto=memanto))
+    graph.add_node("respond", lambda state: respond_node(state, llm=llm))
+
+    # Define edges
+    graph.set_entry_point("research")
+    graph.add_edge("research", "evaluate")
+    graph.add_edge("evaluate", "respond")
+    graph.add_edge("respond", END)
+
+    return graph.compile()
+
+
+# ─── Factory ───────────────────────────────────────────────────
+
+def create_agent(
+    moorcheh_api_key: str | None = None,
+    openai_api_key: str | None = None,
+    model: str = "gpt-4o-mini",
+    agent_id: str = "langgraph-research-agent",
+    scope_id: str = "research",
+) -> Any:
+    """Create and return a compiled LangGraph agent with Memanto memory.
+
+    Args:
+        moorcheh_api_key: Moorcheh API key (or set MOORCHEH_API_KEY env var)
+        openai_api_key: OpenAI API key (or set OPENAI_API_KEY env var)
+        model: LLM model to use
+        agent_id: Unique agent identifier for Memanto
+        scope_id: Memory scope for isolation
+
+    Returns:
+        Compiled LangGraph agent
+    """
+    llm = ChatOpenAI(
+        model=model,
+        api_key=openai_api_key or os.environ.get("OPENAI_API_KEY"),
+        temperature=0.3,
+    )
+
+    memanto = MemantoTool(
+        agent_id=agent_id,
+        scope_id=scope_id,
+        moorcheh_api_key=moorcheh_api_key,
+    )
+
+    return build_graph(llm, memanto)

--- a/examples/langgraph-memanto/agent.py
+++ b/examples/langgraph-memanto/agent.py
@@ -10,6 +10,8 @@ Workflow:
 """
 
 import os
+import logging
+logger = logging.getLogger(__name__)
 import json
 from typing import Any, TypedDict, Annotated
 from datetime import datetime
@@ -64,7 +66,11 @@ def evaluate_node(state: AgentState, *, memanto: MemantoTool) -> dict:
     notes = state.get("research_notes", [])
 
     # 1. Recall relevant memories from previous sessions
-    recalled = memanto.recall(query=query, limit=5)
+    try:
+        recalled = memanto.recall(query=query, limit=5)
+    except Exception as e:
+        logger.warning("Memanto recall failed in evaluate node: %s", e)
+        recalled = []
 
     # 2. Store new findings as typed memories
     new_memories = []

--- a/examples/langgraph-memanto/memanto_tool.py
+++ b/examples/langgraph-memanto/memanto_tool.py
@@ -153,7 +153,7 @@ class MemantoTool:
 
         Args:
             query: Search query for semantic retrieval
-            limit: Maximum number of memories to return
+            limit: Maximum number of memories to return (1-20)
             memory_types: Filter by memory types
             min_confidence: Filter by minimum confidence score
 

--- a/examples/langgraph-memanto/memanto_tool.py
+++ b/examples/langgraph-memanto/memanto_tool.py
@@ -84,8 +84,12 @@ class MemantoTool:
                     namespace_name=self._namespace,
                     source_type="semantic",
                 )
-            except Exception:
-                pass  # Namespace may already exist (race condition)
+            except Exception as e:
+                err_msg = str(e).lower()
+                if "already" in err_msg or "conflict" in err_msg or "409" in err_msg:
+                    logger.debug("Namespace %s already exists (race condition)", self._namespace)
+                else:
+                    logger.warning("Failed to create namespace %s: %s", self._namespace, e)
 
     def remember(
         self,
@@ -160,6 +164,9 @@ class MemantoTool:
         Returns:
             List of memory dicts with content, type, confidence, and timestamp
         """
+        # Clamp limit to valid range
+        limit = max(1, min(20, limit))
+
         kwargs = {
             "query": query,
             "scope_type": self.scope_type,
@@ -212,7 +219,8 @@ class MemantoTool:
                 "sources": result.get("sources", []),
                 "confidence": result.get("confidence", 0.0),
             }
-        except Exception:
+        except Exception as e:
+            logger.warning("Memanto answer() failed, falling back to recall: %s", e)
             # Fallback: recall + format manually
             memories = self.recall(query, limit=3)
             if not memories:

--- a/examples/langgraph-memanto/memanto_tool.py
+++ b/examples/langgraph-memanto/memanto_tool.py
@@ -7,6 +7,9 @@ integrate with LangGraph's tool interface.
 
 import os
 import json
+import logging
+logger = logging.getLogger(__name__)
+
 from datetime import datetime
 from typing import Any
 

--- a/examples/langgraph-memanto/memanto_tool.py
+++ b/examples/langgraph-memanto/memanto_tool.py
@@ -1,0 +1,262 @@
+"""
+MemantoTool — LangGraph-compatible tool wrapping Memanto's three primitives.
+
+Provides `remember`, `recall`, and `answer` as callable methods that
+integrate with LangGraph's tool interface.
+"""
+
+import os
+import json
+from datetime import datetime
+from typing import Any
+
+from memanto.app.core import MemoryRecord, MemoryScope
+from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.services.memory_read_service import MemoryReadService
+
+try:
+    from moorcheh_sdk import MoorchehClient
+except ImportError:
+    MoorchehClient = None
+
+
+# Valid memory types from Memanto
+MEMORY_TYPES = [
+    "fact", "preference", "goal", "decision", "artifact",
+    "learning", "event", "instruction", "relationship",
+    "context", "observation", "commitment", "error",
+]
+
+
+class MemantoTool:
+    """
+    LangGraph-compatible tool that wraps Memanto's remember/recall/answer primitives.
+
+    Usage:
+        tool = MemantoTool(agent_id="research-agent-1", scope_id="research")
+        tool.remember("Quantum error correction uses surface codes", memory_type="fact", confidence=0.9)
+        results = tool.recall("error correction approaches")
+        answer = tool.answer("What did we learn about quantum error correction?")
+    """
+
+    def __init__(
+        self,
+        agent_id: str = "langgraph-agent",
+        scope_type: str = "agent",
+        scope_id: str = "default",
+        moorcheh_api_key: str | None = None,
+    ):
+        self.agent_id = agent_id
+        self.scope_type = scope_type
+        self.scope_id = scope_id
+
+        api_key = moorcheh_api_key or os.environ.get("MOORCHEH_API_KEY", "")
+        if not api_key:
+            raise ValueError(
+                "MOORCHEH_API_KEY is required. Set it in .env or pass moorcheh_api_key."
+            )
+
+        if MoorchehClient is None:
+            raise ImportError(
+                "moorcheh-sdk is required. Install with: pip install moorcheh-sdk"
+            )
+
+        self.client = MoorchehClient(api_key=api_key)
+        self.write_service = MemoryWriteService(self.client)
+        self.read_service = MemoryReadService(self.client)
+
+        # Ensure namespace exists
+        self._namespace = MemoryScope(
+            scope_type=scope_type, scope_id=scope_id
+        ).to_namespace()
+        self._ensure_namespace()
+
+    def _ensure_namespace(self):
+        """Create the Moorcheh namespace if it doesn't exist."""
+        try:
+            self.client.namespaces.get(namespace_name=self._namespace)
+        except Exception:
+            try:
+                self.client.namespaces.create(
+                    namespace_name=self._namespace,
+                    source_type="semantic",
+                )
+            except Exception:
+                pass  # Namespace may already exist (race condition)
+
+    def remember(
+        self,
+        content: str,
+        title: str | None = None,
+        memory_type: str = "fact",
+        confidence: float = 0.8,
+        tags: list[str] | None = None,
+        source: str = "agent_inference",
+    ) -> dict[str, Any]:
+        """
+        Store a new memory in Memanto.
+
+        Args:
+            content: The memory content text
+            title: Short title (auto-generated if None)
+            memory_type: One of Memanto's 13 typed categories
+            confidence: Self-evaluated certainty (0.0 - 1.0)
+            tags: Optional tags for categorization
+            source: Provenance source type
+
+        Returns:
+            Dict with stored memory ID and metadata
+        """
+        if memory_type not in MEMORY_TYPES:
+            raise ValueError(
+                f"Invalid memory_type '{memory_type}'. Must be one of: {MEMORY_TYPES}"
+            )
+        confidence = max(0.0, min(1.0, confidence))
+        if title is None:
+            title = content[:80] + ("..." if len(content) > 80 else "")
+
+        memory = MemoryRecord(
+            type=memory_type,
+            title=title,
+            content=content,
+            scope_type=self.scope_type,
+            scope_id=self.scope_id,
+            actor_id=self.agent_id,
+            source=source,
+            confidence=confidence,
+            tags=tags or [],
+            provenance="explicit_statement",
+        )
+
+        result = self.write_service.store_memory(memory)
+        return {
+            "action": "remembered",
+            "memory_id": memory.id,
+            "type": memory_type,
+            "confidence": confidence,
+            "title": title,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+
+    def recall(
+        self,
+        query: str,
+        limit: int = 5,
+        memory_types: list[str] | None = None,
+        min_confidence: float | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Search for relevant memories in Memanto.
+
+        Args:
+            query: Search query for semantic retrieval
+            limit: Maximum number of memories to return
+            memory_types: Filter by memory types
+            min_confidence: Filter by minimum confidence score
+
+        Returns:
+            List of memory dicts with content, type, confidence, and timestamp
+        """
+        kwargs = {
+            "query": query,
+            "scope_type": self.scope_type,
+            "scope_id": self.scope_id,
+            "limit": limit,
+        }
+        if memory_types:
+            kwargs["type"] = memory_types
+        if min_confidence is not None:
+            kwargs["min_confidence"] = min_confidence
+
+        result = self.read_service.search_memories(**kwargs)
+
+        memories = []
+        items = result.get("memories", result.get("items", []))
+        for item in items:
+            memories.append({
+                "memory_id": item.get("id", ""),
+                "type": item.get("memory_type", item.get("type", "unknown")),
+                "title": item.get("title", ""),
+                "content": item.get("content", item.get("text", "")),
+                "confidence": item.get("confidence", 0.0),
+                "created_at": item.get("created_at", ""),
+            })
+
+        return memories
+
+    def answer(self, query: str) -> dict[str, Any]:
+        """
+        Get an LLM-grounded answer from Memanto's memory.
+
+        This uses Memanto's native `answer` primitive, which generates
+        a response directly from stored memories without requiring an
+        external LLM call.
+
+        Args:
+            query: Question to answer from memory
+
+        Returns:
+            Dict with answer text, source memories, and confidence
+        """
+        try:
+            # Use Memanto's answer endpoint
+            result = self.client.answer(
+                namespace_name=self._namespace,
+                question=query,
+            )
+            return {
+                "answer": result.get("answer", ""),
+                "sources": result.get("sources", []),
+                "confidence": result.get("confidence", 0.0),
+            }
+        except Exception:
+            # Fallback: recall + format manually
+            memories = self.recall(query, limit=3)
+            if not memories:
+                return {
+                    "answer": "No relevant memories found.",
+                    "sources": [],
+                    "confidence": 0.0,
+                }
+            answer_parts = []
+            for m in memories:
+                answer_parts.append(
+                    f"[{m['type'].upper()}] {m['content']} (confidence: {m['confidence']})"
+                )
+            return {
+                "answer": "\n".join(answer_parts),
+                "sources": memories,
+                "confidence": max(m["confidence"] for m in memories) if memories else 0.0,
+            }
+
+    def get_langchain_tools(self) -> list:
+        """
+        Return LangChain-compatible tool definitions for use with LangGraph.
+
+        Returns three tools: remember, recall, answer.
+        """
+        from langchain_core.tools import tool as lc_tool
+
+        memanto_instance = self
+
+        @lc_tool
+        def remember_memory(content: str, memory_type: str = "fact", confidence: float = 0.8) -> str:
+            """Store a new memory. Use memory_type: fact, observation, decision, goal, preference, instruction."""
+            result = memanto_instance.remember(
+                content=content, memory_type=memory_type, confidence=confidence
+            )
+            return json.dumps(result)
+
+        @lc_tool
+        def recall_memories(query: str, limit: int = 5) -> str:
+            """Search for relevant memories from previous sessions."""
+            results = memanto_instance.recall(query=query, limit=limit)
+            return json.dumps(results, default=str)
+
+        @lc_tool
+        def answer_from_memory(query: str) -> str:
+            """Get an answer grounded in the agent's persistent memory."""
+            result = memanto_instance.answer(query=query)
+            return json.dumps(result, default=str)
+
+        return [remember_memory, recall_memories, answer_from_memory]

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,3 +1,4 @@
+moorcheh-sdk>=0.2.0
 langgraph>=0.2.0
 langchain>=0.3.0
 langchain-openai>=0.2.0

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,6 +1,5 @@
-moorcheh-sdk>=0.2.0
-langgraph>=0.2.0
+langgraph>=0.2.28
 langchain>=0.3.0
 langchain-openai>=0.2.0
-memanto>=0.3.0
+moorcheh-sdk>=0.2.0
 python-dotenv>=1.0.0

--- a/examples/langgraph-memanto/requirements.txt
+++ b/examples/langgraph-memanto/requirements.txt
@@ -1,0 +1,5 @@
+langgraph>=0.2.0
+langchain>=0.3.0
+langchain-openai>=0.2.0
+memanto>=0.3.0
+python-dotenv>=1.0.0

--- a/examples/langgraph-memanto/run_agent.py
+++ b/examples/langgraph-memanto/run_agent.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Run the LangGraph Research Agent with Memanto Persistent Memory.
+
+Usage:
+    python run_agent.py                                    # Interactive mode
+    python run_agent.py --query "quantum error correction" # Single query
+    python run_agent.py --session my-session --query "AI safety"
+"""
+
+import os
+import argparse
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from agent import create_agent
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LangGraph + Memanto Research Agent")
+    parser.add_argument("--query", "-q", type=str, help="Research query")
+    parser.add_argument("--session", "-s", type=str, default="default", help="Session ID")
+    parser.add_argument("--model", "-m", type=str, default="gpt-4o-mini", help="LLM model")
+    parser.add_argument("--agent-id", type=str, default="langgraph-research-agent", help="Agent ID")
+    parser.add_argument("--scope-id", type=str, default="research", help="Memanto scope ID")
+    args = parser.parse_args()
+
+    print("🧠 LangGraph + Memanto Research Agent")
+    print("=" * 50)
+
+    # Create the agent
+    print(f"🔧 Initializing agent (scope: {args.scope_id})...")
+    agent = create_agent(
+        agent_id=args.agent_id,
+        scope_id=args.scope_id,
+        model=args.model,
+    )
+    print("✅ Agent ready!\n")
+
+    if args.query:
+        # Single query mode
+        _run_query(agent, args.query, args.session)
+    else:
+        # Interactive mode
+        print("Enter your research queries (Ctrl+C to exit):\n")
+        while True:
+            try:
+                query = input("🔍 > ").strip()
+                if not query:
+                    continue
+                _run_query(agent, query, args.session)
+                print()
+            except (KeyboardInterrupt, EOFError):
+                print("\n👋 Goodbye!")
+                break
+
+
+def _run_query(agent, query: str, session_id: str):
+    """Run a single query through the agent."""
+    print(f"\n🔍 Researching: {query}")
+    print("-" * 40)
+
+    result = agent.invoke({
+        "query": query,
+        "session_id": session_id,
+        "research_notes": [],
+        "recalled_memories": [],
+        "new_memories": [],
+        "final_answer": "",
+    })
+
+    # Show recalled memories
+    recalled = result.get("recalled_memories", [])
+    if recalled:
+        print(f"\n🔎 Recalled {len(recalled)} memories from previous sessions:")
+        for m in recalled:
+            print(f"  - [{m.get('type', '?').upper()}] {m.get('content', '')[:60]}... "
+                  f"(conf: {m.get('confidence', 0):.2f})")
+
+    # Show new memories stored
+    new = result.get("new_memories", [])
+    if new:
+        print(f"\n📝 Stored {len(new)} new memories:")
+
+    # Show final answer
+    answer = result.get("final_answer", "")
+    if answer:
+        print(f"\n✅ Answer:\n{answer}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph-memanto/test_integration.py
+++ b/examples/langgraph-memanto/test_integration.py
@@ -1,0 +1,229 @@
+"""
+Unit tests for the LangGraph + Memanto integration.
+
+These tests use mocks for the Moorcheh client so they can run
+without API keys.
+"""
+
+import pytest
+import json
+from unittest.mock import MagicMock, patch
+
+from memanto_tool import MemantoTool
+
+
+class TestMemantoToolUnit:
+    """Unit tests for MemantoTool without requiring API access."""
+
+    @patch("memanto_tool.MoorchehClient")
+    def test_remember_validates_memory_type(self, MockClient):
+        """remember() should reject invalid memory types."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+
+        with pytest.raises(ValueError, match="Invalid memory_type"):
+            tool.remember("test content", memory_type="invalid_type")
+
+    @pytest.mark.parametrize("memory_type", [
+        "fact", "preference", "goal", "decision", "artifact",
+        "learning", "event", "instruction", "relationship",
+        "context", "observation", "commitment", "error",
+    ])
+    @patch("memanto_tool.MoorchehClient")
+    def test_remember_accepts_all_valid_types(self, MockClient, memory_type):
+        """remember() should accept all 13 Memanto memory types."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+        mock_write_service = MagicMock()
+        mock_write_service.store_memory.return_value = {"id": "mem-123"}
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+        tool.write_service = mock_write_service
+
+        result = tool.remember("test content", memory_type=memory_type)
+        assert result["action"] == "remembered"
+        assert result["type"] == memory_type
+
+    @patch("memanto_tool.MoorchehClient")
+    def test_remember_clamps_confidence(self, MockClient):
+        """remember() should clamp confidence to [0.0, 1.0]."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+        mock_write_service = MagicMock()
+        mock_write_service.store_memory.return_value = {"id": "mem-123"}
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+        tool.write_service = mock_write_service
+
+        result = tool.remember("test", confidence=1.5)
+        assert result["confidence"] == 1.0
+
+        result = tool.remember("test", confidence=-0.5)
+        assert result["confidence"] == 0.0
+
+    @patch("memanto_tool.MoorchehClient")
+    def test_remember_auto_generates_title(self, MockClient):
+        """remember() should auto-generate title from content if not provided."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+        mock_write_service = MagicMock()
+        mock_write_service.store_memory.return_value = {"id": "mem-123"}
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+        tool.write_service = mock_write_service
+
+        result = tool.remember("Short content")
+        assert result["title"] == "Short content"
+
+        long = "x" * 100
+        result = tool.remember(long)
+        assert result["title"].endswith("...")
+
+    @patch("memanto_tool.MoorchehClient")
+    def test_recall_returns_list(self, MockClient):
+        """recall() should return a list of memory dicts."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+        mock_read_service = MagicMock()
+        mock_read_service.search_memories.return_value = {
+            "memories": [
+                {
+                    "id": "mem-1",
+                    "memory_type": "fact",
+                    "title": "Test fact",
+                    "content": "This is a test fact",
+                    "confidence": 0.9,
+                    "created_at": "2026-05-22T00:00:00",
+                },
+            ]
+        }
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+        tool.read_service = mock_read_service
+
+        results = tool.recall("test query")
+        assert len(results) == 1
+        assert results[0]["type"] == "fact"
+        assert results[0]["confidence"] == 0.9
+
+    @patch("memanto_tool.MoorchehClient")
+    def test_recall_empty(self, MockClient):
+        """recall() should return empty list when no memories found."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+        mock_read_service = MagicMock()
+        mock_read_service.search_memories.return_value = {"memories": []}
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+        tool.read_service = mock_read_service
+
+        results = tool.recall("nonexistent topic")
+        assert results == []
+
+    @patch("memanto_tool.MoorchehClient")
+    def test_answer_uses_client(self, MockClient):
+        """answer() should use the Moorcheh client's answer endpoint."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+        mock_client.answer.return_value = {
+            "answer": "Surface codes are the leading approach to QECC",
+            "sources": [{"id": "mem-1"}],
+            "confidence": 0.92,
+        }
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+        tool.client = mock_client
+
+        result = tool.answer("What is the best QECC approach?")
+        assert "Surface codes" in result["answer"]
+        assert result["confidence"] == 0.92
+
+    @patch("memanto_tool.MoorchehClient")
+    def test_answer_fallback_on_error(self, MockClient):
+        """answer() should fall back to recall when client.answer fails."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+        mock_client.answer.side_effect = Exception("API error")
+
+        mock_read_service = MagicMock()
+        mock_read_service.search_memories.return_value = {
+            "memories": [
+                {
+                    "id": "mem-1",
+                    "memory_type": "fact",
+                    "content": "Surface codes are best",
+                    "confidence": 0.9,
+                    "created_at": "2026-05-22",
+                },
+            ]
+        }
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+        tool.client = mock_client
+        tool.read_service = mock_read_service
+
+        result = tool.answer("What is the best QECC approach?")
+        assert "Surface codes" in result["answer"]
+        assert result["confidence"] == 0.9
+
+    @patch("memanto_tool.MoorchehClient")
+    def test_answer_no_memories(self, MockClient):
+        """answer() should report no memories when none exist."""
+        mock_client = MockClient.return_value
+        mock_client.namespaces.get.return_value = True
+        mock_client.answer.side_effect = Exception("API error")
+
+        mock_read_service = MagicMock()
+        mock_read_service.search_memories.return_value = {"memories": []}
+
+        tool = MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="fake")
+        tool.client = mock_client
+        tool.read_service = mock_read_service
+
+        result = tool.answer("unknown topic")
+        assert "No relevant memories" in result["answer"]
+        assert result["confidence"] == 0.0
+
+
+class TestNoteClassification:
+    """Test the _classify_note helper function."""
+
+    def test_decision(self):
+        from agent import _classify_note
+        assert _classify_note("We decided to use Python 3.12") == "decision"
+
+    def test_goal(self):
+        from agent import _classify_note
+        assert _classify_note("The goal is to achieve 99% uptime") == "goal"
+
+    def test_instruction(self):
+        from agent import _classify_note
+        assert _classify_note("You must always validate inputs") == "instruction"
+
+    def test_observation(self):
+        from agent import _classify_note
+        assert _classify_note("We observed that latency decreased by 50%") == "observation"
+
+    def test_plan(self):
+        from agent import _classify_note
+        assert _classify_note("The plan involves three phases of deployment") == "goal"
+
+    def test_default_fact(self):
+        from agent import _classify_note
+        assert _classify_note("Python was created in 1991") == "fact"
+
+
+import os
+
+class TestMemantoToolNoKey:
+    """Test that MemantoTool fails gracefully without an API key."""
+
+    def test_no_api_key_raises(self):
+        """Should raise ValueError if no API key is provided."""
+        with patch.dict("os.environ", {}, clear=True):
+            # Ensure MOORCHEH_API_KEY is not set
+            os.environ.pop("MOORCHEH_API_KEY", None)
+            with pytest.raises(ValueError, match="MOORCHEH_API_KEY"):
+                MemantoTool(agent_id="test", scope_id="test", moorcheh_api_key="")


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review comments from PR #559 and #560.

### Changes

**memanto_tool.py** (both examples):
- Replace bare `pass` in namespace creation with proper error classification (409/conflict = already exists, else log warning)
- Add logging to `answer()` fallback with exception detail  
- Add `recall()` limit clamping (1-20 range)
- Add `memory_type` validation against allowed enum values

**agent.py** (langgraph-customer-support):
- Add LLM output validation: severity/category clamped to allowed values with warning log for invalid outputs
- Add `_classify_investigation()` helper for typed memory storage
- Wrap all `memanto.remember()` calls in try/except with logging

**test_integration.py** (both examples):
- Fix `min_confidence` check (`is not None` vs truthy — handles 0.0 correctly)

**requirements.txt**:
- Add `moorcheh-sdk` dependency (was imported but missing from requirements)

**README.md**:
- Add language identifiers (`text`/`bash`) to all code blocks

### Test Evidence
All 7 + 28 = 35 integration tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two complete LangGraph example apps demonstrating persistent Memanto-backed cross-session memory: a customer support agent (triage→investigate→resolve→follow-up) and a research agent (research→evaluate→respond), with interactive CLI runners.

* **Documentation**
  * Added full READMEs and .env templates with placeholder API variables and quick-start instructions.

* **Tests**
  * Added unit and integration tests covering memory remember/recall/answer behavior and end-to-end workflows.

* **Chores**
  * Added example dependency manifests for easy setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->