### PR TITLE
Add Claude Code skills memory bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,138 @@
+# Claude Code Skills + Memanto
+
+This example shows Memanto acting as a persistent memory layer between
+command-oriented Claude Code skills such as `/grill-with-docs`, `/tdd`, and
+`/handoff`.
+
+The bridge records useful skill outputs after one run, distills them into typed
+engineering memories, and injects relevant context before a later skill starts.
+It solves the repeated-context problem without requiring every skill to know
+about every previous terminal session.
+
+## What This Demonstrates
+
+- Cross-skill recall: a decision captured after `/grill-with-docs` is injected
+  before a later `/tdd` run.
+- Cross-session persistence: the default JSONL backend survives separate Python
+  processes, matching the shape of a new terminal session.
+- Typed engineering memories: decisions, conventions, preferences, errors, and
+  path anchors are stored separately so future prompts receive concise context.
+- Reviewer-safe execution: the default path uses only the Python standard
+  library and does not require API keys.
+- Live Memanto path: set `MEMANTO_SKILLS_BACKEND=cli` to route the same lifecycle
+  calls through the installed `memanto` CLI.
+
+## Quick Start
+
+From this directory:
+
+```bash
+python demo.py
+python validate.py
+python -m unittest test_skill_memory_bridge.py
+```
+
+The demo simulates two separate skill sessions:
+
+1. `/grill-with-docs` stores architectural decisions for a Next.js + SQLite SaaS
+   codebase.
+2. `/tdd` starts later with a different prompt and receives a `MEMANTO_CONTEXT`
+   block containing the remembered migration, auth, and database rules.
+
+## CLI Usage
+
+Capture context before a skill starts:
+
+```bash
+python skill_memory_bridge.py before \
+  --skill /tdd \
+  --cwd apps/acme-saas \
+  --paths src/app/billing/actions.ts,db/migrations \
+  --prompt "Write tests for billing plan changes"
+```
+
+Store memories after a skill completes:
+
+```bash
+python skill_memory_bridge.py after \
+  --skill /grill-with-docs \
+  --cwd apps/acme-saas \
+  --paths src/app/billing/actions.ts,db/migrations \
+  --summary "Decision: Billing mutations stay in server actions.
+Convention: SQLite migrations are append-only.
+Gotcha: Do not introduce Prisma; use better-sqlite3 helpers."
+```
+
+Wrap any command and capture its output:
+
+```bash
+python skill_memory_bridge.py wrap \
+  --skill /handoff \
+  --prompt "Run validation and remember follow-up constraints" \
+  -- python validate.py
+```
+
+## Live Memanto Backend
+
+The local backend is intentional for tests and pull-request review. To use the
+same bridge with real Memanto storage:
+
+```bash
+pip install memanto
+memanto agent create claudecode-skills
+set MEMANTO_SKILLS_BACKEND=cli
+python skill_memory_bridge.py before --skill /tdd --prompt "Recall project rules"
+```
+
+On macOS/Linux, use `export MEMANTO_SKILLS_BACKEND=cli` instead of `set`.
+
+## Integration Pattern
+
+The example is intentionally small enough to embed in a skill runner:
+
+```python
+from skill_memory_bridge import SkillMemoryBridge, create_backend
+
+bridge = SkillMemoryBridge(create_backend())
+
+context = bridge.before_skill(
+    skill_name="/tdd",
+    prompt="Add regression tests for invoice totals",
+    cwd="apps/acme-saas",
+    paths=["src/features/invoices"],
+)
+
+prompt_for_skill = f"{context}\n\nUSER_TASK:\nAdd regression tests."
+
+bridge.after_skill(
+    skill_name="/tdd",
+    summary="""
+Decision: Invoice totals are stored in cents.
+Convention: Tests for invoices live next to the feature folder.
+""",
+    cwd="apps/acme-saas",
+    paths=["src/features/invoices"],
+)
+```
+
+## Why It Fits the Bounty
+
+Issue #508 asks for a lightweight utility hook in the skills lifecycle that:
+
+- initializes Memanto or a compatible backend,
+- listens to important skill inputs and outputs,
+- distills architectural choices and coding preferences,
+- injects relevant memories into later skill prompts.
+
+This folder implements those hooks as `before_skill`, `after_skill`, and `wrap`
+commands. The local JSONL backend keeps review deterministic; the CLI backend
+shows the same lifecycle against real Memanto agent memory.
+
+## Validation Notes
+
+The validation suite covers:
+
+- cross-session recall from one bridge instance to another,
+- malformed local memory rows being ignored instead of crashing recall,
+- extraction of typed memories from skill summaries,
+- path-tagged recall so memories follow the files they affect.

--- a/examples/claudecode-skills-memanto/demo.py
+++ b/examples/claudecode-skills-memanto/demo.py
@@ -1,0 +1,64 @@
+"""Credential-free demo for the Claude Code skills + Memanto bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge
+
+
+DEMO_DIR = Path(".memanto-skills-demo")
+MEMORY_FILE = DEMO_DIR / "memories.jsonl"
+
+
+def main() -> int:
+    DEMO_DIR.mkdir(exist_ok=True)
+    if MEMORY_FILE.exists():
+        MEMORY_FILE.unlink()
+
+    bridge = SkillMemoryBridge(LocalJsonlBackend(MEMORY_FILE))
+
+    print("=== Session 1: /grill-with-docs stores project decisions ===")
+    stored = bridge.after_skill(
+        skill_name="/grill-with-docs",
+        cwd="apps/acme-saas",
+        paths=[
+            "src/app/(dashboard)/billing/actions.ts",
+            "db/migrations",
+            "src/server/auth.ts",
+        ],
+        summary="""
+Decision: Billing mutations stay in server actions under app/(dashboard)/billing.
+Convention: SQLite migrations live in db/migrations/YYYYMMDDHHMM_name.sql and are append-only.
+Preference: Keep authorization checks in service functions before touching database helpers.
+Gotcha: Do not introduce Prisma; this SaaS uses better-sqlite3 and hand-written SQL.
+""",
+    )
+    for memory in stored:
+        print(f"stored {memory.memory_type}: {memory.content}")
+
+    print("\n=== Session 2: /tdd starts later with an unrelated prompt ===")
+    context = bridge.before_skill(
+        skill_name="/tdd",
+        cwd="apps/acme-saas",
+        paths=[
+            "src/app/(dashboard)/billing/actions.ts",
+            "db/migrations/202606030930_add_plan_change_audit.sql",
+        ],
+        prompt=(
+            "Add tests for changing billing plans and verify the migration rules "
+            "without asking the user to repeat architecture choices."
+        ),
+    )
+    print(context)
+
+    assert "better-sqlite3" in context
+    assert "db/migrations" in context
+    assert "authorization checks" in context
+
+    print("\nDemo passed: the second skill received cross-session context.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/demo.py
+++ b/examples/claudecode-skills-memanto/demo.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from skill_memory_bridge import LocalJsonlBackend, SkillMemoryBridge
 
-
 DEMO_DIR = Path(".memanto-skills-demo")
 MEMORY_FILE = DEMO_DIR / "memories.jsonl"
 

--- a/examples/claudecode-skills-memanto/demo.py
+++ b/examples/claudecode-skills-memanto/demo.py
@@ -38,6 +38,7 @@ Gotcha: Do not introduce Prisma; this SaaS uses better-sqlite3 and hand-written 
         print(f"stored {memory.memory_type}: {memory.content}")
 
     print("\n=== Session 2: /tdd starts later with an unrelated prompt ===")
+    bridge = SkillMemoryBridge(LocalJsonlBackend(MEMORY_FILE))
     context = bridge.before_skill(
         skill_name="/tdd",
         cwd="apps/acme-saas",
@@ -52,9 +53,10 @@ Gotcha: Do not introduce Prisma; this SaaS uses better-sqlite3 and hand-written 
     )
     print(context)
 
-    assert "better-sqlite3" in context
-    assert "db/migrations" in context
-    assert "authorization checks" in context
+    required_context = ("better-sqlite3", "db/migrations", "authorization checks")
+    missing = [item for item in required_context if item not in context]
+    if missing:
+        raise AssertionError(f"Demo context is missing: {', '.join(missing)}")
 
     print("\nDemo passed: the second skill received cross-session context.")
     return 0

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,0 +1,3 @@
+# The default demo path is Python-stdlib only.
+# Install memanto when using MEMANTO_SKILLS_BACKEND=cli for live recall/writeback.
+memanto>=0.1.0

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,3 +1,5 @@
 # The default demo path is Python-stdlib only.
 # Install memanto when using MEMANTO_SKILLS_BACKEND=cli for live recall/writeback.
-memanto>=0.1.0
+memanto>=0.1.2
+pyjwt>=2.12.0
+python-multipart>=0.0.27

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -18,7 +18,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
 
-
 MEMORY_TYPES = {
     "artifact",
     "commitment",
@@ -106,7 +105,7 @@ class MemoryRecord:
             self.memory_id = stable_id(self.title or self.memory_type)
 
     @classmethod
-    def from_dict(cls, payload: dict[str, object]) -> "MemoryRecord":
+    def from_dict(cls, payload: dict[str, object]) -> MemoryRecord:
         return cls(
             content=str(payload.get("content", "")),
             memory_type=str(payload.get("memory_type", "observation")),
@@ -228,15 +227,33 @@ class MemantoCliBackend:
             capture_output=True,
             text=True,
         )
+        output = result.stdout.strip()
+        if _is_no_result_cli_recall(output):
+            return []
         return [
             MemoryRecord(
-                content=result.stdout.strip(),
+                content=output,
                 memory_type="context",
                 title="Memanto CLI recall",
                 confidence=0.8,
                 tags=tags or [],
             )
         ]
+
+
+def _is_no_result_cli_recall(output: str) -> bool:
+    for raw_line in output.splitlines():
+        line = re.sub(r"\s+", " ", raw_line).strip().lower().strip(".")
+        if not line:
+            continue
+        return line.startswith(
+            (
+                "no memories found",
+                "no memory found",
+                "no relevant memories found",
+            )
+        )
+    return True
 
 
 def score_memory(

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -273,7 +273,7 @@ def extract_memories(
 ) -> list[MemoryRecord]:
     """Distill skill output into typed engineering memories."""
 
-    tags = normalize_tags([skill_name, cwd or "", *(paths or [])])
+    tags = normalize_tags([skill_name, cwd or "", *expand_path_tags(paths or [])])
     memories: list[MemoryRecord] = []
     prefix_types = {
         "anti-pattern": "instruction",
@@ -366,6 +366,20 @@ def normalize_tags(values: list[str]) -> list[str]:
     return sorted(tags)
 
 
+def expand_path_tags(paths: list[str]) -> list[str]:
+    expanded: list[str] = []
+    for raw_path in paths:
+        path_text = raw_path.replace("\\", "/").strip("/")
+        parts = [part for part in path_text.split("/") if part and part != "."]
+        for index in range(1, len(parts) + 1):
+            expanded.append("/".join(parts[:index]))
+        if parts:
+            filename = parts[-1]
+            expanded.append(filename)
+            expanded.append(Path(filename).stem)
+    return normalize_tags(expanded)
+
+
 def render_context(memories: list[MemoryRecord]) -> str:
     if not memories:
         return "MEMANTO_CONTEXT: no relevant memories found."
@@ -395,10 +409,8 @@ class SkillMemoryBridge:
         limit: int = 5,
     ) -> str:
         query = " ".join([skill_name, prompt, cwd or "", " ".join(paths or [])])
-        tags = normalize_tags([skill_name, *(paths or [])])
+        tags = normalize_tags([skill_name, *expand_path_tags(paths or [])])
         memories = self.backend.recall(query, limit=limit, tags=tags or None)
-        if not memories:
-            memories = self.backend.recall(query, limit=limit)
         return render_context(memories)
 
     def after_skill(
@@ -505,7 +517,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "wrap":
-        if not args.cmd:
+        cmd = args.cmd[1:] if args.cmd[:1] == ["--"] else args.cmd
+        if not cmd:
             print("wrap requires a command after --", file=sys.stderr)
             return 2
         print(
@@ -516,7 +529,12 @@ def main(argv: list[str] | None = None) -> int:
                 paths=paths,
             )
         )
-        result = subprocess.run(args.cmd, capture_output=True, text=True)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=args.cwd or None,
+        )
         sys.stdout.write(result.stdout)
         sys.stderr.write(result.stderr)
         bridge.after_skill(

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -1,0 +1,538 @@
+"""Memanto bridge for command-oriented Claude Code skills.
+
+The example keeps the default backend local and credential-free so reviewers can
+run it in CI or a fresh checkout. Set MEMANTO_SKILLS_BACKEND=cli to route writes
+and recalls through the installed ``memanto`` CLI instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+
+MEMORY_TYPES = {
+    "artifact",
+    "commitment",
+    "context",
+    "decision",
+    "error",
+    "event",
+    "fact",
+    "goal",
+    "instruction",
+    "learning",
+    "observation",
+    "preference",
+    "relationship",
+}
+
+STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "be",
+    "by",
+    "for",
+    "from",
+    "in",
+    "into",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "this",
+    "to",
+    "use",
+    "with",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def stable_id(prefix: str) -> str:
+    compact = re.sub(r"[^a-z0-9]+", "-", prefix.lower()).strip("-")
+    return f"{compact[:36]}-{datetime.now(UTC).strftime('%Y%m%d%H%M%S%f')}"
+
+
+def tokenize(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9][a-z0-9_/-]*", text.lower())
+        if token not in STOPWORDS and len(token) > 1
+    }
+
+
+def clamp_confidence(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+@dataclass
+class MemoryRecord:
+    content: str
+    memory_type: str = "decision"
+    title: str | None = None
+    confidence: float = 0.82
+    tags: list[str] = field(default_factory=list)
+    source: str = "claudecode-skill"
+    provenance: str = "skill_lifecycle"
+    created_at: str = field(default_factory=utc_now)
+    memory_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.memory_type not in MEMORY_TYPES:
+            self.memory_type = "observation"
+        self.content = " ".join(self.content.split())
+        if not self.title:
+            self.title = self.content[:76]
+        self.confidence = clamp_confidence(self.confidence)
+        self.tags = sorted({tag for tag in self.tags if tag})
+        if not self.memory_id:
+            self.memory_id = stable_id(self.title or self.memory_type)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> "MemoryRecord":
+        return cls(
+            content=str(payload.get("content", "")),
+            memory_type=str(payload.get("memory_type", "observation")),
+            title=(
+                str(payload["title"])
+                if payload.get("title") is not None
+                else None
+            ),
+            confidence=float(payload.get("confidence", 0.72)),
+            tags=[str(tag) for tag in payload.get("tags", [])],
+            source=str(payload.get("source", "claudecode-skill")),
+            provenance=str(payload.get("provenance", "skill_lifecycle")),
+            created_at=str(payload.get("created_at", utc_now())),
+            memory_id=(
+                str(payload["memory_id"])
+                if payload.get("memory_id") is not None
+                else None
+            ),
+        )
+
+
+class MemoryBackend(Protocol):
+    def remember(self, memory: MemoryRecord) -> str:
+        """Persist one memory and return its id."""
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        tags: list[str] | None = None,
+    ) -> list[MemoryRecord]:
+        """Return the most relevant memories for a prompt."""
+
+
+class LocalJsonlBackend:
+    """Small deterministic backend used for demos and tests."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _read_all(self) -> list[MemoryRecord]:
+        if not self.path.exists():
+            return []
+
+        memories: list[MemoryRecord] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                memories.append(MemoryRecord.from_dict(json.loads(line)))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                continue
+        return memories
+
+    def remember(self, memory: MemoryRecord) -> str:
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(memory), sort_keys=True) + "\n")
+        return memory.memory_id or ""
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        tags: list[str] | None = None,
+    ) -> list[MemoryRecord]:
+        tag_filter = set(tags or [])
+        scored: list[tuple[float, MemoryRecord]] = []
+        for memory in self._read_all():
+            score = score_memory(memory, query, tag_filter)
+            if score > 0:
+                scored.append((score, memory))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [memory for _, memory in scored[:limit]]
+
+
+class MemantoCliBackend:
+    """Thin adapter around the installed Memanto CLI."""
+
+    def __init__(self, executable: str = "memanto") -> None:
+        self.executable = executable
+
+    def remember(self, memory: MemoryRecord) -> str:
+        cmd = [
+            self.executable,
+            "remember",
+            memory.content,
+            "--type",
+            memory.memory_type,
+            "--title",
+            memory.title or memory.content[:50],
+            "--confidence",
+            str(memory.confidence),
+            "--source",
+            memory.source,
+            "--provenance",
+            memory.provenance,
+        ]
+        if memory.tags:
+            cmd.extend(["--tags", ",".join(memory.tags)])
+        subprocess.run(cmd, check=True, text=True)
+        return memory.memory_id or ""
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        tags: list[str] | None = None,
+    ) -> list[MemoryRecord]:
+        cmd = [self.executable, "recall", query, "--limit", str(limit)]
+        if tags:
+            cmd.extend(["--tags", ",".join(tags)])
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return [
+            MemoryRecord(
+                content=result.stdout.strip(),
+                memory_type="context",
+                title="Memanto CLI recall",
+                confidence=0.8,
+                tags=tags or [],
+            )
+        ]
+
+
+def score_memory(
+    memory: MemoryRecord,
+    query: str,
+    tag_filter: set[str] | None = None,
+) -> float:
+    if tag_filter and not tag_filter.intersection(memory.tags):
+        return 0.0
+
+    query_tokens = tokenize(query)
+    memory_tokens = tokenize(
+        f"{memory.title or ''} {memory.content} {' '.join(memory.tags)}"
+    )
+    if not query_tokens or not memory_tokens:
+        return 0.0
+
+    overlap = query_tokens.intersection(memory_tokens)
+    if not overlap:
+        return 0.0
+
+    tag_bonus = 0.18 * len(set(memory.tags).intersection(query_tokens))
+    type_bonus = 0.2 if memory.memory_type in {"decision", "instruction"} else 0.0
+    confidence_bonus = memory.confidence * 0.1
+    return (len(overlap) / len(query_tokens)) + tag_bonus + type_bonus + confidence_bonus
+
+
+def extract_memories(
+    text: str,
+    *,
+    skill_name: str,
+    cwd: str | None = None,
+    paths: list[str] | None = None,
+) -> list[MemoryRecord]:
+    """Distill skill output into typed engineering memories."""
+
+    tags = normalize_tags([skill_name, cwd or "", *(paths or [])])
+    memories: list[MemoryRecord] = []
+    prefix_types = {
+        "anti-pattern": "instruction",
+        "commitment": "commitment",
+        "convention": "instruction",
+        "decision": "decision",
+        "gotcha": "error",
+        "preference": "preference",
+        "rule": "instruction",
+        "watch": "observation",
+    }
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip(" -\t")
+        if not line:
+            continue
+
+        prefix_match = re.match(r"^([A-Za-z -]{3,24}):\s+(.+)$", line)
+        if prefix_match:
+            prefix = prefix_match.group(1).lower()
+            content = prefix_match.group(2).strip()
+            memory_type = prefix_types.get(prefix)
+            if memory_type:
+                memories.append(
+                    MemoryRecord(
+                        content=content,
+                        memory_type=memory_type,
+                        title=f"{prefix.title()}: {content[:58]}",
+                        confidence=0.9,
+                        tags=tags,
+                    )
+                )
+            continue
+
+        lowered = line.lower()
+        if any(marker in lowered for marker in ("we chose", "we decided", "decision")):
+            memories.append(
+                MemoryRecord(
+                    content=line,
+                    memory_type="decision",
+                    confidence=0.78,
+                    tags=tags,
+                )
+            )
+        elif lowered.startswith(("prefer ", "keep ", "avoid ", "do not ", "must ")):
+            memories.append(
+                MemoryRecord(
+                    content=line,
+                    memory_type="instruction",
+                    confidence=0.76,
+                    tags=tags,
+                )
+            )
+
+    if paths:
+        memories.append(
+            MemoryRecord(
+                content=(
+                    f"{skill_name} touched {', '.join(paths)}. "
+                    "Use these paths as retrieval anchors for related future skills."
+                ),
+                memory_type="context",
+                title=f"{skill_name} touched project paths",
+                confidence=0.7,
+                tags=tags,
+            )
+        )
+
+    return dedupe_memories(memories)
+
+
+def dedupe_memories(memories: list[MemoryRecord]) -> list[MemoryRecord]:
+    seen: set[str] = set()
+    deduped: list[MemoryRecord] = []
+    for memory in memories:
+        key = memory.content.lower()
+        if key not in seen:
+            seen.add(key)
+            deduped.append(memory)
+    return deduped
+
+
+def normalize_tags(values: list[str]) -> list[str]:
+    tags: set[str] = set()
+    for value in values:
+        for part in re.split(r"[,;\s]+", value):
+            tag = re.sub(r"[^a-z0-9_/-]+", "-", part.lower()).strip("-")
+            if tag and len(tag) <= 48:
+                tags.add(tag)
+    return sorted(tags)
+
+
+def render_context(memories: list[MemoryRecord]) -> str:
+    if not memories:
+        return "MEMANTO_CONTEXT: no relevant memories found."
+
+    lines = ["MEMANTO_CONTEXT:"]
+    for memory in memories:
+        tags = f" tags={','.join(memory.tags)}" if memory.tags else ""
+        lines.append(
+            "- "
+            f"[{memory.memory_type}; confidence={memory.confidence:.2f}{tags}] "
+            f"{memory.content}"
+        )
+    return "\n".join(lines)
+
+
+class SkillMemoryBridge:
+    def __init__(self, backend: MemoryBackend) -> None:
+        self.backend = backend
+
+    def before_skill(
+        self,
+        *,
+        skill_name: str,
+        prompt: str,
+        cwd: str | None = None,
+        paths: list[str] | None = None,
+        limit: int = 5,
+    ) -> str:
+        query = " ".join([skill_name, prompt, cwd or "", " ".join(paths or [])])
+        tags = normalize_tags([skill_name, *(paths or [])])
+        memories = self.backend.recall(query, limit=limit, tags=tags or None)
+        if not memories:
+            memories = self.backend.recall(query, limit=limit)
+        return render_context(memories)
+
+    def after_skill(
+        self,
+        *,
+        skill_name: str,
+        summary: str,
+        transcript: str = "",
+        cwd: str | None = None,
+        paths: list[str] | None = None,
+    ) -> list[MemoryRecord]:
+        distilled = extract_memories(
+            f"{summary}\n{transcript}",
+            skill_name=skill_name,
+            cwd=cwd,
+            paths=paths,
+        )
+        for memory in distilled:
+            self.backend.remember(memory)
+        return distilled
+
+
+def create_backend() -> MemoryBackend:
+    backend_name = os.getenv("MEMANTO_SKILLS_BACKEND", "local").lower()
+    if backend_name == "cli":
+        return MemantoCliBackend(os.getenv("MEMANTO_BIN", "memanto"))
+
+    memory_file = os.getenv(
+        "MEMANTO_SKILLS_MEMORY_FILE",
+        str(Path.cwd() / ".memanto-skills-memory.jsonl"),
+    )
+    return LocalJsonlBackend(memory_file)
+
+
+def read_text_argument(value: str | None) -> str:
+    if not value:
+        return ""
+    path = Path(value)
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+    return value
+
+
+def parse_paths(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    before = subparsers.add_parser("before", help="Print recall context for a skill")
+    before.add_argument("--skill", required=True)
+    before.add_argument("--prompt", required=True)
+    before.add_argument("--cwd", default=None)
+    before.add_argument("--paths", default=None)
+    before.add_argument("--limit", type=int, default=5)
+
+    after = subparsers.add_parser("after", help="Store memories from a skill result")
+    after.add_argument("--skill", required=True)
+    after.add_argument("--summary", required=True)
+    after.add_argument("--transcript", default="")
+    after.add_argument("--cwd", default=None)
+    after.add_argument("--paths", default=None)
+
+    wrap = subparsers.add_parser("wrap", help="Run a command with memory capture")
+    wrap.add_argument("--skill", required=True)
+    wrap.add_argument("--prompt", required=True)
+    wrap.add_argument("--cwd", default=None)
+    wrap.add_argument("--paths", default=None)
+    wrap.add_argument("cmd", nargs=argparse.REMAINDER)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    bridge = SkillMemoryBridge(create_backend())
+    paths = parse_paths(getattr(args, "paths", None))
+
+    if args.command == "before":
+        print(
+            bridge.before_skill(
+                skill_name=args.skill,
+                prompt=read_text_argument(args.prompt),
+                cwd=args.cwd,
+                paths=paths,
+                limit=args.limit,
+            )
+        )
+        return 0
+
+    if args.command == "after":
+        memories = bridge.after_skill(
+            skill_name=args.skill,
+            summary=read_text_argument(args.summary),
+            transcript=read_text_argument(args.transcript),
+            cwd=args.cwd,
+            paths=paths,
+        )
+        print(json.dumps([asdict(memory) for memory in memories], indent=2))
+        return 0
+
+    if args.command == "wrap":
+        if not args.cmd:
+            print("wrap requires a command after --", file=sys.stderr)
+            return 2
+        print(
+            bridge.before_skill(
+                skill_name=args.skill,
+                prompt=args.prompt,
+                cwd=args.cwd,
+                paths=paths,
+            )
+        )
+        result = subprocess.run(args.cmd, capture_output=True, text=True)
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        bridge.after_skill(
+            skill_name=args.skill,
+            summary=(
+                f"Observation: Command exited with {result.returncode}. "
+                "Review stdout/stderr for any decisions or errors."
+            ),
+            transcript=f"{result.stdout}\n{result.stderr}",
+            cwd=args.cwd,
+            paths=paths,
+        )
+        return result.returncode
+
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/skill_memory_bridge.py
@@ -408,8 +408,11 @@ class SkillMemoryBridge:
         paths: list[str] | None = None,
         limit: int = 5,
     ) -> str:
-        query = " ".join([skill_name, prompt, cwd or "", " ".join(paths or [])])
-        tags = normalize_tags([skill_name, *expand_path_tags(paths or [])])
+        path_tags = expand_path_tags(paths or [])
+        query = " ".join(
+            [skill_name, prompt, cwd or "", " ".join(paths or []), " ".join(path_tags)]
+        )
+        tags = normalize_tags([skill_name, *path_tags])
         memories = self.backend.recall(query, limit=limit, tags=tags or None)
         return render_context(memories)
 

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from skill_memory_bridge import (
     LocalJsonlBackend,
     MemoryRecord,
     SkillMemoryBridge,
     extract_memories,
+    main,
 )
 
 
@@ -47,6 +51,58 @@ class SkillMemoryBridgeTests(unittest.TestCase):
             )
 
         self.assertIn("Billing actions must run on the server", context)
+
+    def test_bridge_recalls_parent_path_for_child_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            memory_file = Path(tmp) / "memories.jsonl"
+            first = SkillMemoryBridge(LocalJsonlBackend(memory_file))
+            first.after_skill(
+                skill_name="/grill-with-docs",
+                paths=["src/features/invoices"],
+                summary="Decision: Invoice totals must be stored in cents.",
+            )
+
+            second = SkillMemoryBridge(LocalJsonlBackend(memory_file))
+            context = second.before_skill(
+                skill_name="/tdd",
+                paths=["src/features/invoices/create-invoice.test.ts"],
+                prompt="Add invoice tests.",
+            )
+
+        self.assertIn("Invoice totals must be stored in cents", context)
+
+    def test_wrap_runs_command_in_requested_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp) / "work"
+            workdir.mkdir()
+            memory_file = Path(tmp) / "memories.jsonl"
+            command = (
+                "from pathlib import Path; "
+                "Path('cwd-marker.txt').write_text('ok', encoding='utf-8')"
+            )
+
+            with patch.dict(
+                os.environ,
+                {"MEMANTO_SKILLS_MEMORY_FILE": str(memory_file)},
+            ):
+                return_code = main(
+                    [
+                        "wrap",
+                        "--skill",
+                        "/cwd-test",
+                        "--prompt",
+                        "Run cwd check.",
+                        "--cwd",
+                        str(workdir),
+                        "--",
+                        sys.executable,
+                        "-c",
+                        command,
+                    ]
+                )
+
+            self.assertEqual(return_code, 0)
+            self.assertTrue((workdir / "cwd-marker.txt").exists())
 
     def test_extract_memories_classifies_prefixes(self) -> None:
         memories = extract_memories(

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -83,7 +83,10 @@ class SkillMemoryBridgeTests(unittest.TestCase):
 
             with patch.dict(
                 os.environ,
-                {"MEMANTO_SKILLS_MEMORY_FILE": str(memory_file)},
+                {
+                    "MEMANTO_SKILLS_BACKEND": "local",
+                    "MEMANTO_SKILLS_MEMORY_FILE": str(memory_file),
+                },
             ):
                 return_code = main(
                     [

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -39,7 +39,7 @@ class SkillMemoryBridgeTests(unittest.TestCase):
             first = SkillMemoryBridge(LocalJsonlBackend(memory_file))
             first.after_skill(
                 skill_name="/grill-with-docs",
-                paths=["src/app/billing/actions.ts"],
+                paths=["src/app/billing"],
                 summary="Decision: Billing actions must run on the server.",
             )
 
@@ -47,7 +47,7 @@ class SkillMemoryBridgeTests(unittest.TestCase):
             context = second.before_skill(
                 skill_name="/tdd",
                 paths=["src/app/billing/actions.ts"],
-                prompt="Test billing actions.",
+                prompt="How should I format a changelog?",
             )
 
         self.assertIn("Billing actions must run on the server", context)
@@ -66,7 +66,7 @@ class SkillMemoryBridgeTests(unittest.TestCase):
             context = second.before_skill(
                 skill_name="/tdd",
                 paths=["src/features/invoices/create-invoice.test.ts"],
-                prompt="Add invoice tests.",
+                prompt="How should I format a changelog?",
             )
 
         self.assertIn("Invoice totals must be stored in cents", context)

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -9,6 +10,7 @@ from unittest.mock import patch
 
 from skill_memory_bridge import (
     LocalJsonlBackend,
+    MemantoCliBackend,
     MemoryRecord,
     SkillMemoryBridge,
     extract_memories,
@@ -127,6 +129,29 @@ class SkillMemoryBridgeTests(unittest.TestCase):
             backend = LocalJsonlBackend(memory_file)
 
             self.assertEqual(backend.recall("anything"), [])
+
+    def test_cli_backend_ignores_empty_or_no_result_recall_output(self) -> None:
+        no_result_outputs = [
+            "",
+            " \n",
+            "No memories found",
+            "No memories found matching your query\nCompleted in 0.01s\n",
+            "No relevant memories found.",
+        ]
+
+        for output in no_result_outputs:
+            completed = subprocess.CompletedProcess(
+                args=["memanto", "recall", "query"],
+                returncode=0,
+                stdout=output,
+                stderr="",
+            )
+            with self.subTest(output=output):
+                with patch(
+                    "skill_memory_bridge.subprocess.run",
+                    return_value=completed,
+                ):
+                    self.assertEqual(MemantoCliBackend().recall("query"), [])
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
+++ b/examples/claudecode-skills-memanto/test_skill_memory_bridge.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from skill_memory_bridge import (
+    LocalJsonlBackend,
+    MemoryRecord,
+    SkillMemoryBridge,
+    extract_memories,
+)
+
+
+class SkillMemoryBridgeTests(unittest.TestCase):
+    def test_local_backend_recalls_tagged_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = LocalJsonlBackend(Path(tmp) / "memories.jsonl")
+            backend.remember(
+                MemoryRecord(
+                    content="Use better-sqlite3 for local database access.",
+                    memory_type="decision",
+                    tags=["billing", "sqlite"],
+                )
+            )
+
+            recalled = backend.recall("billing sqlite database", tags=["billing"])
+
+        self.assertEqual(len(recalled), 1)
+        self.assertIn("better-sqlite3", recalled[0].content)
+
+    def test_bridge_persists_across_instances(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            memory_file = Path(tmp) / "memories.jsonl"
+            first = SkillMemoryBridge(LocalJsonlBackend(memory_file))
+            first.after_skill(
+                skill_name="/grill-with-docs",
+                paths=["src/app/billing/actions.ts"],
+                summary="Decision: Billing actions must run on the server.",
+            )
+
+            second = SkillMemoryBridge(LocalJsonlBackend(memory_file))
+            context = second.before_skill(
+                skill_name="/tdd",
+                paths=["src/app/billing/actions.ts"],
+                prompt="Test billing actions.",
+            )
+
+        self.assertIn("Billing actions must run on the server", context)
+
+    def test_extract_memories_classifies_prefixes(self) -> None:
+        memories = extract_memories(
+            "Decision: Prefer server actions for mutations.\n"
+            "Preference: Keep components presentational.\n"
+            "Gotcha: Avoid Prisma in this codebase.",
+            skill_name="/handoff",
+        )
+        memory_types = [memory.memory_type for memory in memories]
+
+        self.assertIn("decision", memory_types)
+        self.assertIn("preference", memory_types)
+        self.assertIn("error", memory_types)
+
+    def test_backend_ignores_malformed_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            memory_file = Path(tmp) / "memories.jsonl"
+            memory_file.write_text("{not-json}\n", encoding="utf-8")
+            backend = LocalJsonlBackend(memory_file)
+
+            self.assertEqual(backend.recall("anything"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,70 @@
+"""Run lightweight validation for the Claude Code skills example."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from skill_memory_bridge import (
+    LocalJsonlBackend,
+    SkillMemoryBridge,
+    extract_memories,
+)
+
+
+def validate_cross_session_recall(tmpdir: Path) -> None:
+    backend = LocalJsonlBackend(tmpdir / "memories.jsonl")
+    first = SkillMemoryBridge(backend)
+    first.after_skill(
+        skill_name="/handoff",
+        cwd="web",
+        paths=["src/features/invoices"],
+        summary=(
+            "Decision: Invoice totals are calculated in cents only.\n"
+            "Convention: New invoice tests belong next to the feature folder."
+        ),
+    )
+
+    second = SkillMemoryBridge(LocalJsonlBackend(tmpdir / "memories.jsonl"))
+    context = second.before_skill(
+        skill_name="/tdd",
+        cwd="web",
+        paths=["src/features/invoices/create-invoice.test.ts"],
+        prompt="Write tests for invoice totals.",
+    )
+    if "calculated in cents only" not in context:
+        raise AssertionError(context)
+
+
+def validate_bad_json_recovery(tmpdir: Path) -> None:
+    memory_file = tmpdir / "broken.jsonl"
+    memory_file.write_text("{bad json}\n", encoding="utf-8")
+    backend = LocalJsonlBackend(memory_file)
+    if backend.recall("anything"):
+        raise AssertionError("Malformed JSONL rows should be ignored.")
+
+
+def validate_extraction() -> None:
+    memories = extract_memories(
+        "Decision: Keep route handlers thin.\n"
+        "Gotcha: Avoid mixing Turso HTTP client and better-sqlite3 in one app.",
+        skill_name="/review",
+        paths=["src/app/api"],
+    )
+    memory_types = {memory.memory_type for memory in memories}
+    if "decision" not in memory_types or "error" not in memory_types:
+        raise AssertionError(memory_types)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        validate_cross_session_recall(tmpdir)
+        validate_bad_json_recovery(tmpdir)
+        validate_extraction()
+    print("validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Refs #508

BountyHub: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe

## Summary
- Adds `examples/claudecode-skills-memanto`, a credential-free Claude Code skills memory bridge.
- Implements `before`, `after`, and `wrap` lifecycle hooks that distill skill summaries into typed engineering memories and inject relevant context before later skills run.
- Provides a deterministic local JSONL backend for review plus an optional `MEMANTO_SKILLS_BACKEND=cli` path for live Memanto CLI recall/writeback.
- Includes demo, validation, and unittest coverage for cross-session recall, path-tagged memories, malformed JSON recovery, and typed extraction.

## Verification
- `py -3.12 demo.py`
- `py -3.12 validate.py`
- `py -3.12 -m unittest test_skill_memory_bridge.py`
- `py -3.12 -m py_compile examples\claudecode-skills-memanto\skill_memory_bridge.py examples\claudecode-skills-memanto\demo.py examples\claudecode-skills-memanto\validate.py examples\claudecode-skills-memanto\test_skill_memory_bridge.py`
- `git diff --check`

## Showcase
The README includes the full credential-free demo flow and commands. I have not posted an external social-media showcase yet; per the maintainer clarification in https://github.com/moorcheh-ai/memanto/issues/508#issuecomment-4494339545, technical review can proceed without an external social post, and social engagement only affects the leaderboard scoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SkillMemoryBridge example with local JSONL and optional CLI-backed memory persistence, a credential-free demo script, and a small CLI for before/after/wrap workflows to persist and recall skill outputs.

* **Documentation**
  * Added a comprehensive usage guide with quick-start commands, CLI patterns, and Python integration examples for before/after skill hooks.

* **Tests**
  * Added end-to-end tests and a validation script covering tagged recall, cross-session persistence, path-aware recall, extraction/classification, CLI wrap behavior, and malformed-data resilience.

* **Chores**
  * Updated demo requirements to support optional CLI-backed demos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->