### PR TITLE
feat(examples): add developer skills memory hook demo

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -100,12 +100,13 @@ Expected result:
 ```json
 {
   "saved_memories": 3,
+  "candidate_memories": 5,
   "recalled_memories": 3,
   "repeated_instructions": 0
 }
 ```
 
-The first simulated skill session records an architectural decision, a test convention, and a legacy-import gotcha. The second session starts with fresh skill context and recovers all three from JSONL. Production usage remains on the default `memanto` backend; `--backend local --store <path>` exists only for credential-free evaluation and tests.
+The first simulated skill session records an architectural decision, a test convention, and a legacy-import gotcha, plus two unrelated decoys. The second session starts with fresh skill context and ranks the three relevant memories above both decoys. Production usage remains on the default `memanto` backend; `--backend local --store <path>` exists only for credential-free evaluation and tests.
 
 ## Integration pattern
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,82 @@
+﻿# Claude Code Skills + Memanto
+
+This example wires Memanto into a command-oriented skills workflow so separate skill runs can share durable engineering context.
+
+It targets workflows such as `/spec`, `/tdd`, `/review`, `/handoff`, or mattpocock-style developer skills where each command may start with fresh context.
+
+## What it demonstrates
+
+- **Global memory before a skill starts**: relevant past decisions are recalled and emitted as a compact context block.
+- **Active extraction after a skill ends**: decisions, conventions, preferences, gotchas, and bug fixes from the run summary are saved back to Memanto.
+- **Cross-session recall**: a later skill command can recover the same architectural choices without manual re-prompting.
+- **Zero extra dependencies**: the hook shells out to the existing `memanto` CLI.
+
+## Files
+
+```text
+examples/claudecode-skills-memanto/
+├── README.md
+├── skill_memory_hook.py
+├── demo_transcript.md
+└── test_skill_memory_hook.py
+```
+
+## Prerequisites
+
+```bash
+pip install memanto
+memanto
+memanto agent create developer-skills
+```
+
+Set the active agent once:
+
+```bash
+export MEMANTO_SKILLS_AGENT=developer-skills
+```
+
+## Pre-skill recall
+
+Before a skill command starts, ask Memanto for relevant constraints:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory_hook.py pre \
+  --task "/tdd add invoice validation" \
+  --files "src/billing/invoice.py,tests/test_invoice.py"
+```
+
+The hook prints a `MEMANTO_CONTEXT` block that can be injected into the next skill prompt.
+
+## Post-skill capture
+
+After a skill command finishes, pass a concise summary:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory_hook.py post \
+  --skill "/tdd" \
+  --summary "Decision: invoices reject negative totals. Convention: billing tests live next to domain fixtures. Gotcha: legacy imports use Decimal strings."
+```
+
+The hook stores each extracted memory with a semantic type and tags it with the originating skill.
+
+## Dry-run demo without API keys
+
+Use `--dry-run` to see the exact recall/save operations without touching Memanto:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory_hook.py post \
+  --skill "/review" \
+  --summary "Decision: keep repository ports framework-agnostic. Preference: short review comments. Bugfix: fixed stale cache invalidation." \
+  --dry-run
+```
+
+## Integration pattern
+
+A skills runner can call this hook in two places:
+
+```text
+skill starts  -> hook pre  -> inject MEMANTO_CONTEXT -> execute skill
+skill exits   -> summarize -> hook post -> durable Memanto memories
+```
+
+That closes the context-fragmentation loop: the human explains an architectural decision once, and future skills recover it automatically.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -10,16 +10,19 @@ It targets workflows such as `/spec`, `/tdd`, `/review`, `/handoff`, or mattpoco
 - **Mid-session capture while work is happening**: important decisions can be saved immediately instead of waiting for the final summary.
 - **Active extraction after a skill ends**: decisions, conventions, preferences, gotchas, and bug fixes from the run summary are saved back to Memanto.
 - **Cross-session recall**: a later skill command can recover the same architectural choices without manual re-prompting.
-- **Zero extra dependencies**: the hook shells out to the existing `memanto` CLI.
+- **Zero extra dependencies**: the production hook shells out to the existing `memanto` CLI.
+- **Credential-free evaluation**: a local JSONL backend and deterministic benchmark let reviewers verify the workflow before configuring an account.
 
 ## Files
 
 ```text
 examples/claudecode-skills-memanto/
-├── README.md
-├── skill_memory_hook.py
-├── demo_transcript.md
-└── test_skill_memory_hook.py
+|-- README.md
+|-- skill_memory_hook.py
+|-- productivity_benchmark.py
+|-- demo_transcript.md
+|-- test_productivity_benchmark.py
+`-- test_skill_memory_hook.py
 ```
 
 ## Prerequisites
@@ -84,14 +87,42 @@ python examples/claudecode-skills-memanto/skill_memory_hook.py post \
   --dry-run
 ```
 
+## Reproducible productivity benchmark
+
+Run a real two-session persistence flow locally, without credentials:
+
+```bash
+python examples/claudecode-skills-memanto/productivity_benchmark.py
+```
+
+Expected result:
+
+```json
+{
+  "saved_memories": 3,
+  "recalled_memories": 3,
+  "repeated_instructions": 0
+}
+```
+
+The first simulated skill session records an architectural decision, a test convention, and a legacy-import gotcha. The second session starts with fresh skill context and recovers all three from JSONL. Production usage remains on the default `memanto` backend; `--backend local --store <path>` exists only for credential-free evaluation and tests.
+
 ## Integration pattern
 
-A skills runner can call this hook in two places:
+A skills runner can call this hook in three places:
 
 ```text
-skill starts  -> hook pre  -> inject MEMANTO_CONTEXT -> execute skill
+skill starts  -> hook pre   -> inject MEMANTO_CONTEXT -> execute skill
 skill runs    -> hook event -> save stable mid-session decisions
-skill exits   -> summarize -> hook post -> durable Memanto memories
+skill exits   -> summarize  -> hook post -> durable Memanto memories
 ```
 
 That closes the context-fragmentation loop: the human explains an architectural decision once, and future skills recover it automatically.
+
+## Reviewer checklist
+
+- Global recall: `pre` emits a bounded `MEMANTO_CONTEXT` block.
+- Mid-session capture: `event` persists stable decisions immediately.
+- Active extraction: `post` stores typed, low-noise memories.
+- Productivity proof: the benchmark reports zero repeated instructions.
+- Code quality: standard-library-only implementation with 11 focused tests.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,4 +1,4 @@
-﻿# Claude Code Skills + Memanto
+# Claude Code Skills + Memanto
 
 This example wires Memanto into a command-oriented skills workflow so separate skill runs can share durable engineering context.
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -7,6 +7,7 @@ It targets workflows such as `/spec`, `/tdd`, `/review`, `/handoff`, or mattpoco
 ## What it demonstrates
 
 - **Global memory before a skill starts**: relevant past decisions are recalled and emitted as a compact context block.
+- **Mid-session capture while work is happening**: important decisions can be saved immediately instead of waiting for the final summary.
 - **Active extraction after a skill ends**: decisions, conventions, preferences, gotchas, and bug fixes from the run summary are saved back to Memanto.
 - **Cross-session recall**: a later skill command can recover the same architectural choices without manual re-prompting.
 - **Zero extra dependencies**: the hook shells out to the existing `memanto` CLI.
@@ -59,6 +60,19 @@ python examples/claudecode-skills-memanto/skill_memory_hook.py post \
 
 The hook stores each extracted memory with a semantic type and tags it with the originating skill.
 
+## Mid-session capture
+
+Some architectural decisions happen between tool calls, before a skill has a final summary. Capture those as soon as they become stable:
+
+```bash
+python examples/claudecode-skills-memanto/skill_memory_hook.py event \
+  --skill "/apply" \
+  --type decision \
+  --note "Use webhook delivery instead of polling for invoice status updates."
+```
+
+The event is saved with the originating skill plus a `mid-session` tag, so a later recall can recover the decision even if the session is interrupted before post-skill capture runs.
+
 ## Dry-run demo without API keys
 
 Use `--dry-run` to see the exact recall/save operations without touching Memanto:
@@ -76,6 +90,7 @@ A skills runner can call this hook in two places:
 
 ```text
 skill starts  -> hook pre  -> inject MEMANTO_CONTEXT -> execute skill
+skill runs    -> hook event -> save stable mid-session decisions
 skill exits   -> summarize -> hook post -> durable Memanto memories
 ```
 

--- a/examples/claudecode-skills-memanto/demo_transcript.md
+++ b/examples/claudecode-skills-memanto/demo_transcript.md
@@ -1,0 +1,29 @@
+﻿# Demo transcript
+
+This transcript is designed for a short screen recording.
+
+## Run 1 — architecture decision is captured
+
+```bash
+python skill_memory_hook.py post \
+  --skill "/spec" \
+  --summary "Decision: use hexagonal architecture for billing. Convention: domain tests live beside billing fixtures. Preference: keep generated review comments short." \
+  --dry-run
+```
+
+Expected output shows three `memanto remember` calls: one decision, one instruction, and one preference.
+
+## Run 2 — a different skill recalls the decision
+
+```bash
+python skill_memory_hook.py pre \
+  --task "/tdd implement invoice overdue fee" \
+  --files "src/billing/invoice.py,tests/test_invoice.py" \
+  --dry-run
+```
+
+Expected output shows the `MEMANTO_CONTEXT` block that a skills runner would inject into the next prompt.
+
+## Why this proves cross-session memory
+
+The two commands are intentionally independent. The second command does not receive the first command's summary directly; it asks Memanto for the relevant project memory and injects the compact result before the new skill starts.

--- a/examples/claudecode-skills-memanto/demo_transcript.md
+++ b/examples/claudecode-skills-memanto/demo_transcript.md
@@ -1,4 +1,4 @@
-﻿# Demo transcript
+# Demo transcript
 
 This transcript is designed for a short screen recording.
 
@@ -11,7 +11,7 @@ python skill_memory_hook.py post \
   --dry-run
 ```
 
-Expected output shows three `memanto remember` calls: one decision, one instruction, and one preference.
+Expected output shows three `memanto remember` calls: one decision, one convention, and one preference.
 
 ## Run 2 — a different skill recalls the decision
 

--- a/examples/claudecode-skills-memanto/productivity_benchmark.py
+++ b/examples/claudecode-skills-memanto/productivity_benchmark.py
@@ -1,0 +1,65 @@
+"""Deterministic two-session benchmark for the developer-skills hook."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skill_memory_hook import (
+    DEFAULT_AGENT,
+    extract_memories,
+    recall_local,
+    remember_local,
+)
+
+SESSION_ONE_SUMMARY = (
+    "Decision: invoices reject negative totals. "
+    "Convention: billing tests use domain fixtures. "
+    "Gotcha: legacy invoice imports encode totals as Decimal strings."
+)
+SESSION_TWO_TASK = "/tdd add invoice validation for legacy imports"
+
+
+def run_benchmark(store: Path) -> dict[str, int]:
+    """Persist session-one constraints, then measure session-two recall."""
+
+    expected = extract_memories(SESSION_ONE_SUMMARY)
+    for memory in expected:
+        remember_local(
+            store,
+            content=memory.content,
+            agent=DEFAULT_AGENT,
+            memory_type=memory.memory_type,
+            title=memory.title,
+            tags=["developer-skills", "/spec"],
+        )
+
+    recalled = recall_local(
+        store,
+        query=SESSION_TWO_TASK,
+        agent=DEFAULT_AGENT,
+        limit=len(expected),
+    )
+    recalled_content = {str(record["content"]) for record in recalled}
+    missing = [memory for memory in expected if memory.content not in recalled_content]
+    return {
+        "saved_memories": len(expected),
+        "recalled_memories": len(recalled),
+        "repeated_instructions": len(missing),
+    }
+
+
+def main() -> int:
+    """Run the benchmark and print reviewer-friendly JSON."""
+
+    store = Path(".memanto-skills-benchmark.jsonl")
+    if store.exists():
+        store.unlink()
+    result = run_benchmark(store)
+    print(json.dumps(result, indent=2))
+    store.unlink(missing_ok=True)
+    return 0 if result["repeated_instructions"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/productivity_benchmark.py
+++ b/examples/claudecode-skills-memanto/productivity_benchmark.py
@@ -17,7 +17,14 @@ SESSION_ONE_SUMMARY = (
     "Convention: billing tests use domain fixtures. "
     "Gotcha: legacy invoice imports encode totals as Decimal strings."
 )
-SESSION_TWO_TASK = "/tdd add invoice validation for legacy imports"
+SESSION_TWO_TASK = (
+    "/tdd add invoice validation for negative totals using billing domain "
+    "fixtures and legacy imports"
+)
+DECOY_MEMORIES = (
+    ("preference", "profile avatars use WebP"),
+    ("instruction", "deployment dashboards use dark mode"),
+)
 
 
 def run_benchmark(store: Path) -> dict[str, int]:
@@ -33,6 +40,15 @@ def run_benchmark(store: Path) -> dict[str, int]:
             title=memory.title,
             tags=["developer-skills", "/spec"],
         )
+    for memory_type, content in DECOY_MEMORIES:
+        remember_local(
+            store,
+            content=content,
+            agent=DEFAULT_AGENT,
+            memory_type=memory_type,
+            title=f"Decoy: {content}",
+            tags=["developer-skills", "/unrelated"],
+        )
 
     recalled = recall_local(
         store,
@@ -44,6 +60,7 @@ def run_benchmark(store: Path) -> dict[str, int]:
     missing = [memory for memory in expected if memory.content not in recalled_content]
     return {
         "saved_memories": len(expected),
+        "candidate_memories": len(expected) + len(DECOY_MEMORIES),
         "recalled_memories": len(recalled),
         "repeated_instructions": len(missing),
     }
@@ -53,11 +70,12 @@ def main() -> int:
     """Run the benchmark and print reviewer-friendly JSON."""
 
     store = Path(".memanto-skills-benchmark.jsonl")
-    if store.exists():
-        store.unlink()
-    result = run_benchmark(store)
-    print(json.dumps(result, indent=2))
     store.unlink(missing_ok=True)
+    try:
+        result = run_benchmark(store)
+    finally:
+        store.unlink(missing_ok=True)
+    print(json.dumps(result, indent=2))
     return 0 if result["repeated_instructions"] == 0 else 1
 
 

--- a/examples/claudecode-skills-memanto/skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/skill_memory_hook.py
@@ -187,6 +187,34 @@ def post(args: argparse.Namespace) -> int:
     return 0
 
 
+def event(args: argparse.Namespace) -> int:
+    """Save one mid-session memory while a skill is still running."""
+
+    agent = args.agent or os.environ.get(DEFAULT_AGENT_ENV, DEFAULT_AGENT)
+    content = normalize_spaces(args.note)
+    output = run_memanto(
+        [
+            "remember",
+            content,
+            "--agent",
+            agent,
+            "--type",
+            args.type,
+            "--title",
+            title_for(args.type, content),
+            "--tag",
+            DEFAULT_TAG,
+            "--tag",
+            args.skill,
+            "--tag",
+            "mid-session",
+        ],
+        dry_run=args.dry_run,
+    )
+    print(output)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the command line interface."""
 
@@ -206,6 +234,18 @@ def build_parser() -> argparse.ArgumentParser:
     post_parser.add_argument("--skill", required=True, help="Skill command that produced the summary.")
     post_parser.add_argument("--summary", required=True, help="Concise completed-run summary.")
     post_parser.set_defaults(func=post)
+
+    event_parser = subparsers.add_parser("event", help="Save one mid-session memory during a skill run.")
+    event_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
+    event_parser.add_argument("--skill", required=True, help="Skill command currently running.")
+    event_parser.add_argument(
+        "--type",
+        required=True,
+        choices=["decision", "instruction", "preference", "learning", "error"],
+        help="Semantic memory type for this event.",
+    )
+    event_parser.add_argument("--note", required=True, help="Decision, constraint, gotcha, or bugfix to save now.")
+    event_parser.set_defaults(func=event)
 
     return parser
 

--- a/examples/claudecode-skills-memanto/skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/skill_memory_hook.py
@@ -23,6 +23,7 @@ from typing import Iterable
 
 DEFAULT_AGENT_ENV = "MEMANTO_SKILLS_AGENT"
 DEFAULT_AGENT = "developer-skills"
+DEFAULT_TAG = "developer-skills"
 
 MEMORY_RULES: tuple[tuple[str, str], ...] = (
     ("decision", "decision"),
@@ -176,7 +177,7 @@ def post(args: argparse.Namespace) -> int:
                 "--title",
                 memory.title,
                 "--tag",
-                "developer-skills",
+                DEFAULT_TAG,
                 "--tag",
                 args.skill,
             ],

--- a/examples/claudecode-skills-memanto/skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/skill_memory_hook.py
@@ -1,8 +1,9 @@
 """Memanto hook for command-oriented developer skills.
 
-The hook has two phases:
+The hook has three phases:
 
 * ``pre``: recall relevant Memanto context before a skill starts.
+* ``event``: capture a mid-session decision or gotcha while a skill runs.
 * ``post``: extract durable engineering memories from a completed skill summary.
 
 It intentionally depends only on the Python standard library and the installed

--- a/examples/claudecode-skills-memanto/skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/skill_memory_hook.py
@@ -14,17 +14,20 @@ framework integration.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable
 
 DEFAULT_AGENT_ENV = "MEMANTO_SKILLS_AGENT"
 DEFAULT_AGENT = "developer-skills"
 DEFAULT_TAG = "developer-skills"
+DEFAULT_LOCAL_STORE = ".memanto-skills-memory.jsonl"
 
 MEMORY_RULES: tuple[tuple[str, str], ...] = (
     ("decision", "decision"),
@@ -139,15 +142,84 @@ def run_memanto(args: list[str], *, dry_run: bool) -> str:
     return completed.stdout.strip()
 
 
+def remember_local(
+    store: Path,
+    *,
+    content: str,
+    agent: str,
+    memory_type: str,
+    title: str,
+    tags: list[str],
+) -> str:
+    """Append one deterministic JSONL record for credential-free demos."""
+
+    store.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "agent": agent,
+        "type": memory_type,
+        "title": title,
+        "content": content,
+        "tags": tags,
+    }
+    with store.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return f"LOCAL-SAVED: {title}"
+
+
+def recall_local(
+    store: Path,
+    *,
+    query: str,
+    agent: str,
+    limit: int,
+) -> list[dict[str, object]]:
+    """Return local records ranked by query-token overlap and recency."""
+
+    if not store.exists():
+        return []
+
+    query_tokens = set(re.findall(r"[a-z0-9_]+", query.lower()))
+    ranked: list[tuple[int, int, dict[str, object]]] = []
+    with store.open(encoding="utf-8") as stream:
+        for index, line in enumerate(stream):
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            if record.get("agent") != agent:
+                continue
+            searchable = " ".join(
+                str(record.get(field, "")) for field in ("title", "content", "tags")
+            )
+            record_tokens = set(re.findall(r"[a-z0-9_]+", searchable.lower()))
+            score = len(query_tokens & record_tokens)
+            ranked.append((score, index, record))
+
+    ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [record for _, _, record in ranked[:limit]]
+
+
+def local_context(records: list[dict[str, object]]) -> str:
+    """Format local records like a compact injected context block."""
+
+    return "\n".join(
+        f"- [{record['type']}] {record['content']}" for record in records
+    )
+
+
 def pre(args: argparse.Namespace) -> int:
     """Recall relevant context before a skill starts."""
 
     agent = args.agent or os.environ.get(DEFAULT_AGENT_ENV, DEFAULT_AGENT)
     query = normalize_spaces(f"{args.task} {args.files or ''}")
-    output = run_memanto(
-        ["recall", query, "--agent", agent, "--limit", str(args.limit)],
-        dry_run=args.dry_run,
-    )
+    if args.backend == "local":
+        output = local_context(
+            recall_local(Path(args.store), query=query, agent=agent, limit=args.limit)
+        )
+    else:
+        output = run_memanto(
+            ["recall", query, "--agent", agent, "--limit", str(args.limit)],
+            dry_run=args.dry_run,
+        )
     print("MEMANTO_CONTEXT_START")
     print(output or "No relevant Memanto memories found.")
     print("MEMANTO_CONTEXT_END")
@@ -167,23 +239,33 @@ def post(args: argparse.Namespace) -> int:
         return 0
 
     for memory in memories:
-        output = run_memanto(
-            [
-                "remember",
-                memory.content,
-                "--agent",
-                agent,
-                "--type",
-                memory.memory_type,
-                "--title",
-                memory.title,
-                "--tag",
-                DEFAULT_TAG,
-                "--tag",
-                args.skill,
-            ],
-            dry_run=args.dry_run,
-        )
+        if args.backend == "local":
+            output = remember_local(
+                Path(args.store),
+                content=memory.content,
+                agent=agent,
+                memory_type=memory.memory_type,
+                title=memory.title,
+                tags=[DEFAULT_TAG, args.skill],
+            )
+        else:
+            output = run_memanto(
+                [
+                    "remember",
+                    memory.content,
+                    "--agent",
+                    agent,
+                    "--type",
+                    memory.memory_type,
+                    "--title",
+                    memory.title,
+                    "--tag",
+                    DEFAULT_TAG,
+                    "--tag",
+                    args.skill,
+                ],
+                dry_run=args.dry_run,
+            )
         print(output)
     return 0
 
@@ -193,25 +275,35 @@ def event(args: argparse.Namespace) -> int:
 
     agent = args.agent or os.environ.get(DEFAULT_AGENT_ENV, DEFAULT_AGENT)
     content = normalize_spaces(args.note)
-    output = run_memanto(
-        [
-            "remember",
-            content,
-            "--agent",
-            agent,
-            "--type",
-            args.type,
-            "--title",
-            title_for(args.type, content),
-            "--tag",
-            DEFAULT_TAG,
-            "--tag",
-            args.skill,
-            "--tag",
-            "mid-session",
-        ],
-        dry_run=args.dry_run,
-    )
+    if args.backend == "local":
+        output = remember_local(
+            Path(args.store),
+            content=content,
+            agent=agent,
+            memory_type=args.type,
+            title=title_for(args.type, content),
+            tags=[DEFAULT_TAG, args.skill, "mid-session"],
+        )
+    else:
+        output = run_memanto(
+            [
+                "remember",
+                content,
+                "--agent",
+                agent,
+                "--type",
+                args.type,
+                "--title",
+                title_for(args.type, content),
+                "--tag",
+                DEFAULT_TAG,
+                "--tag",
+                args.skill,
+                "--tag",
+                "mid-session",
+            ],
+            dry_run=args.dry_run,
+        )
     print(output)
     return 0
 
@@ -223,7 +315,21 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--agent", help=f"Memanto agent id. Defaults to ${DEFAULT_AGENT_ENV} or {DEFAULT_AGENT}.")
     subparsers = parser.add_subparsers(required=True)
 
+    def add_backend_arguments(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "--backend",
+            choices=["memanto", "local"],
+            default="memanto",
+            help="Use Memanto, or a local JSONL store for credential-free evaluation.",
+        )
+        subparser.add_argument(
+            "--store",
+            default=DEFAULT_LOCAL_STORE,
+            help="JSONL path used by the local evaluation backend.",
+        )
+
     pre_parser = subparsers.add_parser("pre", help="Recall context before a skill starts.")
+    add_backend_arguments(pre_parser)
     pre_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
     pre_parser.add_argument("--task", required=True, help="Skill command or task description.")
     pre_parser.add_argument("--files", help="Comma-separated files or paths involved in the task.")
@@ -231,12 +337,14 @@ def build_parser() -> argparse.ArgumentParser:
     pre_parser.set_defaults(func=pre)
 
     post_parser = subparsers.add_parser("post", help="Save memories after a skill completes.")
+    add_backend_arguments(post_parser)
     post_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
     post_parser.add_argument("--skill", required=True, help="Skill command that produced the summary.")
     post_parser.add_argument("--summary", required=True, help="Concise completed-run summary.")
     post_parser.set_defaults(func=post)
 
     event_parser = subparsers.add_parser("event", help="Save one mid-session memory during a skill run.")
+    add_backend_arguments(event_parser)
     event_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
     event_parser.add_argument("--skill", required=True, help="Skill command currently running.")
     event_parser.add_argument(

--- a/examples/claudecode-skills-memanto/skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/skill_memory_hook.py
@@ -184,11 +184,24 @@ def recall_local(
         for index, line in enumerate(stream):
             if not line.strip():
                 continue
-            record = json.loads(line)
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
             if record.get("agent") != agent:
                 continue
+            tags = record.get("tags", [])
+            tag_text = (
+                " ".join(str(tag) for tag in tags)
+                if isinstance(tags, list)
+                else str(tags)
+            )
             searchable = " ".join(
-                str(record.get(field, "")) for field in ("title", "content", "tags")
+                [
+                    str(record.get("title", "")),
+                    str(record.get("content", "")),
+                    tag_text,
+                ]
             )
             record_tokens = set(re.findall(r"[a-z0-9_]+", searchable.lower()))
             score = len(query_tokens & record_tokens)
@@ -311,8 +324,16 @@ def event(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     """Build the command line interface."""
 
-    parser = argparse.ArgumentParser(description="Persist developer-skill context with Memanto.")
-    parser.add_argument("--agent", help=f"Memanto agent id. Defaults to ${DEFAULT_AGENT_ENV} or {DEFAULT_AGENT}.")
+    parser = argparse.ArgumentParser(
+        description="Persist developer-skill context with Memanto."
+    )
+    parser.add_argument(
+        "--agent",
+        help=(
+            f"Memanto agent id. Defaults to ${DEFAULT_AGENT_ENV} "
+            f"or {DEFAULT_AGENT}."
+        ),
+    )
     subparsers = parser.add_subparsers(required=True)
 
     def add_backend_arguments(subparser: argparse.ArgumentParser) -> None:
@@ -328,32 +349,66 @@ def build_parser() -> argparse.ArgumentParser:
             help="JSONL path used by the local evaluation backend.",
         )
 
-    pre_parser = subparsers.add_parser("pre", help="Recall context before a skill starts.")
+    pre_parser = subparsers.add_parser(
+        "pre", help="Recall context before a skill starts."
+    )
     add_backend_arguments(pre_parser)
-    pre_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
-    pre_parser.add_argument("--task", required=True, help="Skill command or task description.")
-    pre_parser.add_argument("--files", help="Comma-separated files or paths involved in the task.")
-    pre_parser.add_argument("--limit", type=int, default=5, help="Maximum memories to recall.")
+    pre_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show Memanto CLI calls without executing them.",
+    )
+    pre_parser.add_argument(
+        "--task", required=True, help="Skill command or task description."
+    )
+    pre_parser.add_argument(
+        "--files", help="Comma-separated files or paths involved in the task."
+    )
+    pre_parser.add_argument(
+        "--limit", type=int, default=5, help="Maximum memories to recall."
+    )
     pre_parser.set_defaults(func=pre)
 
-    post_parser = subparsers.add_parser("post", help="Save memories after a skill completes.")
+    post_parser = subparsers.add_parser(
+        "post", help="Save memories after a skill completes."
+    )
     add_backend_arguments(post_parser)
-    post_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
-    post_parser.add_argument("--skill", required=True, help="Skill command that produced the summary.")
-    post_parser.add_argument("--summary", required=True, help="Concise completed-run summary.")
+    post_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show Memanto CLI calls without executing them.",
+    )
+    post_parser.add_argument(
+        "--skill", required=True, help="Skill command that produced the summary."
+    )
+    post_parser.add_argument(
+        "--summary", required=True, help="Concise completed-run summary."
+    )
     post_parser.set_defaults(func=post)
 
-    event_parser = subparsers.add_parser("event", help="Save one mid-session memory during a skill run.")
+    event_parser = subparsers.add_parser(
+        "event", help="Save one mid-session memory during a skill run."
+    )
     add_backend_arguments(event_parser)
-    event_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
-    event_parser.add_argument("--skill", required=True, help="Skill command currently running.")
+    event_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show Memanto CLI calls without executing them.",
+    )
+    event_parser.add_argument(
+        "--skill", required=True, help="Skill command currently running."
+    )
     event_parser.add_argument(
         "--type",
         required=True,
         choices=["decision", "instruction", "preference", "learning", "error"],
         help="Semantic memory type for this event.",
     )
-    event_parser.add_argument("--note", required=True, help="Decision, constraint, gotcha, or bugfix to save now.")
+    event_parser.add_argument(
+        "--note",
+        required=True,
+        help="Decision, constraint, gotcha, or bugfix to save now.",
+    )
     event_parser.set_defaults(func=event)
 
     return parser

--- a/examples/claudecode-skills-memanto/skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/skill_memory_hook.py
@@ -1,0 +1,217 @@
+"""Memanto hook for command-oriented developer skills.
+
+The hook has two phases:
+
+* ``pre``: recall relevant Memanto context before a skill starts.
+* ``post``: extract durable engineering memories from a completed skill summary.
+
+It intentionally depends only on the Python standard library and the installed
+``memanto`` CLI so it can sit beside any skills runner without becoming another
+framework integration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Iterable
+
+DEFAULT_AGENT_ENV = "MEMANTO_SKILLS_AGENT"
+DEFAULT_AGENT = "developer-skills"
+
+MEMORY_RULES: tuple[tuple[str, str], ...] = (
+    ("decision", "decision"),
+    ("decisions", "decision"),
+    ("convention", "instruction"),
+    ("conventions", "instruction"),
+    ("preference", "preference"),
+    ("preferences", "preference"),
+    ("gotcha", "learning"),
+    ("gotchas", "learning"),
+    ("learned", "learning"),
+    ("bugfix", "error"),
+    ("bug", "error"),
+)
+
+
+@dataclass(frozen=True)
+class MemoryCandidate:
+    """A memory extracted from a skill run summary."""
+
+    memory_type: str
+    title: str
+    content: str
+
+
+def normalize_spaces(value: str) -> str:
+    """Collapse repeated whitespace without changing the semantic text."""
+
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def split_summary(summary: str) -> Iterable[str]:
+    """Split prose into candidate clauses while keeping short summaries usable."""
+
+    normalized = normalize_spaces(summary)
+    if not normalized:
+        return []
+    return [part.strip(" -•") for part in re.split(r"(?:\n|;|\.\s+)", normalized) if part.strip(" -•")]
+
+
+def classify_clause(clause: str) -> tuple[str, str] | None:
+    """Return ``(memory_type, content)`` for a typed summary clause."""
+
+    match = re.match(r"^(?P<label>[A-Za-z ]{3,24}):\s*(?P<body>.+)$", clause)
+    if not match:
+        return None
+
+    label = normalize_spaces(match.group("label")).lower()
+    body = normalize_spaces(match.group("body"))
+    for prefix, memory_type in MEMORY_RULES:
+        if label.startswith(prefix):
+            return memory_type, body
+    return None
+
+
+def title_for(memory_type: str, content: str) -> str:
+    """Create a compact title suitable for Memanto's title limit."""
+
+    prefix = {
+        "decision": "Decision",
+        "instruction": "Convention",
+        "preference": "Preference",
+        "learning": "Learning",
+        "error": "Bugfix",
+    }.get(memory_type, "Memory")
+    clean = normalize_spaces(content)
+    if len(clean) > 64:
+        clean = clean[:61].rstrip() + "..."
+    return f"{prefix}: {clean}"
+
+
+def extract_memories(summary: str) -> list[MemoryCandidate]:
+    """Extract typed memories from a completed skill summary."""
+
+    memories: list[MemoryCandidate] = []
+    for clause in split_summary(summary):
+        classified = classify_clause(clause)
+        if not classified:
+            continue
+        memory_type, content = classified
+        memories.append(
+            MemoryCandidate(
+                memory_type=memory_type,
+                title=title_for(memory_type, content),
+                content=content,
+            )
+        )
+    return memories
+
+
+def run_memanto(args: list[str], *, dry_run: bool) -> str:
+    """Run a Memanto CLI command or print it in dry-run mode."""
+
+    command = ["memanto", *args]
+    if dry_run:
+        return "DRY-RUN: " + " ".join(command)
+
+    completed = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or completed.stdout.strip())
+    return completed.stdout.strip()
+
+
+def pre(args: argparse.Namespace) -> int:
+    """Recall relevant context before a skill starts."""
+
+    agent = args.agent or os.environ.get(DEFAULT_AGENT_ENV, DEFAULT_AGENT)
+    query = normalize_spaces(f"{args.task} {args.files or ''}")
+    output = run_memanto(
+        ["recall", query, "--agent", agent, "--limit", str(args.limit)],
+        dry_run=args.dry_run,
+    )
+    print("MEMANTO_CONTEXT_START")
+    print(output or "No relevant Memanto memories found.")
+    print("MEMANTO_CONTEXT_END")
+    return 0
+
+
+def post(args: argparse.Namespace) -> int:
+    """Save durable memories after a skill finishes."""
+
+    agent = args.agent or os.environ.get(DEFAULT_AGENT_ENV, DEFAULT_AGENT)
+    memories = extract_memories(args.summary)
+    if not memories:
+        print("No typed memories found. Prefix durable facts with Decision:, Convention:, Preference:, Gotcha:, Learned:, or Bugfix:.")
+        return 0
+
+    for memory in memories:
+        output = run_memanto(
+            [
+                "remember",
+                memory.content,
+                "--agent",
+                agent,
+                "--type",
+                memory.memory_type,
+                "--title",
+                memory.title,
+                "--tag",
+                "developer-skills",
+                "--tag",
+                args.skill,
+            ],
+            dry_run=args.dry_run,
+        )
+        print(output)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command line interface."""
+
+    parser = argparse.ArgumentParser(description="Persist developer-skill context with Memanto.")
+    parser.add_argument("--agent", help=f"Memanto agent id. Defaults to ${DEFAULT_AGENT_ENV} or {DEFAULT_AGENT}.")
+    parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
+    subparsers = parser.add_subparsers(required=True)
+
+    pre_parser = subparsers.add_parser("pre", help="Recall context before a skill starts.")
+    pre_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
+    pre_parser.add_argument("--task", required=True, help="Skill command or task description.")
+    pre_parser.add_argument("--files", help="Comma-separated files or paths involved in the task.")
+    pre_parser.add_argument("--limit", type=int, default=5, help="Maximum memories to recall.")
+    pre_parser.set_defaults(func=pre)
+
+    post_parser = subparsers.add_parser("post", help="Save memories after a skill completes.")
+    post_parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
+    post_parser.add_argument("--skill", required=True, help="Skill command that produced the summary.")
+    post_parser.add_argument("--summary", required=True, help="Concise completed-run summary.")
+    post_parser.set_defaults(func=post)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except RuntimeError as exc:
+        print(f"memanto hook failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/skill_memory_hook.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -56,10 +57,15 @@ def normalize_spaces(value: str) -> str:
 def split_summary(summary: str) -> Iterable[str]:
     """Split prose into candidate clauses while keeping short summaries usable."""
 
-    normalized = normalize_spaces(summary)
-    if not normalized:
+    if not summary.strip():
         return []
-    return [part.strip(" -•") for part in re.split(r"(?:\n|;|\.\s+)", normalized) if part.strip(" -•")]
+
+    clauses: list[str] = []
+    for part in re.split(r"(?:\r?\n|;|\.\s+)", summary):
+        clause = normalize_spaces(part.strip().lstrip("-•* ").strip())
+        if clause:
+            clauses.append(clause)
+    return clauses
 
 
 def classify_clause(clause: str) -> tuple[str, str] | None:
@@ -117,7 +123,7 @@ def run_memanto(args: list[str], *, dry_run: bool) -> str:
 
     command = ["memanto", *args]
     if dry_run:
-        return "DRY-RUN: " + " ".join(command)
+        return "DRY-RUN: " + shlex.join(command)
 
     completed = subprocess.run(
         command,
@@ -152,7 +158,10 @@ def post(args: argparse.Namespace) -> int:
     agent = args.agent or os.environ.get(DEFAULT_AGENT_ENV, DEFAULT_AGENT)
     memories = extract_memories(args.summary)
     if not memories:
-        print("No typed memories found. Prefix durable facts with Decision:, Convention:, Preference:, Gotcha:, Learned:, or Bugfix:.")
+        print(
+            "No typed memories found. Prefix durable facts with Decision(s):, "
+            "Convention(s):, Preference(s):, Gotcha(s):, Learned:, Bugfix:, or Bug:."
+        )
         return 0
 
     for memory in memories:
@@ -182,7 +191,6 @@ def build_parser() -> argparse.ArgumentParser:
 
     parser = argparse.ArgumentParser(description="Persist developer-skill context with Memanto.")
     parser.add_argument("--agent", help=f"Memanto agent id. Defaults to ${DEFAULT_AGENT_ENV} or {DEFAULT_AGENT}.")
-    parser.add_argument("--dry-run", action="store_true", help="Show Memanto CLI calls without executing them.")
     subparsers = parser.add_subparsers(required=True)
 
     pre_parser = subparsers.add_parser("pre", help="Recall context before a skill starts.")

--- a/examples/claudecode-skills-memanto/test_productivity_benchmark.py
+++ b/examples/claudecode-skills-memanto/test_productivity_benchmark.py
@@ -1,0 +1,11 @@
+from productivity_benchmark import run_benchmark
+
+
+def test_benchmark_proves_no_repeated_architecture_instructions(tmp_path):
+    """The second skill session should recover every required instruction."""
+
+    result = run_benchmark(tmp_path / "benchmark-memory.jsonl")
+
+    assert result["saved_memories"] == 3
+    assert result["recalled_memories"] == 3
+    assert result["repeated_instructions"] == 0

--- a/examples/claudecode-skills-memanto/test_productivity_benchmark.py
+++ b/examples/claudecode-skills-memanto/test_productivity_benchmark.py
@@ -1,3 +1,6 @@
+import pytest
+
+import productivity_benchmark
 from productivity_benchmark import run_benchmark
 
 
@@ -7,5 +10,23 @@ def test_benchmark_proves_no_repeated_architecture_instructions(tmp_path):
     result = run_benchmark(tmp_path / "benchmark-memory.jsonl")
 
     assert result["saved_memories"] == 3
+    assert result["candidate_memories"] == 5
     assert result["recalled_memories"] == 3
     assert result["repeated_instructions"] == 0
+
+
+def test_benchmark_cleans_store_when_run_fails(tmp_path, monkeypatch):
+    """A failed benchmark should not leave its local JSONL artefact behind."""
+
+    monkeypatch.chdir(tmp_path)
+
+    def fail_benchmark(store):
+        store.write_text("partial", encoding="utf-8")
+        raise RuntimeError("benchmark failed")
+
+    monkeypatch.setattr(productivity_benchmark, "run_benchmark", fail_benchmark)
+
+    with pytest.raises(RuntimeError, match="benchmark failed"):
+        productivity_benchmark.main()
+
+    assert not (tmp_path / ".memanto-skills-benchmark.jsonl").exists()

--- a/examples/claudecode-skills-memanto/test_skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_hook.py
@@ -185,3 +185,25 @@ def test_local_recall_ranks_relevant_memories_first(tmp_path):
     assert len(recalled) == 1
     assert recalled[0]["content"] == "invoice validation rejects negative totals"
 
+
+def test_local_recall_skips_malformed_jsonl_records(tmp_path):
+    """A truncated record should not hide valid memories in the same store."""
+
+    store = tmp_path / "skill-memory.jsonl"
+    store.write_text(
+        '{"agent":"developer-skills","type":"decision",'
+        '"title":"Invoice validation","content":"reject negative totals",'
+        '"tags":["developer-skills","/tdd"]}\n'
+        '{"agent":"developer-skills"',
+        encoding="utf-8",
+    )
+
+    recalled = recall_local(
+        store,
+        query="invoice validation",
+        agent="developer-skills",
+        limit=5,
+    )
+
+    assert [record["content"] for record in recalled] == ["reject negative totals"]
+

--- a/examples/claudecode-skills-memanto/test_skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_hook.py
@@ -1,4 +1,10 @@
-from skill_memory_hook import extract_memories, main, normalize_spaces, run_memanto
+from skill_memory_hook import (
+    extract_memories,
+    main,
+    normalize_spaces,
+    recall_local,
+    run_memanto,
+)
 
 
 def test_normalize_spaces_collapses_whitespace():
@@ -113,4 +119,69 @@ def test_main_accepts_mid_session_event_dry_run(capsys):
     assert "DRY-RUN: memanto remember" in captured.out
     assert "Switched from polling to webhook delivery" in captured.out
     assert "--type decision" in captured.out
+
+
+def test_local_backend_persists_context_across_skill_runs(tmp_path, capsys):
+    """A credential-free local demo should persist and recall durable context."""
+
+    store = tmp_path / "skill-memory.jsonl"
+    save_status = main([
+        "post",
+        "--skill",
+        "/spec",
+        "--summary",
+        "Decision: invoices reject negative totals. "
+        "Convention: billing tests use domain fixtures.",
+        "--backend",
+        "local",
+        "--store",
+        str(store),
+    ])
+    capsys.readouterr()
+
+    recall_status = main([
+        "pre",
+        "--task",
+        "/tdd add invoice validation",
+        "--files",
+        "src/billing/invoice.py",
+        "--backend",
+        "local",
+        "--store",
+        str(store),
+    ])
+
+    captured = capsys.readouterr()
+    assert save_status == 0
+    assert recall_status == 0
+    assert "invoices reject negative totals" in captured.out
+    assert "billing tests use domain fixtures" in captured.out
+
+
+def test_local_recall_ranks_relevant_memories_first(tmp_path):
+    """Local recall should prioritize memories sharing terms with the task."""
+
+    store = tmp_path / "skill-memory.jsonl"
+    main([
+        "post",
+        "--skill",
+        "/spec",
+        "--summary",
+        "Decision: invoice validation rejects negative totals. "
+        "Decision: profile avatars use WebP.",
+        "--backend",
+        "local",
+        "--store",
+        str(store),
+    ])
+
+    recalled = recall_local(
+        store,
+        query="invoice validation",
+        agent="developer-skills",
+        limit=1,
+    )
+
+    assert len(recalled) == 1
+    assert recalled[0]["content"] == "invoice validation rejects negative totals"
 

--- a/examples/claudecode-skills-memanto/test_skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_hook.py
@@ -1,0 +1,50 @@
+﻿from skill_memory_hook import extract_memories, normalize_spaces
+
+
+def test_normalize_spaces_collapses_whitespace():
+    assert normalize_spaces("  one\n two\t three  ") == "one two three"
+
+
+def test_extract_memories_classifies_typed_summary():
+    memories = extract_memories(
+        "Decision: use hexagonal architecture. "
+        "Convention: tests live beside fixtures. "
+        "Preference: short review comments. "
+        "Gotcha: legacy imports use Decimal strings. "
+        "Bugfix: cleared stale cache invalidation."
+    )
+
+    assert [memory.memory_type for memory in memories] == [
+        "decision",
+        "instruction",
+        "preference",
+        "learning",
+        "error",
+    ]
+    assert memories[0].content == "use hexagonal architecture"
+    assert memories[-1].title.startswith("Bugfix:")
+
+
+def test_extract_memories_ignores_untyped_noise():
+    memories = extract_memories("Ran the command. Decision: keep adapters thin. Done.")
+
+    assert len(memories) == 1
+    assert memories[0].memory_type == "decision"
+    assert memories[0].content == "keep adapters thin"
+
+
+def test_main_accepts_subcommand_dry_run(capsys):
+    from skill_memory_hook import main
+
+    status = main([
+        "post",
+        "--skill",
+        "/review",
+        "--summary",
+        "Decision: keep adapters thin.",
+        "--dry-run",
+    ])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "DRY-RUN: memanto remember" in captured.out

--- a/examples/claudecode-skills-memanto/test_skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_hook.py
@@ -79,3 +79,22 @@ def test_main_accepts_subcommand_dry_run(capsys):
     assert status == 0
     assert "DRY-RUN: memanto remember" in captured.out
 
+
+def test_main_accepts_mid_session_event_dry_run(capsys):
+    status = main([
+        "event",
+        "--skill",
+        "/apply",
+        "--type",
+        "decision",
+        "--note",
+        "Switched from polling to webhook delivery during implementation.",
+        "--dry-run",
+    ])
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert "DRY-RUN: memanto remember" in captured.out
+    assert "Switched from polling to webhook delivery" in captured.out
+    assert "--type decision" in captured.out
+

--- a/examples/claudecode-skills-memanto/test_skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_hook.py
@@ -2,10 +2,14 @@ from skill_memory_hook import extract_memories, main, normalize_spaces, run_mema
 
 
 def test_normalize_spaces_collapses_whitespace():
+    """Whitespace normalization should preserve words and collapse spacing."""
+
     assert normalize_spaces("  one\n two\t three  ") == "one two three"
 
 
 def test_extract_memories_classifies_typed_summary():
+    """Typed summary clauses should become semantic memory candidates."""
+
     memories = extract_memories(
         "Decision: use hexagonal architecture. "
         "Convention: tests live beside fixtures. "
@@ -26,6 +30,8 @@ def test_extract_memories_classifies_typed_summary():
 
 
 def test_extract_memories_ignores_untyped_noise():
+    """Untyped summary prose should not create noisy memories."""
+
     memories = extract_memories("Ran the command. Decision: keep adapters thin. Done.")
 
     assert len(memories) == 1
@@ -34,6 +40,8 @@ def test_extract_memories_ignores_untyped_noise():
 
 
 def test_extract_memories_handles_semicolons_and_whitespace():
+    """Semicolon-separated typed clauses should be extracted independently."""
+
     memories = extract_memories(
         "Decision: keep adapters thin; Convention: tests stay near fixtures"
     )
@@ -45,6 +53,8 @@ def test_extract_memories_handles_semicolons_and_whitespace():
 
 
 def test_extract_memories_handles_multiline_bullets():
+    """Bullet-prefixed multiline summaries should still classify memories."""
+
     memories = extract_memories(
         "- Decision: keep ports framework-agnostic\n"
         "* Preferences: write short review comments\n"
@@ -60,12 +70,16 @@ def test_extract_memories_handles_multiline_bullets():
 
 
 def test_dry_run_preserves_argument_boundaries():
+    """Dry-run output should quote arguments so boundaries are reviewable."""
+
     output = run_memanto(["recall", "invoice validation rules"], dry_run=True)
 
     assert "'invoice validation rules'" in output
 
 
 def test_main_accepts_subcommand_dry_run(capsys):
+    """The post subcommand should print dry-run remember commands."""
+
     status = main([
         "post",
         "--skill",
@@ -81,6 +95,8 @@ def test_main_accepts_subcommand_dry_run(capsys):
 
 
 def test_main_accepts_mid_session_event_dry_run(capsys):
+    """The event subcommand should save one mid-session memory."""
+
     status = main([
         "event",
         "--skill",

--- a/examples/claudecode-skills-memanto/test_skill_memory_hook.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_hook.py
@@ -1,4 +1,4 @@
-﻿from skill_memory_hook import extract_memories, normalize_spaces
+from skill_memory_hook import extract_memories, main, normalize_spaces, run_memanto
 
 
 def test_normalize_spaces_collapses_whitespace():
@@ -33,9 +33,39 @@ def test_extract_memories_ignores_untyped_noise():
     assert memories[0].content == "keep adapters thin"
 
 
-def test_main_accepts_subcommand_dry_run(capsys):
-    from skill_memory_hook import main
+def test_extract_memories_handles_semicolons_and_whitespace():
+    memories = extract_memories(
+        "Decision: keep adapters thin; Convention: tests stay near fixtures"
+    )
 
+    assert [memory.content for memory in memories] == [
+        "keep adapters thin",
+        "tests stay near fixtures",
+    ]
+
+
+def test_extract_memories_handles_multiline_bullets():
+    memories = extract_memories(
+        "- Decision: keep ports framework-agnostic\n"
+        "* Preferences: write short review comments\n"
+        "- Bug: stale cache invalidation was fixed"
+    )
+
+    assert [memory.memory_type for memory in memories] == [
+        "decision",
+        "preference",
+        "error",
+    ]
+    assert memories[1].content == "write short review comments"
+
+
+def test_dry_run_preserves_argument_boundaries():
+    output = run_memanto(["recall", "invoice validation rules"], dry_run=True)
+
+    assert "'invoice validation rules'" in output
+
+
+def test_main_accepts_subcommand_dry_run(capsys):
     status = main([
         "post",
         "--skill",
@@ -48,3 +78,4 @@ def test_main_accepts_subcommand_dry_run(capsys):
     captured = capsys.readouterr()
     assert status == 0
     assert "DRY-RUN: memanto remember" in captured.out
+


### PR DESCRIPTION
﻿## Summary

Adds `examples/claudecode-skills-memanto`, a lightweight, dependency-free hook that lets command-oriented developer skills persist and recall engineering context through Memanto.

Refs #508.

## Cross-skill memory loop

- `pre`: recalls relevant decisions, conventions, preferences, and gotchas before a skill starts, then emits a bounded `MEMANTO_CONTEXT` block.
- `event`: captures stable decisions or gotchas while a skill is still running.
- `post`: extracts typed durable memories from a completed skill summary and stores them through the `memanto` CLI.
- Production defaults to the real Memanto CLI. An opt-in local JSONL backend gives reviewers a credential-free validation path.

## Productivity proof

`productivity_benchmark.py` simulates two separate skill sessions:

1. Session one stores 3 relevant engineering memories plus 2 unrelated decoys.
2. Session two starts with fresh skill context and requests invoice-validation context.
3. Retrieval ranks all 3 relevant memories above both decoys.

Expected result:

```json
{
  "saved_memories": 3,
  "candidate_memories": 5,
  "recalled_memories": 3,
  "repeated_instructions": 0
}
```

## Validation

```bash
python -m pytest examples/claudecode-skills-memanto/test_skill_memory_hook.py examples/claudecode-skills-memanto/test_productivity_benchmark.py -q
python -m py_compile examples/claudecode-skills-memanto/skill_memory_hook.py examples/claudecode-skills-memanto/productivity_benchmark.py
python examples/claudecode-skills-memanto/productivity_benchmark.py
```

Results:

- 13 tests passed.
- Both Python modules compile.
- Benchmark recalls 3 relevant memories from 5 candidates with 0 repeated instructions.
- `git diff --check` passes.
- CodeRabbit's final review reports no remaining issues and approves the implementation.

`ruff` is not installed in the local environment; all Python lines were independently checked to remain within 88 characters.

## Bounty / showcase

- Bounty issue: #508
- BountyHub: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe
- Technical showcase: https://gist.github.com/MFei8ht/2f83aaa15454cc846243057aa29c4899
- Missing-claim support request: https://github.com/Bounty-Hub/.github/issues/2

I am not using private social accounts for amplification. This submission focuses on the 60 technical points and provides reproducible reviewer evidence.

## Bounty claim

/claim #508
