### PR TITLE
Add Claude Code skills Memanto decision-trail example

### DIFF
--- a/examples/claudecode-skills-memanto/.gitignore
+++ b/examples/claudecode-skills-memanto/.gitignore
@@ -1,0 +1,6 @@
+.demo-memanto-skills-memory.jsonl
+.demo-memanto-skill-events.jsonl
+.memanto-skills-memory.jsonl
+.memanto-skill-events.jsonl
+__pycache__/
+tests/__pycache__/

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,100 @@
+# Claude Code Skills + Memanto Decision Trail
+
+This example shows how to use Memanto as a shared memory layer for
+command-oriented developer skills such as `/grill-with-docs`, `/tdd`, and
+`/handoff`.
+
+The important distinction from a simple pre/post wrapper is the **decision
+trail tap**: a skill run can record mid-session events while the conversation
+is still happening. Those events are distilled into typed engineering memories
+and then recalled by later skills, even in a fresh terminal session.
+
+## What It Demonstrates
+
+- **Before-skill recall**: injects a compact `MEMANTO_CONTEXT` block based on
+  the skill name, task text, cwd, and touched files.
+- **During-skill event capture**: records decisions, constraints, gotchas, and
+  file-specific notes as they happen, instead of relying only on a final
+  summary.
+- **After-skill distillation**: converts transcript and event log entries into
+  typed memories with confidence, tags, provenance, and file/module scopes.
+- **Credential-free review path**: the local JSONL backend proves the lifecycle
+  without requiring a Moorcheh API key.
+- **Live Memanto path**: set `MEMANTO_SKILLS_BACKEND=memanto-cli` to call the
+  installed `memanto recall` and `memanto remember` commands for real storage.
+
+## Quick Demo
+
+Run the demo from this folder:
+
+```bash
+python run_demo.py --reset
+```
+
+Expected result:
+
+1. Session A simulates `/grill-with-docs` deciding how Stripe webhook handling
+   should work.
+2. Session A stores the extracted decision trail.
+3. Session B simulates a fresh `/tdd` run for the same module.
+4. The `/tdd` run receives a `MEMANTO_CONTEXT` block containing the previous
+   Stripe webhook idempotency and locking decisions.
+
+## Validation
+
+```bash
+python -m py_compile skill_memory.py run_demo.py
+python -m unittest discover -s tests -q
+python run_demo.py --reset
+```
+
+## Live Memanto Mode
+
+Use the normal Memanto CLI setup first:
+
+```bash
+memanto agent create developer-skills
+memanto agent activate developer-skills
+```
+
+Then run:
+
+```bash
+MEMANTO_SKILLS_BACKEND=memanto-cli python run_demo.py --reset
+```
+
+In this mode, extracted memories are written through `memanto remember`, and
+future context is recalled through `memanto recall`.
+
+## Integration Sketch
+
+Wrap a skill command:
+
+```python
+from skill_memory import SkillRun, SkillMemoryBridge, default_backend
+
+bridge = SkillMemoryBridge(default_backend())
+run = SkillRun(
+    skill="/grill-with-docs",
+    task="Design Stripe webhook processing",
+    cwd="/repo/payments",
+    files=["app/webhooks/stripe.py", "tests/test_stripe_webhooks.py"],
+)
+
+context = bridge.before_skill(run)
+print(context.as_env_block())
+
+# During the skill:
+bridge.tap.record(
+    "decision",
+    "Use event_id as idempotency key",
+    files=["app/webhooks/stripe.py"],
+)
+bridge.tap.record("constraint", "Do not acknowledge webhook before durable write")
+
+# After the skill:
+bridge.after_skill(run, transcript_text)
+```
+
+The same interface works with the local backend and the live Memanto CLI
+backend.

--- a/examples/claudecode-skills-memanto/run_demo.py
+++ b/examples/claudecode-skills-memanto/run_demo.py
@@ -30,11 +30,13 @@ SESSION_A_TRANSCRIPT = "\n".join(
 SESSION_B_TRANSCRIPT = """
 /tdd: Write tests for the Stripe webhook path.
 
+DECISION: Cover duplicate event_id delivery as a successful idempotent replay.
 The test module should cover first delivery, duplicate delivery, and lock contention.
 """
 
 
 def run_demo(reset: bool) -> None:
+    """Run a two-session cross-skill memory demo."""
     if reset:
         for path in (STORE, EVENTS):
             if path.exists():
@@ -74,10 +76,15 @@ def run_demo(reset: bool) -> None:
     print()
     print(recalled.as_env_block())
 
-    bridge.after_skill(tdd_run, SESSION_B_TRANSCRIPT)
+    session_b_memories = bridge.after_skill(tdd_run, SESSION_B_TRANSCRIPT)
+    print()
+    print("Memories from second session:")
+    for memory in session_b_memories:
+        print(f"- {memory.memory_type}: {memory.content}")
 
 
 def main() -> None:
+    """Parse demo flags and run the example."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--reset", action="store_true")
     args = parser.parse_args()

--- a/examples/claudecode-skills-memanto/run_demo.py
+++ b/examples/claudecode-skills-memanto/run_demo.py
@@ -1,0 +1,88 @@
+"""Credential-free demo for the Claude Code skills Memanto bridge."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from skill_memory import LocalJsonlBackend, SkillMemoryBridge, SkillRun
+
+STORE = Path(".demo-memanto-skills-memory.jsonl")
+EVENTS = Path(".demo-memanto-skill-events.jsonl")
+
+
+SESSION_A_TRANSCRIPT = "\n".join(
+    [
+        "/grill-with-docs: Stripe webhook architecture review",
+        "",
+        "DECISION: Use Stripe event_id as the durable idempotency key in "
+        "app/webhooks/stripe.py.",
+        "CONSTRAINT: Do not acknowledge a webhook before the database write commits.",
+        "We chose a short advisory lock around event_id so parallel deliveries "
+        "cannot double-create invoices.",
+        "GOTCHA: The retry path must treat duplicate event_id as success, "
+        "not as a 500.",
+        "",
+    ]
+)
+
+
+SESSION_B_TRANSCRIPT = """
+/tdd: Write tests for the Stripe webhook path.
+
+The test module should cover first delivery, duplicate delivery, and lock contention.
+"""
+
+
+def run_demo(reset: bool) -> None:
+    if reset:
+        for path in (STORE, EVENTS):
+            if path.exists():
+                path.unlink()
+
+    backend = LocalJsonlBackend(STORE)
+    bridge = SkillMemoryBridge(backend)
+
+    design_run = SkillRun(
+        skill="/grill-with-docs",
+        task="Design Stripe webhook processing",
+        cwd="/workspace/payments-service",
+        files=["app/webhooks/stripe.py", "tests/test_stripe_webhooks.py"],
+    )
+
+    bridge.tap.path = EVENTS
+    bridge.tap.record(
+        "decision",
+        "Keep webhook side effects behind a process_stripe_event(event_id) boundary.",
+        files=["app/webhooks/stripe.py"],
+        skill=design_run.skill,
+    )
+    stored = bridge.after_skill(design_run, SESSION_A_TRANSCRIPT)
+
+    tdd_run = SkillRun(
+        skill="/tdd",
+        task="Write tests for Stripe webhook duplicate handling",
+        cwd="/workspace/payments-service",
+        files=["tests/test_stripe_webhooks.py", "app/webhooks/stripe.py"],
+    )
+    recalled = bridge.before_skill(tdd_run)
+
+    print("Stored memories:")
+    for memory in stored:
+        print(f"- {memory.memory_type}: {memory.content}")
+
+    print()
+    print(recalled.as_env_block())
+
+    bridge.after_skill(tdd_run, SESSION_B_TRANSCRIPT)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reset", action="store_true")
+    args = parser.parse_args()
+    run_demo(reset=args.reset)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,526 @@
+"""Memanto bridge for command-oriented developer skills.
+
+The module is intentionally dependency-free so maintainers can review and run
+the example without API keys. Set MEMANTO_SKILLS_BACKEND=memanto-cli to switch
+the same lifecycle hooks to the real Memanto CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+
+MEMORY_TYPES = {
+    "instruction",
+    "fact",
+    "decision",
+    "goal",
+    "commitment",
+    "preference",
+    "relationship",
+    "context",
+    "event",
+    "learning",
+    "observation",
+    "artifact",
+    "error",
+}
+
+EXPLICIT_MARKER_RE = re.compile(
+    r"^\s*(decision|constraint|preference|gotcha|artifact|followup|error)\s*:\s*(.+)$",
+    re.IGNORECASE,
+)
+FILE_RE = re.compile(r"(?P<file>[\w./-]+\.(?:py|ts|tsx|js|jsx|go|rs|md|yml|yaml|json))")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def normalize_tag(value: str) -> str:
+    cleaned = re.sub(r"[^a-zA-Z0-9_.:/-]+", "-", value.strip().lower())
+    return cleaned.strip("-")[:80]
+
+
+def unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            out.append(value)
+            seen.add(value)
+    return out
+
+
+@dataclass(frozen=True)
+class SkillRun:
+    skill: str
+    task: str
+    cwd: str
+    files: list[str] = field(default_factory=list)
+
+    def query_terms(self) -> list[str]:
+        return unique(
+            [
+                normalize_tag(self.skill),
+                *[normalize_tag(part) for part in self.task.split()],
+                *[normalize_tag(path) for path in self.files],
+                normalize_tag(Path(self.cwd).name),
+            ]
+        )
+
+
+@dataclass
+class SkillMemory:
+    memory_type: str
+    content: str
+    confidence: float
+    source: str
+    tags: list[str]
+    provenance: str = "inferred"
+    created_at: str = field(default_factory=utc_now)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "type": self.memory_type,
+            "content": self.content,
+            "confidence": self.confidence,
+            "source": self.source,
+            "tags": self.tags,
+            "provenance": self.provenance,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass
+class RecalledContext:
+    run: SkillRun
+    memories: list[SkillMemory]
+
+    def as_env_block(self) -> str:
+        if not self.memories:
+            return "MEMANTO_CONTEXT: no relevant prior engineering memories found."
+
+        lines = ["MEMANTO_CONTEXT:"]
+        for memory in self.memories:
+            tags = ", ".join(memory.tags[:5])
+            lines.append(
+                f"- [{memory.memory_type} {memory.confidence:.2f}] "
+                f"{memory.content} ({tags})"
+            )
+        return "\n".join(lines)
+
+
+class MemoryBackend(Protocol):
+    def recall(self, query_terms: list[str], limit: int = 5) -> list[SkillMemory]:
+        """Return relevant memories for a future skill run."""
+
+    def remember(self, memories: list[SkillMemory]) -> None:
+        """Persist distilled memories after a skill run."""
+
+
+class LocalJsonlBackend:
+    """Reviewer-safe backend with deterministic scoring."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def recall(self, query_terms: list[str], limit: int = 5) -> list[SkillMemory]:
+        query = {term for term in query_terms if term}
+        scored: list[tuple[int, SkillMemory]] = []
+        for memory in self._read_all():
+            haystack = {
+                normalize_tag(memory.memory_type),
+                *memory.tags,
+                *[normalize_tag(part) for part in memory.content.split()],
+            }
+            score = len(query & haystack)
+            if score:
+                scored.append((score, memory))
+
+        scored.sort(key=lambda item: (item[0], item[1].created_at), reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+    def remember(self, memories: list[SkillMemory]) -> None:
+        existing = {(m.memory_type, m.content) for m in self._read_all()}
+        with self.path.open("a", encoding="utf-8") as handle:
+            for memory in memories:
+                key = (memory.memory_type, memory.content)
+                if key in existing:
+                    continue
+                handle.write(json.dumps(memory.to_json(), sort_keys=True) + "\n")
+                existing.add(key)
+
+    def _read_all(self) -> list[SkillMemory]:
+        if not self.path.exists():
+            return []
+
+        memories: list[SkillMemory] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            item = json.loads(line)
+            memories.append(
+                SkillMemory(
+                    memory_type=str(item["type"]),
+                    content=str(item["content"]),
+                    confidence=float(item["confidence"]),
+                    source=str(item["source"]),
+                    tags=[str(tag) for tag in item.get("tags", [])],
+                    provenance=str(item.get("provenance", "inferred")),
+                    created_at=str(item.get("created_at", utc_now())),
+                )
+            )
+        return memories
+
+
+class MemantoCliBackend:
+    """Live backend that routes through the installed Memanto CLI."""
+
+    def __init__(self, command: str = "memanto") -> None:
+        self.command = command
+
+    def recall(self, query_terms: list[str], limit: int = 5) -> list[SkillMemory]:
+        query = " ".join(query_terms)
+        result = subprocess.run(
+            [self.command, "recall", query, "--limit", str(limit)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return []
+
+        memories: list[SkillMemory] = []
+        for line in result.stdout.splitlines():
+            text = line.strip(" -")
+            if not text or "Memory ID:" in text:
+                continue
+            memories.append(
+                SkillMemory(
+                    memory_type="context",
+                    content=text,
+                    confidence=0.70,
+                    source="memanto-cli",
+                    tags=[normalize_tag(term) for term in query_terms[:5]],
+                    provenance="retrieved",
+                )
+            )
+            if len(memories) >= limit:
+                break
+        return memories
+
+    def remember(self, memories: list[SkillMemory]) -> None:
+        for memory in memories:
+            args = [
+                self.command,
+                "remember",
+                memory.content,
+                "--type",
+                memory.memory_type,
+                "--confidence",
+                f"{memory.confidence:.2f}",
+                "--source",
+                memory.source,
+                "--provenance",
+                memory.provenance,
+            ]
+            if memory.tags:
+                args.extend(["--tags", ",".join(memory.tags)])
+            subprocess.run(args, check=True)
+
+
+class DecisionTrailTap:
+    """Append-only event tap for mid-session skill decisions."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        if path is None:
+            path = Path(".memanto-skill-events.jsonl")
+        self.path = path
+
+    def record(
+        self,
+        kind: str,
+        content: str,
+        *,
+        files: list[str] | None = None,
+        skill: str | None = None,
+    ) -> None:
+        event = {
+            "kind": normalize_tag(kind),
+            "content": content.strip(),
+            "files": files or [],
+            "skill": skill,
+            "created_at": utc_now(),
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+    def consume(self) -> list[dict[str, object]]:
+        if not self.path.exists():
+            return []
+        events = [
+            json.loads(line)
+            for line in self.path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        self.path.unlink()
+        return events
+
+
+class TranscriptDistiller:
+    """Extract typed engineering memories from transcripts and tap events."""
+
+    def distill(
+        self,
+        run: SkillRun,
+        transcript: str,
+        events: list[dict[str, object]],
+    ) -> list[SkillMemory]:
+        memories: list[SkillMemory] = []
+        for event in events:
+            memories.append(self._memory_from_event(run, event))
+
+        for raw_line in transcript.splitlines():
+            line = raw_line.strip(" -*")
+            if not line:
+                continue
+
+            explicit = EXPLICIT_MARKER_RE.match(line)
+            if explicit:
+                memory_type = self._type_for_marker(explicit.group(1))
+                memories.append(
+                    self._build_memory(
+                        run,
+                        memory_type,
+                        explicit.group(2),
+                        self._tags_for_line(run, line),
+                        0.90,
+                        "explicit_marker",
+                    )
+                )
+                continue
+
+            inferred = self._infer_memory(run, line)
+            if inferred:
+                memories.append(inferred)
+
+        return self._dedupe(memories)
+
+    def _memory_from_event(
+        self, run: SkillRun, event: dict[str, object]
+    ) -> SkillMemory:
+        kind = self._type_for_marker(str(event.get("kind", "observation")))
+        content = str(event.get("content", "")).strip()
+        files = [str(item) for item in event.get("files", []) if item]
+        tags = self._base_tags(run) + [normalize_tag(path) for path in files]
+        return self._build_memory(run, kind, content, tags, 0.95, "event_tap")
+
+    def _infer_memory(self, run: SkillRun, line: str) -> SkillMemory | None:
+        lowered = line.lower()
+        memory_type: str | None = None
+        confidence = 0.72
+
+        if "we chose" in lowered or "we decided" in lowered or "decision" in lowered:
+            memory_type = "decision"
+            confidence = 0.82
+        elif "must" in lowered or "do not" in lowered or "never" in lowered:
+            memory_type = "instruction"
+            confidence = 0.76
+        elif "prefer" in lowered or "style" in lowered:
+            memory_type = "preference"
+        elif "bug" in lowered or "gotcha" in lowered or "risk" in lowered:
+            memory_type = "error"
+        elif "use " in lowered and any(
+            path in lowered for path in ("module", "file", "test")
+        ):
+            memory_type = "context"
+
+        if memory_type is None:
+            return None
+
+        return self._build_memory(
+            run,
+            memory_type,
+            line,
+            self._tags_for_line(run, line),
+            confidence,
+            "heuristic_transcript",
+        )
+
+    def _build_memory(
+        self,
+        run: SkillRun,
+        memory_type: str,
+        content: str,
+        tags: list[str],
+        confidence: float,
+        provenance: str,
+    ) -> SkillMemory:
+        if memory_type not in MEMORY_TYPES:
+            memory_type = "observation"
+        return SkillMemory(
+            memory_type=memory_type,
+            content=content.strip(),
+            confidence=confidence,
+            source=f"skill:{run.skill}",
+            tags=unique(tags),
+            provenance=provenance,
+        )
+
+    def _tags_for_line(self, run: SkillRun, line: str) -> list[str]:
+        file_tags = [
+            normalize_tag(match.group("file")) for match in FILE_RE.finditer(line)
+        ]
+        word_tags = [
+            normalize_tag(part)
+            for part in re.findall(r"[A-Za-z][\w-]{3,}", line)
+        ]
+        return self._base_tags(run) + file_tags + word_tags[:8]
+
+    def _base_tags(self, run: SkillRun) -> list[str]:
+        return [
+            normalize_tag(f"skill:{run.skill}"),
+            normalize_tag(f"cwd:{Path(run.cwd).name}"),
+            *[normalize_tag(f"file:{path}") for path in run.files],
+        ]
+
+    def _type_for_marker(self, marker: str) -> str:
+        normalized = marker.lower()
+        if normalized == "constraint":
+            return "instruction"
+        if normalized == "gotcha":
+            return "error"
+        if normalized == "followup":
+            return "commitment"
+        return normalized if normalized in MEMORY_TYPES else "observation"
+
+    def _dedupe(self, memories: list[SkillMemory]) -> list[SkillMemory]:
+        seen: set[tuple[str, str]] = set()
+        out: list[SkillMemory] = []
+        for memory in memories:
+            key = (memory.memory_type, re.sub(r"\s+", " ", memory.content.lower()))
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(memory)
+        return out
+
+
+class SkillMemoryBridge:
+    """Before/during/after lifecycle adapter for developer skill commands."""
+
+    def __init__(
+        self,
+        backend: MemoryBackend,
+        tap: DecisionTrailTap | None = None,
+        distiller: TranscriptDistiller | None = None,
+    ) -> None:
+        self.backend = backend
+        self.tap = tap or DecisionTrailTap()
+        self.distiller = distiller or TranscriptDistiller()
+
+    def before_skill(self, run: SkillRun, limit: int = 5) -> RecalledContext:
+        return RecalledContext(
+            run=run,
+            memories=self.backend.recall(run.query_terms(), limit),
+        )
+
+    def after_skill(self, run: SkillRun, transcript: str) -> list[SkillMemory]:
+        events = self.tap.consume()
+        memories = self.distiller.distill(run, transcript, events)
+        if memories:
+            self.backend.remember(memories)
+        return memories
+
+
+def default_backend() -> MemoryBackend:
+    backend = os.getenv("MEMANTO_SKILLS_BACKEND", "local").strip().lower()
+    if backend == "memanto-cli":
+        return MemantoCliBackend()
+    path = Path(os.getenv("MEMANTO_SKILLS_STORE", ".memanto-skills-memory.jsonl"))
+    return LocalJsonlBackend(path)
+
+
+def command_tap(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Record a decision-trail event.")
+    parser.add_argument("kind")
+    parser.add_argument("content")
+    parser.add_argument("--file", dest="files", action="append", default=[])
+    parser.add_argument("--skill")
+    parser.add_argument("--events", default=".memanto-skill-events.jsonl")
+    args = parser.parse_args(argv)
+
+    DecisionTrailTap(Path(args.events)).record(
+        args.kind,
+        args.content,
+        files=args.files,
+        skill=args.skill,
+    )
+    return 0
+
+
+def command_wrap(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Wrap a skill command.")
+    parser.add_argument("--skill", required=True)
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--cwd", default=os.getcwd())
+    parser.add_argument("--file", dest="files", action="append", default=[])
+    parser.add_argument("--transcript", help="Write command output transcript here")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    if not args.command:
+        parser.error("command is required after --")
+
+    bridge = SkillMemoryBridge(default_backend())
+    run = SkillRun(args.skill, args.task, args.cwd, args.files)
+    context = bridge.before_skill(run)
+    print(context.as_env_block())
+
+    env = os.environ.copy()
+    env["MEMANTO_CONTEXT"] = context.as_env_block()
+    completed = subprocess.run(
+        args.command,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    transcript = "\n".join(
+        part for part in [completed.stdout, completed.stderr] if part
+    )
+    if args.transcript:
+        Path(args.transcript).write_text(transcript, encoding="utf-8")
+    bridge.after_skill(run, transcript)
+    sys.stdout.write(completed.stdout)
+    sys.stderr.write(completed.stderr)
+    return completed.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        print("Usage: skill_memory.py {tap|wrap} ...", file=sys.stderr)
+        return 2
+    command, rest = argv[0], argv[1:]
+    if command == "tap":
+        return command_tap(rest)
+    if command == "wrap":
+        return command_wrap(rest)
+    print(f"Unknown command: {command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -359,7 +359,12 @@ class TranscriptDistiller:
         """Convert one event-tap row into a typed memory."""
         kind = self._type_for_marker(str(event.get("kind", "observation")))
         content = str(event.get("content", "")).strip()
-        files = [str(item) for item in event.get("files", []) if item]
+        raw_files = event.get("files", [])
+        files = (
+            [str(item) for item in raw_files if item]
+            if isinstance(raw_files, list)
+            else []
+        )
         tags = self._base_tags(run) + [normalize_tag(path) for path in files]
         return self._build_memory(run, kind, content, tags, 0.95, "event_tap")
 
@@ -529,6 +534,8 @@ def command_wrap(argv: list[str]) -> int:
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
 
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
     if not args.command:
         parser.error("command is required after --")
 

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -42,15 +42,18 @@ FILE_RE = re.compile(r"(?P<file>[\w./-]+\.(?:py|ts|tsx|js|jsx|go|rs|md|yml|yaml|
 
 
 def utc_now() -> str:
+    """Return an ISO-8601 UTC timestamp for memory records."""
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
 def normalize_tag(value: str) -> str:
+    """Normalize arbitrary skill, path, or task text into a compact tag."""
     cleaned = re.sub(r"[^a-zA-Z0-9_.:/-]+", "-", value.strip().lower())
     return cleaned.strip("-")[:80]
 
 
 def unique(values: list[str]) -> list[str]:
+    """Return values in first-seen order without duplicates."""
     seen: set[str] = set()
     out: list[str] = []
     for value in values:
@@ -62,12 +65,15 @@ def unique(values: list[str]) -> list[str]:
 
 @dataclass(frozen=True)
 class SkillRun:
+    """Description of the skill execution currently being wrapped."""
+
     skill: str
     task: str
     cwd: str
     files: list[str] = field(default_factory=list)
 
     def query_terms(self) -> list[str]:
+        """Build recall terms from skill name, task, cwd, and touched files."""
         return unique(
             [
                 normalize_tag(self.skill),
@@ -80,6 +86,8 @@ class SkillRun:
 
 @dataclass
 class SkillMemory:
+    """Typed memory extracted from a skill transcript or event tap."""
+
     memory_type: str
     content: str
     confidence: float
@@ -89,6 +97,7 @@ class SkillMemory:
     created_at: str = field(default_factory=utc_now)
 
     def to_json(self) -> dict[str, object]:
+        """Serialize the memory to the JSONL backend format."""
         return {
             "type": self.memory_type,
             "content": self.content,
@@ -102,10 +111,13 @@ class SkillMemory:
 
 @dataclass
 class RecalledContext:
+    """Prior memories recalled for a specific skill run."""
+
     run: SkillRun
     memories: list[SkillMemory]
 
     def as_env_block(self) -> str:
+        """Render memories as a compact environment/prompt context block."""
         if not self.memories:
             return "MEMANTO_CONTEXT: no relevant prior engineering memories found."
 
@@ -120,6 +132,8 @@ class RecalledContext:
 
 
 class MemoryBackend(Protocol):
+    """Storage adapter used by the skill bridge."""
+
     def recall(self, query_terms: list[str], limit: int = 5) -> list[SkillMemory]:
         """Return relevant memories for a future skill run."""
 
@@ -131,10 +145,12 @@ class LocalJsonlBackend:
     """Reviewer-safe backend with deterministic scoring."""
 
     def __init__(self, path: Path) -> None:
+        """Create a local backend at the given JSONL path."""
         self.path = path
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def recall(self, query_terms: list[str], limit: int = 5) -> list[SkillMemory]:
+        """Recall memories using deterministic tag and content overlap."""
         query = {term for term in query_terms if term}
         scored: list[tuple[int, SkillMemory]] = []
         for memory in self._read_all():
@@ -151,6 +167,7 @@ class LocalJsonlBackend:
         return [memory for _, memory in scored[:limit]]
 
     def remember(self, memories: list[SkillMemory]) -> None:
+        """Append new memories, skipping exact type/content duplicates."""
         existing = {(m.memory_type, m.content) for m in self._read_all()}
         with self.path.open("a", encoding="utf-8") as handle:
             for memory in memories:
@@ -161,6 +178,7 @@ class LocalJsonlBackend:
                 existing.add(key)
 
     def _read_all(self) -> list[SkillMemory]:
+        """Read memories while tolerating malformed JSONL rows."""
         if not self.path.exists():
             return []
 
@@ -168,18 +186,21 @@ class LocalJsonlBackend:
         for line in self.path.read_text(encoding="utf-8").splitlines():
             if not line.strip():
                 continue
-            item = json.loads(line)
-            memories.append(
-                SkillMemory(
-                    memory_type=str(item["type"]),
-                    content=str(item["content"]),
-                    confidence=float(item["confidence"]),
-                    source=str(item["source"]),
-                    tags=[str(tag) for tag in item.get("tags", [])],
-                    provenance=str(item.get("provenance", "inferred")),
-                    created_at=str(item.get("created_at", utc_now())),
+            try:
+                item = json.loads(line)
+                memories.append(
+                    SkillMemory(
+                        memory_type=str(item["type"]),
+                        content=str(item["content"]),
+                        confidence=float(item["confidence"]),
+                        source=str(item["source"]),
+                        tags=[str(tag) for tag in item.get("tags", [])],
+                        provenance=str(item.get("provenance", "inferred")),
+                        created_at=str(item.get("created_at", utc_now())),
+                    )
                 )
-            )
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+                continue
         return memories
 
 
@@ -187,9 +208,11 @@ class MemantoCliBackend:
     """Live backend that routes through the installed Memanto CLI."""
 
     def __init__(self, command: str = "memanto") -> None:
+        """Create a backend that invokes the given Memanto CLI command."""
         self.command = command
 
     def recall(self, query_terms: list[str], limit: int = 5) -> list[SkillMemory]:
+        """Recall memory text by shelling out to `memanto recall`."""
         query = " ".join(query_terms)
         result = subprocess.run(
             [self.command, "recall", query, "--limit", str(limit)],
@@ -220,6 +243,7 @@ class MemantoCliBackend:
         return memories
 
     def remember(self, memories: list[SkillMemory]) -> None:
+        """Persist memories through `memanto remember` on a best-effort basis."""
         for memory in memories:
             args = [
                 self.command,
@@ -236,13 +260,17 @@ class MemantoCliBackend:
             ]
             if memory.tags:
                 args.extend(["--tags", ",".join(memory.tags)])
-            subprocess.run(args, check=True)
+            try:
+                subprocess.run(args, check=True, timeout=30)
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+                continue
 
 
 class DecisionTrailTap:
     """Append-only event tap for mid-session skill decisions."""
 
     def __init__(self, path: Path | None = None) -> None:
+        """Create an append-only event tap at the given path."""
         if path is None:
             path = Path(".memanto-skill-events.jsonl")
         self.path = path
@@ -255,6 +283,7 @@ class DecisionTrailTap:
         files: list[str] | None = None,
         skill: str | None = None,
     ) -> None:
+        """Record a mid-session event for later distillation."""
         event = {
             "kind": normalize_tag(kind),
             "content": content.strip(),
@@ -267,13 +296,19 @@ class DecisionTrailTap:
             handle.write(json.dumps(event, sort_keys=True) + "\n")
 
     def consume(self) -> list[dict[str, object]]:
+        """Read and clear tap events while ignoring malformed rows."""
         if not self.path.exists():
             return []
-        events = [
-            json.loads(line)
-            for line in self.path.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
+        events: list[dict[str, object]] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(item, dict):
+                events.append(item)
         self.path.unlink()
         return events
 
@@ -287,6 +322,7 @@ class TranscriptDistiller:
         transcript: str,
         events: list[dict[str, object]],
     ) -> list[SkillMemory]:
+        """Turn transcript lines and event-tap rows into typed memories."""
         memories: list[SkillMemory] = []
         for event in events:
             memories.append(self._memory_from_event(run, event))
@@ -320,6 +356,7 @@ class TranscriptDistiller:
     def _memory_from_event(
         self, run: SkillRun, event: dict[str, object]
     ) -> SkillMemory:
+        """Convert one event-tap row into a typed memory."""
         kind = self._type_for_marker(str(event.get("kind", "observation")))
         content = str(event.get("content", "")).strip()
         files = [str(item) for item in event.get("files", []) if item]
@@ -327,6 +364,7 @@ class TranscriptDistiller:
         return self._build_memory(run, kind, content, tags, 0.95, "event_tap")
 
     def _infer_memory(self, run: SkillRun, line: str) -> SkillMemory | None:
+        """Infer a memory type from a useful natural-language transcript line."""
         lowered = line.lower()
         memory_type: str | None = None
         confidence = 0.72
@@ -367,6 +405,7 @@ class TranscriptDistiller:
         confidence: float,
         provenance: str,
     ) -> SkillMemory:
+        """Create a memory record with normalized metadata."""
         if memory_type not in MEMORY_TYPES:
             memory_type = "observation"
         return SkillMemory(
@@ -379,6 +418,7 @@ class TranscriptDistiller:
         )
 
     def _tags_for_line(self, run: SkillRun, line: str) -> list[str]:
+        """Extract path and keyword tags from a transcript line."""
         file_tags = [
             normalize_tag(match.group("file")) for match in FILE_RE.finditer(line)
         ]
@@ -389,6 +429,7 @@ class TranscriptDistiller:
         return self._base_tags(run) + file_tags + word_tags[:8]
 
     def _base_tags(self, run: SkillRun) -> list[str]:
+        """Return tags shared by all memories from a skill run."""
         return [
             normalize_tag(f"skill:{run.skill}"),
             normalize_tag(f"cwd:{Path(run.cwd).name}"),
@@ -396,6 +437,7 @@ class TranscriptDistiller:
         ]
 
     def _type_for_marker(self, marker: str) -> str:
+        """Map explicit transcript/event markers to Memanto memory types."""
         normalized = marker.lower()
         if normalized == "constraint":
             return "instruction"
@@ -406,6 +448,7 @@ class TranscriptDistiller:
         return normalized if normalized in MEMORY_TYPES else "observation"
 
     def _dedupe(self, memories: list[SkillMemory]) -> list[SkillMemory]:
+        """Remove duplicate extracted memories while preserving first occurrence."""
         seen: set[tuple[str, str]] = set()
         out: list[SkillMemory] = []
         for memory in memories:
@@ -426,17 +469,20 @@ class SkillMemoryBridge:
         tap: DecisionTrailTap | None = None,
         distiller: TranscriptDistiller | None = None,
     ) -> None:
+        """Wire the bridge to a backend, event tap, and transcript distiller."""
         self.backend = backend
         self.tap = tap or DecisionTrailTap()
         self.distiller = distiller or TranscriptDistiller()
 
     def before_skill(self, run: SkillRun, limit: int = 5) -> RecalledContext:
+        """Recall memories before a skill command starts."""
         return RecalledContext(
             run=run,
             memories=self.backend.recall(run.query_terms(), limit),
         )
 
     def after_skill(self, run: SkillRun, transcript: str) -> list[SkillMemory]:
+        """Distill and persist memories after a skill command finishes."""
         events = self.tap.consume()
         memories = self.distiller.distill(run, transcript, events)
         if memories:
@@ -445,6 +491,7 @@ class SkillMemoryBridge:
 
 
 def default_backend() -> MemoryBackend:
+    """Select the local or live Memanto backend from environment settings."""
     backend = os.getenv("MEMANTO_SKILLS_BACKEND", "local").strip().lower()
     if backend == "memanto-cli":
         return MemantoCliBackend()
@@ -453,6 +500,7 @@ def default_backend() -> MemoryBackend:
 
 
 def command_tap(argv: list[str]) -> int:
+    """CLI entrypoint for recording an event-tap row."""
     parser = argparse.ArgumentParser(description="Record a decision-trail event.")
     parser.add_argument("kind")
     parser.add_argument("content")
@@ -471,6 +519,7 @@ def command_tap(argv: list[str]) -> int:
 
 
 def command_wrap(argv: list[str]) -> int:
+    """CLI entrypoint for recalling context, running a command, and storing output."""
     parser = argparse.ArgumentParser(description="Wrap a skill command.")
     parser.add_argument("--skill", required=True)
     parser.add_argument("--task", required=True)
@@ -490,13 +539,26 @@ def command_wrap(argv: list[str]) -> int:
 
     env = os.environ.copy()
     env["MEMANTO_CONTEXT"] = context.as_env_block()
-    completed = subprocess.run(
-        args.command,
-        check=False,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    timeout = timeout_from_env()
+    try:
+        completed = subprocess.run(
+            args.command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        transcript = timeout_transcript(exc)
+        if args.transcript:
+            Path(args.transcript).write_text(transcript, encoding="utf-8")
+        bridge.after_skill(run, transcript)
+        print(
+            f"Wrapped command timed out after {timeout} seconds",
+            file=sys.stderr,
+        )
+        return 124
     transcript = "\n".join(
         part for part in [completed.stdout, completed.stderr] if part
     )
@@ -508,7 +570,32 @@ def command_wrap(argv: list[str]) -> int:
     return completed.returncode
 
 
+def timeout_from_env() -> float | None:
+    """Read an optional wrapper timeout from MEMANTO_WRAP_TIMEOUT_SECONDS."""
+    raw = os.getenv("MEMANTO_WRAP_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return None
+    try:
+        timeout = float(raw)
+    except ValueError:
+        return None
+    return timeout if timeout > 0 else None
+
+
+def timeout_transcript(exc: subprocess.TimeoutExpired) -> str:
+    """Build a transcript from any output captured before a timeout."""
+    parts: list[str] = []
+    for stream in (exc.stdout, exc.stderr):
+        if isinstance(stream, bytes):
+            parts.append(stream.decode(errors="replace"))
+        elif isinstance(stream, str):
+            parts.append(stream)
+    parts.append(f"ERROR: command timed out after {exc.timeout} seconds.")
+    return "\n".join(part for part in parts if part)
+
+
 def main(argv: list[str] | None = None) -> int:
+    """Dispatch the module CLI."""
     argv = list(sys.argv[1:] if argv is None else argv)
     if not argv:
         print("Usage: skill_memory.py {tap|wrap} ...", file=sys.stderr)

--- a/examples/claudecode-skills-memanto/tests/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/tests/test_skill_memory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 import unittest
@@ -16,6 +17,7 @@ from skill_memory import (
     SkillMemoryBridge,
     SkillRun,
     TranscriptDistiller,
+    command_wrap,
 )
 
 
@@ -114,6 +116,57 @@ class SkillMemoryTests(unittest.TestCase):
             lines = store.read_text(encoding="utf-8").splitlines()
 
         self.assertEqual(1, len(lines))
+
+    def test_distiller_ignores_malformed_event_files_field(self) -> None:
+        """Malformed event file metadata does not abort distillation."""
+        run = SkillRun(
+            skill="/handoff",
+            task="Record release note",
+            cwd="/repo",
+            files=[],
+        )
+        memories = TranscriptDistiller().distill(
+            run,
+            "",
+            [{"kind": "decision", "content": "Keep notes short.", "files": None}],
+        )
+
+        self.assertEqual(1, len(memories))
+        self.assertEqual("Keep notes short.", memories[0].content)
+
+    def test_wrap_strips_command_separator(self) -> None:
+        """The CLI wrapper accepts the conventional -- command separator."""
+        old_cwd = os.getcwd()
+        old_store = os.environ.get("MEMANTO_SKILLS_STORE")
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            os.environ["MEMANTO_SKILLS_STORE"] = str(Path(tmp) / "memory.jsonl")
+            transcript = Path(tmp) / "transcript.txt"
+            try:
+                result = command_wrap(
+                    [
+                        "--skill",
+                        "/tdd",
+                        "--task",
+                        "demo",
+                        "--transcript",
+                        str(transcript),
+                        "--",
+                        sys.executable,
+                        "-c",
+                        "print('wrapped-ok')",
+                    ]
+                )
+            finally:
+                os.chdir(old_cwd)
+                if old_store is None:
+                    os.environ.pop("MEMANTO_SKILLS_STORE", None)
+                else:
+                    os.environ["MEMANTO_SKILLS_STORE"] = old_store
+            transcript_text = transcript.read_text(encoding="utf-8")
+
+        self.assertEqual(0, result)
+        self.assertIn("wrapped-ok", transcript_text)
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/tests/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/tests/test_skill_memory.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+
+EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+if str(EXAMPLE_ROOT) not in sys.path:
+    sys.path.insert(0, str(EXAMPLE_ROOT))
 
 from skill_memory import (
     DecisionTrailTap,
@@ -16,6 +21,7 @@ from skill_memory import (
 
 class SkillMemoryTests(unittest.TestCase):
     def test_distills_explicit_markers_and_file_tags(self) -> None:
+        """Explicit transcript markers become typed memories."""
         run = SkillRun(
             skill="/grill-with-docs",
             task="Design Stripe webhook flow",
@@ -38,6 +44,7 @@ class SkillMemoryTests(unittest.TestCase):
         self.assertIn("file:app/webhooks/stripe.py", memories[0].tags)
 
     def test_event_tap_captures_mid_session_decision(self) -> None:
+        """The event tap records and clears mid-session decisions."""
         with tempfile.TemporaryDirectory() as tmp:
             event_path = Path(tmp) / "events.jsonl"
             tap = DecisionTrailTap(event_path)
@@ -55,6 +62,7 @@ class SkillMemoryTests(unittest.TestCase):
         self.assertFalse(event_path.exists())
 
     def test_local_backend_recalls_by_file_and_task_terms(self) -> None:
+        """The local backend recalls prior decisions by file overlap."""
         with tempfile.TemporaryDirectory() as tmp:
             store = Path(tmp) / "memory.jsonl"
             backend = LocalJsonlBackend(store)
@@ -87,11 +95,17 @@ class SkillMemoryTests(unittest.TestCase):
         self.assertIn("event_id", context.as_env_block())
 
     def test_duplicate_memories_are_not_rewritten(self) -> None:
+        """Repeated post-skill extraction does not duplicate exact memories."""
         with tempfile.TemporaryDirectory() as tmp:
             store = Path(tmp) / "memory.jsonl"
             backend = LocalJsonlBackend(store)
             bridge = SkillMemoryBridge(backend)
-            run = SkillRun("/handoff", "Record release note", "/repo", [])
+            run = SkillRun(
+                skill="/handoff",
+                task="Record release note",
+                cwd="/repo",
+                files=[],
+            )
             transcript = "DECISION: Keep release notes in docs/releases.md."
 
             bridge.after_skill(run, transcript)

--- a/examples/claudecode-skills-memanto/tests/test_skill_memory.py
+++ b/examples/claudecode-skills-memanto/tests/test_skill_memory.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from skill_memory import (
+    DecisionTrailTap,
+    LocalJsonlBackend,
+    RecalledContext,
+    SkillMemoryBridge,
+    SkillRun,
+    TranscriptDistiller,
+)
+
+
+class SkillMemoryTests(unittest.TestCase):
+    def test_distills_explicit_markers_and_file_tags(self) -> None:
+        run = SkillRun(
+            skill="/grill-with-docs",
+            task="Design Stripe webhook flow",
+            cwd="/repo/payments",
+            files=["app/webhooks/stripe.py"],
+        )
+        transcript = (
+            "DECISION: Use event_id as the idempotency key in app/webhooks/stripe.py.\n"
+            "CONSTRAINT: Do not acknowledge before the durable write commits.\n"
+            "GOTCHA: Duplicate delivery should return success.\n"
+        )
+
+        memories = TranscriptDistiller().distill(run, transcript, [])
+
+        self.assertEqual(
+            ["decision", "instruction", "error"],
+            [memory.memory_type for memory in memories],
+        )
+        self.assertIn("app/webhooks/stripe.py", memories[0].content)
+        self.assertIn("file:app/webhooks/stripe.py", memories[0].tags)
+
+    def test_event_tap_captures_mid_session_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = Path(tmp) / "events.jsonl"
+            tap = DecisionTrailTap(event_path)
+            tap.record(
+                "decision",
+                "Use advisory locks around payment event ids.",
+                files=["app/payments.py"],
+                skill="/grill-with-docs",
+            )
+
+            events = tap.consume()
+
+        self.assertEqual(1, len(events))
+        self.assertEqual("decision", events[0]["kind"])
+        self.assertFalse(event_path.exists())
+
+    def test_local_backend_recalls_by_file_and_task_terms(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = Path(tmp) / "memory.jsonl"
+            backend = LocalJsonlBackend(store)
+            bridge = SkillMemoryBridge(
+                backend,
+                tap=DecisionTrailTap(Path(tmp) / "events.jsonl"),
+            )
+            first = SkillRun(
+                skill="/grill-with-docs",
+                task="Design Stripe webhook processing",
+                cwd="/repo/payments",
+                files=["app/webhooks/stripe.py"],
+            )
+            bridge.after_skill(
+                first,
+                "DECISION: Use Stripe event_id as idempotency key in "
+                "app/webhooks/stripe.py.",
+            )
+
+            second = SkillRun(
+                skill="/tdd",
+                task="Write duplicate webhook tests",
+                cwd="/repo/payments",
+                files=["tests/test_stripe_webhooks.py", "app/webhooks/stripe.py"],
+            )
+            context = bridge.before_skill(second)
+
+        self.assertIsInstance(context, RecalledContext)
+        self.assertEqual(1, len(context.memories))
+        self.assertIn("event_id", context.as_env_block())
+
+    def test_duplicate_memories_are_not_rewritten(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = Path(tmp) / "memory.jsonl"
+            backend = LocalJsonlBackend(store)
+            bridge = SkillMemoryBridge(backend)
+            run = SkillRun("/handoff", "Record release note", "/repo", [])
+            transcript = "DECISION: Keep release notes in docs/releases.md."
+
+            bridge.after_skill(run, transcript)
+            bridge.after_skill(run, transcript)
+
+            lines = store.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(1, len(lines))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #508

Refs #508.

## Summary

This adds `examples/claudecode-skills-memanto`, a credential-free Claude
Code / mattpocock-style skills integration example with an optional live
Memanto CLI backend.

The differentiator is a decision-trail tap: the example records mid-session
decisions, constraints, gotchas, and file-specific notes while a skill is
running, then distills them into typed memories for later skills. This avoids
depending only on a final skill summary, which can miss the architectural
choices that happen during tool-driven work.

## What is included

- `SkillMemoryBridge.before_skill()` recalls relevant memories and emits a
  compact `MEMANTO_CONTEXT` block for injection.
- `DecisionTrailTap.record()` captures in-flight events such as decisions,
  constraints, and gotchas before they are lost from the final transcript.
- `TranscriptDistiller` converts explicit markers and useful transcript lines
  into typed memories with confidence, provenance, source, and tags.
- `LocalJsonlBackend` gives reviewers a no-key deterministic validation path.
- `MemantoCliBackend` routes the same lifecycle through `memanto recall` and
  `memanto remember` when `MEMANTO_SKILLS_BACKEND=memanto-cli` is set.
- `run_demo.py` proves cross-session recall from `/grill-with-docs` into a
  fresh `/tdd` run.

## Validation

```bash
cd examples/claudecode-skills-memanto
python3 -B -m py_compile skill_memory.py run_demo.py
python3 -B -m unittest discover -s tests -q
python3 -B run_demo.py --reset
```

Results:

- `py_compile` passed.
- `unittest` passed: 4 tests.
- Demo stored 5 engineering memories and injected the Stripe webhook
  idempotency / advisory-lock / duplicate-delivery context into the later
  `/tdd` run.

`ruff` is not available in this local environment, so I also ran
`git diff --cached --check` before commit and manually checked line lengths.

No private keys, API keys, wallet material, or payout details are included.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an example showcasing a Memanto-backed skill-memory workflow with a credential-free demo and CLI wrap/tap capability.

* **Documentation**
  * Added README with quick-start demo, live mode setup, validation steps, and a Python integration guide.

* **Tests**
  * Added tests for distillation robustness (tolerates malformed event metadata), command-wrap handling of separators, event tapping, recall, and idempotent persistence.

* **Chores**
  * Updated .gitignore to exclude local JSONL demo data and Python cache files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->