### PR TITLE
feat: Memanto + Claude Code Skills engineering memory integration

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,128 @@
+# Claude Code Skills + Memanto Engineering Memory
+
+This integration gives [mattpocock/skills](https://github.com/mattpocock/skills) persistent engineering memory across terminal sessions using [Memanto](https://memanto.ai/).
+
+## Problem
+
+The `mattpocock/skills` ecosystem provides sharp CLI primitives (`/grill-with-docs`, `/tdd`, `/handoff`) but each execution starts with a blank context. Decisions made during one skill run are invisible to subsequent runs in different sessions.
+
+## Solution
+
+A pre/post skill hook that wraps any skill execution:
+
+```
+Normal:      skill run → [no memory] → result
+With Memanto: skill run → [recall past decisions] → result → [store new decisions]
+```
+
+### Integration files
+
+| File | Purpose |
+|------|---------|
+| `memanto_skills_hook.py` | Pre/post hook: recalls context before a skill, stores decisions after |
+| `pyproject.toml` | Package entry point so `memanto-skills` is available as a CLI command |
+
+## Quick Start
+
+### Prerequisites
+
+1. Memanto installed: `pip install memanto`
+2. [Moorcheh API key](https://moorcheh.ai/) configured via `memanto setup`
+3. An active Memanto agent: `memanto agent create claude-code-skills`
+4. Node.js (for running Claude Code skills)
+
+### Setup
+
+```bash
+# Set environment variables (or add to ~/.zshrc)
+export MEMANTO_AGENT_ID=claude-code-skills
+export MEMANTO_SKILLS_NS=claude-code-skills
+
+# Install the hook as a CLI tool
+pip install -e .
+```
+
+### Usage
+
+```bash
+# Pre-hook: recall context before a skill
+memanto-skills pre grill-with-docs
+
+# Post-hook: store decisions after a skill
+cat transcript.txt | memanto-skills post grill-with-docs
+
+# Full run: pre + skill + post in one command
+memanto-skills run grill-with-docs -- --file src/main.py
+```
+
+### Example
+
+```bash
+# First run — no context yet
+memanto-skills run grill-with-docs -- --file src/main.py
+# Output: "# No relevant engineering context found."
+#         (executes skill normally)
+
+# Second run — previous decisions are recalled
+memanto-skills run grill-with-docs -- --file src/main.py
+# Output: "--- Memanto Context for 'grill-with-docs' ---"
+#         (includes decisions from first run)
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    memanto-skills                    │
+│                                                      │
+│  pre(skill_name)                                     │
+│    ├─ Query Memanto: "decisions related to {skill}"  │
+│    └─ Print compact context block                    │
+│                                                      │
+│  run(skill_name, args)                               │
+│    ├─ pre(skill_name)        ← recall context        │
+│    ├─ exec skill_name args   ← execute the skill     │
+│    └─ post(skill_name, out)  ← store new decisions   │
+│                                                      │
+│  post(skill_name, transcript)                        │
+│    └─ Store summary in Memanto                       │
+└─────────────────────────────────────────────────────┘
+```
+
+## How it works
+
+### Pre-hook (`memanto-skills pre <skill>`)
+
+1. Calls `memanto memory export` to retrieve stored engineering decisions
+2. Formats them as a compact context block
+3. Prints to stdout for piping into the skill prompt
+
+### Post-hook (`memanto-skills post <skill>`)
+
+1. Reads the skill transcript from stdin
+2. Stores a summary as a memory via Memanto
+3. Future pre-hooks will recall this decision
+
+### Full run (`memanto-skills run <skill> -- <args>`)
+
+1. Pre-hook: recall relevant context
+2. Execute the skill with original arguments
+3. Post-hook: store new decisions
+
+## Customization
+
+| Environment variable | Default | Description |
+|---------------------|---------|-------------|
+| `MEMANTO_AGENT_ID` | `claude-code-skills` | Memanto agent to use |
+| `MEMANTO_SKILLS_NS` | `claude-code-skills` | Namespace for skill memories |
+| `MEMANTO_CONTEXT_LIMIT` | `3000` | Max context length to inject |
+
+## Verification
+
+```bash
+# Test pre-hook works (no API key needed for help)
+memanto-skills
+
+# With Memanto configured, verify context recall
+memanto-skills pre tdd
+```

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -93,19 +93,21 @@ memanto-skills run grill-with-docs -- --file src/main.py
 
 ### Pre-hook (`memanto-skills pre <skill>`)
 
-1. Calls `memanto memory export` to retrieve stored engineering decisions
-2. Formats them as a compact context block
-3. Prints to stdout for piping into the skill prompt
+1. Calls `memanto memory export` with a `--query` parameter specific to the skill name
+2. Retrieves stored engineering decisions related to that skill
+3. Formats them as a compact context block
+4. Prints to stdout for piping into the skill prompt
 
 ### Post-hook (`memanto-skills post <skill>`)
 
 1. Reads the skill transcript from stdin
-2. Stores a summary as a memory via Memanto
-3. Future pre-hooks will recall this decision
+2. Writes a summary to a temp file
+3. Calls `memanto memory import` to persist the decision summary as a typed memory
+4. Future pre-hooks will recall this decision
 
 ### Full run (`memanto-skills run <skill> -- <args>`)
 
-1. Pre-hook: recall relevant context
+1. Pre-hook: recall relevant context (with API key check)
 2. Execute the skill with original arguments
 3. Post-hook: store new decisions
 

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -143,6 +143,8 @@ def run_skill(skill_name: str, skill_args: list[str]) -> None:
         sys.exit(1)
 
     post_hook(skill_name, output)
+    if proc.returncode != 0:
+        sys.exit(proc.returncode)
 
 
 def main() -> None:

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -1,0 +1,147 @@
+"""Memanto → Claude Code Skills Integration Hook
+
+Pre/post skill hooks that give Claude Code skills persistent engineering
+memory across terminal sessions.
+
+Phases:
+  - pre:  Recall relevant engineering context before a skill starts.
+  - post: Distill decisions from the completed skill and persist them.
+
+Usage:
+  memanto-skills pre <skill_name>
+  memanto-skills post <skill_name> <transcript_or_summary>
+  memanto-skills run <skill_name> -- <skill_args...>
+"""
+
+import json
+import os
+import sys
+import subprocess
+from pathlib import Path
+from typing import Any, Optional
+
+
+MEMANTO_AGENT_ID = os.getenv("MEMANTO_AGENT_ID", "claude-code-skills")
+MEMANTO_SKILLS_NS = os.getenv("MEMANTO_SKILLS_NS", "claude-code-skills")
+CONTEXT_LIMIT = int(os.getenv("MEMANTO_CONTEXT_LIMIT", "3000"))
+
+
+def _ensure_api_key() -> str:
+    """Get Moorcheh API key from env or config file."""
+    key = os.getenv("MOORCHEH_API_KEY")
+    if key:
+        return key
+    env_path = Path.home() / ".memanto" / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if line.startswith("MOORCHEH_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    print("ERROR: MOORCHEH_API_KEY not set. Run `memanto setup` first.")
+    sys.exit(1)
+
+
+def pre_hook(skill_name: str) -> None:
+    """Pre-skill hook: recall relevant engineering context.
+
+    Queries Memanto for memories related to the skill being executed
+    and prints a compact context block that can be appended to the
+    skill prompt.
+    """
+    agent_id = MEMANTO_AGENT_ID
+    query = f"engineering decisions related to {skill_name}"
+
+    try:
+        result = subprocess.run(
+            ["memanto", "memory", "export", "--agent", agent_id, "--limit", "10"],
+            capture_output=True, text=True, timeout=15,
+        )
+        context = result.stdout[:CONTEXT_LIMIT] if result.stdout else ""
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        context = f""  # Fail open: if Memanto is unavailable, run without context
+
+    if context.strip():
+        print(f"--- Memanto Context for '{skill_name}' ---")
+        print(context[:CONTEXT_LIMIT])
+        print("--- End Memanto Context ---")
+    else:
+        print("# No relevant engineering context found.")
+
+
+def post_hook(skill_name: str, transcript: str) -> None:
+    """Post-skill hook: persist engineering decisions.
+
+    Extracts key decisions from the skill transcript and stores them
+    as Memanto memories for future recall.
+    """
+    agent_id = MEMANTO_AGENT_ID
+
+    memory_text = (
+        f"After running skill '{skill_name}':\n"
+        f"{transcript[:2000]}"
+    )
+
+    try:
+        result = subprocess.run(
+            ["memanto", "memory", "export", "--agent", agent_id],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    print(f"# Engineering context from '{skill_name}' stored in Memanto.")
+
+
+def run_skill(skill_name: str, skill_args: list[str]) -> None:
+    """Run a skill with Memanto pre/post hooks."""
+    pre_hook(skill_name)
+    print(f"\n# Running skill: {skill_name}\n")
+
+    try:
+        proc = subprocess.run(
+            ["npx", skill_name, *skill_args],
+            capture_output=True, text=True, timeout=300,
+        )
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+        output = stdout + stderr
+        print(stdout)
+        if stderr:
+            print(stderr, file=sys.stderr)
+    except FileNotFoundError:
+        print(f"ERROR: Skill '{skill_name}' not found. Is it installed?")
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print(f"ERROR: Skill '{skill_name}' timed out.")
+        sys.exit(1)
+
+    post_hook(skill_name, output)
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print("Usage:")
+        print("  memanto-skills pre <skill_name>")
+        print("  memanto-skills post <skill_name>")
+        print("  memanto-skills run <skill_name> [-- <args...>]")
+        sys.exit(1)
+
+    command = sys.argv[1]
+    skill_name = sys.argv[2]
+
+    if command == "pre":
+        _ensure_api_key()
+        pre_hook(skill_name)
+    elif command == "post":
+        _ensure_api_key()
+        transcript = sys.stdin.read() if not sys.stdin.isatty() else ""
+        post_hook(skill_name, transcript)
+    elif command == "run":
+        skill_args = sys.argv[3:]
+        run_skill(skill_name, skill_args)
+    else:
+        print(f"Unknown command: {command}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -5,7 +5,7 @@ memory across terminal sessions.
 
 Phases:
   - pre:  Recall relevant engineering context before a skill starts.
-  - post: Distill decisions from the completed skill and persist them.
+  - post: Persist decisions from the completed skill into Memanto.
   - run:  pre + skill execution + post in one command.
 
 Usage:
@@ -14,7 +14,6 @@ Usage:
   memanto-skills run <skill_name> -- <skill_args...>
 """
 
-import json
 import os
 import subprocess
 import sys
@@ -45,58 +44,80 @@ def _ensure_api_key() -> str:
 def pre_hook(skill_name: str) -> None:
     """Pre-skill hook: recall relevant engineering context.
 
-    Queries Memanto for memories related to the skill being executed
-    and prints a compact context block that can be appended to the
-    skill prompt.
+    Uses `memanto recall` to search for memories related to the skill
+    being executed. If recall fails or returns nothing, falls back to
+    exporting all memories as a baseline context.
     """
     _ensure_api_key()
     agent_id = MEMANTO_AGENT_ID
 
+    query = f"engineering decisions about {skill_name}"
     try:
         result = subprocess.run(
-            ["memanto", "memory", "export", "--agent", agent_id,
-             "--limit", "10", "--query", f"engineering decisions related to {skill_name}"],
+            ["memanto", "recall", query, "--agent", agent_id],
             capture_output=True, text=True, timeout=15,
         )
-        context = result.stdout.strip()[:CONTEXT_LIMIT] if result.stdout else ""
-    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        context = ""
+        if result.returncode == 0 and result.stdout.strip():
+            context = result.stdout.strip()[:CONTEXT_LIMIT]
+            print(f"--- Memanto Context for '{skill_name}' ---")
+            print(context)
+            print("--- End Memanto Context ---")
+            return
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
 
-    if context:
-        print(f"--- Memanto Context for '{skill_name}' ---")
-        print(context)
-        print("--- End Memanto Context ---")
-    else:
-        print("# No relevant engineering context found.")
+    # Fallback: export all memories if targeted recall fails
+    try:
+        result = subprocess.run(
+            ["memanto", "memory", "export", "--agent", agent_id, "--limit", "10"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            context = result.stdout.strip()[:CONTEXT_LIMIT]
+            if context:
+                print(f"--- Memanto Context for '{skill_name}' ---")
+                print(context)
+                print("--- End Memanto Context ---")
+                return
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    print("# No relevant engineering context found.")
 
 
 def post_hook(skill_name: str, transcript: str) -> None:
     """Post-skill hook: persist engineering decisions.
 
-    Extracts key decisions from the skill transcript and stores them
-    as Memanto memories for future recall.
+    Stores a decision summary as a Memanto memory using `memanto remember`.
+    Uses a securely-generated temp file for the memory content.
     """
     _ensure_api_key()
     agent_id = MEMANTO_AGENT_ID
 
     summary = f"Skill '{skill_name}' completed.\n{transcript[:2000]}"
+    tmp_path = None
 
     try:
-        path = "/tmp/memanto_skill_summary.md"
-        with open(path, "w") as f:
+        # Write summary to a secure temp file
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", prefix="memanto_skill_", delete=False
+        ) as f:
             f.write(summary)
+            tmp_path = Path(f.name)
 
         result = subprocess.run(
-            ["memanto", "memory", "import", path, "--agent", agent_id,
-             "--type", "decision"],
+            ["memanto", "remember", str(tmp_path), "--agent", agent_id],
             capture_output=True, text=True, timeout=15,
         )
         if result.returncode == 0:
             print(f"# Engineering context from '{skill_name}' stored in Memanto.")
         else:
-            print(f"# Warning: Failed to store context: {result.stderr.strip()}")
+            print(f"# Warning: Failed to store context: {result.stderr.strip()[:200]}")
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        print("# Warning: Memanto not available, context not stored.")
+        print(f"# Warning: Memanto not available, context not stored: {e}")
+    finally:
+        if tmp_path and tmp_path.exists():
+            tmp_path.unlink()
 
 
 def run_skill(skill_name: str, skill_args: list[str]) -> None:

--- a/examples/claudecode-skills-memanto/memanto_skills_hook.py
+++ b/examples/claudecode-skills-memanto/memanto_skills_hook.py
@@ -6,17 +6,19 @@ memory across terminal sessions.
 Phases:
   - pre:  Recall relevant engineering context before a skill starts.
   - post: Distill decisions from the completed skill and persist them.
+  - run:  pre + skill execution + post in one command.
 
 Usage:
   memanto-skills pre <skill_name>
-  memanto-skills post <skill_name> <transcript_or_summary>
+  memanto-skills post <skill_name>
   memanto-skills run <skill_name> -- <skill_args...>
 """
 
 import json
 import os
-import sys
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
@@ -47,21 +49,22 @@ def pre_hook(skill_name: str) -> None:
     and prints a compact context block that can be appended to the
     skill prompt.
     """
+    _ensure_api_key()
     agent_id = MEMANTO_AGENT_ID
-    query = f"engineering decisions related to {skill_name}"
 
     try:
         result = subprocess.run(
-            ["memanto", "memory", "export", "--agent", agent_id, "--limit", "10"],
+            ["memanto", "memory", "export", "--agent", agent_id,
+             "--limit", "10", "--query", f"engineering decisions related to {skill_name}"],
             capture_output=True, text=True, timeout=15,
         )
-        context = result.stdout[:CONTEXT_LIMIT] if result.stdout else ""
+        context = result.stdout.strip()[:CONTEXT_LIMIT] if result.stdout else ""
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        context = f""  # Fail open: if Memanto is unavailable, run without context
+        context = ""
 
-    if context.strip():
+    if context:
         print(f"--- Memanto Context for '{skill_name}' ---")
-        print(context[:CONTEXT_LIMIT])
+        print(context)
         print("--- End Memanto Context ---")
     else:
         print("# No relevant engineering context found.")
@@ -73,26 +76,32 @@ def post_hook(skill_name: str, transcript: str) -> None:
     Extracts key decisions from the skill transcript and stores them
     as Memanto memories for future recall.
     """
+    _ensure_api_key()
     agent_id = MEMANTO_AGENT_ID
 
-    memory_text = (
-        f"After running skill '{skill_name}':\n"
-        f"{transcript[:2000]}"
-    )
+    summary = f"Skill '{skill_name}' completed.\n{transcript[:2000]}"
 
     try:
-        result = subprocess.run(
-            ["memanto", "memory", "export", "--agent", agent_id],
-            capture_output=True, text=True, timeout=10,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
+        path = "/tmp/memanto_skill_summary.md"
+        with open(path, "w") as f:
+            f.write(summary)
 
-    print(f"# Engineering context from '{skill_name}' stored in Memanto.")
+        result = subprocess.run(
+            ["memanto", "memory", "import", path, "--agent", agent_id,
+             "--type", "decision"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode == 0:
+            print(f"# Engineering context from '{skill_name}' stored in Memanto.")
+        else:
+            print(f"# Warning: Failed to store context: {result.stderr.strip()}")
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print("# Warning: Memanto not available, context not stored.")
 
 
 def run_skill(skill_name: str, skill_args: list[str]) -> None:
     """Run a skill with Memanto pre/post hooks."""
+    _ensure_api_key()
     pre_hook(skill_name)
     print(f"\n# Running skill: {skill_name}\n")
 
@@ -101,12 +110,10 @@ def run_skill(skill_name: str, skill_args: list[str]) -> None:
             ["npx", skill_name, *skill_args],
             capture_output=True, text=True, timeout=300,
         )
-        stdout = proc.stdout or ""
-        stderr = proc.stderr or ""
-        output = stdout + stderr
-        print(stdout)
-        if stderr:
-            print(stderr, file=sys.stderr)
+        output = (proc.stdout or "") + (proc.stderr or "")
+        print(proc.stdout or "")
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr)
     except FileNotFoundError:
         print(f"ERROR: Skill '{skill_name}' not found. Is it installed?")
         sys.exit(1)
@@ -129,14 +136,12 @@ def main() -> None:
     skill_name = sys.argv[2]
 
     if command == "pre":
-        _ensure_api_key()
         pre_hook(skill_name)
     elif command == "post":
-        _ensure_api_key()
         transcript = sys.stdin.read() if not sys.stdin.isatty() else ""
         post_hook(skill_name, transcript)
     elif command == "run":
-        skill_args = sys.argv[3:]
+        skill_args = sys.argv[3:] if len(sys.argv) > 3 else []
         run_skill(skill_name, skill_args)
     else:
         print(f"Unknown command: {command}")


### PR DESCRIPTION
Fixes #508

## Summary

Add pre/post skill hooks that give Claude Code skills (mattpocock/skills) persistent engineering memory across terminal sessions via Memanto.

## Changes

| File | Change |
|------|--------|
| `examples/claudecode-skills-memanto/memanto_skills_hook.py` | Pre-hook: recalls relevant engineering context before a skill starts. Post-hook: stores decisions after skill completes. run subcommand: pre + skill + post in one command. |
| `examples/claudecode-skills-memanto/README.md` | Setup docs, architecture diagram, usage examples, environment variables reference |

## Architecture

```
pre(skill_name)
  ├─ Query Memanto: "decisions related to {skill}"
  └─ Print compact context block

run(skill_name, args)
  ├─ pre(skill_name)        ← recall context
  ├─ exec skill_name args   ← execute the skill
  └─ post(skill_name, out)  ← store new decisions

post(skill_name, transcript)
  └─ Store summary in Memanto
```

## Usage

```bash
# Pre-hook: recall context before a skill
memanto-skills pre grill-with-docs

# Post-hook: store decisions after a skill
cat transcript.txt | memanto-skills post grill-with-docs

# Full run with hooks
memanto-skills run grill-with-docs -- --file src/main.py
```

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| MEMANTO_AGENT_ID | claude-code-skills | Memanto agent to use |
| MEMANTO_SKILLS_NS | claude-code-skills | Namespace for skill memories |
| MEMANTO_CONTEXT_LIMIT | 3000 | Max context length to inject |

## Verification

```bash
memanto-skills
memanto-skills pre tdd
memanto-skills run grill-with-docs -- --file src/main.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Memanto integration to persist engineering memory across CLI skill runs: pre-run recall (with fallback) and post-run summary storage; captures skill transcripts and supports piped input; configurable via environment variables and requires an API key.

* **Documentation**
  * New integration guide with quick-start, configuration reference, usage examples, run behavior examples, architecture diagram, and verification/customization instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->