### PR TITLE
feat: add Memanto global memory integration for claudecode skills (#508)

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,75 @@
+# Memanto Skills Companion for Claude Code
+
+**A global, persistent cross-session memory layer for AI agent skills.**
+
+This example demonstrates how to solve **Context Fragmentation** in modular developer workflows (like [mattpocock/skills](https://github.com/mattpocock/skills) or custom AI agent prompts) using **Memanto**.
+
+---
+
+## 🐜 The Problem: Context Fragmentation
+
+Modular agent skills (like `/grill-with-docs`, `/tdd`, and `/handoff`) optimize productivity by focusing the LLM on a single task. However:
+1. **No Cross-Session Memory**: If you use a skill to align on an architectural design, that vital context is lost when you start a fresh session to write the code.
+2. **Repeated Instruction Fatigue**: You have to repeatedly tell the agent your style guides, framework choices, and codebase quirks.
+3. **Forgotten Errors**: The agent might repeat a mistake that it resolved in a previous debugging session.
+
+## 🧠 The Solution: Memanto Skills Companion
+
+This integration layer acts as a global active memory companion. By running simple hook commands before and after skill execution, Memanto:
+- **Autonomously Distills & Remembers**: Saves architectural decisions, developer preferences, lessons learned, and error resolutions when a session ends.
+- **Dynamically Recalls & Injects**: Searches the persistent memory using semantic search before a new session starts, injecting relevant past engineering decisions directly into the workspace context.
+
+---
+
+## 🛠️ Setup
+
+1. **Get an API Key**: Grab your free API key at [moorcheh.ai](https://moorcheh.ai/).
+2. **Set Environment Variable**:
+   ```bash
+   export MOORCHEH_API_KEY="your_api_key_here"
+   ```
+3. **Install Dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+---
+
+## 🚀 How to Use
+
+The companion provides a single script, `memanto_skills.py`, which integrates into your CLI or shell hooks.
+
+### 1. Start of Session (Dynamic Injection)
+Before launching Claude Code or running a skill, query Memanto for relevant past engineering decisions and write them to the workspace context:
+```bash
+python memanto_skills.py start --task "Refactor the authentication endpoint to support OAuth2" --file "apps/api/auth.py"
+```
+
+This queries Memanto for memories matching the task and file path and generates a beautiful `.claude/skills_memory.md` file in your workspace containing:
+- Codebase style guides
+- Architecture decisions
+- Preferred libraries and patterns
+- Past errors avoided in this module
+
+Your Claude Code skills can then reference `.claude/skills_memory.md` (e.g., in a `.clauderc` system prompt or by instructing the agent to read it first).
+
+### 2. End of Session (Active Extraction)
+When the session is complete, store the distilled insights, structural decisions, or preferences to Memanto so they are available next time:
+```bash
+python memanto_skills.py end --task "Refactor authentication" --summary "We replaced raw JWT tokens with OAuth2 bearer authentication, using the authlib library. The developer prefers using PyJWT only for decoding local tokens." --confidence 1.0 --tags "auth,jwt,oauth2"
+```
+
+Memanto will persist these decisions across all future sessions!
+
+---
+
+## 📊 Example Workflow Demo
+
+To see cross-session persistence in action, run our simple automated simulation:
+```bash
+python test_skills.py
+```
+
+This simulation will:
+1. **Session 1 (Design)**: Record architectural decisions about using a specific naming convention and caching mechanism.
+2. **Session 2 (Implementation)**: Query Memanto with a new task to write the code, proving that the decisions from Session 1 are successfully recalled and injected.

--- a/examples/claudecode-skills-memanto/memanto_skills.py
+++ b/examples/claudecode-skills-memanto/memanto_skills.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Memanto Skills Companion for Claude Code
+
+A CLI integration layer that injects persistent cross-session memory 
+into modular developer skill workflows, preventing Context Fragmentation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from memanto.app.utils.errors import AgentAlreadyExistsError
+from memanto.cli.client.sdk_client import SdkClient
+
+# Load local environment variables if available
+load_dotenv()
+
+
+def get_client() -> SdkClient:
+    """Initialize SdkClient from environment variable."""
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        print(
+            "Error: MOORCHEH_API_KEY environment variable is not set.\n"
+            "Please export your Moorcheh API key: export MOORCHEH_API_KEY='mch_...'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return SdkClient(api_key=api_key)
+
+
+def ensure_agent_active(client: SdkClient, agent_id: str) -> None:
+    """Ensure the target agent exists and has an active session."""
+    try:
+        client.create_agent(
+            agent_id=agent_id,
+            pattern="tool",
+            description="Global memory for Claude Code skills",
+        )
+    except AgentAlreadyExistsError:
+        pass
+    except Exception:
+        # Ignore other duplicate/validation errors, and attempt session activation
+        pass
+
+    # Activate agent session for 24 hours
+    client.activate_agent(agent_id, duration_hours=24)
+
+
+def handle_start(args: argparse.Namespace) -> None:
+    """
+    Handle the start of a skill execution.
+    Queries Memanto for relevant past engineering decisions and writes
+    them to a local workspace file for the AI agent to consume.
+    """
+    client = get_client()
+    agent_id = args.agent_id or "claudecode-skills"
+    
+    print(f"[*] Connecting to Memanto (Agent: {agent_id})...")
+    ensure_agent_active(client, agent_id)
+
+    # Build search query from task and file path
+    query_parts = [args.task]
+    if args.file:
+        query_parts.append(f"in file {args.file}")
+    query = " ".join(query_parts)
+
+    print(f"[*] Querying memory for: '{query}'...")
+    
+    # Recall memories matching our task
+    recall_result = client.recall(
+        agent_id=agent_id,
+        query=query,
+        limit=5,
+        min_similarity=0.3,
+    )
+
+    memories = recall_result.get("memories", [])
+    
+    # Format as a beautiful Markdown document
+    output_lines = [
+        "# 🧠 Memanto Persistent Context\n",
+        "This file is dynamically managed by the **Memanto Skills Companion**.",
+        "It injects relevant past architectural decisions, codebase preferences, "
+        "and guidelines to prevent Context Fragmentation across different sessions.\n",
+        "---",
+        f"**Active Task:** *{args.task}*",
+    ]
+    if args.file:
+        output_lines.append(f"**Current File Path:** `{args.file}`")
+    output_lines.append("")
+
+    if memories:
+        output_lines.append("## 🔑 Relevant Architectural Decisions & Preferences found:")
+        for idx, mem in enumerate(memories, 1):
+            mem_type = mem.get("type", "fact")
+            title = mem.get("title", "Untitled Memory")
+            content = mem.get("content", "")
+            confidence = mem.get("confidence", 1.0)
+            tags = mem.get("tags", [])
+            tag_str = f" `[{', '.join(tags)}]`" if tags else ""
+            
+            output_lines.append(
+                f"### {idx}. [{mem_type.upper()}] {title} (Confidence: {confidence}){tag_str}\n"
+                f"{content}\n"
+            )
+        print(f"[+] Found {len(memories)} relevant memories. Injecting into workspace...")
+    else:
+        output_lines.append(
+            "## 🆕 Fresh Workspace Context\n"
+            "No matching architectural decisions or preferences found in Memanto yet.\n"
+            "Feel free to build and make choices! They will be recorded on session end."
+        )
+        print("[*] No matching memories found. Injecting fresh workspace template...")
+
+    # Write file to the specified out_file
+    out_path = Path(args.out_file)
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text("\n".join(output_lines), encoding="utf-8")
+        print(f"[+] Context successfully injected to: {out_path}")
+        print("[!] Tip: Tell your Claude Code agent to read this file before writing code.")
+    except Exception as e:
+        print(f"[-] Failed to write context file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def handle_end(args: argparse.Namespace) -> None:
+    """
+    Handle the end of a skill execution.
+    Distills and saves the session's key choices and preferences into Memanto.
+    """
+    client = get_client()
+    agent_id = args.agent_id or "claudecode-skills"
+
+    print(f"[*] Connecting to Memanto (Agent: {agent_id})...")
+    ensure_agent_active(client, agent_id)
+
+    # Classify the memory type based on content or user tags
+    memory_type = "decision"
+    tags_list = [t.strip().lower() for t in args.tags.split(",") if t.strip()]
+    
+    if "preference" in tags_list:
+        memory_type = "preference"
+    elif "error" in tags_list or "bug" in tags_list:
+        memory_type = "error"
+    elif "learning" in tags_list:
+        memory_type = "learning"
+
+    title = f"Decision: {args.task[:50]}"
+    if len(args.task) > 50:
+        title += "..."
+
+    print(f"[*] Distilling and storing new memory: '{title}'...")
+    
+    result = client.remember(
+        agent_id=agent_id,
+        memory_type=memory_type,
+        title=title,
+        content=args.summary,
+        confidence=args.confidence,
+        tags=tags_list,
+        source="claudecode-skills",
+        provenance="skills_companion",
+    )
+
+    print(f"[+] Memory successfully stored in Memanto!")
+    print(f"    - Memory ID: {result['memory_id']}")
+    print(f"    - Type: {memory_type.upper()}")
+    print(f"    - Title: {title}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Memanto Skills Companion for Claude Code - Cross-Session Persistent Memory Layer"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # 'start' command
+    start_parser = subparsers.add_parser(
+        "start",
+        help="Query Memanto for relevant context and inject it into the local workspace.",
+    )
+    start_parser.add_argument("--task", required=True, help="Description of the active task.")
+    start_parser.add_argument("--file", help="Path to the file being edited or reviewed.")
+    start_parser.add_argument(
+        "--agent-id",
+        default="claudecode-skills",
+        help="Memanto agent/namespace ID to query (default: claudecode-skills).",
+    )
+    start_parser.add_argument(
+        "--out-file",
+        default=".claude/skills_memory.md",
+        help="Path where the context Markdown file will be written (default: .claude/skills_memory.md).",
+    )
+
+    # 'end' command
+    end_parser = subparsers.add_parser(
+        "end",
+        help="Distill and save session decisions and engineering preferences to Memanto.",
+    )
+    end_parser.add_argument(
+        "--task", required=True, help="Description of the task that was completed."
+    )
+    end_parser.add_argument(
+        "--summary",
+        required=True,
+        help="Summary of architectural decisions, preferences, or learnings to remember.",
+    )
+    end_parser.add_argument(
+        "--confidence",
+        type=float,
+        default=0.9,
+        help="Confidence score from 0.0 to 1.0 (default: 0.9).",
+    )
+    end_parser.add_argument(
+        "--tags",
+        default="",
+        help="Comma-separated list of tags (e.g. 'auth,jwt,preference').",
+    )
+    end_parser.add_argument(
+        "--agent-id",
+        default="claudecode-skills",
+        help="Memanto agent/namespace ID to store memory in (default: claudecode-skills).",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "start":
+        handle_start(args)
+    elif args.command == "end":
+        handle_end(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,0 +1,2 @@
+memanto
+python-dotenv

--- a/examples/claudecode-skills-memanto/test_skills.py
+++ b/examples/claudecode-skills-memanto/test_skills.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Verification Script for Memanto Skills Companion
+
+Simulates a real-world multi-session developer workflow:
+1. Session 1: The developer aligns on a database design and stores it to Memanto.
+2. Session 2: The developer starts coding a model. The companion dynamically 
+   recalls the design and injects it as context, avoiding repeat prompt instructions.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Paths
+BASE_DIR = Path(__file__).parent.resolve()
+SKILLS_SCRIPT = BASE_DIR / "memanto_skills.py"
+OUTPUT_FILE = BASE_DIR / "test_output_memory.md"
+AGENT_ID = "test-skills-agent-mch"
+
+
+def main() -> None:
+    print("=" * 70)
+    print("🎯 Simulating Cross-Session Persistent Memory in Claude Code")
+    print("=" * 70)
+
+    # 1. Verify environment
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        print("Error: MOORCHEH_API_KEY is not set.")
+        print("Please export it before running: export MOORCHEH_API_KEY='mch_...'")
+        sys.exit(1)
+
+    # Make sure target output file is clean
+    if OUTPUT_FILE.exists():
+        OUTPUT_FILE.unlink()
+
+    # 2. Simulate Session 1 (Design Phase complete)
+    # The developer finishes a design task and saves architectural decisions to Memanto
+    print("\n[Step 1] Session 1: Design Phase completed.")
+    print("Storing architectural decision in Memanto...")
+    
+    summary_text = (
+        "We decided to use PostgreSQL for our database and SQLAlchemy as the ORM. "
+        "The developer strongly prefers using asynchronous database queries "
+        "via SQLAlchemy's AsyncSession to ensure high concurrency and non-blocking I/O. "
+        "Do NOT write synchronous database queries."
+    )
+    
+    cmd_session1 = [
+        sys.executable,
+        str(SKILLS_SCRIPT),
+        "end",
+        "--task", "Setup database schema and choosing ORM",
+        "--summary", summary_text,
+        "--tags", "db,orm,preference,postgres",
+        "--agent-id", AGENT_ID
+    ]
+    
+    try:
+        subprocess.run(cmd_session1, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"[-] Session 1 failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print("\n" + "-" * 50)
+
+    # 3. Simulate Session 2 (Coding Phase starts)
+    # The developer opens a fresh terminal, starts a coding task, and queries Memanto
+    print("[Step 2] Session 2: Fresh Coding Session starts.")
+    print("Querying Memanto for relevant context and injecting into the workspace...")
+
+    cmd_session2 = [
+        sys.executable,
+        str(SKILLS_SCRIPT),
+        "start",
+        "--task", "Implement user model and postgres database connections",
+        "--file", "src/models/user.py",
+        "--agent-id", AGENT_ID,
+        "--out-file", str(OUTPUT_FILE)
+    ]
+
+    try:
+        subprocess.run(cmd_session2, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"[-] Session 2 failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print("\n" + "-" * 50)
+
+    # 4. Verify Output
+    print("[Step 3] Verifying injected workspace context...")
+    if not OUTPUT_FILE.exists():
+        print("[-] Error: Injected memory file was not created!", file=sys.stderr)
+        sys.exit(1)
+
+    content = OUTPUT_FILE.read_text(encoding="utf-8")
+    print(f"\n[+] Injected Context File Contents ({OUTPUT_FILE.name}):")
+    print("=" * 60)
+    print(content)
+    print("=" * 60)
+
+    # Check for crucial keywords
+    if "PostgreSQL" in content and "SQLAlchemy" in content and "AsyncSession" in content:
+        print("\n🎉 SUCCESS! Memanto successfully recalled and injected the architectural")
+        print("    decisions across separate skill executions with zero repeat instructions!")
+    else:
+        print("\n[-] Validation failed: Injected context did not contain the expected memory.", file=sys.stderr)
+        sys.exit(1)
+
+    # Clean up output file after validation
+    if OUTPUT_FILE.exists():
+        OUTPUT_FILE.unlink()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_skills_companion.py
+++ b/tests/test_skills_companion.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+import pytest
+import argparse
+import sys
+from pathlib import Path
+
+# Add examples directory to sys.path to import memanto_skills directly
+SKILLS_DIR = Path(__file__).parent.parent / "examples" / "claudecode-skills-memanto"
+sys.path.insert(0, str(SKILLS_DIR))
+
+from memanto_skills import handle_start, handle_end
+
+
+def test_memanto_skills_end():
+    """Test that the end command distills and saves the decision memory correctly."""
+    with patch("memanto_skills.get_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        
+        mock_client.remember.return_value = {"memory_id": "test-mem-123"}
+        
+        args_end = argparse.Namespace(
+            command="end",
+            task="Test architectural choice",
+            summary="Use asyncio for all database calls.",
+            confidence=0.9,
+            tags="db,async,preference",
+            agent_id="test-agent"
+        )
+        
+        handle_end(args_end)
+        
+        # Verify remember was called correctly with distilled memory_type="preference"
+        mock_client.remember.assert_called_once_with(
+            agent_id="test-agent",
+            memory_type="preference",
+            title="Decision: Test architectural choice",
+            content="Use asyncio for all database calls.",
+            confidence=0.9,
+            tags=["db", "async", "preference"],
+            source="claudecode-skills",
+            provenance="skills_companion",
+        )
+
+
+def test_memanto_skills_start(tmp_path):
+    """Test that the start command queries Memanto and injects context into the workspace."""
+    out_file = tmp_path / "skills_memory.md"
+    
+    with patch("memanto_skills.get_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        
+        # Mock recall to return a relevant memory
+        mock_client.recall.return_value = {
+            "memories": [
+                {
+                    "type": "decision",
+                    "title": "Decision: Test architectural choice",
+                    "content": "Use asyncio for all database calls.",
+                    "confidence": 0.9,
+                    "tags": ["db", "async"]
+                }
+            ]
+        }
+        
+        args_start = argparse.Namespace(
+            command="start",
+            task="Implement user model",
+            file="user.py",
+            agent_id="test-agent",
+            out_file=str(out_file)
+        )
+        
+        handle_start(args_start)
+        
+        # Verify recall was called with the correct built query
+        mock_client.recall.assert_called_once_with(
+            agent_id="test-agent",
+            query="Implement user model in file user.py",
+            limit=5,
+            min_similarity=0.3
+        )
+        
+        # Verify the context file was generated and has the expected content
+        assert out_file.exists()
+        content = out_file.read_text(encoding="utf-8")
+        assert "Use asyncio for all database calls." in content
+        assert "Test architectural choice" in content
+        assert "Implement user model" in content


### PR DESCRIPTION
Closes #508. This PR adds the Memanto Skills Companion for Claude Code, which acts as a global, persistent cross-session memory layer for AI agent skills to solve Context Fragmentation. It includes: 1. A CLI utility (memanto_skills.py) for dynamic injection and active extraction, 2. A simulated e2e walkthrough, 3. Comprehensive mocked tests (test_skills_companion.py) integrated into the core pytest suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Memanto Skills Companion example for Claude Code, enabling dynamic context management across development sessions.
  * Includes command-line tools for storing session summaries and automatically retrieving relevant context.

* **Documentation**
  * Added setup guide and usage instructions for the Skills Companion.

* **Tests**
  * Added comprehensive test suite validating context storage, retrieval, and multi-session workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->