### PR TITLE
Add Claude Code skills Memanto memory bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,79 @@
+# Claude Code skills + Memanto memory bridge
+
+This example shows a lightweight integration layer for using Memanto as a global memory companion around Claude Code skill-style workflows.
+
+It has two tiny shell hooks:
+
+- `scripts/skill-start.sh` — recall relevant engineering memory before a skill starts and write a prompt-injection snippet.
+- `scripts/skill-finish.sh` — distill the just-finished skill transcript/summary into Memanto memory.
+
+The goal is zero repeated instructions across terminal sessions: decisions saved after one skill become concise constraints for the next skill.
+
+## Setup
+
+```bash
+pip install memanto
+export MOORCHEH_API_KEY="..."
+memanto status
+```
+
+Copy this example into any project that uses Claude Code skills:
+
+```bash
+cp -R examples/claudecode-skills-memanto .memanto-skills
+```
+
+## Start a skill with dynamic memory injection
+
+```bash
+.memanto-skills/scripts/skill-start.sh \
+  --skill tdd \
+  --task "implement billing retry tests" \
+  --path src/billing/retry.ts
+```
+
+The script writes `.memanto-skills/generated/memanto-context.md`. Paste/include that file at the top of the next Claude Code skill prompt.
+
+Example output:
+
+```md
+## Memanto engineering memory
+- Prefer pytest-style table tests for retry logic.
+- Billing code keeps provider errors wrapped; never leak raw gateway messages.
+```
+
+## Finish a skill and persist the useful context
+
+```bash
+.memanto-skills/scripts/skill-finish.sh \
+  --skill tdd \
+  --summary-file /tmp/skill-summary.md \
+  --tags billing,retry,claude-code
+```
+
+Only durable engineering decisions should be stored: architecture choices, project quirks, coding preferences, and gotchas. Avoid secrets and large raw transcripts.
+
+## Optional Claude Code hook
+
+Claude Code can run Memanto sync at session start via `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memanto memory sync --project-dir .",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Use the hook for baseline sync, then use `skill-start.sh` / `skill-finish.sh` for active per-skill recall and distillation.

--- a/examples/claudecode-skills-memanto/scripts/skill-finish.sh
+++ b/examples/claudecode-skills-memanto/scripts/skill-finish.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL="unknown"
+SUMMARY_FILE=""
+TAGS="claude-code,skills,memanto"
+SOURCE="claude_code"
+TYPE="context"
+CONFIDENCE="0.9"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skill) SKILL="$2"; shift 2 ;;
+    --summary-file) SUMMARY_FILE="$2"; shift 2 ;;
+    --tags) TAGS="$2"; shift 2 ;;
+    --source) SOURCE="$2"; shift 2 ;;
+    --type) TYPE="$2"; shift 2 ;;
+    --confidence) CONFIDENCE="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$SUMMARY_FILE" || ! -f "$SUMMARY_FILE" ]]; then
+  echo "--summary-file is required" >&2
+  exit 2
+fi
+
+SUMMARY="$(sed -e 's/[[:space:]]\+/ /g' "$SUMMARY_FILE" | head -c 4000)"
+MEMORY="Claude Code skill '${SKILL}' completed. Durable engineering context: ${SUMMARY}"
+
+if command -v memanto >/dev/null 2>&1; then
+  memanto remember "$MEMORY" \
+    --type "$TYPE" \
+    --tags "$TAGS" \
+    --confidence "$CONFIDENCE" \
+    --provenance observed \
+    --source "$SOURCE"
+else
+  echo "memanto CLI not found; run: pip install memanto" >&2
+  exit 127
+fi

--- a/examples/claudecode-skills-memanto/scripts/skill-start.sh
+++ b/examples/claudecode-skills-memanto/scripts/skill-start.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL="unknown"
+TASK=""
+PATH_HINT="."
+OUT=".memanto-skills/generated/memanto-context.md"
+LIMIT="8"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skill) SKILL="$2"; shift 2 ;;
+    --task) TASK="$2"; shift 2 ;;
+    --path) PATH_HINT="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$(dirname "$OUT")"
+QUERY="Claude Code skill ${SKILL}. Task: ${TASK}. Path: ${PATH_HINT}. Recall relevant engineering decisions, preferences, constraints, gotchas."
+
+{
+  echo "## Memanto engineering memory"
+  echo
+  if command -v memanto >/dev/null 2>&1; then
+    memanto recall "$QUERY" --limit "$LIMIT" 2>/dev/null || true
+  else
+    echo "- memanto CLI not found; run: pip install memanto"
+  fi
+} > "$OUT"
+
+echo "$OUT"


### PR DESCRIPTION
Implements a lightweight Claude Code skills + Memanto integration example for bounty #508.

What is included:
- `examples/claudecode-skills-memanto/README.md` with setup and workflow
- `skill-start.sh` to recall relevant engineering memories before a skill starts and write `.memanto-skills/generated/memanto-context.md`
- `skill-finish.sh` to persist durable engineering context after a skill completes
- Optional Claude Code SessionStart hook docs for baseline sync

This focuses on the technical integration layer: active extraction after a skill and dynamic injection before the next skill.

Validation:
- Ran `skill-start.sh` locally; it creates the context file and degrades safely when the `memanto` CLI is not installed.

Bounty: #508
Social showcase: not posted yet; can add before deadline if required by judging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added integration guide showing how to use Memanto with Claude Code workflows, including installation, configuration, and usage patterns

* **New Features**
  * Added example scripts for generating memory context injections and persisting engineering decisions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->