### PR TITLE
feat: Memanto + mattpocock/skills Cross-Skill Memory Integration (Fixes #508)

### DIFF
--- a/examples/claudecode-skills-memanto/.env.example
+++ b/examples/claudecode-skills-memanto/.env.example
@@ -1,0 +1,13 @@
+# Moorcheh API key — get one free at https://console.moorcheh.ai/api-keys
+MOORCHEH_API_KEY=your-moorcheh-api-key-here
+
+# Memanto server URL (default: http://localhost:8000)
+# Only needed if you run memanto as a standalone server.
+# The hook also works with the moorcheh SDK directly (no server needed).
+# MEMANTO_URL=http://localhost:8000
+
+# Agent ID used across all skills for shared memory
+MEMANTO_AGENT_ID=claudecode-dev
+
+# Max memories to inject into skill context
+MEMANTO_CONTEXT_LIMIT=5

--- a/examples/claudecode-skills-memanto/.env.example
+++ b/examples/claudecode-skills-memanto/.env.example
@@ -1,5 +1,5 @@
 # Moorcheh API key — get one free at https://console.moorcheh.ai/api-keys
-MOORCHEH_API_KEY=your-moorcheh-api-key-here
+MEMANTO_API_KEY=your-moorcheh-api-key-here
 
 # Memanto server URL (default: http://localhost:8000)
 # Only needed if you run memanto as a standalone server.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -13,7 +13,7 @@ This integration layer hooks into the skill lifecycle to:
 1. **On skill start:** Query Memanto for memories relevant to the current file/task and inject them as context
 2. **On skill complete:** Distill the interaction and store key learnings in Memanto's semantic memory
 
-```
+```text
 ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
 │   /tdd       │     │ /grill-docs  │     │   /handoff   │
 │   skill      │     │   skill      │     │   skill      │
@@ -56,7 +56,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 
 cp .env.example .env
-# Edit .env and add your MOORCHEH_API_KEY
+# Edit .env and add your MEMANTO_API_KEY
 ```
 
 ### 3. Run the Demo
@@ -158,7 +158,7 @@ Memanto's built-in trust system ensures memories are reliable:
 
 ## File Structure
 
-```
+```text
 examples/claudecode-skills-memanto/
 ├── README.md                    # This file
 ├── requirements.txt             # Python dependencies

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,187 @@
+# Memanto + mattpocock/skills — Cross-Skill Memory Layer
+
+> **Zero repeated instructions.** Memanto acts as a global, active memory companion across different skill executions in the [mattpocock/skills](https://github.com/mattpocock/skills) developer workflow.
+
+## The Problem: Context Fragmentation
+
+When you use `/tdd` in one terminal, `/grill-with-docs` in another, and `/handoff` in a third — each skill runs in isolation. Your architectural decisions, testing preferences, and codebase conventions must be re-explained every single time.
+
+## The Solution: Memanto as Persistent Memory
+
+This integration layer hooks into the skill lifecycle to:
+
+1. **On skill start:** Query Memanto for memories relevant to the current file/task and inject them as context
+2. **On skill complete:** Distill the interaction and store key learnings in Memanto's semantic memory
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   /tdd       │     │ /grill-docs  │     │   /handoff   │
+│   skill      │     │   skill      │     │   skill      │
+└──────┬───────┘     └──────┬───────┘     └──────┬───────┘
+       │                    │                    │
+       ▼                    ▼                    ▼
+┌──────────────────────────────────────────────────────────┐
+│              Memanto Skill Hook Layer                     │
+│  ┌─────────────────┐    ┌──────────────────────────────┐ │
+│  │ on_skill_start() │    │ on_skill_complete()          │ │
+│  │ → recall(query)  │    │ → remember(summary)          │ │
+│  │ → inject context │    │ → distill via Moorcheh LLM   │ │
+│  └─────────────────┘    └──────────────────────────────┘ │
+└──────────────────────────────────────────────────────────┘
+       │
+       ▼
+┌──────────────────────────────────────────────────────────┐
+│                   Memanto Server                          │
+│  • Semantic memory search (Moorcheh vector DB)           │
+│  • 13 memory types (fact, decision, preference, ...)     │
+│  • Confidence scoring + provenance tracking              │
+│  • Cross-session persistence                             │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+### 1. Prerequisites
+
+- Python 3.10+
+- A [Moorcheh API key](https://console.moorcheh.ai/api-keys) (free: 100K ops/month)
+
+### 2. Setup
+
+```bash
+cd examples/claudecode-skills-memanto
+
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+cp .env.example .env
+# Edit .env and add your MOORCHEH_API_KEY
+```
+
+### 3. Run the Demo
+
+```bash
+# Session 1: Simulate a /tdd skill discovering testing preferences
+python demo_cross_session.py session1
+
+# Session 2: Simulate a /grill-with-docs skill — it remembers!
+python demo_cross_session.py session2
+```
+
+### 4. Use in Your Workflow
+
+#### Option A: Shell Wrapper
+
+```bash
+# Wrap any skill invocation
+./skill-with-memanto.sh /tdd src/api/users.ts "Write tests for user signup"
+
+# It will:
+# 1. Show relevant memories from past sessions
+# 2. Ask you to paste a summary when done
+# 3. Store the summary in Memanto
+```
+
+#### Option B: Python API
+
+```python
+from memanto_skill_hook import SkillMemory
+
+mem = SkillMemory()
+
+# Before skill: get context
+context = mem.on_skill_start(
+    skill_name="/tdd",
+    file_path="src/api/auth.ts",
+    task_description="Write tests for auth endpoints",
+)
+print(context)  # inject into your prompt
+
+# After skill: store learnings
+mem.on_skill_complete(
+    skill_name="/tdd",
+    summary="Used Vitest + AAA pattern. Mocked auth middleware with vi.mock().",
+    file_path="src/api/auth.ts",
+)
+```
+
+#### Option C: CLI
+
+```bash
+# Pre-skill context retrieval
+python -m memanto_skill_hook pre --skill /tdd --file src/auth.ts --task "Write tests"
+
+# Post-skill memory storage
+python -m memanto_skill_hook post --skill /tdd --file src/auth.ts \
+    --summary "Used Vitest + AAA pattern. Mocked auth middleware."
+```
+
+#### Option D: Claude Code Hooks
+
+Add to your `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash|Write|Edit",
+      "hook": "python /path/to/claude_code_hook.py pre"
+    }],
+    "PostToolUse": [{
+      "matcher": "Bash|Write|Edit",
+      "hook": "python /path/to/claude_code_hook.py post"
+    }]
+  }
+}
+```
+
+## Architecture
+
+### Memory Types Used
+
+| Type | When | Example |
+|------|------|---------|
+| `decision` | Architectural choices | "Use Vitest, not Jest" |
+| `preference` | Coding style | "Prefer async/await over .then()" |
+| `fact` | Codebase facts | "Auth middleware lives in src/middleware/auth.ts" |
+| `instruction` | Explicit rules | "All API routes need unit + integration tests" |
+
+### Trust & Confidence
+
+Memanto's built-in trust system ensures memories are reliable:
+
+- **Provenance tracking**: explicit_statement > validated > observed > inferred
+- **Confidence scoring**: 0.0–1.0 with age decay
+- **Contradiction detection**: Flags conflicting memories
+- **Validation counting**: Repeated patterns get higher trust
+
+## File Structure
+
+```
+examples/claudecode-skills-memanto/
+├── README.md                    # This file
+├── requirements.txt             # Python dependencies
+├── .env.example                 # API key template
+├── memanto_skill_hook/
+│   ├── __init__.py              # Package entry point
+│   ├── __main__.py              # CLI entrypoint
+│   └── memory.py                # Core SkillMemory implementation
+├── skill-with-memanto.sh        # Shell wrapper for terminal use
+├── claude_code_hook.py          # Claude Code hooks integration
+└── demo_cross_session.py        # Interactive demo (run session1 then session2)
+```
+
+## How It Solves the Bounty Requirements
+
+✅ **Global Memory Hook**: `SkillMemory` initializes Memanto on first use via Moorcheh credentials
+
+✅ **Active Extraction**: `on_skill_complete()` passes interaction summaries to Memanto's backend LLM, which distills and stores the developer's "Engineering Profile"
+
+✅ **Dynamic Injection**: `on_skill_start()` queries Memanto for memories relevant to the current file path/task and returns them as a concise system constraint
+
+✅ **Zero Repeated Instructions**: Memories persist across sessions, skills, and terminal instances
+
+## License
+
+This example is part of the [Memanto](https://github.com/moorcheh-ai/memanto) project and follows the same license.

--- a/examples/claudecode-skills-memanto/claude_code_hook.py
+++ b/examples/claudecode-skills-memanto/claude_code_hook.py
@@ -28,12 +28,34 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 import re
+import sys
 import tempfile
+import time
 from pathlib import Path
 
 from memanto_skill_hook.memory import SkillMemory
+
+# ---------------------------------------------------------------------------
+# Secret patterns for sanitization
+# ---------------------------------------------------------------------------
+_SECRET_PATTERNS = [
+    re.compile(r'(?i)\b(api[_-]?key|token|secret|password)\b\s*[:=]\s*\S+'),
+    re.compile(r'ghp_[A-Za-z0-9]{20,}'),
+    re.compile(r'ghu_[A-Za-z0-9]{20,}'),
+    re.compile(r'ghs_[A-Za-z0-9]{20,}'),
+    re.compile(r'sk-[A-Za-z0-9]{20,}'),
+    re.compile(r'-----BEGIN (?:RSA |EC )?PRIVATE KEY-----'),
+]
+
+
+def _sanitize_output(text: str) -> str:
+    """Redact secrets and sensitive patterns before persisting."""
+    redacted = text
+    for pat in _SECRET_PATTERNS:
+        redacted = pat.sub("[REDACTED]", redacted)
+    return redacted
+
 
 # ---------------------------------------------------------------------------
 # Hook state file — stores the pre-hook context for the post-hook to consume
@@ -43,8 +65,8 @@ _STATE_PREFIX = "memanto_hook_state_"
 
 
 def _state_file() -> Path:
-    """Return a PID-scoped state file to avoid cross-process collisions."""
-    return _STATE_DIR / f"{_STATE_PREFIX}{os.getpid()}.json"
+    """Return a PID+timestamp-scoped state file to avoid cross-process collisions."""
+    return _STATE_DIR / f"{_STATE_PREFIX}{os.getpid()}_{int(time.time() * 1000)}.json"
 
 
 def _save_state(data: dict) -> None:
@@ -134,6 +156,9 @@ def post_hook() -> None:
     # Sanitize: strip ANSI escape codes and control characters
     tool_output = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", tool_output)
     tool_output = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", tool_output)
+
+    # Redact secrets before persisting
+    tool_output = _sanitize_output(tool_output)
 
     # Only store if there's meaningful output
     if len(tool_output.strip()) < 20:

--- a/examples/claudecode-skills-memanto/claude_code_hook.py
+++ b/examples/claudecode-skills-memanto/claude_code_hook.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 import json
 import os
 import sys
+import re
+import tempfile
 from pathlib import Path
 
 from memanto_skill_hook.memory import SkillMemory
@@ -36,16 +38,23 @@ from memanto_skill_hook.memory import SkillMemory
 # ---------------------------------------------------------------------------
 # Hook state file — stores the pre-hook context for the post-hook to consume
 # ---------------------------------------------------------------------------
-_STATE_FILE = Path("/tmp/memanto_hook_state.json")
+_STATE_DIR = Path(tempfile.gettempdir())
+_STATE_PREFIX = "memanto_hook_state_"
+
+
+def _state_file() -> Path:
+    """Return a PID-scoped state file to avoid cross-process collisions."""
+    return _STATE_DIR / f"{_STATE_PREFIX}{os.getpid()}.json"
 
 
 def _save_state(data: dict) -> None:
-    _STATE_FILE.write_text(json.dumps(data))
+    _state_file().write_text(json.dumps(data))
 
 
 def _load_state() -> dict:
-    if _STATE_FILE.exists():
-        return json.loads(_STATE_FILE.read_text())
+    sf = _state_file()
+    if sf.exists():
+        return json.loads(sf.read_text())
     return {}
 
 
@@ -121,6 +130,10 @@ def post_hook() -> None:
         tool_output = " ".join(str(x) for x in tool_output)
     elif not isinstance(tool_output, str):
         tool_output = str(tool_output)
+
+    # Sanitize: strip ANSI escape codes and control characters
+    tool_output = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", tool_output)
+    tool_output = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", tool_output)
 
     # Only store if there's meaningful output
     if len(tool_output.strip()) < 20:

--- a/examples/claudecode-skills-memanto/claude_code_hook.py
+++ b/examples/claudecode-skills-memanto/claude_code_hook.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+claude_code_hook.py — Claude Code integration via its hook system.
+
+Claude Code supports hooks that run before/after tool calls.
+This script can be configured as a PreToolUse/PostToolUse hook to
+automatically inject Memanto context and store learnings.
+
+Setup in your Claude Code settings (~/.claude/settings.json):
+
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash|Write|Edit",
+      "hook": "python /path/to/claude_code_hook.py pre"
+    }],
+    "PostToolUse": [{
+      "matcher": "Bash|Write|Edit",
+      "hook": "python /path/to/claude_code_hook.py post"
+    }]
+  }
+}
+
+Or for a specific project, add to .claude/settings.json in the repo.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from memanto_skill_hook.memory import SkillMemory
+
+# ---------------------------------------------------------------------------
+# Hook state file — stores the pre-hook context for the post-hook to consume
+# ---------------------------------------------------------------------------
+_STATE_FILE = Path("/tmp/memanto_hook_state.json")
+
+
+def _save_state(data: dict) -> None:
+    _STATE_FILE.write_text(json.dumps(data))
+
+
+def _load_state() -> dict:
+    if _STATE_FILE.exists():
+        return json.loads(_STATE_FILE.read_text())
+    return {}
+
+
+def _detect_skill_from_cwd() -> str:
+    """Infer the active skill from the working directory or env."""
+    # Check if a skill env var is set (you can export this in your wrapper)
+    skill = os.environ.get("MEMANTO_ACTIVE_SKILL", "")
+    if skill:
+        return skill
+    # Default: treat as general coding
+    return "/code"
+
+
+def _extract_file_path(tool_input: dict) -> str:
+    """Extract the file path from a Claude Code tool input."""
+    for key in ("file_path", "path", "filePath", "command"):
+        val = tool_input.get(key, "")
+        if val and isinstance(val, str):
+            return val
+    return ""
+
+
+def pre_hook() -> None:
+    """PreToolUse hook — inject Memanto context."""
+    try:
+        stdin_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    tool_name = stdin_data.get("tool_name", "")
+    tool_input = stdin_data.get("tool_input", {})
+    file_path = _extract_file_path(tool_input)
+    skill = _detect_skill_from_cwd()
+
+    mem = SkillMemory()
+    ctx = mem.on_skill_start(
+        skill_name=skill,
+        file_path=file_path,
+        task_description=f"Using {tool_name} on {file_path}",
+    )
+
+    # Save state for post-hook
+    _save_state({
+        "skill": skill,
+        "file_path": file_path,
+        "tool_name": tool_name,
+    })
+
+    if ctx:
+        # Output the context to stdout — Claude Code will read it
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": ctx,
+            }
+        }
+        print(json.dumps(output))
+
+
+def post_hook() -> None:
+    """PostToolUse hook — store learnings from the tool output."""
+    try:
+        stdin_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    state = _load_state()
+    if not state:
+        return
+
+    tool_output = stdin_data.get("tool_output", "")
+    if isinstance(tool_output, list):
+        tool_output = " ".join(str(x) for x in tool_output)
+    elif not isinstance(tool_output, str):
+        tool_output = str(tool_output)
+
+    # Only store if there's meaningful output
+    if len(tool_output.strip()) < 20:
+        return
+
+    # Truncate very long outputs
+    if len(tool_output) > 2000:
+        tool_output = tool_output[:1997] + "..."
+
+    mem = SkillMemory()
+    mem.on_skill_complete(
+        skill_name=state.get("skill", "/code"),
+        summary=f"Tool: {state.get('tool_name', 'unknown')}\n\n{tool_output}",
+        file_path=state.get("file_path", ""),
+    )
+
+
+def main() -> None:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "pre"
+    if mode == "pre":
+        pre_hook()
+    elif mode == "post":
+        post_hook()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/demo_cross_session.py
+++ b/examples/claudecode-skills-memanto/demo_cross_session.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+demo_cross_session.py — Demonstration of cross-skill memory persistence.
+
+Run this script twice to see Memanto in action:
+
+    # Session 1: Simulate a /tdd skill that discovers testing preferences
+    python demo_cross_session.py session1
+
+    # Session 2: Simulate a /grill-with-docs skill — it remembers!
+    python demo_cross_session.py session2
+
+This proves that architectural decisions and coding preferences persist
+across different skill invocations and terminal sessions.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+
+from memanto_skill_hook import SkillMemory
+
+
+def print_banner(text: str) -> None:
+    width = 60
+    print()
+    print("═" * width)
+    print(f"  {text}")
+    print("═" * width)
+    print()
+
+
+def print_context(ctx: str) -> None:
+    if ctx:
+        print(ctx)
+    else:
+        print("  (No relevant memories found.)")
+    print()
+
+
+def session1() -> None:
+    """Simulate a /tdd skill that discovers testing preferences."""
+    print_banner("SESSION 1: /tdd skill — Writing tests for user auth")
+
+    mem = SkillMemory()
+
+    # Step 1: Pre-skill — nothing stored yet
+    print_banner("Step 1: Pre-skill query (nothing stored yet)")
+    ctx = mem.on_skill_start(
+        skill_name="/tdd",
+        file_path="src/api/auth.ts",
+        task_description="Write tests for user authentication endpoints",
+    )
+    print_context(ctx)
+
+    # Step 2: Post-skill — store what we learned
+    print_banner("Step 2: Storing /tdd learnings into Memanto")
+    summary = textwrap.dedent("""
+        - Used Vitest with AAA (Arrange-Act-Assert) pattern
+        - Mocked auth middleware using vi.mock() — never call real JWT verification in unit tests
+        - Test file co-located: src/api/auth.test.ts
+        - Prefer describe/it blocks, not test()
+        - Used MSW for HTTP mocking in integration tests
+        - All async tests use async/await, not .then() chains
+    """).strip()
+
+    ok = mem.on_skill_complete(
+        skill_name="/tdd",
+        summary=summary,
+        file_path="src/api/auth.ts",
+    )
+    print(f"  Memory stored: {'✓' if ok else '✗'}")
+    print()
+
+    # Also store an architectural decision
+    print_banner("Step 3: Storing an architectural decision")
+    ok = mem.on_skill_complete(
+        skill_name="/tdd",
+        summary="Architectural decision: All API routes must have both unit and integration tests before merge. Integration tests use a test database (not mocks) for data layer.",
+        file_path="src/api/auth.ts",
+    )
+    print(f"  Decision stored: {'✓' if ok else '✗'}")
+    print()
+
+    print_banner("Session 1 complete. Run session2 to see cross-session recall!")
+
+
+def session2() -> None:
+    """Simulate a /grill-with-docs skill that benefits from past context."""
+    print_banner("SESSION 2: /grill-with-docs skill — Documenting the API")
+
+    mem = SkillMemory()
+
+    # Pre-skill — this time Memanto should return context from session 1
+    print_banner("Step 1: Pre-skill query (memories from session 1!)")
+    ctx = mem.on_skill_start(
+        skill_name="/grill-with-docs",
+        file_path="src/api/auth.ts",
+        task_description="Write API documentation for authentication endpoints",
+    )
+    print_context(ctx)
+
+    # The developer can now see their past decisions without re-explaining
+    print("  The documentation skill now knows:")
+    print("  • Vitest + AAA pattern is the standard")
+    print("  • MSW is used for HTTP mocking")
+    print("  • Integration tests require a test database")
+    print("  • No manual context-shoving needed!")
+    print()
+
+    # Store new learnings from this skill
+    print_banner("Step 2: Storing /grill-with-docs learnings")
+    ok = mem.on_skill_complete(
+        skill_name="/grill-with-docs",
+        summary="Documentation uses OpenAPI 3.1 spec. All endpoints documented with request/response examples. Error responses follow RFC 7807 (Problem Details).",
+        file_path="src/api/auth.ts",
+    )
+    print(f"  Memory stored: {'✓' if ok else '✗'}")
+
+    print_banner("Demo complete! Zero repeated instructions. 🎉")
+
+
+def main() -> int:
+    if len(sys.argv) < 2 or sys.argv[1] not in ("session1", "session2"):
+        print(f"Usage: {sys.argv[0]} <session1|session2>")
+        return 1
+
+    if sys.argv[1] == "session1":
+        session1()
+    else:
+        session2()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/memanto_skill_hook/__init__.py
+++ b/examples/claudecode-skills-memanto/memanto_skill_hook/__init__.py
@@ -1,0 +1,52 @@
+"""
+Memanto Skill Hook — Cross-Skill Memory for mattpocock/skills Workflow
+
+This module provides a lightweight integration layer between the
+mattpocock/skills developer workflow and Memanto's persistent memory.
+
+Instead of treating each skill invocation (/grill-with-docs, /tdd, /handoff)
+as an isolated event, the hook:
+
+  1. On skill start: queries Memanto for memories relevant to the current
+     file path or task, and returns them as a context string to inject.
+  2. On skill complete: passes the interaction summary to Memanto so its
+     backend LLM can update the developer's "Engineering Profile".
+
+Usage as a library:
+
+    from memanto_skill_hook import SkillMemory
+
+    mem = SkillMemory()
+
+    # Before running a skill — get relevant context
+    context = mem.on_skill_start(
+        skill_name="/tdd",
+        file_path="src/api/routes.ts",
+        task_description="Write tests for the new user endpoint",
+    )
+    print(context)  # inject into your prompt
+
+    # After running a skill — distill and store learnings
+    mem.on_skill_complete(
+        skill_name="/tdd",
+        summary="Wrote 12 tests using Vitest. Preferred AAA pattern.
+                 Discovered that the auth middleware must be mocked.",
+        file_path="src/api/routes.ts",
+    )
+
+Usage via CLI wrapper (for terminal scripts):
+
+    # Before skill
+    python -m memanto_skill_hook pre --skill /tdd --file src/api/routes.ts \
+        --task "Write tests for the new user endpoint"
+
+    # After skill
+    python -m memanto_skill_hook post --skill /tdd \
+        --file src/api/routes.ts \
+        --summary "Wrote 12 tests using Vitest. Preferred AAA pattern."
+"""
+
+from memanto_skill_hook.memory import SkillMemory
+
+__all__ = ["SkillMemory"]
+__version__ = "0.1.0"

--- a/examples/claudecode-skills-memanto/memanto_skill_hook/__main__.py
+++ b/examples/claudecode-skills-memanto/memanto_skill_hook/__main__.py
@@ -1,0 +1,94 @@
+"""
+CLI entrypoint for memanto-skill-hook.
+
+Lets shell scripts and terminal wrappers call the hook directly:
+
+    # Pre-skill: get memory context to inject into prompt
+    python -m memanto_skill_hook pre --skill /tdd --file src/auth.ts
+
+    # Post-skill: store distilled learnings
+    python -m memanto_skill_hook post --skill /tdd --file src/auth.ts \
+        --summary "Used AAA pattern, vitest, mocked auth middleware"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from memanto_skill_hook.memory import SkillMemory
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="memanto-skill-hook",
+        description="Cross-skill persistent memory for the mattpocock/skills workflow",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    # ---- pre (on_skill_start) ----
+    pre = sub.add_parser(
+        "pre",
+        help="Query Memanto before a skill runs (returns context to inject)",
+    )
+    pre.add_argument("--skill", required=True, help="Skill name, e.g. /tdd")
+    pre.add_argument("--file", default="", help="Target file path")
+    pre.add_argument("--task", default="", help="Task description")
+    pre.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (text for prompt injection, json for scripts)",
+    )
+
+    # ---- post (on_skill_complete) ----
+    post = sub.add_parser(
+        "post",
+        help="Store distilled learnings after a skill completes",
+    )
+    post.add_argument("--skill", required=True, help="Skill name, e.g. /tdd")
+    post.add_argument("--file", default="", help="Target file path")
+    post.add_argument(
+        "--summary", required=True, help="Summary of what the skill produced"
+    )
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    mem = SkillMemory()
+
+    if args.command == "pre":
+        ctx = mem.on_skill_start(
+            skill_name=args.skill,
+            file_path=args.file,
+            task_description=args.task,
+        )
+        if args.format == "json":
+            print(json.dumps({"context": ctx, "has_memories": bool(ctx)}))
+        else:
+            if ctx:
+                print(ctx)
+        return 0
+
+    if args.command == "post":
+        ok = mem.on_skill_complete(
+            skill_name=args.skill,
+            summary=args.summary,
+            file_path=args.file,
+        )
+        if args.format == "json":
+            print(json.dumps({"stored": ok}))
+        else:
+            print("ok" if ok else "failed", file=sys.stderr)
+        return 0 if ok else 1
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/memanto_skill_hook/__main__.py
+++ b/examples/claudecode-skills-memanto/memanto_skill_hook/__main__.py
@@ -52,6 +52,12 @@ def _build_parser() -> argparse.ArgumentParser:
     post.add_argument(
         "--summary", required=True, help="Summary of what the skill produced"
     )
+    post.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (text for humans, json for scripts)",
+    )
 
     return p
 

--- a/examples/claudecode-skills-memanto/memanto_skill_hook/memory.py
+++ b/examples/claudecode-skills-memanto/memanto_skill_hook/memory.py
@@ -49,7 +49,10 @@ class SkillMemoryConfig:
 
     def __post_init__(self) -> None:
         if not self.api_key:
-            self.api_key = os.getenv(f"{_ENV_PREFIX}API_KEY", "")
+            self.api_key = (
+                os.getenv(f"{_ENV_PREFIX}API_KEY")
+                or os.getenv("MOORCHEH_API_KEY", "")
+            )
         if not self.agent_id or self.agent_id == "claudecode-dev":
             self.agent_id = os.getenv(
                 f"{_ENV_PREFIX}AGENT_ID", self.agent_id
@@ -153,7 +156,7 @@ class SkillMemory:
 
             if not self.config.api_key:
                 raise RuntimeError(
-                    "MEMANTO_API_KEY is not set. "
+                    "MEMANTO_API_KEY (or MOORCHEH_API_KEY) is not set. "
                     "Export it or add it to your .env file."
                 )
             self._sdk_client = MoorchehClient(api_key=self.config.api_key)

--- a/examples/claudecode-skills-memanto/memanto_skill_hook/memory.py
+++ b/examples/claudecode-skills-memanto/memanto_skill_hook/memory.py
@@ -1,0 +1,310 @@
+"""
+Core SkillMemory implementation.
+
+Connects to the Memanto REST API (or directly via Moorcheh SDK) to provide
+cross-skill memory for the mattpocock/skills developer workflow.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import requests
+
+logger = logging.getLogger("memanto_skill_hook")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_ENV_PREFIX = "MEMANTO_"
+
+# Try loading .env if python-dotenv is available (optional dep)
+try:
+    from dotenv import load_dotenv
+
+    # Look for .env in cwd, then in the example directory
+    _cwd_env = Path.cwd() / ".env"
+    _example_env = Path(__file__).resolve().parent.parent / ".env"
+    load_dotenv(_cwd_env)
+    load_dotenv(_example_env)
+except ImportError:
+    pass  # dotenv not installed — user must export vars manually
+
+
+@dataclass
+class SkillMemoryConfig:
+    """Runtime configuration resolved from environment / constructor args."""
+
+    api_key: str = ""
+    agent_id: str = "claudecode-dev"
+    memanto_url: str = ""  # empty → use SDK directly
+    context_limit: int = 5
+    auto_distill: bool = True  # let Memanto LLM distill memories
+
+    def __post_init__(self) -> None:
+        if not self.api_key:
+            self.api_key = os.getenv(f"{_ENV_PREFIX}API_KEY", "")
+        if not self.agent_id or self.agent_id == "claudecode-dev":
+            self.agent_id = os.getenv(
+                f"{_ENV_PREFIX}AGENT_ID", self.agent_id
+            )
+        if not self.memanto_url:
+            self.memanto_url = os.getenv(f"{_ENV_PREFIX}URL", "")
+        limit = os.getenv(f"{_ENV_PREFIX}CONTEXT_LIMIT")
+        if limit:
+            self.context_limit = int(limit)
+
+    @property
+    def has_server(self) -> bool:
+        return bool(self.memanto_url)
+
+
+# ---------------------------------------------------------------------------
+# SkillMemory — the public API
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SkillMemory:
+    """Provides persistent cross-skill memory via Memanto.
+
+    Attributes:
+        config: Runtime configuration. Auto-populated from env vars.
+        _sdk_client: Lazy-initialized MoorchehClient (SDK path).
+    """
+
+    config: SkillMemoryConfig = field(default_factory=SkillMemoryConfig)
+    _sdk_client: Any = None
+
+    # ------------------------------------------------------------------
+    # Public lifecycle hooks
+    # ------------------------------------------------------------------
+
+    def on_skill_start(
+        self,
+        *,
+        skill_name: str,
+        file_path: str = "",
+        task_description: str = "",
+    ) -> str:
+        """Query Memanto for context relevant to the upcoming skill.
+
+        Returns a plain-text block to prepend to the skill's system prompt.
+        """
+        query = self._build_recall_query(skill_name, file_path, task_description)
+        try:
+            results = self._recall(query)
+        except Exception as exc:
+            logger.warning("recall failed (%s) — continuing without memory", exc)
+            return ""
+
+        if not results:
+            return ""
+
+        return self._format_context(results, skill_name)
+
+    def on_skill_complete(
+        self,
+        *,
+        skill_name: str,
+        summary: str,
+        file_path: str = "",
+    ) -> bool:
+        """Store distilled learnings from a completed skill execution.
+
+        Returns True on success, False on failure.
+        """
+        content = self._build_memory_content(
+            skill_name, summary, file_path
+        )
+        try:
+            self._remember(
+                title=f"Skill: {skill_name} — {Path(file_path).name or 'general'}",
+                content=content,
+                memory_type="decision",
+                tags=self._infer_tags(skill_name, file_path),
+                source=skill_name.lstrip("/"),
+            )
+            return True
+        except Exception as exc:
+            logger.warning("remember failed: %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # SDK / API helpers
+    # ------------------------------------------------------------------
+
+    def _get_sdk_client(self) -> Any:
+        """Lazy-initialize the Moorcheh SDK client."""
+        if self._sdk_client is None:
+            from moorcheh_sdk import MoorchehClient
+
+            if not self.config.api_key:
+                raise RuntimeError(
+                    "MOORCHEH_API_KEY is not set. "
+                    "Export it or add it to your .env file."
+                )
+            self._sdk_client = MoorchehClient(api_key=self.config.api_key)
+        return self._sdk_client
+
+    def _recall(self, query: str) -> list[dict]:
+        """Semantic search for relevant memories."""
+        if self.config.has_server:
+            return self._recall_via_server(query)
+        return self._recall_via_sdk(query)
+
+    def _recall_via_server(self, query: str) -> list[dict]:
+        url = f"{self.config.memanto_url.rstrip('/')}/api/v2/recall"
+        resp = requests.post(
+            url,
+            json={
+                "agent_id": self.config.agent_id,
+                "query": query,
+                "limit": self.config.context_limit,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("memories", [])
+
+    def _recall_via_sdk(self, query: str) -> list[dict]:
+        client = self._get_sdk_client()
+        result = client.recall(
+            agent_id=self.config.agent_id,
+            query=query,
+            limit=self.config.context_limit,
+        )
+        return result.get("memories", [])
+
+    def _remember(
+        self,
+        *,
+        title: str,
+        content: str,
+        memory_type: str = "decision",
+        tags: list[str] | None = None,
+        source: str = "skill-hook",
+    ) -> dict:
+        """Store a memory."""
+        if self.config.has_server:
+            return self._remember_via_server(
+                title=title,
+                content=content,
+                memory_type=memory_type,
+                tags=tags,
+                source=source,
+            )
+        return self._remember_via_sdk(
+            title=title,
+            content=content,
+            memory_type=memory_type,
+            tags=tags,
+            source=source,
+        )
+
+    def _remember_via_server(self, **kwargs: Any) -> dict:
+        url = f"{self.config.memanto_url.rstrip('/')}/api/v2/remember"
+        resp = requests.post(
+            url,
+            json={
+                "agent_id": self.config.agent_id,
+                **kwargs,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _remember_via_sdk(self, **kwargs: Any) -> dict:
+        client = self._get_sdk_client()
+        return client.remember(
+            agent_id=self.config.agent_id,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Prompt construction helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_recall_query(
+        skill_name: str, file_path: str, task_description: str
+    ) -> str:
+        """Build a natural-language recall query from skill metadata."""
+        parts: list[str] = []
+        if task_description:
+            parts.append(task_description)
+        if file_path:
+            parts.append(f"working in {file_path}")
+        # Add skill-specific context keywords
+        skill_keywords = {
+            "/tdd": "testing strategy test patterns preferences",
+            "/grill-with-docs": "documentation standards API design decisions",
+            "/handoff": "architecture decisions codebase conventions team patterns",
+            "/review": "code review feedback style preferences",
+            "/refactor": "refactoring patterns architectural choices",
+        }
+        if skill_name in skill_keywords:
+            parts.append(skill_keywords[skill_name])
+        if not parts:
+            parts.append(f"developer preferences and past decisions for {skill_name}")
+        return " | ".join(parts)
+
+    @staticmethod
+    def _build_memory_content(
+        skill_name: str, summary: str, file_path: str
+    ) -> str:
+        """Format a skill summary into a storable memory."""
+        sections = [
+            f"## Skill: {skill_name}",
+            f"### File: {file_path}" if file_path else "",
+            "",
+            summary,
+        ]
+        return "\n".join(s for s in sections if s is not None)
+
+    @staticmethod
+    def _format_context(memories: list[dict], skill_name: str) -> str:
+        """Format recalled memories into a context injection block."""
+        if not memories:
+            return ""
+        lines = [
+            f"<memanto-context skill=\"{skill_name}\">",
+            "  <engineering-profile>",
+            "  The following memories from past sessions are relevant:",
+            "",
+        ]
+        for m in memories:
+            mtype = m.get("type", "unknown")
+            title = m.get("title", "untitled")
+            content = m.get("content", "")
+            score = m.get("score", "")
+            score_str = f" (relevance: {score:.2f})" if score else ""
+            lines.append(f"  [{mtype.upper()}] {title}{score_str}")
+            # Truncate very long content
+            if len(content) > 500:
+                content = content[:497] + "..."
+            lines.append(f"    {content}")
+            lines.append("")
+        lines.append("  </engineering-profile>")
+        lines.append("</memanto-context>")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _infer_tags(skill_name: str, file_path: str) -> list[str]:
+        """Infer tags from skill name and file path."""
+        tags = ["skill-hook"]
+        if skill_name:
+            tags.append(skill_name.lstrip("/"))
+        if file_path:
+            ext = Path(file_path).suffix.lstrip(".")
+            if ext:
+                tags.append(f"lang:{ext}")
+        return tags

--- a/examples/claudecode-skills-memanto/memanto_skill_hook/memory.py
+++ b/examples/claudecode-skills-memanto/memanto_skill_hook/memory.py
@@ -58,7 +58,13 @@ class SkillMemoryConfig:
             self.memanto_url = os.getenv(f"{_ENV_PREFIX}URL", "")
         limit = os.getenv(f"{_ENV_PREFIX}CONTEXT_LIMIT")
         if limit:
-            self.context_limit = int(limit)
+            try:
+                self.context_limit = int(limit)
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Invalid MEMANTO_CONTEXT_LIMIT=%r, using default %d",
+                    limit, self.context_limit,
+                )
 
     @property
     def has_server(self) -> bool:
@@ -147,7 +153,7 @@ class SkillMemory:
 
             if not self.config.api_key:
                 raise RuntimeError(
-                    "MOORCHEH_API_KEY is not set. "
+                    "MEMANTO_API_KEY is not set. "
                     "Export it or add it to your .env file."
                 )
             self._sdk_client = MoorchehClient(api_key=self.config.api_key)

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,3 +1,4 @@
 memanto>=0.2.0
 moorcheh-sdk>=0.1.0
 requests>=2.31.0
+python-dotenv>=1.0.0

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,0 +1,3 @@
+memanto>=0.2.0
+moorcheh-sdk>=0.1.0
+requests>=2.31.0

--- a/examples/claudecode-skills-memanto/skill-with-memanto.sh
+++ b/examples/claudecode-skills-memanto/skill-with-memanto.sh
@@ -14,7 +14,7 @@
 #   3. After the skill completes, stores the summary in Memanto
 #
 # Environment variables (export or put in .env):
-#   MOORCHEH_API_KEY   — required
+#   MEMANTO_API_KEY    — required
 #   MEMANTO_AGENT_ID   — default: claudecode-dev
 #   MEMANTO_CONTEXT_LIMIT — default: 5
 # ──────────────────────────────────────────────────────────────────────
@@ -33,7 +33,7 @@ echo "════════════════════════�
 echo ""
 
 # Step 1: Query Memanto for relevant context
-CONTEXT=$(python -m memanto_skill_hook pre \
+CONTEXT=$(cd "$SCRIPT_DIR" && python -m memanto_skill_hook pre \
     --skill "$SKILL" \
     --file "$FILE" \
     --task "$TASK" 2>/dev/null || true)
@@ -55,9 +55,9 @@ echo ""
 read -r -p "Summary: " SUMMARY
 
 if [ -n "$SUMMARY" ]; then
-    python -m memanto_skill_hook post \
+    (cd "$SCRIPT_DIR" && python -m memanto_skill_hook post \
         --skill "$SKILL" \
         --file "$FILE" \
-        --summary "$SUMMARY" 2>/dev/null
+        --summary "$SUMMARY") 2>/dev/null
     echo "✓ Memory stored in Memanto."
 fi

--- a/examples/claudecode-skills-memanto/skill-with-memanto.sh
+++ b/examples/claudecode-skills-memanto/skill-with-memanto.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────
+# skill-with-memanto.sh
+#
+# Drop-in wrapper that adds Memanto persistent memory to any
+# mattpocock/skills invocation.
+#
+# Usage:
+#   ./skill-with-memanto.sh /tdd src/api/users.ts "Write tests for user signup"
+#
+# What happens:
+#   1. Queries Memanto for memories relevant to the file/task
+#   2. Prints the context block (pipe it into your skill prompt)
+#   3. After the skill completes, stores the summary in Memanto
+#
+# Environment variables (export or put in .env):
+#   MOORCHEH_API_KEY   — required
+#   MEMANTO_AGENT_ID   — default: claudecode-dev
+#   MEMANTO_CONTEXT_LIMIT — default: 5
+# ──────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+SKILL="${1:?Usage: $0 <skill-name> [file-path] [task-description]}"
+FILE="${2:-}"
+TASK="${3:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Memanto Cross-Skill Memory — Pre-Skill Context"
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+
+# Step 1: Query Memanto for relevant context
+CONTEXT=$(python -m memanto_skill_hook pre \
+    --skill "$SKILL" \
+    --file "$FILE" \
+    --task "$TASK" 2>/dev/null || true)
+
+if [ -n "$CONTEXT" ]; then
+    echo "$CONTEXT"
+    echo ""
+    echo "───────────────────────────────────────────────────────────────"
+    echo "  ↑ Inject the above into your skill's system prompt."
+    echo "───────────────────────────────────────────────────────────────"
+else
+    echo "(No relevant memories found — starting fresh.)"
+fi
+
+echo ""
+echo "Now run your skill. When done, paste a one-line summary below."
+echo "Or press Ctrl+C to skip storing."
+echo ""
+read -r -p "Summary: " SUMMARY
+
+if [ -n "$SUMMARY" ]; then
+    python -m memanto_skill_hook post \
+        --skill "$SKILL" \
+        --file "$FILE" \
+        --summary "$SUMMARY" 2>/dev/null
+    echo "✓ Memory stored in Memanto."
+fi

--- a/examples/claudecode-skills-memanto/skill-with-memanto.sh
+++ b/examples/claudecode-skills-memanto/skill-with-memanto.sh
@@ -26,6 +26,7 @@ FILE="${2:-}"
 TASK="${3:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
 
 echo "═══════════════════════════════════════════════════════════════"
 echo "  Memanto Cross-Skill Memory — Pre-Skill Context"


### PR DESCRIPTION
## Summary

Implements a cross-skill memory layer that eliminates **context fragmentation** in the mattpocock/skills developer workflow. Memanto acts as a persistent memory companion across `/tdd`, `/grill-with-docs`, `/handoff`, and other skills.

**Fixes #508**

## What This Solves

When you use different skills across terminal sessions, vital context (architectural choices, testing preferences, codebase conventions) is lost. This integration makes Memanto the shared memory layer so skills automatically inherit past decisions.

## Implementation

### Components

| File | Purpose |
|------|---------|
| `memanto_skill_hook/memory.py` | Core `SkillMemory` class — recall + remember lifecycle |
| `memanto_skill_hook/__main__.py` | CLI: `pre` / `post` commands for shell integration |
| `claude_code_hook.py` | Claude Code `PreToolUse` / `PostToolUse` hooks |
| `skill-with-memanto.sh` | Interactive shell wrapper for any skill |
| `demo_cross_session.py` | End-to-end demo proving cross-session persistence |

### Addresses the Three Guidelines

1. **Global Memory Hook** ✅ — `SkillMemory` auto-initializes with Moorcheh credentials from env
2. **Active Extraction** ✅ — `on_skill_complete()` passes interaction summaries to Memanto's backend LLM, which distills and stores the developer's "Engineering Profile"  
3. **Dynamic Injection** ✅ — `on_skill_start()` queries Memanto for memories relevant to the current file path/task and returns them as XML-formatted context to prepend to the skill prompt

### Usage

```python
from memanto_skill_hook import SkillMemory

mem = SkillMemory()

# Before skill: inject past context
context = mem.on_skill_start(skill_name="/tdd", file_path="src/auth.ts")

# After skill: store learnings
mem.on_skill_complete(skill_name="/tdd", summary="Used Vitest + AAA pattern", file_path="src/auth.ts")
```

## PR Checklist

- [x] Implementation in `examples/claudecode-skills-memanto/`
- [x] README with architecture diagram, setup, and usage
- [x] Demo script proving cross-session persistence
- [x] CLI, Python API, shell wrapper, and Claude Code hooks integration
- [x] Follows existing example patterns (crewai-memory, langgraph-memanto)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Memanto cross-skill memory example with Claude Code hook support, CLI entrypoints, a shell wrapper, and demo scripts to persist and recall context across skill runs.
  * Included environment example and package entrypoint with versioning.

* **Documentation**
  * Added a comprehensive README covering setup, usage (CLI, Python API, shell), architecture, quick-start, and example workflows.

* **Chores**
  * Added example requirements for the demo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->