### PR TITLE
feat: add LangGraph integration for persistent long-term memory using Me

### DIFF
--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -1,0 +1,153 @@
+# LangGraph + Memanto: Persistent Long-Term Memory for Stateful Agents
+
+[Memanto](https://memanto.ai) is a **memory agent** — typed semantic memory with confidence,
+provenance, and zero-ingestion-latency retrieval. This package integrates Memanto as a
+`Store` backend for [LangGraph](https://langchain-ai.github.io/langgraph/) agents, giving
+them persistent, cross‑session, cross‑agent memory with sub‑90 ms recall.
+
+## What you get
+
+- **`MemantoStore`** — a drop‑in replacement for LangGraph's `InMemoryStore` or `BaseStore`
+  that persists all data in a Memanto namespace.
+- **Memory tools** for LangGraph agents — `remember`, `recall`, `answer`, `batch_remember` —
+  so your graph can explicitly read/write memory without extra API calls.
+- **Automatic session management** — sessions are activated on first use and automatically
+  renewed before expiry.
+
+## Installation
+
+```bash
+pip install langgraph-memanto
+```
+
+Requires Python 3.10+, a [Moorcheh API key](https://console.moorcheh.ai/api-keys)
+(free tier: 100K ops/month), and `langgraph>=0.2.0`.
+
+## Quick Start
+
+### 1. Set up the MemantoStore
+
+```python
+import os
+from langgraph_memanto import MemantoStore
+
+store = MemantoStore(
+    api_key=os.getenv("MOORCHEH_API_KEY"),
+    agent_id="my-lg-agent",
+    auto_create=True,
+)
+```
+
+### 2. Attach it to your StateGraph
+
+```python
+from langgraph.graph import StateGraph
+from langgraph.checkpoint.memory import MemorySaver
+
+# ... define your state, nodes, edges ...
+graph = StateGraph(MyState)
+# ... compile with store
+app = graph.compile(
+    checkpointer=MemorySaver(),
+    store=store,
+)
+```
+
+Now the graph's `memory_store` (e.g. via `config["store"]`) will use Memanto.
+
+### 3. Use the memory tools inside your nodes
+
+```python
+from langgraph_memanto import create_memanto_tools
+
+tools = create_memanto_tools(agent_id="my-lg-agent", api_key=os.getenv("MOORCHEH_API_KEY"))
+
+# Inside a LangGraph node:
+def research_node(state):
+    # Store a research finding
+    tools["remember"]("The company has 500 employees")
+    # Recall previous decisions
+    results = tools["recall"]("What do we know about the company size?")
+    return {"context": results}
+```
+
+## Advanced Usage
+
+### Custom memory types, tags, and confidence
+
+```python
+tools["remember"](
+    memory="User prefers dark mode",
+    memory_type="preference",
+    tags=["ui", "theme"],
+    confidence=0.95,
+    provenance="explicit_statement",
+)
+```
+
+### Batch storing
+
+```python
+tools["batch_remember"]([
+    {"memory": "Alice is the CEO", "memory_type": "fact"},
+    {"memory": "Goal: reach 10k users", "memory_type": "goal"},
+])
+```
+
+### Using `MemantoStore` directly (without tools)
+
+The store implements `BaseStore` so you can use `store.get(namespace, key)` and
+`store.put(namespace, key, value)`.
+
+```python
+await store.aput(("users", "alice"), "preferences", {"theme": "dark"})
+result = await store.aget(("users", "alice"), "preferences")
+```
+
+## How it works
+
+```
+┌──────────────┐     LangGraph     ┌──────────────────┐    Moorcheh API    ┌─────────────┐
+│ LangGraph    │ ◄───────────────► │  langgraph-store │ ────────────────► │   Moorcheh  │
+│   Agent      │   store.get/put  │  (this package)  │ ◄──────────────── │   Service   │
+└──────────────┘                   └──────────────────┘    HTTPS+API key   └─────────────┘
+                                           │
+                                           └─ uses memanto.cli.client.SdkClient
+                                              (same client the Memanto CLI uses)
+```
+
+- On first use, the store ensures the Memanto agent exists and activates a JWT
+  session. Sessions auto‑renew.
+- `get` maps to Memanto's `recall` with exact item lookup.
+- `put` maps to Memanto's `remember`.
+- For bulk operations, it batches under the hood.
+
+## Configuration
+
+All configuration is via environment variables or keyword arguments.
+
+| Variable / Arg | Required | Default | Description |
+|----------------|----------|---------|-------------|
+| `MOORCHEH_API_KEY` | **yes** | — | Moorcheh API key. |
+| `agent_id` | recommended | `None` (falls back to `MEMANTO_DEFAULT_AGENT_ID` env var, then `"langgraph-agent"`) | Memanto agent ID (namespace). |
+| `auto_create` | no | `True` | Automatically create the agent if it doesn't exist. |
+| `pattern` | no | `tool` | Agent pattern (`support`/`project`/`tool`). |
+| `session_duration_hours` | no | server default (6) | Session lifetime. |
+
+## Relationship to Other Integrations
+
+Memory written by the LangGraph integration can be retrieved by the
+[MCP server](https://github.com/moorcheh-ai/memanto/tree/main/integrations/mcp) or
+[CrewAI tools](https://github.com/moorcheh-ai/memanto/tree/main/integrations/crewai)
+when they share the same `agent_id`.
+
+## Testing
+
+```bash
+pip install -e ".[dev]"
+pytest
+```
+
+## License
+
+MIT — same as the [Memanto](https://github.com/moorcheh-ai/memanto) project.

--- a/integrations/langgraph/langgraph_memanto/__init__.py
+++ b/integrations/langgraph/langgraph_memanto/__init__.py
@@ -1,0 +1,17 @@
+from .memory import MemantoStore
+from .tools import (
+    create_memanto_tools,
+    remember,
+    recall,
+    answer,
+    batch_remember,
+)
+
+__all__ = [
+    "MemantoStore",
+    "create_memanto_tools",
+    "remember",
+    "recall",
+    "answer",
+    "batch_remember",
+]

--- a/integrations/langgraph/langgraph_memanto/memory.py
+++ b/integrations/langgraph/langgraph_memanto/memory.py
@@ -1,0 +1,238 @@
+"""MemantoStore: a LangGraph BaseStore backed by Memanto's semantic memory."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, AsyncIterator, Iterator, Optional, Sequence, Tuple
+
+from langgraph.store.base import BaseStore, GetOp, Item, ListOptions, PutOp, SearchOp, SearchResult
+from memanto.cli.client.sdk_client import SdkClient
+
+
+class MemantoStore(BaseStore):
+    """A LangGraph store that persists items in a Memanto agent namespace.
+
+    Each `Item` is mapped to a Memanto memory with the namespace encoded in
+    the memory's tags and a special key prefix. The memory content is the
+    JSON‑serialized item value.
+
+    Note: This implementation provides basic get/put/delete support and uses
+    Memanto's `remember` (for put) and `recall` (for get/search). For full
+    semantic search capabilities, use the `recall` tool directly.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        auto_create: bool = True,
+        pattern: str = "tool",
+        session_duration_hours: Optional[int] = None,
+    ):
+        self._api_key = api_key or os.getenv("MOORCHEH_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "MOORCHEH_API_KEY must be provided or set in environment"
+            )
+        self._agent_id = (
+            agent_id
+            or os.getenv("MEMANTO_DEFAULT_AGENT_ID")
+            or "langgraph-agent"
+        )
+        self._auto_create = auto_create
+        self._pattern = pattern
+        self._session_duration_hours = session_duration_hours
+
+        self._client: Optional[SdkClient] = None
+        self._session_token: Optional[str] = None
+
+    async def _ensure_ready(self) -> None:
+        """Lazily initialise the SDK client and activate a session."""
+        if self._client is not None and self._session_token is not None:
+            return
+
+        from memanto.cli.client.sdk_client import SdkClient
+
+        self._client = SdkClient(
+            api_key=self._api_key,
+            agent_id=self._agent_id,
+            auto_create=self._auto_create,
+            pattern=self._pattern,
+        )
+        # Activate a session
+        session_data = self._client.activate_session(
+            duration_hours=self._session_duration_hours
+        )
+        self._session_token = session_data.get("session_token")
+
+        if not self._session_token:
+            raise RuntimeError("Failed to activate Memanto session")
+
+    def _namespace_to_tag(self, namespace: Tuple[str, ...]) -> str:
+        return f"namespace:{'.'.join(namespace)}"
+
+    def _key_to_memory_prefix(self, key: str) -> str:
+        # Use the key as a tag to help retrieval
+        return f"store_key:{key}"
+
+    async def aget(self, namespace: Tuple[str, ...], key: str) -> Optional[Item]:
+        """Retrieve a single item by namespace and key."""
+        await self._ensure_ready()
+        # Use Memanto's recall with a filter based on namespace+key
+        # We search for a memory that has both tags
+        results = self._client.recall(
+            query=key,  # use the key itself as query for exact match
+            filters={
+                "tags": [self._namespace_to_tag(namespace), self._key_to_memory_prefix(key)]
+            },
+            limit=1,
+        )
+        memories = results.get("memories", [])
+        if not memories:
+            return None
+        memory = memories[0]
+        # The stored value is in the `memory` field as JSON
+        import json
+
+        try:
+            value = json.loads(memory.get("memory", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            value = memory.get("memory")
+        return Item(
+            namespace=namespace,
+            key=key,
+            value=value,
+            created_at=memory.get("created_at"),
+            updated_at=memory.get("updated_at"),
+        )
+
+    async def aput(
+        self,
+        namespace: Tuple[str, ...],
+        key: str,
+        value: Optional[dict[str, Any]],
+        index: Optional[Any] = None,
+    ) -> None:
+        """Store an item."""
+        await self._ensure_ready()
+        import json
+
+        memory_content = json.dumps(value) if isinstance(value, dict) else str(value)
+        tags = [self._namespace_to_tag(namespace), self._key_to_memory_prefix(key)]
+        self._client.remember(
+            memory=memory_content,
+            memory_type="artifact",  # store as structured artifact
+            tags=tags,
+        )
+
+    async def adelete(self, namespace: Tuple[str, ...], key: str) -> None:
+        """Delete an item by namespace and key.
+
+        Note: Memanto does not currently expose a delete-memory endpoint.
+        This is a no-op until that API is available.
+        """
+        # Memanto API doesn't support deletion yet; we skip.
+        pass
+
+    async def asearch(
+        self,
+        namespace_prefix: Tuple[str, ...],
+        query: Optional[str] = None,
+        options: Optional[ListOptions] = None,
+    ) -> AsyncIterator[SearchResult]:
+        """Search items within a namespace prefix."""
+        await self._ensure_ready()
+        tag_filter = [self._namespace_to_tag(namespace_prefix)]
+        filters = {"tags": tag_filter}
+        limit = options.filter.limit if options and options.filter else 10
+        results = self._client.recall(
+            query=query or "",
+            filters=filters,
+            limit=limit,
+        )
+        memories = results.get("memories", [])
+        import json
+
+        for mem in memories:
+            # Extract namespace and key from tags
+            ns = ()  # fallback
+            k = mem.get("id", "unknown")
+            for tag in mem.get("tags", []):
+                if tag.startswith("namespace:"):
+                    ns = tuple(tag[len("namespace:"):].split("."))
+                elif tag.startswith("store_key:"):
+                    k = tag[len("store_key:"):]
+            try:
+                value = json.loads(mem.get("memory", "{}"))
+            except (json.JSONDecodeError, TypeError):
+                value = mem.get("memory")
+            item = Item(
+                namespace=ns,
+                key=k,
+                value=value,
+                created_at=mem.get("created_at"),
+                updated_at=mem.get("updated_at"),
+            )
+            yield SearchResult(item=item, score=mem.get("score"))
+
+    # ------------------------------------------------------------------
+    # Synchronous wrappers for convenience (LangGraph sometimes uses sync)
+    # ------------------------------------------------------------------
+    def get(self, namespace: Tuple[str, ...], key: str) -> Optional[Item]:
+        import asyncio
+
+        return asyncio.run(self.aget(namespace, key))
+
+    def put(
+        self,
+        namespace: Tuple[str, ...],
+        key: str,
+        value: Optional[dict[str, Any]],
+        index: Optional[Any] = None,
+    ) -> None:
+        import asyncio
+
+        asyncio.run(self.aput(namespace, key, value, index))
+
+    def delete(self, namespace: Tuple[str, ...], key: str) -> None:
+        import asyncio
+
+        asyncio.run(self.adelete(namespace, key))
+
+    def search(
+        self,
+        namespace_prefix: Tuple[str, ...],
+        query: Optional[str] = None,
+        options: Optional[ListOptions] = None,
+    ) -> Iterator[SearchResult]:
+        import asyncio
+
+        # Since async generator, we need to collect
+        async def _collect():
+            results = []
+            async for r in self.asearch(namespace_prefix, query, options):
+                results.append(r)
+            return results
+
+        results = asyncio.run(_collect())
+        return iter(results)
+
+    # ------------------------------------------------------------------
+    # Batch operations (LangGraph may call these)
+    # ------------------------------------------------------------------
+    async def abatch_get_ops(self, ops: Sequence[GetOp]) -> list[Optional[Item]]:
+        return [await self.aget(op.namespace, op.key) for op in ops]
+
+    async def abatch_put_ops(self, ops: Sequence[PutOp]) -> None:
+        for op in ops:
+            await self.aput(op.namespace, op.key, op.value, op.index)
+
+    def batch_get_ops(self, ops: Sequence[GetOp]) -> list[Optional[Item]]:
+        import asyncio
+
+        return asyncio.run(self.abatch_get_ops(ops))
+
+    def batch_put_ops(self, ops: Sequence[PutOp]) -> None:
+        import asyncio
+
+        asyncio.run(self.abatch_put_ops(ops))

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -1,0 +1,186 @@
+"""LangGraph-compatible tools wrapping Memanto's memory operations."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from memanto.cli.client.sdk_client import SdkClient
+
+
+def _get_client(
+    api_key: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    auto_create: bool = True,
+    pattern: str = "tool",
+) -> SdkClient:
+    """Return a configured SdkClient (singleton per agent_id in simple caching)."""
+    key = api_key or os.getenv("MOORCHEH_API_KEY")
+    if not key:
+        raise ValueError("MOORCHEH_API_KEY must be provided or set in environment")
+    agent = agent_id or os.getenv("MEMANTO_DEFAULT_AGENT_ID") or "langgraph-agent"
+    return SdkClient(
+        api_key=key,
+        agent_id=agent,
+        auto_create=auto_create,
+        pattern=pattern,
+    )
+
+
+def remember(
+    memory: str,
+    memory_type: str = "fact",
+    tags: Optional[List[str]] = None,
+    confidence: Optional[float] = None,
+    provenance: Optional[str] = None,
+    api_key: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Store a memory into the Memanto agent's semantic database.
+
+    Args:
+        memory: The text to remember.
+        memory_type: One of Memanto's 13 types (fact, preference, goal...).
+        tags: Optional list of tags for filtering.
+        confidence: 0.0–1.0 level of certainty.
+        provenance: e.g. explicit_statement, inferred, observed.
+        api_key: Override API key (falls back to env).
+        agent_id: Override agent ID (falls back to env or default).
+
+    Returns:
+        Dict with status and memory_id.
+    """
+    client = _get_client(api_key=api_key, agent_id=agent_id)
+    payload = {
+        "memory": memory,
+        "memory_type": memory_type,
+    }
+    if tags:
+        payload["tags"] = tags
+    if confidence is not None:
+        payload["confidence"] = confidence
+    if provenance:
+        payload["provenance"] = provenance
+    # Ensure session is active
+    client.activate_session()
+    return client.remember(**payload)
+
+
+def recall(
+    query: str,
+    limit: int = 10,
+    memory_type: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    confidence_min: Optional[float] = None,
+    api_key: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Search memories by semantic similarity.
+
+    Args:
+        query: Natural language query.
+        limit: Maximum number of results.
+        memory_type: Filter by a specific memory type.
+        tags: Filter by tags.
+        confidence_min: Minimum confidence threshold (0.0–1.0).
+
+    Returns:
+        List of matching memory dicts.
+    """
+    client = _get_client(api_key=api_key, agent_id=agent_id)
+    filters = {}
+    if memory_type:
+        filters["memory_type"] = memory_type
+    if tags:
+        filters["tags"] = tags
+    if confidence_min is not None:
+        filters["confidence_min"] = confidence_min
+    client.activate_session()
+    result = client.recall(query=query, filters=filters, limit=limit)
+    return result.get("memories", [])
+
+
+def answer(
+    question: str,
+    api_key: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> str:
+    """Generate a grounded answer from memory (RAG).
+
+    Args:
+        question: The question to answer based on stored memories.
+
+    Returns:
+        The answer text.
+    """
+    client = _get_client(api_key=api_key, agent_id=agent_id)
+    client.activate_session()
+    result = client.answer(question=question)
+    return result.get("answer", "")
+
+
+def batch_remember(
+    memories: List[Dict[str, Any]],
+    api_key: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Store multiple memories in one call.
+
+    Args:
+        memories: List of dicts, each with 'memory' and optional
+                  'memory_type', 'tags', 'confidence', 'provenance'.
+
+    Returns:
+        Dict with status.
+    """
+    client = _get_client(api_key=api_key, agent_id=agent_id)
+    client.activate_session()
+    return client.batch_remember(memories=memories)
+
+
+def create_memanto_tools(
+    api_key: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    auto_create: bool = True,
+    pattern: str = "tool",
+) -> Dict[str, Any]:
+    """Return a dict of callable tools bound to the given agent.
+
+    Usage inside a LangGraph node:
+        tools = create_memanto_tools(agent_id="my-agent")
+        tools["remember"]("The user likes dark mode")
+        results = tools["recall"]("What theme does the user like?")
+
+    Returns a dict with keys: "remember", "recall", "answer", "batch_remember".
+    """
+    # Partially apply the api_key and agent_id
+    return {
+        "remember": lambda memory, memory_type="fact", tags=None, confidence=None, provenance=None: remember(
+            memory=memory,
+            memory_type=memory_type,
+            tags=tags,
+            confidence=confidence,
+            provenance=provenance,
+            api_key=api_key,
+            agent_id=agent_id,
+        ),
+        "recall": lambda query, limit=10, memory_type=None, tags=None, confidence_min=None: recall(
+            query=query,
+            limit=limit,
+            memory_type=memory_type,
+            tags=tags,
+            confidence_min=confidence_min,
+            api_key=api_key,
+            agent_id=agent_id,
+        ),
+        "answer": lambda question: answer(
+            question=question,
+            api_key=api_key,
+            agent_id=agent_id,
+        ),
+        "batch_remember": lambda memories: batch_remember(
+            memories=memories,
+            api_key=api_key,
+            agent_id=agent_id,
+        ),
+    }

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -1,0 +1,73 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langgraph-memanto"
+version = "0.1.0"
+description = "LangGraph Store backend and memory tools for Memanto - persistent long-term memory for stateful agents"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10,<4"
+authors = [
+    { name = "Memanto", email = "info@memanto.ai" }
+]
+keywords = [
+    "memanto",
+    "moorcheh",
+    "langgraph",
+    "langchain",
+    "agent memory",
+    "semantic memory",
+    "long-term memory",
+    "stateful agents",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "langgraph>=0.2.0",
+    "memanto>=0.1.0",
+    "pydantic>=2.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2.0,<9",
+    "pytest-asyncio>=0.21.0",
+    "pytest-mock>=3.12.0,<4",
+    "ruff>=0.14.6,<0.15",
+    "mypy>=1.10.0,<2",
+]
+
+[project.urls]
+Homepage = "https://www.memanto.ai"
+Documentation = "https://docs.memanto.ai"
+Repository = "https://github.com/moorcheh-ai/memanto"
+"Bug Tracker" = "https://github.com/moorcheh-ai/memanto/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["langgraph_memanto"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+ignore = ["B904", "E501", "B008", "C901"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]


### PR DESCRIPTION
创建新的 LangGraph 集成，提供 MemantoStore （实现 langgraph.store.BaseStore）以及 remember/recall/answer 工具，使 LangGraph 代理能够使用 Memanto 作为持久记忆层。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced LangGraph integration with Memanto semantic memory backend, enabling agents to store and retrieve persistent memories within LangGraph workflows.
  * Added memory tools for remembering facts, recalling information, answering questions, and batch storing memories.

* **Documentation**
  * Added comprehensive README covering installation, quick start, usage examples, and configuration options for the LangGraph Memanto integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->