### PR TITLE
Add Claude Code skills Memanto memory bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,80 @@
+# Claude Code Skills + Memanto
+
+This example shows how Memanto can act as a cross-session memory layer for
+command-oriented developer skills such as `/grill-with-docs`, `/tdd`, and
+`/handoff`.
+
+The important part is the **decision trail tap**. A start/end hook can only see
+the prompt and final summary; many durable engineering choices happen between
+tool calls. This example records those mid-session decisions, constraints,
+preferences, and gotchas, then injects the relevant memories into a later skill
+run as a compact `MEMANTO_CONTEXT` block.
+
+## What It Demonstrates
+
+- Before a skill starts, `SkillMemoryBridge.begin_skill()` recalls project,
+  file, and task-relevant memories.
+- During a skill, `record_event()` captures mid-session decisions and
+  constraints with file provenance.
+- After a skill, `end_skill()` persists typed memories plus a completion
+  summary.
+- Later skills receive the remembered engineering context without repeated
+  prompting.
+- Reviewers can run everything locally without a Moorcheh API key.
+
+## Run The Demo
+
+```bash
+cd examples/claudecode-skills-memanto
+python demo.py
+```
+
+Expected behavior:
+
+1. The first `/grill-with-docs` run starts with no recalled memory.
+2. It records a payment retry decision, a non-retry constraint, and a test
+   gotcha.
+3. A later `/tdd` run receives a `MEMANTO_CONTEXT` block containing those
+   decisions.
+
+## Run Tests
+
+```bash
+python -m pytest examples/claudecode-skills-memanto -q
+```
+
+## Live Memanto Mode
+
+The local JSONL backend is only for deterministic review. To use the installed
+Memanto CLI instead:
+
+```python
+from skill_memory_bridge import MemantoCliBackend, SkillMemoryBridge
+
+bridge = SkillMemoryBridge(
+    MemantoCliBackend(),
+    project_slug="checkout-service",
+)
+```
+
+Activate an agent first:
+
+```bash
+memanto agent activate checkout-service
+```
+
+The adapter never handles API keys directly. It delegates credentials and active
+session state to the existing `memanto` CLI.
+
+## Why This Is Different From A Start/End Wrapper
+
+Boundary-only hooks are clean, but they miss the decision path:
+
+- a branch discarded after a failed tool run,
+- a constraint discovered while editing a file,
+- a style preference agreed during review,
+- a test gotcha that only appears in intermediate output.
+
+The event tap stores those moments as first-class memories. Retrieval can then
+key off the current task, file path, and skill name so a future `/tdd` run can
+see architectural choices made during a previous `/grill-with-docs` session.

--- a/examples/claudecode-skills-memanto/demo.py
+++ b/examples/claudecode-skills-memanto/demo.py
@@ -6,6 +6,7 @@ from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge
 
 
 def main() -> None:
+    """Run a two-skill workflow that demonstrates cross-session recall."""
     memory_path = Path(".memanto-demo/skills-memory.jsonl")
     if memory_path.exists():
         memory_path.unlink()

--- a/examples/claudecode-skills-memanto/demo.py
+++ b/examples/claudecode-skills-memanto/demo.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge
+
+
+def main() -> None:
+    memory_path = Path(".memanto-demo/skills-memory.jsonl")
+    if memory_path.exists():
+        memory_path.unlink()
+
+    bridge = SkillMemoryBridge(
+        LocalJsonlBackend(memory_path),
+        project_slug="checkout-service",
+    )
+
+    architecture = bridge.begin_skill(
+        "/grill-with-docs",
+        "Choose a retry policy for checkout payment capture.",
+        cwd="/repo/checkout-service",
+        files=["src/payments/capture.ts"],
+    )
+    print("=== First skill context ===")
+    print(bridge.context_block(architecture))
+
+    bridge.record_event(
+        architecture,
+        "decision",
+        "Use idempotency keys around payment capture because retries can double-charge.",
+        files=["src/payments/capture.ts"],
+        tags=["payments", "retry-policy"],
+        confidence=0.95,
+    )
+    bridge.record_event(
+        architecture,
+        "constraint",
+        "Avoid retrying card_declined responses; only retry network and gateway timeout errors.",
+        files=["src/payments/errors.ts"],
+        tags=["payments", "error-handling"],
+        confidence=0.9,
+    )
+    bridge.record_event(
+        architecture,
+        "tool_output",
+        "Test runner failed once because the gateway mock reused the same request id.",
+        files=["tests/payments/capture.test.ts"],
+        tags=["test-gotcha"],
+        confidence=0.85,
+    )
+    bridge.end_skill(
+        architecture,
+        "Selected a safe retry policy for payment capture and documented edge cases.",
+    )
+
+    tdd = bridge.begin_skill(
+        "/tdd",
+        "Write tests for payment capture retry behavior.",
+        cwd="/repo/checkout-service",
+        files=["tests/payments/capture.test.ts"],
+    )
+    print("\n=== Later skill context ===")
+    print(bridge.context_block(tdd))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -1,0 +1,337 @@
+"""
+Memanto bridge for command-oriented developer skills.
+
+The example is intentionally usable without credentials. LocalJsonlBackend gives
+reviewers a deterministic way to run the workflow, while MemantoCliBackend shows
+the same lifecycle against an active `memanto` CLI session.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+from uuid import uuid4
+
+MEMORY_TYPES = {
+    "decision",
+    "preference",
+    "instruction",
+    "artifact",
+    "learning",
+    "context",
+    "observation",
+    "error",
+}
+
+DECISION_MARKERS = (
+    "decide",
+    "decision",
+    "chosen",
+    "we will",
+    "use ",
+    "prefer",
+    "avoid",
+    "because",
+    "gotcha",
+    "bug",
+    "constraint",
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def normalize_tokens(text: str) -> set[str]:
+    return {token for token in re.findall(r"[a-z0-9_./-]+", text.lower()) if len(token) > 2}
+
+
+@dataclass
+class MemoryRecord:
+    memory_type: str
+    title: str
+    content: str
+    confidence: float = 0.8
+    tags: list[str] = field(default_factory=list)
+    source: str = "claudecode-skills-memanto"
+    provenance: str = "derived_from_skill_event"
+    created_at: str = field(default_factory=utc_now)
+    memory_id: str = field(default_factory=lambda: str(uuid4()))
+
+    def __post_init__(self) -> None:
+        if self.memory_type not in MEMORY_TYPES:
+            msg = f"Unsupported memory type: {self.memory_type}"
+            raise ValueError(msg)
+        if not 0.0 <= self.confidence <= 1.0:
+            msg = "confidence must be between 0.0 and 1.0"
+            raise ValueError(msg)
+
+
+@dataclass
+class SkillEvent:
+    kind: str
+    text: str
+    files: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+    confidence: float = 0.8
+    created_at: str = field(default_factory=utc_now)
+
+
+@dataclass
+class SkillRun:
+    skill_name: str
+    prompt: str
+    cwd: str
+    files: list[str]
+    run_id: str = field(default_factory=lambda: str(uuid4()))
+    events: list[SkillEvent] = field(default_factory=list)
+    started_at: str = field(default_factory=utc_now)
+    recalled_memories: list[MemoryRecord] = field(default_factory=list)
+
+
+class MemoryBackend(Protocol):
+    def remember(self, memory: MemoryRecord) -> None:
+        """Persist a memory."""
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        """Return relevant memories for a query."""
+
+
+class LocalJsonlBackend:
+    """Credential-free local backend used by the demo and tests."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def remember(self, memory: MemoryRecord) -> None:
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(memory), sort_keys=True) + "\n")
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        query_tokens = normalize_tokens(query)
+        scored: list[tuple[float, MemoryRecord]] = []
+
+        for memory in self._load():
+            haystack = " ".join([memory.title, memory.content, " ".join(memory.tags)])
+            memory_tokens = normalize_tokens(haystack)
+            overlap = len(query_tokens & memory_tokens)
+            if overlap == 0:
+                continue
+            type_boost = 1.5 if memory.memory_type in {"decision", "instruction"} else 1.0
+            score = overlap * type_boost + memory.confidence
+            scored.append((score, memory))
+
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+    def _load(self) -> list[MemoryRecord]:
+        if not self.path.exists():
+            return []
+
+        records: list[MemoryRecord] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            records.append(MemoryRecord(**json.loads(line)))
+        return records
+
+
+class MemantoCliBackend:
+    """
+    Backend that uses an already configured Memanto CLI.
+
+    It expects callers to run `memanto agent activate <agent-id>` first. The CLI
+    owns credentials and active-session state, so this adapter never handles API
+    keys directly.
+    """
+
+    def __init__(self, memanto_bin: str = "memanto") -> None:
+        self.memanto_bin = memanto_bin
+
+    def remember(self, memory: MemoryRecord) -> None:
+        command = [
+            self.memanto_bin,
+            "remember",
+            memory.content,
+            "--type",
+            memory.memory_type,
+            "--title",
+            memory.title,
+            "--confidence",
+            str(memory.confidence),
+            "--tags",
+            ",".join(memory.tags),
+            "--source",
+            memory.source,
+            "--provenance",
+            memory.provenance,
+        ]
+        subprocess.run(command, check=True)
+
+    def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        command = [self.memanto_bin, "recall", query, "--limit", str(limit)]
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        return [
+            MemoryRecord(
+                memory_type="context",
+                title="Memanto CLI recall",
+                content=result.stdout.strip(),
+                confidence=0.7,
+                tags=["memanto-cli", "recall"],
+                provenance="cli_recall_output",
+            )
+        ]
+
+
+class SkillMemoryBridge:
+    """Lifecycle hook that recalls, taps mid-session events, and persists them."""
+
+    def __init__(self, backend: MemoryBackend, project_slug: str) -> None:
+        self.backend = backend
+        self.project_slug = project_slug
+
+    def begin_skill(
+        self,
+        skill_name: str,
+        prompt: str,
+        cwd: str,
+        files: list[str] | None = None,
+    ) -> SkillRun:
+        files = files or []
+        query = self._query_for(skill_name, prompt, cwd, files)
+        recalled = self.backend.recall(query, limit=5)
+        return SkillRun(
+            skill_name=skill_name,
+            prompt=prompt,
+            cwd=cwd,
+            files=files,
+            recalled_memories=recalled,
+        )
+
+    def record_event(
+        self,
+        run: SkillRun,
+        kind: str,
+        text: str,
+        files: list[str] | None = None,
+        tags: list[str] | None = None,
+        confidence: float = 0.8,
+    ) -> None:
+        run.events.append(
+            SkillEvent(
+                kind=kind,
+                text=text.strip(),
+                files=files or [],
+                tags=tags or [],
+                confidence=confidence,
+            )
+        )
+
+    def end_skill(self, run: SkillRun, output_summary: str) -> list[MemoryRecord]:
+        memories: list[MemoryRecord] = []
+        for event in run.events:
+            memory = self._event_to_memory(run, event)
+            if memory:
+                self.backend.remember(memory)
+                memories.append(memory)
+
+        summary = MemoryRecord(
+            memory_type="artifact",
+            title=f"{run.skill_name} output summary",
+            content=(
+                f"Skill `{run.skill_name}` ran in `{run.cwd}` for project "
+                f"`{self.project_slug}`. Summary: {output_summary.strip()}"
+            ),
+            confidence=0.75,
+            tags=[self.project_slug, run.skill_name, "skill-summary"],
+            provenance="skill_completion_summary",
+        )
+        self.backend.remember(summary)
+        memories.append(summary)
+        return memories
+
+    def context_block(self, run: SkillRun) -> str:
+        if not run.recalled_memories:
+            return "MEMANTO_CONTEXT: no relevant cross-session memories found."
+
+        lines = ["MEMANTO_CONTEXT:"]
+        for memory in run.recalled_memories:
+            tags = ", ".join(memory.tags) if memory.tags else "untagged"
+            lines.append(
+                f"- [{memory.memory_type}] {memory.title} "
+                f"(confidence={memory.confidence:.2f}, tags={tags})"
+            )
+            lines.append(f"  {memory.content}")
+        return "\n".join(lines)
+
+    def _event_to_memory(
+        self, run: SkillRun, event: SkillEvent
+    ) -> MemoryRecord | None:
+        if not event.text:
+            return None
+
+        event_type = self._classify_event(event)
+        if event.kind == "tool_output" and not self._is_memory_worthy(event.text):
+            return None
+
+        files = ", ".join(event.files or run.files)
+        file_part = f" Files: {files}." if files else ""
+        content = (
+            f"During `{run.skill_name}` in `{run.cwd}`, "
+            f"{event.kind} captured: {event.text}.{file_part}"
+        )
+        tags = sorted(
+            {
+                self.project_slug,
+                run.skill_name,
+                event.kind,
+                *event.tags,
+                *[Path(file).name for file in event.files],
+            }
+        )
+
+        return MemoryRecord(
+            memory_type=event_type,
+            title=self._title_from(event),
+            content=content,
+            confidence=event.confidence,
+            tags=tags,
+        )
+
+    def _classify_event(self, event: SkillEvent) -> str:
+        text = event.text.lower()
+        if event.kind in {"decision", "constraint", "preference", "error"}:
+            return {
+                "decision": "decision",
+                "constraint": "instruction",
+                "preference": "preference",
+                "error": "error",
+            }[event.kind]
+        if "prefer" in text or "style" in text:
+            return "preference"
+        if "must" in text or "avoid" in text or "require" in text:
+            return "instruction"
+        if "bug" in text or "failed" in text or "gotcha" in text:
+            return "error"
+        if "decide" in text or "because" in text:
+            return "decision"
+        return "observation"
+
+    def _is_memory_worthy(self, text: str) -> bool:
+        lowered = text.lower()
+        return any(marker in lowered for marker in DECISION_MARKERS)
+
+    def _query_for(
+        self, skill_name: str, prompt: str, cwd: str, files: list[str]
+    ) -> str:
+        return " ".join([self.project_slug, skill_name, prompt, cwd, *files])
+
+    def _title_from(self, event: SkillEvent) -> str:
+        title = re.sub(r"\s+", " ", event.text).strip()
+        return title[:76] + "..." if len(title) > 79 else title

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -49,15 +49,19 @@ logger = logging.getLogger(__name__)
 
 
 def utc_now() -> str:
+    """Return a compact UTC timestamp for persisted memory metadata."""
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
 def normalize_tokens(text: str) -> set[str]:
+    """Normalize free text into lowercase tokens for lightweight matching."""
     return {token for token in re.findall(r"[a-z0-9_./-]+", text.lower()) if len(token) > 2}
 
 
 @dataclass
 class MemoryRecord:
+    """Typed memory payload shared by local and CLI-backed storage."""
+
     memory_type: str
     title: str
     content: str
@@ -69,6 +73,7 @@ class MemoryRecord:
     memory_id: str = field(default_factory=lambda: str(uuid4()))
 
     def __post_init__(self) -> None:
+        """Validate fields that should stay portable across backends."""
         if self.memory_type not in MEMORY_TYPES:
             msg = f"Unsupported memory type: {self.memory_type}"
             raise ValueError(msg)
@@ -79,6 +84,8 @@ class MemoryRecord:
 
 @dataclass
 class SkillEvent:
+    """Intermediate skill event that can be promoted into a memory."""
+
     kind: str
     text: str
     files: list[str] = field(default_factory=list)
@@ -89,6 +96,8 @@ class SkillEvent:
 
 @dataclass
 class SkillRun:
+    """In-flight skill invocation with recalled memories and captured events."""
+
     skill_name: str
     prompt: str
     cwd: str
@@ -100,6 +109,8 @@ class SkillRun:
 
 
 class MemoryBackend(Protocol):
+    """Storage contract required by the skill memory bridge."""
+
     def remember(self, memory: MemoryRecord) -> None:
         """Persist a memory."""
 
@@ -111,14 +122,17 @@ class LocalJsonlBackend:
     """Credential-free local backend used by the demo and tests."""
 
     def __init__(self, path: Path) -> None:
+        """Create a JSONL backend rooted at the given file path."""
         self.path = path
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def remember(self, memory: MemoryRecord) -> None:
+        """Append one serialized memory record to local JSONL storage."""
         with self.path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(asdict(memory), sort_keys=True) + "\n")
 
     def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        """Rank local memories by token overlap with the recall query."""
         query_tokens = normalize_tokens(query)
         scored: list[tuple[float, MemoryRecord]] = []
 
@@ -136,6 +150,7 @@ class LocalJsonlBackend:
         return [memory for _, memory in scored[:limit]]
 
     def _load(self) -> list[MemoryRecord]:
+        """Load all valid records from local JSONL storage."""
         if not self.path.exists():
             return []
 
@@ -161,6 +176,7 @@ class MemantoCliBackend:
         memanto_bin: str = "memanto",
         timeout_seconds: float | None = None,
     ) -> None:
+        """Configure the CLI adapter and enforce a positive timeout."""
         self.memanto_bin = memanto_bin
         self.timeout_seconds = (
             timeout_seconds
@@ -177,6 +193,7 @@ class MemantoCliBackend:
             raise ValueError(msg)
 
     def remember(self, memory: MemoryRecord) -> None:
+        """Persist a memory by delegating to `memanto remember`."""
         command = [
             self.memanto_bin,
             "remember",
@@ -202,6 +219,7 @@ class MemantoCliBackend:
             raise TimeoutError(msg) from exc
 
     def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
+        """Recall memories by delegating to `memanto recall`."""
         command = [self.memanto_bin, "recall", query, "--limit", str(limit)]
         try:
             result = subprocess.run(
@@ -231,6 +249,7 @@ class SkillMemoryBridge:
     """Lifecycle hook that recalls, taps mid-session events, and persists them."""
 
     def __init__(self, backend: MemoryBackend, project_slug: str) -> None:
+        """Bind the bridge to a memory backend and project namespace."""
         self.backend = backend
         self.project_slug = project_slug
 
@@ -241,6 +260,7 @@ class SkillMemoryBridge:
         cwd: str,
         files: list[str] | None = None,
     ) -> SkillRun:
+        """Start a skill run and attach memories relevant to its prompt."""
         files = files or []
         query = self._query_for(skill_name, prompt, cwd, files)
         recalled = self.backend.recall(query, limit=5)
@@ -261,6 +281,7 @@ class SkillMemoryBridge:
         tags: list[str] | None = None,
         confidence: float = 0.8,
     ) -> None:
+        """Capture a mid-session event for later memory extraction."""
         run.events.append(
             SkillEvent(
                 kind=kind,
@@ -272,6 +293,7 @@ class SkillMemoryBridge:
         )
 
     def end_skill(self, run: SkillRun, output_summary: str) -> list[MemoryRecord]:
+        """Persist selected events and a final summary for a completed skill."""
         memories: list[MemoryRecord] = []
         for event in run.events:
             memory = self._event_to_memory(run, event)
@@ -295,6 +317,7 @@ class SkillMemoryBridge:
         return memories
 
     def context_block(self, run: SkillRun) -> str:
+        """Render recalled memories as a compact prompt context block."""
         if not run.recalled_memories:
             return "MEMANTO_CONTEXT: no relevant cross-session memories found."
 
@@ -311,6 +334,7 @@ class SkillMemoryBridge:
     def _event_to_memory(
         self, run: SkillRun, event: SkillEvent
     ) -> MemoryRecord | None:
+        """Convert a captured event into a typed memory when it is useful."""
         if not event.text:
             return None
 
@@ -343,6 +367,7 @@ class SkillMemoryBridge:
         )
 
     def _classify_event(self, event: SkillEvent) -> str:
+        """Map event kind and text cues onto Memanto memory types."""
         text = event.text.lower()
         if event.kind in {"decision", "constraint", "preference", "error"}:
             return {
@@ -362,14 +387,17 @@ class SkillMemoryBridge:
         return "observation"
 
     def _is_memory_worthy(self, text: str) -> bool:
+        """Return whether tool output contains durable decision signals."""
         lowered = text.lower()
         return any(marker in lowered for marker in DECISION_MARKERS)
 
     def _query_for(
         self, skill_name: str, prompt: str, cwd: str, files: list[str]
     ) -> str:
+        """Build a recall query from project, skill, task, and file context."""
         return " ".join([self.project_slug, skill_name, prompt, cwd, *files])
 
     def _title_from(self, event: SkillEvent) -> str:
+        """Derive a concise memory title from the event text."""
         title = re.sub(r"\s+", " ", event.text).strip()
         return title[:76] + "..." if len(title) > 79 else title

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -9,6 +9,8 @@ the same lifecycle against an active `memanto` CLI session.
 from __future__ import annotations
 
 import json
+import logging
+import os
 import re
 import subprocess
 from dataclasses import asdict, dataclass, field
@@ -41,6 +43,9 @@ DECISION_MARKERS = (
     "bug",
     "constraint",
 )
+
+DEFAULT_MEMANTO_CLI_TIMEOUT_SECONDS = 10.0
+logger = logging.getLogger(__name__)
 
 
 def utc_now() -> str:
@@ -151,8 +156,25 @@ class MemantoCliBackend:
     keys directly.
     """
 
-    def __init__(self, memanto_bin: str = "memanto") -> None:
+    def __init__(
+        self,
+        memanto_bin: str = "memanto",
+        timeout_seconds: float | None = None,
+    ) -> None:
         self.memanto_bin = memanto_bin
+        self.timeout_seconds = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else float(
+                os.getenv(
+                    "MEMANTO_CLI_TIMEOUT_SECONDS",
+                    str(DEFAULT_MEMANTO_CLI_TIMEOUT_SECONDS),
+                )
+            )
+        )
+        if self.timeout_seconds <= 0:
+            msg = "timeout_seconds must be greater than 0"
+            raise ValueError(msg)
 
     def remember(self, memory: MemoryRecord) -> None:
         command = [
@@ -172,11 +194,27 @@ class MemantoCliBackend:
             "--provenance",
             memory.provenance,
         ]
-        subprocess.run(command, check=True)
+        try:
+            subprocess.run(command, check=True, timeout=self.timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            logger.error("memanto remember timed out after %.1fs", self.timeout_seconds)
+            msg = f"memanto remember timed out after {self.timeout_seconds:.1f}s"
+            raise TimeoutError(msg) from exc
 
     def recall(self, query: str, limit: int = 5) -> list[MemoryRecord]:
         command = [self.memanto_bin, "recall", query, "--limit", str(limit)]
-        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        try:
+            result = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            logger.error("memanto recall timed out after %.1fs", self.timeout_seconds)
+            msg = f"memanto recall timed out after {self.timeout_seconds:.1f}s"
+            raise TimeoutError(msg) from exc
         return [
             MemoryRecord(
                 memory_type="context",

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge
+
+
+def test_mid_session_decision_is_recalled_by_later_skill(tmp_path: Path) -> None:
+    bridge = SkillMemoryBridge(
+        LocalJsonlBackend(tmp_path / "memory.jsonl"),
+        project_slug="checkout-service",
+    )
+
+    first = bridge.begin_skill(
+        "/grill-with-docs",
+        "Choose payment retry behavior.",
+        cwd="/repo/checkout-service",
+        files=["src/payments/capture.ts"],
+    )
+    bridge.record_event(
+        first,
+        "decision",
+        "Use idempotency keys around payment capture because retries can double-charge.",
+        files=["src/payments/capture.ts"],
+        tags=["payments"],
+        confidence=0.95,
+    )
+    bridge.end_skill(first, "Payment retry policy selected.")
+
+    second = bridge.begin_skill(
+        "/tdd",
+        "Write payment capture tests.",
+        cwd="/repo/checkout-service",
+        files=["tests/payments/capture.test.ts"],
+    )
+
+    context = bridge.context_block(second)
+    assert "idempotency keys" in context
+    assert "double-charge" in context
+    assert "[decision]" in context
+
+
+def test_unimportant_tool_output_is_not_stored(tmp_path: Path) -> None:
+    backend = LocalJsonlBackend(tmp_path / "memory.jsonl")
+    bridge = SkillMemoryBridge(backend, project_slug="docs")
+
+    run = bridge.begin_skill("/handoff", "Summarize docs work.", cwd="/repo/docs")
+    bridge.record_event(run, "tool_output", "3 files scanned.")
+    memories = bridge.end_skill(run, "No reusable decisions.")
+
+    assert len(memories) == 1
+    assert memories[0].memory_type == "artifact"
+    assert backend.recall("3 files scanned") == []
+
+
+def test_context_block_reports_empty_memory(tmp_path: Path) -> None:
+    bridge = SkillMemoryBridge(
+        LocalJsonlBackend(tmp_path / "memory.jsonl"),
+        project_slug="empty",
+    )
+
+    run = bridge.begin_skill("/tdd", "Start clean.", cwd="/repo/empty")
+
+    assert bridge.context_block(run) == (
+        "MEMANTO_CONTEXT: no relevant cross-session memories found."
+    )

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -104,3 +104,18 @@ def test_memanto_cli_backend_converts_timeout(
 
     with pytest.raises(TimeoutError, match="memanto recall timed out"):
         backend.recall("anything")
+
+
+def test_memanto_cli_backend_converts_remember_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    backend = MemantoCliBackend(timeout_seconds=1.0)
+
+    with pytest.raises(TimeoutError, match="memanto remember timed out after 1.0s"):
+        backend.remember(
+            MemoryRecord(memory_type="decision", title="Choice", content="Use JSONL.")
+        )

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
+from typing import Any
 
-from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge
+import pytest
+from skill_memory_bridge import (
+    LocalJsonlBackend,
+    MemantoCliBackend,
+    MemoryRecord,
+    SkillMemoryBridge,
+)
 
 
 def test_mid_session_decision_is_recalled_by_later_skill(tmp_path: Path) -> None:
@@ -64,3 +72,35 @@ def test_context_block_reports_empty_memory(tmp_path: Path) -> None:
     assert bridge.context_block(run) == (
         "MEMANTO_CONTEXT: no relevant cross-session memories found."
     )
+
+
+def test_memanto_cli_backend_uses_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append({"command": command, **kwargs})
+        return subprocess.CompletedProcess(command, 0, stdout="memory", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    backend = MemantoCliBackend(timeout_seconds=2.5)
+
+    backend.remember(
+        MemoryRecord(memory_type="decision", title="Choice", content="Use JSONL.")
+    )
+    backend.recall("JSONL", limit=1)
+
+    assert calls[0]["timeout"] == 2.5
+    assert calls[1]["timeout"] == 2.5
+
+
+def test_memanto_cli_backend_converts_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    backend = MemantoCliBackend(timeout_seconds=1.0)
+
+    with pytest.raises(TimeoutError, match="memanto recall timed out"):
+        backend.recall("anything")

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -14,6 +14,7 @@ from skill_memory_bridge import (
 
 
 def test_mid_session_decision_is_recalled_by_later_skill(tmp_path: Path) -> None:
+    """Later skills receive decisions captured during an earlier skill."""
     bridge = SkillMemoryBridge(
         LocalJsonlBackend(tmp_path / "memory.jsonl"),
         project_slug="checkout-service",
@@ -49,6 +50,7 @@ def test_mid_session_decision_is_recalled_by_later_skill(tmp_path: Path) -> None
 
 
 def test_unimportant_tool_output_is_not_stored(tmp_path: Path) -> None:
+    """Low-signal tool output is ignored while the run summary is retained."""
     backend = LocalJsonlBackend(tmp_path / "memory.jsonl")
     bridge = SkillMemoryBridge(backend, project_slug="docs")
 
@@ -62,6 +64,7 @@ def test_unimportant_tool_output_is_not_stored(tmp_path: Path) -> None:
 
 
 def test_context_block_reports_empty_memory(tmp_path: Path) -> None:
+    """The context block is explicit when there are no recalled memories."""
     bridge = SkillMemoryBridge(
         LocalJsonlBackend(tmp_path / "memory.jsonl"),
         project_slug="empty",
@@ -75,9 +78,11 @@ def test_context_block_reports_empty_memory(tmp_path: Path) -> None:
 
 
 def test_memanto_cli_backend_uses_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI adapter forwards configured timeouts to remember and recall."""
     calls: list[dict[str, Any]] = []
 
     def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Record subprocess calls without invoking the real Memanto CLI."""
         calls.append({"command": command, **kwargs})
         return subprocess.CompletedProcess(command, 0, stdout="memory", stderr="")
 
@@ -96,7 +101,9 @@ def test_memanto_cli_backend_uses_timeout(monkeypatch: pytest.MonkeyPatch) -> No
 def test_memanto_cli_backend_converts_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Recall timeouts are converted into a backend-neutral TimeoutError."""
     def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Simulate a recall command that exceeds its timeout."""
         raise subprocess.TimeoutExpired(command, kwargs["timeout"])
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -109,7 +116,9 @@ def test_memanto_cli_backend_converts_timeout(
 def test_memanto_cli_backend_converts_remember_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Remember timeouts are converted into a backend-neutral TimeoutError."""
     def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Simulate a remember command that exceeds its timeout."""
         raise subprocess.TimeoutExpired(command, kwargs["timeout"])
 
     monkeypatch.setattr(subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary
- add examples/claudecode-skills-memanto as a command-oriented developer skills memory bridge
- include before-skill recall, mid-session decision/constraint/gotcha capture, and after-skill persistence
- provide a credential-free JSONL backend for review plus optional Memanto CLI backend for live sessions
- add tests proving a mid-session decision is recalled by a later skill

## Bounty
Addresses #508.
BountyHub: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe
Showcase: https://gist.github.com/auruminternum/abee535665f19ea8dccf4fabddf781e4

## Validation
- python -m ruff check examples/claudecode-skills-memanto
- python -m pytest examples/claudecode-skills-memanto -q
- python examples/claudecode-skills-memanto/demo.py
- python -m py_compile examples/claudecode-skills-memanto/skill_memory_bridge.py examples/claudecode-skills-memanto/demo.py examples/claudecode-skills-memanto/test_skill_memory_bridge.py
- git diff --check

/claim #508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-contained example that provides cross-session memory for Claude Code skills, including a runnable demo and both a local JSONL backend and an optional CLI-backed backend.

* **Documentation**
  * New README describing the “decision trail” concept, demo usage, setup and activation instructions, and how to run the example and tests.

* **Tests**
  * Added tests for the CLI-backed backend, including timeout handling and error conversion for recall and remember operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->