### PR TITLE
feat: add memory forget command

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -299,6 +299,52 @@ async def batch_remember(
         raise map_error_to_http_exception(e)
 
 
+@router.delete("/{agent_id}/memories/{memory_id}")
+async def delete_memory(
+    agent_id: str,
+    memory_id: str,
+    session: Session = Depends(get_current_session),
+    client=Depends(get_moorcheh_client),
+):
+    """
+    Delete one memory from the active agent's namespace (Session-based).
+
+    Requires:
+    - X-Session-Token: {session_token}
+
+    The session must be for the specified agent_id.
+    """
+    if session.agent_id != agent_id:
+        raise map_error_to_http_exception(
+            Exception(
+                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
+            )
+        )
+
+    try:
+        write_service = MemoryWriteService(client)
+        deleted = await asyncio.to_thread(
+            write_service.delete_memory, memory_id, session.namespace
+        )
+        if not deleted:
+            raise HTTPException(
+                status_code=404, detail=f"Memory '{memory_id}' was not found."
+            )
+
+        return {
+            "agent_id": agent_id,
+            "session_id": session.session_id,
+            "namespace": session.namespace,
+            "memory_id": memory_id,
+            "status": "deleted",
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise map_error_to_http_exception(e)
+
+
 @router.post("/{agent_id}/upload-file")
 async def upload_file(
     agent_id: str,

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -729,6 +729,34 @@ class DirectClient:
 
         return result
 
+    def delete_memory(self, agent_id: str, memory_id: str) -> dict[str, Any]:
+        """
+        Delete a single memory from the active agent namespace.
+
+        Args:
+            agent_id: Target agent.
+            memory_id: Memory document ID to delete.
+
+        Returns:
+            Dict with deletion status metadata.
+
+        Raises:
+            ValueError: If the memory does not exist or was not deleted.
+        """
+        session = self._get_validated_session_for_agent(agent_id)
+        deleted = self._get_write_service().delete_memory(
+            memory_id, session.namespace
+        )
+        if not deleted:
+            raise ValueError(f"Memory '{memory_id}' was not found")
+
+        return {
+            "agent_id": agent_id,
+            "namespace": session.namespace,
+            "memory_id": memory_id,
+            "status": "deleted",
+        }
+
     def recall(
         self,
         agent_id: str,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -566,6 +566,34 @@ class SdkClient:
 
         return result
 
+    def delete_memory(self, agent_id: str, memory_id: str) -> dict[str, Any]:
+        """
+        Delete a single memory from the active agent namespace.
+
+        Args:
+            agent_id: Target agent.
+            memory_id: Memory document ID to delete.
+
+        Returns:
+            Dict with deletion status metadata.
+
+        Raises:
+            ValueError: If the memory does not exist or was not deleted.
+        """
+        session = self._get_validated_session_for_agent(agent_id)
+        deleted = self._get_write_service().delete_memory(
+            memory_id, session.namespace
+        )
+        if not deleted:
+            raise ValueError(f"Memory '{memory_id}' was not found")
+
+        return {
+            "agent_id": agent_id,
+            "namespace": session.namespace,
+            "memory_id": memory_id,
+            "status": "deleted",
+        }
+
     def upload_file(self, agent_id: str, file_path: str) -> dict[str, Any]:
         """
         Upload a file directly to the agent's memory namespace.

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -173,6 +173,47 @@ def remember(
 
 
 @app.command()
+def forget(
+    memory_id: str = typer.Argument(..., help="Memory ID to delete"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Delete without asking for confirmation"
+    ),
+):
+    """Delete one memory from the active agent."""
+    start = time.perf_counter()
+    active_agent_id, active_session_token = config_manager.get_active_session()
+
+    if not active_agent_id or not active_session_token:
+        _error(
+            "No active agent.", hint="Run 'memanto agent activate <agent-id>' first."
+        )
+
+    if not force:
+        confirmed = typer.confirm(
+            f"Delete memory '{memory_id}' from agent '{active_agent_id}'?"
+        )
+        if not confirmed:
+            console.print("[yellow]Deletion cancelled.[/yellow]")
+            raise typer.Exit(0)
+
+    client = get_client()
+
+    try:
+        with console.status("[cyan]Deleting memory...", spinner="dots"):
+            result = client.delete_memory(
+                agent_id=active_agent_id, memory_id=memory_id
+            )
+        elapsed = time.perf_counter() - start
+
+        console.print("[green]Memory deleted successfully![/green]")
+        console.print(f"[dim]Memory ID: {result.get('memory_id', memory_id)}[/dim]")
+        console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")
+
+    except Exception as e:
+        _error(f"Failed to delete memory: {e}")
+
+
+@app.command()
 def upload(
     file_path: str = typer.Argument(..., help="Path to the file to upload"),
 ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,18 @@
 import os
 import shutil
 import tempfile
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import settings
 from memanto.app.main import app
+from memanto.app.models.session import Session
+from memanto.app.routes.auth_deps import get_current_session
 
 # Set test environment
 os.environ["MOORCHEH_API_KEY"] = "test-api-key"
@@ -245,6 +249,65 @@ class TestMEMANTOAPI:
 
         assert response.status_code == 200
         assert response.json()["status"] == "queued"
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_with_session(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Test deleting one memory with session token."""
+        mock_moorcheh.documents.delete.return_value = {"actual_deletions": 1}
+
+        app.dependency_overrides[get_current_session] = lambda: Session(
+            session_id="sess-test",
+            session_token="token-test",
+            agent_id=self.TEST_AGENT_ID,
+            namespace=f"memanto_agent_{self.TEST_AGENT_ID}",
+            started_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+        app.dependency_overrides[get_moorcheh_client] = lambda: mock_moorcheh
+        try:
+            response = await client.delete(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/memories/mem-123",
+                headers=auth_headers,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "deleted"
+        assert data["memory_id"] == "mem-123"
+        mock_moorcheh.documents.delete.assert_called_once_with(
+            namespace_name=f"memanto_agent_{self.TEST_AGENT_ID}", ids=["mem-123"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_returns_404_when_missing(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Test deleting a missing memory returns a clear 404."""
+        mock_moorcheh.documents.delete.return_value = {"actual_deletions": 0}
+
+        app.dependency_overrides[get_current_session] = lambda: Session(
+            session_id="sess-test",
+            session_token="token-test",
+            agent_id=self.TEST_AGENT_ID,
+            namespace=f"memanto_agent_{self.TEST_AGENT_ID}",
+            started_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+        app.dependency_overrides[get_moorcheh_client] = lambda: mock_moorcheh
+        try:
+            response = await client.delete(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/memories/missing-memory",
+                headers=auth_headers,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 404
+        assert "missing-memory" in response.json()["detail"]
 
     @pytest.mark.asyncio
     async def test_answer_with_session(self, client, auth_headers, mock_moorcheh):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,6 +209,30 @@ class TestMEMANTOCLI:
         assert "stored successfully" in result.stdout.lower()
         assert "mem-123" in result.stdout
 
+    def test_forget_force(self, mock_all_clients):
+        """Test 'memanto forget --force' deletes one memory."""
+        mock_all_clients.delete_memory.return_value = {
+            "memory_id": "mem-123",
+            "status": "deleted",
+        }
+
+        result = runner.invoke(app, ["forget", "mem-123", "--force"])
+
+        assert result.exit_code == 0
+        assert "deleted successfully" in result.stdout.lower()
+        assert "mem-123" in result.stdout
+        mock_all_clients.delete_memory.assert_called_once_with(
+            agent_id="test-agent", memory_id="mem-123"
+        )
+
+    def test_forget_confirmation_declined(self, mock_all_clients):
+        """Test 'memanto forget' can be cancelled before deletion."""
+        result = runner.invoke(app, ["forget", "mem-123"], input="n\n")
+
+        assert result.exit_code == 0
+        assert "cancelled" in result.stdout.lower()
+        mock_all_clients.delete_memory.assert_not_called()
+
     def test_recall(self, mock_all_clients):
         """Test 'memanto recall'"""
         mock_all_clients.recall.return_value = {


### PR DESCRIPTION
## Summary
- add DELETE `/api/v2/agents/{agent_id}/memories/{memory_id}` for session-scoped single-memory deletion
- expose `delete_memory()` through both DirectClient and SdkClient
- add `memanto forget <memory_id>` with confirmation by default and `--force` for automation
- cover success, missing-memory 404, forced delete, and cancelled confirmation paths

Fixes #539

## Validation
- `python -m pytest tests/test_cli.py::TestMEMANTOCLI::test_forget_force tests/test_cli.py::TestMEMANTOCLI::test_forget_confirmation_declined tests/test_api.py::TestMEMANTOAPI::test_delete_memory_with_session tests/test_api.py::TestMEMANTOAPI::test_delete_memory_returns_404_when_missing -q`
- `python -m ruff check memanto/app/routes/memory.py memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py memanto/cli/commands/memory.py tests/test_api.py tests/test_cli.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `forget` to delete a single memory from your active agent workspace, with optional confirmation bypass via `--force`.
  * Exposed memory deletion through both the CLI and client interfaces for programmatic use.
  * Successful deletions return a clear `status: "deleted"` result, while missing memories yield a not-found response.
* **Tests**
  * Added API and CLI integration/contract tests covering successful deletion, missing-memory handling, and confirmation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->