### PR TITLE
feat: add LangGraph integration for long-term memory via Memanto (#397)

### DIFF
--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -1,0 +1,148 @@
+# LangGraph + Memanto: Persistent Semantic Memory for Stateful Agent Graphs
+
+This package integrates [Memanto](https://memanto.ai) as a long-term memory layer for [LangGraph](https://langchain-ai.github.io/langgraph/) agent graphs. Memanto provides typed semantic memory with confidence, provenance, and sub-90ms retrieval — enabling your LangGraph agents to remember across sessions, manage contradictions, and share knowledge.
+
+## Installation
+
+```bash
+pip install langgraph-memanto
+```
+
+Requires Python 3.10+ and a [Moorcheh API key](https://console.moorcheh.ai/api-keys) (free tier: 100K ops/month).
+
+## How It Works
+
+LangGraph agents operate on a `State` object. Memanto memory lives outside the graph — any node can invoke `remember`, `recall`, or `answer` tools to persist or retrieve information. Memory persists across graph runs, agent restarts, and even across different LangGraph agents sharing the same Memanto agent ID.
+
+## Quick Start
+
+### 1. Configure your API key
+
+Set the `MOORCHEH_API_KEY` environment variable:
+
+```bash
+export MOORCHEH_API_KEY="mch_xxxxxxxxxxxxxxxxxx"
+```
+
+### 2. Create Memanto tools and bind to a graph
+
+```python
+from langgraph.prebuilt import create_react_agent
+from langgraph_memanto import create_memanto_tools
+
+# Create a Memanto client and retrieve LangChain tools
+tools = create_memanto_tools(
+    api_key="your-key",  # or omit to use MOORCHEH_API_KEY env var
+    agent_id="my-langgraph-agent",   # memory namespace
+)
+
+# Use them in a LangGraph agent (e.g., prebuilt ReAct agent)
+from langgraph.prebuilt import create_react_agent
+from langchain_openai import ChatOpenAI  # or any other LLM
+
+model = ChatOpenAI(model="gpt-4")
+graph = create_react_agent(model, tools, state_modifier="You have access to long-term memory tools. Use them to remember user preferences and recall past decisions.")
+
+# Run the graph
+for chunk in graph.stream({"messages": [("human", "Remember that I prefer dark mode")]}):
+    pass  # process stream
+
+# In a new session
+for chunk in graph.stream({"messages": [("human", "What display mode do I prefer?")]}):
+    pass  # agent will recall the stored preference
+```
+
+> **Note**: The tools use a shared Memanto agent namespace. Any LangGraph agent, regardless of session or restart, can access memories persisted by others using the same `agent_id`.
+
+## Available Tools
+
+The tools returned by `create_memanto_tools()` are standard LangChain `Tool` objects:
+
+| Tool | Description |
+|------|-------------|
+| `memanto_remember` | Store a fact, preference, decision, goal, or instruction into long-term memory. Accepts `memory` (text), optional `memory_type` and `confidence`. |
+| `memanto_recall` | Search memory by semantic similarity. Returns the most relevant memories. |
+| `memanto_answer` | Generate a grounded answer using only stored memories (RAG). |
+| `memanto_recall_recent` | Fetch the `n` most recent memories without a query. |
+| `memanto_recall_as_of` | Point-in-time recall: what was known on a specific date. |
+| `memanto_recall_changed_since` | Differential recall: what has changed since a given datetime. |
+
+### Supported Memory Types
+
+`fact`, `preference`, `goal`, `decision`, `artifact`, `learning`, `event`, `instruction`, `relationship`, `context`, `observation`, `commitment`, `error`.
+
+## Advanced Usage: Custom Graph Nodes
+
+For full control, you can use the `MemantoClient` directly in your custom nodes:
+
+```python
+from langgraph.graph import StateGraph
+from langgraph_memanto import MemantoClient
+
+client = MemantoClient(agent_id="custom-agent")
+
+def remember_node(state):
+    last_message = state["messages"][-1].content
+    response = client.remember(
+        memory=last_message,
+        memory_type="observation"
+    )
+    return state
+```
+
+## Configuration
+
+The `create_memanto_tools()` function accepts:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `api_key` | `None` (reads `MOORCHEH_API_KEY` env) | Moorcheh API key |
+| `agent_id` | `"langgraph-default"` | Memanto agent ID (memory namespace) |
+| `agent_pattern` | `"tool"` | Pattern used when auto-creating the agent (`support`, `project`, `tool`) |
+| `agent_auto_create` | `True` | Create agent if it doesn't exist |
+| `session_duration_hours` | `6` | JWT session lifetime |
+
+## Persistence Example: Across Restarts
+
+Run the following script twice to prove cross-session memory:
+
+```python
+# run.py
+import os
+from langgraph_memanto import create_memanto_tools
+from langgraph.prebuilt import create_react_agent
+from langchain_openai import ChatOpenAI
+
+tools = create_memanto_tools(agent_id="demo-agent")
+model = ChatOpenAI(model="gpt-4")
+graph = create_react_agent(model, tools)
+
+for chunk in graph.stream({"messages": [("human",
+    "Remember that my favorite color is blue.")]}):
+    pass
+```
+
+First run stores the fact. Second run can query "What is my favorite color?" and the agent will recall the memory even though the script starts a new process.
+
+## Examples
+
+See the `examples/` directory for runnable scripts demonstrating:
+- Basic memory persistence
+- Cross-agent memory sharing
+- Contradiction detection
+
+## How It Differs from Other Integrations
+
+| Integration | Interface | Best for |
+|------------|-----------|----------|
+| **MCP** | Model Context Protocol tools | Any MCP client (Claude, Cursor, etc.) |
+| **CrewAI** | CrewAI tools | Multi-agent CrewAI pipelines |
+| **LangGraph** | LangChain tools + direct client | Custom LangGraph agent graphs |
+
+All share the same Memanto backend — memory written by one integration is recallable from another when they use the same `agent_id`.
+
+## Support
+
+- [Memanto Documentation](https://docs.memanto.ai)
+- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+- [Moorcheh API Keys](https://console.moorcheh.ai/api-keys)

--- a/integrations/langgraph/langgraph_memanto/__init__.py
+++ b/integrations/langgraph/langgraph_memanto/__init__.py
@@ -1,0 +1,7 @@
+from .client import MemantoClient
+from .tools import create_memanto_tools
+
+__all__ = [
+    "MemantoClient",
+    "create_memanto_tools",
+]

--- a/integrations/langgraph/langgraph_memanto/client.py
+++ b/integrations/langgraph/langgraph_memanto/client.py
@@ -1,0 +1,135 @@
+"""Memanto client wrapper for LangGraph integration."""
+
+import os
+from typing import Optional
+
+from memanto.cli.client.sdk_client import SdkClient
+
+
+class MemantoClient:
+    """Thin wrapper around the Memanto SDK client for use in LangGraph nodes.
+
+    Handles automatic agent creation/session activation, and exposes
+    the core memory operations as simple methods.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        agent_id: str = "langgraph-default",
+        agent_pattern: str = "tool",
+        agent_auto_create: bool = True,
+        session_duration_hours: int = 6,
+    ):
+        self._api_key = api_key or os.environ.get("MOORCHEH_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "MOORCHEH_API_KEY must be provided or set in environment"
+            )
+        self._agent_id = agent_id
+        self._session_duration_hours = session_duration_hours
+
+        # Create the underlying SDK client (used by CLI as well)
+        self._client = SdkClient(api_key=self._api_key)
+
+        # Ensure agent exists and has an active session
+        self._ensure_agent(agent_pattern, agent_auto_create)
+
+    def _ensure_agent(self, pattern: str, auto_create: bool) -> None:
+        """Make sure the agent exists and a session is active."""
+        if auto_create:
+            try:
+                # Check if agent exists
+                agent = self._client.get_agent(self._agent_id)
+            except Exception:
+                agent = None
+
+            if not agent:
+                self._client.create_agent(
+                    agent_id=self._agent_id,
+                    pattern=pattern,
+                )
+
+        # Activate session (returns JWT token, stored internally)
+        self._client.activate_session(
+            agent_id=self._agent_id,
+            duration_hours=self._session_duration_hours,
+        )
+
+    # ── Memory operations ────────────────────────────────────────────────
+
+    def remember(
+        self,
+        memory: str,
+        memory_type: str = "fact",
+        confidence: Optional[float] = None,
+        provenance: str = "explicit_statement",
+        **kwargs,
+    ) -> dict:
+        """Store a memory into the agent's namespace.
+
+        Args:
+            memory: The textual content to remember.
+            memory_type: One of the 13 allowed types.
+            confidence: Optional confidence score (0.0–1.0).
+            provenance: Source tag for the memory.
+
+        Returns:
+            API response dict.
+        """
+        params = {
+            "memory": memory,
+            "memory_type": memory_type,
+            "provenance": provenance,
+        }
+        if confidence is not None:
+            params["confidence"] = confidence
+        params.update(kwargs)
+        return self._client.remember(agent_id=self._agent_id, **params)
+
+    def recall(
+        self,
+        query: str,
+        memory_type: Optional[str] = None,
+        top_k: int = 10,
+        **kwargs,
+    ) -> dict:
+        """Semantic search over the agent's memories."""
+        params = {"query": query, "top_k": top_k}
+        if memory_type:
+            params["memory_type"] = memory_type
+        params.update(kwargs)
+        return self._client.recall(agent_id=self._agent_id, **params)
+
+    def recall_recent(self, top_k: int = 10) -> dict:
+        """Retrieve the most recent memories (no query needed)."""
+        return self._client.recall(
+            agent_id=self._agent_id, query="", top_k=top_k
+        )
+
+    def recall_as_of(self, iso_date: str, query: str = "", top_k: int = 10) -> dict:
+        """Point-in-time recall."""
+        return self._client.recall(
+            agent_id=self._agent_id,
+            query=query,
+            top_k=top_k,
+            as_of=iso_date,
+        )
+
+    def recall_changed_since(self, iso_datetime: str, top_k: int = 10) -> dict:
+        """Recall only memories created/modified after a given datetime."""
+        return self._client.recall(
+            agent_id=self._agent_id,
+            query="",
+            top_k=top_k,
+            changed_since=iso_datetime,
+        )
+
+    def answer(self, question: str, **kwargs) -> dict:
+        """Generate a grounded RAG answer from memory."""
+        return self._client.answer(
+            agent_id=self._agent_id, question=question, **kwargs
+        )
+
+
+__all__ = ["MemantoClient"]

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -1,0 +1,126 @@
+"""Create LangChain Tool objects wrapping Memanto operations."""
+
+from typing import Dict, List, Optional
+
+from langchain_core.tools import Tool
+
+from .client import MemantoClient
+
+
+def create_memanto_tools(
+    api_key: Optional[str] = None,
+    agent_id: str = "langgraph-default",
+    agent_pattern: str = "tool",
+    agent_auto_create: bool = True,
+    session_duration_hours: int = 6,
+) -> Dict[str, Tool]:
+    """Create a dictionary of LangChain Tool objects backed by Memanto.
+
+    Returns a dict keyed by tool name so callers can pick the ones they want:
+
+        tools = create_memanto_tools(agent_id="demo")
+        graph = create_react_agent(model, [tools["memanto_recall"]])
+
+    The returned dict always contains at least:
+        - memanto_remember
+        - memanto_recall
+        - memanto_answer
+        - memanto_recall_recent
+        - memanto_recall_as_of
+        - memanto_recall_changed_since
+    """
+    client = MemantoClient(
+        api_key=api_key,
+        agent_id=agent_id,
+        agent_pattern=agent_pattern,
+        agent_auto_create=agent_auto_create,
+        session_duration_hours=session_duration_hours,
+    )
+
+    def _remember(memory: str, **kwargs) -> str:
+        result = client.remember(memory=memory, **kwargs)
+        return str(result)
+
+    def _recall(query: str, **kwargs) -> str:
+        result = client.recall(query=query, **kwargs)
+        return str(result)
+
+    def _answer(question: str) -> str:
+        result = client.answer(question=question)
+        return str(result)
+
+    def _recall_recent(top_k: int = 10) -> str:
+        result = client.recall_recent(top_k=top_k)
+        return str(result)
+
+    def _recall_as_of(iso_date: str, query: str = "", top_k: int = 10) -> str:
+        result = client.recall_as_of(iso_date=iso_date, query=query, top_k=top_k)
+        return str(result)
+
+    def _recall_changed_since(iso_datetime: str, top_k: int = 10) -> str:
+        result = client.recall_changed_since(iso_datetime=iso_datetime, top_k=top_k)
+        return str(result)
+
+    return {
+        "memanto_remember": Tool(
+            name="memanto_remember",
+            description=(
+                "Store a durable fact, preference, decision, goal, or instruction "
+                "into long-term memory. Accepts 'memory' (string), optional "
+                "'memory_type' (one of: fact, preference, goal, decision, "
+                "artifact, learning, event, instruction, relationship, context, "
+                "observation, commitment, error), optional 'confidence' (0.0-1.0), "
+                "and 'provenance' (explicit_statement, inferred, corrected, "
+                "validated, observed, imported). Returns confirmation."
+            ),
+            func=_remember,
+        ),
+        "memanto_recall": Tool(
+            name="memanto_recall",
+            description=(
+                "Search long-term memory by semantic similarity. "
+                "Accepts 'query' (string), optional 'memory_type' to filter, "
+                "and optional 'top_k' (int, default 10). "
+                "Returns a list of relevant memories with metadata."
+            ),
+            func=_recall,
+        ),
+        "memanto_answer": Tool(
+            name="memanto_answer",
+            description=(
+                "Answer a question using only the agent's stored memories (RAG). "
+                "Accepts 'question' (string). Returns a grounded string answer."
+            ),
+            func=_answer,
+        ),
+        "memanto_recall_recent": Tool(
+            name="memanto_recall_recent",
+            description=(
+                "Fetch the most recent memories without a search query. "
+                "Accepts optional 'top_k' (int, default 10). "
+                "Useful for quickly seeing what was just discussed."
+            ),
+            func=_recall_recent,
+        ),
+        "memanto_recall_as_of": Tool(
+            name="memanto_recall_as_of",
+            description=(
+                "Point-in-time recall: retrieve memories as they existed on "
+                "a given date. Accepts 'iso_date' (string, e.g. '2025-11-01'), "
+                "optional 'query' (string), optional 'top_k' (int, default 10)."
+            ),
+            func=_recall_as_of,
+        ),
+        "memanto_recall_changed_since": Tool(
+            name="memanto_recall_changed_since",
+            description=(
+                "Differential recall: retrieve memories created or modified "
+                "after a given ISO datetime. Accepts 'iso_datetime' (string), "
+                "optional 'top_k' (int, default 10)."
+            ),
+            func=_recall_changed_since,
+        ),
+    }
+
+
+__all__ = ["create_memanto_tools"]

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -1,0 +1,72 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langgraph-memanto"
+version = "0.1.0"
+description = "LangGraph integration for Memanto - persistent semantic memory for stateful agent graphs"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10,<4"
+authors = [
+    { name = "Memanto", email = "info@memanto.ai" }
+]
+keywords = [
+    "memanto",
+    "moorcheh",
+    "langgraph",
+    "langchain",
+    "agent memory",
+    "semantic memory",
+    "graph memory",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "memanto>=0.1.0",
+    "langgraph>=0.2.0",
+    "langchain-core>=0.3.0",
+    "pydantic>=2.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2.0,<9",
+    "pytest-asyncio>=0.21.0",
+    "pytest-mock>=3.12.0,<4",
+    "ruff>=0.14.6,<0.15",
+    "mypy>=1.10.0,<2",
+]
+
+[project.urls]
+Homepage = "https://www.memanto.ai"
+Documentation = "https://docs.memanto.ai"
+Repository = "https://github.com/moorcheh-ai/memanto"
+"Bug Tracker" = "https://github.com/moorcheh-ai/memanto/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["langgraph_memanto"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+ignore = ["B904", "E501", "B008", "C901"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]


### PR DESCRIPTION
为LangGraph代理添加Memanto长期记忆集成的初始实现。包括包配置、文档和一组LangChain工具(remember/recall/answer)，便于在LangGraph状态下存储和检索语义记忆。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LangGraph integration for persistent semantic memory in agent graphs, supporting session-based memory recall across restarts with configurable persistence and multiple recall strategies.

* **Documentation**
  * Added complete integration guide covering installation, quick-start examples with agent creation, available memory management tools, supported memory types, advanced patterns for custom nodes, and detailed comparisons with other integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moorcheh-ai/memanto/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->