### PR TITLE
Add Claude Code skills Memanto example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,99 @@
+# Claude Code Skills + Memanto Memory Companion
+
+This example shows how a `mattpocock/skills`-style skill pack can use Memanto as persistent, typed memory for coding agents.
+
+The goal is simple:
+
+- Skills keep reusable procedures in versioned files.
+- Memanto remembers project facts, decisions, preferences, errors, and lessons across sessions.
+- Claude Code or any shell-capable coding agent can call the helper script before and after a task.
+
+This example is safe for reviewers: every command supports `--dry-run`, so it can be tested without a Moorcheh API key or a live Memanto agent.
+
+## Files
+
+```text
+examples/claudecode-skills-memanto/
+  README.md
+  skills/memanto-project-memory/SKILL.md
+  scripts/memanto_skill_memory.py
+```
+
+## Quick start
+
+```bash
+cd examples/claudecode-skills-memanto
+
+# Preview commands without touching Memanto
+python scripts/memanto_skill_memory.py setup --agent-id demo-project --dry-run
+python scripts/memanto_skill_memory.py remember-decision \
+  --title "Use SQLite for local cache" \
+  --content "Decision: use SQLite for local cache because it is embedded and easy to inspect." \
+  --dry-run
+python scripts/memanto_skill_memory.py recall --query "local cache decision" --dry-run
+```
+
+When Memanto is configured, remove `--dry-run`:
+
+```bash
+memanto agent create demo-project --pattern project
+python scripts/memanto_skill_memory.py remember-decision \
+  --title "Use SQLite for local cache" \
+  --content "Decision: use SQLite for local cache because it is embedded and easy to inspect."
+python scripts/memanto_skill_memory.py recall --query "local cache decision"
+```
+
+## How an agent should use this skill
+
+1. At task start, recall relevant context:
+
+   ```bash
+   python scripts/memanto_skill_memory.py recall --query "current project conventions and recent errors"
+   ```
+
+2. During the task, store durable learnings only:
+
+   ```bash
+   python scripts/memanto_skill_memory.py remember-decision \
+     --title "API pagination style" \
+     --content "Decision: API list endpoints use cursor pagination, not offset pagination."
+   ```
+
+3. After a tricky bug, store the reusable fix:
+
+   ```bash
+   python scripts/memanto_skill_memory.py remember-error \
+     --title "pytest import path failure" \
+     --content "Error: tests failed with ModuleNotFoundError. Solution: run from repo root or set PYTHONPATH=."
+   ```
+
+## What to remember vs. not remember
+
+Good memories:
+
+- Stable project conventions.
+- Architecture decisions.
+- User/team preferences.
+- Reusable debugging lessons.
+- Integration gotchas.
+
+Bad memories:
+
+- Temporary task progress.
+- Raw logs.
+- Secrets or API keys.
+- One-off TODOs that will be stale tomorrow.
+
+## Why this fits Memanto
+
+Memanto's typed memory model maps directly to agent skill workflows:
+
+| Skill workflow item | Memanto type |
+| --- | --- |
+| Project convention | `instruction` or `fact` |
+| Architecture choice | `decision` |
+| Bug fix lesson | `error` or `learning` |
+| User preference | `preference` |
+| Delivered artifact | `artifact` |
+
+This keeps skills small and reusable while Memanto provides recallable project context across agent sessions.

--- a/examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py
+++ b/examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Helper commands for using Memanto from coding-agent skills.
+
+The script intentionally shells out to the public `memanto` CLI instead of
+importing internal modules so it works from a source checkout, an installed
+package, or a copied skill pack.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class MemoryCommand:
+    args: list[str]
+
+    def display(self) -> str:
+        return " ".join(shlex.quote(part) for part in self.args)
+
+
+def run_or_preview(command: MemoryCommand, dry_run: bool) -> int:
+    if dry_run:
+        print(command.display())
+        return 0
+    completed = subprocess.run(command.args, check=False)
+    return completed.returncode
+
+
+def setup_command(args: argparse.Namespace) -> MemoryCommand:
+    return MemoryCommand(
+        [
+            "memanto",
+            "agent",
+            "create",
+            args.agent_id,
+            "--pattern",
+            args.pattern,
+            "--description",
+            args.description,
+        ]
+    )
+
+
+def remember_command(args: argparse.Namespace, memory_type: str) -> MemoryCommand:
+    tags = args.tags or f"skills,{memory_type}"
+    return MemoryCommand(
+        [
+            "memanto",
+            "remember",
+            args.content,
+            "--type",
+            memory_type,
+            "--title",
+            args.title,
+            "--confidence",
+            str(args.confidence),
+            "--provenance",
+            args.provenance,
+            "--source",
+            args.source,
+            "--tags",
+            tags,
+        ]
+    )
+
+
+def recall_command(args: argparse.Namespace) -> MemoryCommand:
+    return MemoryCommand(
+        [
+            "memanto",
+            "recall",
+            args.query,
+            "--limit",
+            str(args.limit),
+        ]
+    )
+
+
+def add_common_remember_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--title", required=True, help="Short memory title")
+    parser.add_argument("--content", required=True, help="Durable memory content")
+    parser.add_argument("--tags", default=None, help="Comma-separated tags")
+    parser.add_argument("--source", default="claude-code-skill", help="Memory source")
+    parser.add_argument("--confidence", type=float, default=0.85, help="0.0-1.0")
+    parser.add_argument(
+        "--provenance",
+        default="explicit_statement",
+        help="Memory provenance, e.g. explicit_statement, inferred, corrected",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print command only")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Use Memanto from Claude Code / mattpocock-style skills."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    setup = subparsers.add_parser("setup", help="Create and activate a Memanto agent")
+    setup.add_argument("--agent-id", required=True)
+    setup.add_argument("--pattern", default="project", choices=("project", "support", "tool"))
+    setup.add_argument(
+        "--description",
+        default="Project memory namespace for coding-agent skills",
+    )
+    setup.add_argument("--dry-run", action="store_true", help="Print command only")
+
+    decision = subparsers.add_parser("remember-decision", help="Store a decision")
+    add_common_remember_args(decision)
+
+    error = subparsers.add_parser("remember-error", help="Store a debugging lesson")
+    add_common_remember_args(error)
+
+    learning = subparsers.add_parser("remember-learning", help="Store a reusable lesson")
+    add_common_remember_args(learning)
+
+    recall = subparsers.add_parser("recall", help="Recall project memory")
+    recall.add_argument("--query", required=True)
+    recall.add_argument("--limit", type=int, default=5)
+    recall.add_argument("--dry-run", action="store_true", help="Print command only")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "setup":
+        return run_or_preview(setup_command(args), args.dry_run)
+    if args.command == "remember-decision":
+        return run_or_preview(remember_command(args, "decision"), args.dry_run)
+    if args.command == "remember-error":
+        return run_or_preview(remember_command(args, "error"), args.dry_run)
+    if args.command == "remember-learning":
+        return run_or_preview(remember_command(args, "learning"), args.dry_run)
+    if args.command == "recall":
+        return run_or_preview(recall_command(args), args.dry_run)
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py
+++ b/examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py
@@ -27,7 +27,13 @@ def run_or_preview(command: MemoryCommand, dry_run: bool) -> int:
     if dry_run:
         print(command.display())
         return 0
-    completed = subprocess.run(command.args, check=False)
+    try:
+        completed = subprocess.run(command.args, check=False)
+    except FileNotFoundError:
+        print(
+            f"Error: memanto CLI was not found while running: {command.display()}",
+        )
+        return 127
     return completed.returncode
 
 

--- a/examples/claudecode-skills-memanto/skills/memanto-project-memory/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/memanto-project-memory/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: memanto-project-memory
+description: Use Memanto as typed persistent memory for Claude Code / mattpocock-style coding skills.
+---
+
+# Memanto Project Memory
+
+Use this skill when a coding agent needs to preserve stable project context across sessions without bloating the skill file itself.
+
+## When to use
+
+- Starting work in a project with existing conventions.
+- Capturing an architecture decision that should survive future sessions.
+- Recording a reusable debugging lesson.
+- Recalling prior project context before editing code.
+
+## Start-of-task recall
+
+Run this before planning or editing:
+
+```bash
+python examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py recall \
+  --query "project conventions decisions preferences recent errors"
+```
+
+Use the recalled facts as context, but do not blindly obey stale memories. If a memory conflicts with repository files or the user's latest instruction, prefer the newer source and store a correction.
+
+## Store a decision
+
+```bash
+python examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py remember-decision \
+  --title "Use cursor pagination" \
+  --content "Decision: API list endpoints use cursor pagination. Rationale: stable pagination during concurrent writes."
+```
+
+## Store a debugging lesson
+
+```bash
+python examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py remember-error \
+  --title "Import path during tests" \
+  --content "Error: pytest cannot import local package. Solution: run from repo root or set PYTHONPATH=."
+```
+
+## Dry-run for reviewers
+
+Every command supports `--dry-run`:
+
+```bash
+python examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py remember-decision \
+  --title "Example" \
+  --content "Decision: this is only a preview." \
+  --dry-run
+```
+
+Dry-run prints the exact `memanto` command instead of executing it.
+
+## Memory hygiene
+
+Remember durable facts only. Do not store secrets, raw logs, temporary task progress, or issue-specific status that will be stale soon.

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import subprocess
+import sys
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "claudecode-skills-memanto"
+SCRIPT = EXAMPLE_DIR / "scripts" / "memanto_skill_memory.py"
+README = EXAMPLE_DIR / "README.md"
+SKILL = EXAMPLE_DIR / "skills" / "memanto-project-memory" / "SKILL.md"
+
+
+def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_claudecode_skills_memanto_example_files_exist():
+    assert README.exists()
+    assert SKILL.exists()
+    assert SCRIPT.exists()
+    assert "dry-run" in README.read_text().lower()
+    assert "memanto-project-memory" in SKILL.read_text()
+
+
+def test_memanto_skill_memory_setup_dry_run_prints_agent_create_command():
+    result = run_script("setup", "--agent-id", "demo-project", "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "memanto agent create demo-project --pattern project" in result.stdout
+
+
+def test_memanto_skill_memory_remember_decision_dry_run_uses_typed_memory():
+    result = run_script(
+        "remember-decision",
+        "--title",
+        "Use SQLite",
+        "--content",
+        "Decision: use SQLite for local cache.",
+        "--dry-run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "memanto remember" in result.stdout
+    assert "--type decision" in result.stdout
+    assert "--title 'Use SQLite'" in result.stdout
+
+
+def test_memanto_skill_memory_recall_dry_run_prints_recall_command():
+    result = run_script("recall", "--query", "local cache", "--limit", "3", "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "memanto recall 'local cache' --limit 3" in result.stdout

--- a/tests/test_claudecode_skills_memanto_example.py
+++ b/tests/test_claudecode_skills_memanto_example.py
@@ -9,12 +9,13 @@ README = EXAMPLE_DIR / "README.md"
 SKILL = EXAMPLE_DIR / "skills" / "memanto-project-memory" / "SKILL.md"
 
 
-def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+def run_script(*args: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(SCRIPT), *args],
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout,
     )
 
 


### PR DESCRIPTION
# PR draft: Add Claude Code skills + Memanto memory companion example

## Bounty

Issue: https://github.com/moorcheh-ai/memanto/issues/508

## Summary

Adds a credential-safe example for using Memanto with Claude Code / mattpocock-style skills:

- `examples/claudecode-skills-memanto/README.md`
- `examples/claudecode-skills-memanto/skills/memanto-project-memory/SKILL.md`
- `examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py`
- `tests/test_claudecode_skills_memanto_example.py`

The example demonstrates how coding-agent skills can use Memanto for typed, durable project memory while keeping the skill itself small and reusable.

## Why this is useful

Many coding-agent skills encode procedures, but project-specific decisions and lessons should live in memory instead of being copied into every skill. This example gives agents a simple workflow:

1. Recall project context before work.
2. Store durable architecture decisions.
3. Store reusable debugging lessons.
4. Avoid storing secrets, raw logs, or temporary task progress.

## Reviewer safety

The helper script supports `--dry-run` for every command, so reviewers can validate behavior without a Moorcheh API key, an active Memanto agent, or network calls.

Example:

```bash
python examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py setup --agent-id demo-project --dry-run
python examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py remember-decision \
  --title "Use SQLite" \
  --content "Decision: use SQLite for local cache." \
  --dry-run
python examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py recall --query "local cache" --limit 3 --dry-run
```

## Local verification performed

```bash
python3 -m py_compile examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py
python3 examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py setup --agent-id demo-project --dry-run
python3 examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py remember-decision --title 'Use SQLite' --content 'Decision: use SQLite for local cache.' --dry-run
python3 examples/claudecode-skills-memanto/scripts/memanto_skill_memory.py recall --query 'local cache' --limit 3 --dry-run
git diff --cached --check
```

Focused pytest was attempted, but the local VM did not have the project dependency `moorcheh_sdk`, and editable install failed in the build backend with `ModuleNotFoundError: packaging.licenses`. The new script itself is stdlib-only and was smoke-tested directly.

## Patch file

`/home/bnutscrazy86/bounty-work/patches/memanto-bounty-508-claudecode-skills.patch`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Example integration of Memanto with Claude Code skills for persistent, typed agent memory
  * A command-line helper to manage agent memory (setup, remember, recall) with a dry-run preview mode

* **Documentation**
  * Guides on setup, workflow, memory types, usage patterns, and hygiene best practices

* **Tests**
  * Added automated tests to validate example README, skill docs, and CLI dry-run behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->