### PR TITLE
Feat/update recall config

### DIFF
--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -141,7 +141,7 @@ class RecallInput(BaseModel):
         ),
     )
     min_similarity: float | None = Field(
-        default=0.0,
+        default=None,
         ge=0.0,
         le=1.0,
         description="Minimum similarity score from 0.0 to 1.0 to filter low-relevance memories.",
@@ -239,7 +239,7 @@ class MemantoRecallTool(BaseTool):
         query: str,
         limit: int = 10,
         memory_types: str = "",
-        min_similarity: float | None = 0.0,
+        min_similarity: float | None = None,
     ) -> str:
         type_list = (
             [t.strip() for t in memory_types.split(",") if t.strip()]

--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -128,8 +128,10 @@ class RecallInput(BaseModel):
         description="Natural language search query to find relevant memories.",
     )
     limit: int = Field(
-        default=5,
-        description="Maximum number of memories to retrieve (1-20).",
+        default=10,
+        ge=1,
+        le=100,
+        description="Maximum number of memories to retrieve.",
     )
     memory_types: str = Field(
         default="",
@@ -137,6 +139,12 @@ class RecallInput(BaseModel):
             "Comma-separated memory types to filter by "
             "(e.g. 'fact,observation'). Leave empty for all types."
         ),
+    )
+    min_similarity: float | None = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Minimum similarity score from 0.0 to 1.0 to filter low-relevance memories.",
     )
 
 
@@ -229,8 +237,9 @@ class MemantoRecallTool(BaseTool):
     def _run(
         self,
         query: str,
-        limit: int = 5,
+        limit: int = 10,
         memory_types: str = "",
+        min_similarity: float | None = 0.0,
     ) -> str:
         type_list = (
             [t.strip() for t in memory_types.split(",") if t.strip()]
@@ -241,8 +250,9 @@ class MemantoRecallTool(BaseTool):
         result = self._client.recall(
             agent_id=self._agent_id,
             query=query,
-            limit=min(limit, 20),
+            limit=limit,
             type=type_list,
+            min_similarity=min_similarity,
         )
 
         memories = result.get("memories", [])

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -397,16 +397,25 @@ async def recall(
         )
 
     recall_cfg = _config_manager.get_recall_config()
-    limit = (
+    raw_limit = (
         request.limit
         if request.limit is not None
         else recall_cfg.get("limit", settings.RECALL_LIMIT)
     )
-    min_similarity = (
+    raw_min_similarity = (
         request.min_similarity
         if request.min_similarity is not None
         else recall_cfg.get("min_similarity")
     )
+    try:
+        limit = int(raw_limit)
+        min_similarity = (
+            None if raw_min_similarity is None else float(raw_min_similarity)
+        )
+    except (TypeError, ValueError) as e:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid recall configuration: {e}"
+        )
     CostGuard.validate_k_limit(limit)
 
     try:

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -30,8 +30,11 @@ from memanto.app.services.memory_write_service import MemoryWriteService
 from memanto.app.utils.errors import map_error_to_http_exception
 from memanto.app.utils.validation import CostGuard
 from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.config.manager import ConfigManager
 
 router = APIRouter()
+
+_config_manager = ConfigManager()
 
 
 class RecallRequest(BaseModel):
@@ -393,7 +396,17 @@ async def recall(
             )
         )
 
-    limit = request.limit if request.limit is not None else settings.RECALL_LIMIT
+    recall_cfg = _config_manager.get_recall_config()
+    limit = (
+        request.limit
+        if request.limit is not None
+        else recall_cfg.get("limit", settings.RECALL_LIMIT)
+    )
+    min_similarity = (
+        request.min_similarity
+        if request.min_similarity is not None
+        else recall_cfg.get("min_similarity")
+    )
     CostGuard.validate_k_limit(limit)
 
     try:
@@ -407,7 +420,7 @@ async def recall(
             scope_type="agent",
             scope_id=agent_id,
             type=request.type,
-            min_similarity_score=request.min_similarity,
+            min_similarity_score=min_similarity,
             limit=limit,
         )
 

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -119,7 +119,10 @@ async def update_ui_config(updates: dict):
     if "recall" in updates and isinstance(updates["recall"], dict):
         rec = updates["recall"]
         _config_manager.set_recall_config(
-            limit=int(rec["limit"]) if "limit" in rec else None
+            limit=int(rec["limit"]) if "limit" in rec else None,
+            min_similarity=float(rec["min_similarity"])
+            if "min_similarity" in rec and rec["min_similarity"] is not None
+            else None,
         )
 
     return {"status": "updated", "updated_keys": list(updates.keys())}

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -1713,10 +1713,10 @@
             </div>
             <!-- TOP N LIMIT -->
             <div class="panel">
-                <div class="panel-title">🎯 Top N Limit</div>
+                <div class="panel-title">🎯 Search & Retrieval</div>
                 <div class="form-row">
                     <div class="form-group"><label>Recall Limit (search results)</label><input type="number" id="cfgRecallLimit" value="${rec.limit ?? 10}" min="1" max="100"></div>
-                    <div class="form-group"></div>
+                    <div class="form-group"><label>Recall Min Similarity (0.0-1.0)</label><input type="number" step="0.01" id="cfgRecallMinSimilarity" value="${rec.min_similarity ?? 0}" min="0" max="1"></div>
                 </div>
             </div>
             <!-- SCHEDULE -->
@@ -1800,6 +1800,7 @@
                     },
                     recall: {
                         limit: parseInt(document.getElementById('cfgRecallLimit').value) || 10,
+                        min_similarity: document.getElementById('cfgRecallMinSimilarity').value ? parseFloat(document.getElementById('cfgRecallMinSimilarity').value) : 0
                     },
                 };
                 await api('PATCH', '/api/ui/config', payload);

--- a/memanto/app/utils/idempotency.py
+++ b/memanto/app/utils/idempotency.py
@@ -28,13 +28,13 @@ class IdempotencyRecord:
 class IdempotencyStore:
     """In-memory idempotency store (production should use Redis/database)"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Storage: idempotency_key -> IdempotencyRecord
         self.records: dict[str, IdempotencyRecord] = {}
         self.last_cleanup = time.time()
         self.cleanup_interval = 3600  # 1 hour
 
-    def _cleanup_expired(self):
+    def _cleanup_expired(self) -> None:
         """Remove expired records"""
         now = time.time()
         if now - self.last_cleanup < self.cleanup_interval:

--- a/memanto/app/utils/safe_deletion.py
+++ b/memanto/app/utils/safe_deletion.py
@@ -29,7 +29,7 @@ class DeletionAuditRecord:
 class DeletionAuditor:
     """Audit logger for deletion operations"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         # In production, this should write to secure audit log storage
         self.audit_log: list[DeletionAuditRecord] = []
 
@@ -43,7 +43,7 @@ class DeletionAuditor:
         request_id: str,
         success: bool,
         error: str | None = None,
-    ):
+    ) -> None:
         """Log deletion operation"""
         record = DeletionAuditRecord(
             timestamp=datetime.utcnow().isoformat(),

--- a/memanto/app/utils/tracing.py
+++ b/memanto/app/utils/tracing.py
@@ -60,7 +60,7 @@ class Span:
 class MemantoTracer:
     """Simple tracer for MEMANTO (production should use OpenTelemetry)"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.spans: list[Span] = []
 
     def start_trace(self, name: str) -> str:

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -755,8 +755,10 @@ class DirectClient:
             Dict with ``agent_id``, ``query``, ``memories`` (list),
             ``count``.
         """
+        recall_cfg = ConfigManager().get_recall_config()
         if limit is None:
-            limit = ConfigManager().get_recall_config()["limit"]
+            limit = recall_cfg["limit"]
+        min_similarity = recall_cfg.get("min_similarity")
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
@@ -773,6 +775,7 @@ class DirectClient:
             type=type,
             tags=tags,
             min_confidence=min_confidence,
+            min_similarity_score=min_similarity,
             created_after=created_after.isoformat() if created_after else None,
             created_before=created_before.isoformat() if created_before else None,
             limit=limit,

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -734,6 +734,7 @@ class DirectClient:
         limit: int | None = None,
         type: list[str] | None = None,
         tags: list[str] | None = None,
+        min_similarity: float | None = None,
         min_confidence: float | None = None,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
@@ -747,6 +748,7 @@ class DirectClient:
             limit: Max results (1–100, defaults to config).
             type: Filter by types (e.g. ``["fact", "decision"]``).
             tags: Filter by tags.
+            min_similarity: Minimum similarity threshold.
             min_confidence: Minimum confidence threshold.
             created_after: Only memories created after this datetime.
             created_before: Only memories created before this datetime.
@@ -758,7 +760,8 @@ class DirectClient:
         recall_cfg = ConfigManager().get_recall_config()
         if limit is None:
             limit = recall_cfg["limit"]
-        min_similarity = recall_cfg.get("min_similarity")
+        if min_similarity is None:
+            min_similarity = recall_cfg.get("min_similarity")
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -617,7 +617,7 @@ class SdkClient:
         limit: int | None = None,
         type: list[str] | None = None,
         tags: list[str] | None = None,
-        min_confidence: float | None = None,
+        min_similarity: float | None = None,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
     ) -> dict[str, Any]:
@@ -630,15 +630,18 @@ class SdkClient:
             limit: Max results (1–100, defaults to config).
             type: Filter by types.
             tags: Filter by tags.
-            min_confidence: Minimum confidence threshold.
+            min_similarity: Minimum similarity threshold.
             created_after: Only memories created after this datetime.
             created_before: Only memories created before this datetime.
 
         Returns:
             Dict with ``agent_id``, ``query``, ``memories``, ``count``.
         """
+        recall_cfg = ConfigManager().get_recall_config()
         if limit is None:
-            limit = ConfigManager().get_recall_config()["limit"]
+            limit = recall_cfg["limit"]
+        if min_similarity is None:
+            min_similarity = recall_cfg.get("min_similarity")
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
@@ -654,7 +657,7 @@ class SdkClient:
             scope_id=agent_id,
             type=type,
             tags=tags,
-            min_confidence=min_confidence,
+            min_similarity_score=min_similarity,
             created_after=created_after.isoformat() if created_after else None,
             created_before=created_before.isoformat() if created_before else None,
             limit=limit,

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -248,8 +248,8 @@ def recall(
     memory_type: str | None = typer.Option(
         None, "--type", "-t", help="Filter by memory type"
     ),
-    min_confidence: float | None = typer.Option(
-        None, "--min-confidence", help="Minimum confidence score"
+    min_similarity: float | None = typer.Option(
+        None, "--min-similarity", help="Minimum similarity score"
     ),
     tags: str | None = typer.Option(
         None, "--tags", help="Filter by tags (comma-separated)"
@@ -363,7 +363,7 @@ def recall(
                     limit=limit,
                     type=type,
                     tags=tag_list,
-                    min_confidence=min_confidence,
+                    min_similarity=min_similarity,
                 )
             else:
                 _error(

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -199,6 +199,11 @@ class ConfigManager:
         if limit is not None:
             recall["limit"] = limit
         if min_similarity is not None:
+            if (
+                not isinstance(min_similarity, (int, float))
+                or not 0.0 <= float(min_similarity) <= 1.0
+            ):
+                raise ValueError("min_similarity must be between 0.0 and 1.0")
             recall["min_similarity"] = min_similarity
         self.save_yaml(data)
 

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -186,16 +186,20 @@ class ConfigManager:
         data = self.load_yaml()
         recall = data.get("recall", {})
 
-        defaults = {"limit": 10}
+        defaults = {"limit": 10, "min_similarity": 0.0}
         defaults.update(recall)
         return defaults
 
-    def set_recall_config(self, limit: int | None = None) -> None:
+    def set_recall_config(
+        self, limit: int | None = None, min_similarity: float | None = None
+    ) -> None:
         """Set Recall config values."""
         data = self.load_yaml()
         recall = data.setdefault("recall", {})
         if limit is not None:
             recall["limit"] = limit
+        if min_similarity is not None:
+            recall["min_similarity"] = min_similarity
         self.save_yaml(data)
 
     # Schedule timing


### PR DESCRIPTION
- Update crewai recall defaults
- Add recall min similarity config to memanto ui
- Update sdk client, direct client, api endpoints to use config as backfall
- Change instances of min_confidence to min_similarity to apply configs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added minimum similarity threshold (0.0–1.0) to filter recalled memories.
  * UI: new "Recall Min Similarity" control in Search & Retrieval.
  * CLI: new --min-similarity option for recall.

* **Improvements**
  * Default recall limit raised to 10 with validation (1–100).
  * Recall now honors configured limit and min-similarity (for quantity and relevance) and forwards the exact limit setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->