### PR TITLE
feat: add claudecode-skills-memanto integration example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,100 @@
+# Memanto + Claude Code Skills: Active Memory Companion
+
+This example demonstrates how to integrate **Memanto** as a global, active memory companion inside the **Claude Code** (or `mattpocock/skills`) developer workflow. 
+
+By wrapping your developer skills (like `/tdd` or `/grill-with-docs`) in Memanto hooks, you completely eliminate **Context Fragmentation**. Your coding agent remembers design choices, styling preferences, and domain guidelines across separate CLI sessions without having to ask the user repeatedly.
+
+---
+
+## 🐜 The Problem: Context Fragmentation
+
+In agentic coding tools like Claude Code, each terminal session and slash command execution is treated as an isolated event:
+* If you run `/grill-with-docs` to define a database schema, that context is lost when you invoke `/tdd` in a fresh terminal session.
+* The agent has to ask you the same architectural questions over and over, wasting tokens and time.
+
+---
+
+## 🧠 The Solution: Active Memory Hooks
+
+This integration injects a lightweight memory hook at the start and end of the skill's execution lifecycle:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    Developer->>Claude Code: Run /tdd <task>
+    Note over Claude Code: Skill Starts
+    Claude Code->>Memanto: python skills_hook.py start (Query task preferences)
+    Memanto-->>Claude Code: Load relevant engineering constraints/rules
+    Note over Claude Code: Execute test-driven cycle following constraints
+    Claude Code->>Developer: Feature completed & tests pass
+    Note over Claude Code: Skill Completes
+    Claude Code->>Memanto: python skills_hook.py end (Save decisions & learnings)
+    Memanto-->>Developer: Memory persisted in developer profile
+```
+
+1. **At Skill Startup (Dynamic Injection):** The skill automatically runs the `skills_hook.py start` script. Memanto retrieves relevant past memories matching the task and injects them as active constraints in the agent's prompt context.
+2. **At Skill Completion (Active Ingestion):** The skill runs `skills_hook.py end`, generating a concise summary of the decisions, design choices, and developer preferences learned during this session, saving it back to Memanto for the next call.
+
+---
+
+## 🛠️ Project Structure
+
+```
+claudecode-skills-memanto/
+├── README.md               # This documentation
+├── requirements.txt       # Dependencies (memanto, pydantic)
+├── skills_hook.py          # The Python CLI Hook (Start/End commands)
+└── skills/                 # Updated Claude Code skill templates
+    ├── tdd/
+    │   └── SKILL.md        # TDD skill template with Memanto hooks
+    └── grill-with-docs/
+        └── SKILL.md        # Interview skill template with Memanto hooks
+```
+
+---
+
+## 🚀 Getting Started
+
+### 1. Prerequisites
+
+First, ensure you have a Moorcheh API key. You can get one for free at [moorcheh.ai](https://moorcheh.ai/).
+
+Configure the key in your terminal session:
+```bash
+export MOORCHEH_API_KEY="your-moorcheh-api-key-here"
+```
+
+### 2. Install Dependencies
+
+Install the required Python packages:
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Deploy the Skills
+
+Copy the customized skills from the `skills/` directory into your project's local Claude config folder:
+```bash
+mkdir -p .claude/skills
+cp -r skills/* .claude/skills/
+```
+
+---
+
+## 📖 Hook CLI Reference
+
+The helper script `skills_hook.py` exposes two commands that orchestrate active memory:
+
+### 1. Start Hook (Inject Memories)
+Queries Memanto for context relevant to the incoming task:
+```bash
+python skills_hook.py start --skill <skill-name> --task "<task-description>"
+```
+*   **Result:** Fetches up to 5 matching memory items and outputs them formatted as a clean markdown block. Claude Code will consume this block to ground its actions.
+
+### 2. End Hook (Remember Learnings)
+Saves engineering choices and user corrections to the profile:
+```bash
+python skills_hook.py end --skill <skill-name> --summary "<learnings-and-decisions>"
+```
+*   **Result:** Analyzes the summary content, dynamically categorizes it (e.g. `preference`, `decision`, `learning`), and stores it in the active session database instantly.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -79,6 +79,21 @@ mkdir -p .claude/skills
 cp -r skills/* .claude/skills/
 ```
 
+### 4. Deploy the Hook Script
+
+The skill templates in `.claude/skills/` reference `skills_hook.py` using the path
+`examples/claudecode-skills-memanto/skills_hook.py`. You need to copy the hook script
+so that path resolves correctly from your **project root**:
+
+```bash
+mkdir -p examples/claudecode-skills-memanto
+cp skills_hook.py examples/claudecode-skills-memanto/skills_hook.py
+```
+
+> **Tip:** If you prefer to keep `skills_hook.py` at the project root and call it directly,
+> update the hook commands inside your `.claude/skills/*/SKILL.md` files to use
+> `python skills_hook.py` instead of the full relative path.
+
 ---
 
 ## 📖 Hook CLI Reference

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -23,17 +23,17 @@ sequenceDiagram
     autonumber
     Developer->>Claude Code: Run /tdd <task>
     Note over Claude Code: Skill Starts
-    Claude Code->>Memanto: python skills_hook.py start (Query task preferences)
+    Claude Code->>Memanto: python examples/claudecode-skills-memanto/skills_hook.py start (Query task preferences)
     Memanto-->>Claude Code: Load relevant engineering constraints/rules
     Note over Claude Code: Execute test-driven cycle following constraints
     Claude Code->>Developer: Feature completed & tests pass
     Note over Claude Code: Skill Completes
-    Claude Code->>Memanto: python skills_hook.py end (Save decisions & learnings)
+    Claude Code->>Memanto: python examples/claudecode-skills-memanto/skills_hook.py end (Save decisions & learnings)
     Memanto-->>Developer: Memory persisted in developer profile
 ```
 
-1. **At Skill Startup (Dynamic Injection):** The skill automatically runs the `skills_hook.py start` script. Memanto retrieves relevant past memories matching the task and injects them as active constraints in the agent's prompt context.
-2. **At Skill Completion (Active Ingestion):** The skill runs `skills_hook.py end`, generating a concise summary of the decisions, design choices, and developer preferences learned during this session, saving it back to Memanto for the next call.
+1. **At Skill Startup (Dynamic Injection):** The skill automatically runs `examples/claudecode-skills-memanto/skills_hook.py start`. Memanto retrieves relevant past memories matching the task and injects them as active constraints in the agent's prompt context.
+2. **At Skill Completion (Active Ingestion):** The skill runs `examples/claudecode-skills-memanto/skills_hook.py end`, generating a concise summary of the decisions, design choices, and developer preferences learned during this session, saving it back to Memanto for the next call.
 
 ---
 
@@ -98,18 +98,21 @@ cp skills_hook.py examples/claudecode-skills-memanto/skills_hook.py
 
 ## 📖 Hook CLI Reference
 
-The helper script `skills_hook.py` exposes two commands that orchestrate active memory:
+The helper script exposes two commands that orchestrate active memory.
+All commands below assume they are run from your **project root**, where
+`examples/claudecode-skills-memanto/skills_hook.py` is the canonical path
+(matching what the deployed SKILL.md templates invoke automatically).
 
 ### 1. Start Hook (Inject Memories)
 Queries Memanto for context relevant to the incoming task:
 ```bash
-python skills_hook.py start --skill <skill-name> --task "<task-description>"
+python examples/claudecode-skills-memanto/skills_hook.py start --skill <skill-name> --task "<task-description>"
 ```
 *   **Result:** Fetches up to 5 matching memory items and outputs them formatted as a clean markdown block. Claude Code will consume this block to ground its actions.
 
 ### 2. End Hook (Remember Learnings)
 Saves engineering choices and user corrections to the profile:
 ```bash
-python skills_hook.py end --skill <skill-name> --summary "<learnings-and-decisions>"
+python examples/claudecode-skills-memanto/skills_hook.py end --skill <skill-name> --summary "<learnings-and-decisions>"
 ```
 *   **Result:** Analyzes the summary content, dynamically categorizes it (e.g. `preference`, `decision`, `learning`), and stores it in the active session database instantly.

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,0 +1,3 @@
+memanto
+pydantic>=2.0
+moorcheh-sdk

--- a/examples/claudecode-skills-memanto/skills/grill-with-docs/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/grill-with-docs/SKILL.md
@@ -9,6 +9,10 @@ You must follow these steps strictly when interviewing the developer:
 
 ## Phase 1: Context Injection (Session Start Hook)
 Before starting the interview:
+> **Note:** The command below uses a path relative to your **project root** (not this skill file's
+> location). Make sure you have completed **Step 4** of the setup in
+> `examples/claudecode-skills-memanto/README.md` so that
+> `examples/claudecode-skills-memanto/skills_hook.py` exists at your project root.
 1. Run the Memanto startup hook command to retrieve past architectural rules, project structures, and developer constraints:
    ```bash
    python examples/claudecode-skills-memanto/skills_hook.py start --skill grill-with-docs --task "$ARGUMENTS"

--- a/examples/claudecode-skills-memanto/skills/grill-with-docs/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: grill-with-docs
+description: Interview the developer to capture project context, requirements, and domain preferences. Integrates with Memanto memory hooks to skip redundant questions and save newly acquired domain details.
+---
+
+# Grill-with-Docs Skill with Memanto Memory Connection
+
+You must follow these steps strictly when interviewing the developer:
+
+## Phase 1: Context Injection (Session Start Hook)
+Before starting the interview:
+1. Run the Memanto startup hook command to retrieve past architectural rules, project structures, and developer constraints:
+   ```bash
+   python examples/claudecode-skills-memanto/skills_hook.py start --skill grill-with-docs --task "$ARGUMENTS"
+   ```
+2. Read the outputted memories. Review what you already know about the project (e.g. databases used, frontend frameworks, naming conventions). **Do not ask the developer any questions about these already established facts.**
+
+## Phase 2: Targeted Interview
+Interview the developer to clarify only the new details or un-documented requirements for the task:
+1. Ask sharp, direct questions.
+2. Ground your questions in the existing project documents (`README.md`, `ARCHITECTURE.md`) and the memories injected in Phase 1.
+
+## Phase 3: Active Ingestion (Session End Hook)
+Once the developer provides the answers and you finalize the design:
+1. Compose a detailed summary of the newly learned project context, framework selections, and structural decisions. Example:
+   *"Project uses Docker for development. Backend relies on FastAPI. Port 8080 is reserved. Code must use snake_case for fields."*
+2. Run the Memanto end hook command to record these facts:
+   ```bash
+   python examples/claudecode-skills-memanto/skills_hook.py end --skill grill-with-docs --summary "<your summary description here>"
+   ```

--- a/examples/claudecode-skills-memanto/skills/grill-with-docs/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/grill-with-docs/SKILL.md
@@ -9,13 +9,9 @@ You must follow these steps strictly when interviewing the developer:
 
 ## Phase 1: Context Injection (Session Start Hook)
 Before starting the interview:
-> **Note:** The command below uses a path relative to your **project root** (not this skill file's
-> location). Make sure you have completed **Step 4** of the setup in
-> `examples/claudecode-skills-memanto/README.md` so that
-> `examples/claudecode-skills-memanto/skills_hook.py` exists at your project root.
 1. Run the Memanto startup hook command to retrieve past architectural rules, project structures, and developer constraints:
    ```bash
-   python examples/claudecode-skills-memanto/skills_hook.py start --skill grill-with-docs --task "$ARGUMENTS"
+   python skills_hook.py start --skill grill-with-docs --task "$ARGUMENTS"
    ```
 2. Read the outputted memories. Review what you already know about the project (e.g. databases used, frontend frameworks, naming conventions). **Do not ask the developer any questions about these already established facts.**
 
@@ -29,8 +25,6 @@ Once the developer provides the answers and you finalize the design:
 1. Compose a detailed summary of the newly learned project context, framework selections, and structural decisions. Example:
    *"Project uses Docker for development. Backend relies on FastAPI. Port 8080 is reserved. Code must use snake_case for fields."*
 2. Run the Memanto end hook command to record these facts:
-> **Note:** Same as Phase 1 — this path is relative to your **project root**.
-> Ensure **Step 4** of the README setup is complete before running this command.
    ```bash
-   python examples/claudecode-skills-memanto/skills_hook.py end --skill grill-with-docs --summary "<your summary description here>"
+   python skills_hook.py end --skill grill-with-docs --summary "<your summary description here>"
    ```

--- a/examples/claudecode-skills-memanto/skills/grill-with-docs/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/grill-with-docs/SKILL.md
@@ -29,6 +29,8 @@ Once the developer provides the answers and you finalize the design:
 1. Compose a detailed summary of the newly learned project context, framework selections, and structural decisions. Example:
    *"Project uses Docker for development. Backend relies on FastAPI. Port 8080 is reserved. Code must use snake_case for fields."*
 2. Run the Memanto end hook command to record these facts:
+> **Note:** Same as Phase 1 — this path is relative to your **project root**.
+> Ensure **Step 4** of the README setup is complete before running this command.
    ```bash
    python examples/claudecode-skills-memanto/skills_hook.py end --skill grill-with-docs --summary "<your summary description here>"
    ```

--- a/examples/claudecode-skills-memanto/skills/tdd/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/tdd/SKILL.md
@@ -9,6 +9,10 @@ You must follow these steps strictly whenever this skill is invoked:
 
 ## Phase 1: Context Injection (Session Start Hook)
 Before making any changes to the codebase:
+> **Note:** The command below uses a path relative to your **project root** (not this skill file's
+> location). Make sure you have completed **Step 4** of the setup in
+> `examples/claudecode-skills-memanto/README.md` so that
+> `examples/claudecode-skills-memanto/skills_hook.py` exists at your project root.
 1. Run the Memanto startup hook command to retrieve existing guidelines, developer preferences, and design decisions relevant to the task:
    ```bash
    python examples/claudecode-skills-memanto/skills_hook.py start --skill tdd --task "$ARGUMENTS"

--- a/examples/claudecode-skills-memanto/skills/tdd/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/tdd/SKILL.md
@@ -30,6 +30,8 @@ Once the task is successfully implemented and verified:
 1. Compose a concise summary of the engineering choices, preferences, or rules established during this cycle. Example:
    *"Decided to use standard logging instead of prints. Noticed the user prefers async/await pattern for API fetches."*
 2. Run the Memanto end hook command to record these outcomes for future terminal sessions:
+> **Note:** Same as Phase 1 — this path is relative to your **project root**.
+> Ensure **Step 4** of the README setup is complete before running this command.
    ```bash
    python examples/claudecode-skills-memanto/skills_hook.py end --skill tdd --summary "<your summary description here>"
    ```

--- a/examples/claudecode-skills-memanto/skills/tdd/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/tdd/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: tdd
+description: Enforce Test-Driven Development (TDD) cycle by writing tests first, verifying failure, coding, and refactoring. Connects to Memanto at startup to load past context and at completion to persist learned preferences.
+---
+
+# TDD Skill with Memanto Memory Connection
+
+You must follow these steps strictly whenever this skill is invoked:
+
+## Phase 1: Context Injection (Session Start Hook)
+Before making any changes to the codebase:
+1. Run the Memanto startup hook command to retrieve existing guidelines, developer preferences, and design decisions relevant to the task:
+   ```bash
+   python examples/claudecode-skills-memanto/skills_hook.py start --skill tdd --task "$ARGUMENTS"
+   ```
+2. Read the command output. Under `🧠 MEMANTO ACTIVE SYSTEM CONSTRAINTS`, you will find list of memories (e.g. styling preferences, architectural rules). You **MUST** strictly adhere to these guidelines.
+
+## Phase 2: Red-Green-Refactor Cycle
+Implement the feature or fix using strict TDD discipline:
+1. **Red**: Write a minimal failing unit test for the desired behavior. Do NOT touch production code yet. Run tests to verify they fail.
+2. **Green**: Write the minimum amount of production code required to make the test pass. Run tests to verify they pass.
+3. **Refactor**: Clean up the code, maintain formatting standards, and verify tests still pass.
+
+## Phase 3: Active Ingestion (Session End Hook)
+Once the task is successfully implemented and verified:
+1. Compose a concise summary of the engineering choices, preferences, or rules established during this cycle. Example:
+   *"Decided to use standard logging instead of prints. Noticed the user prefers async/await pattern for API fetches."*
+2. Run the Memanto end hook command to record these outcomes for future terminal sessions:
+   ```bash
+   python examples/claudecode-skills-memanto/skills_hook.py end --skill tdd --summary "<your summary description here>"
+   ```

--- a/examples/claudecode-skills-memanto/skills/tdd/SKILL.md
+++ b/examples/claudecode-skills-memanto/skills/tdd/SKILL.md
@@ -9,13 +9,9 @@ You must follow these steps strictly whenever this skill is invoked:
 
 ## Phase 1: Context Injection (Session Start Hook)
 Before making any changes to the codebase:
-> **Note:** The command below uses a path relative to your **project root** (not this skill file's
-> location). Make sure you have completed **Step 4** of the setup in
-> `examples/claudecode-skills-memanto/README.md` so that
-> `examples/claudecode-skills-memanto/skills_hook.py` exists at your project root.
 1. Run the Memanto startup hook command to retrieve existing guidelines, developer preferences, and design decisions relevant to the task:
    ```bash
-   python examples/claudecode-skills-memanto/skills_hook.py start --skill tdd --task "$ARGUMENTS"
+   python skills_hook.py start --skill tdd --task "$ARGUMENTS"
    ```
 2. Read the command output. Under `🧠 MEMANTO ACTIVE SYSTEM CONSTRAINTS`, you will find list of memories (e.g. styling preferences, architectural rules). You **MUST** strictly adhere to these guidelines.
 
@@ -30,8 +26,6 @@ Once the task is successfully implemented and verified:
 1. Compose a concise summary of the engineering choices, preferences, or rules established during this cycle. Example:
    *"Decided to use standard logging instead of prints. Noticed the user prefers async/await pattern for API fetches."*
 2. Run the Memanto end hook command to record these outcomes for future terminal sessions:
-> **Note:** Same as Phase 1 — this path is relative to your **project root**.
-> Ensure **Step 4** of the README setup is complete before running this command.
    ```bash
-   python examples/claudecode-skills-memanto/skills_hook.py end --skill tdd --summary "<your summary description here>"
+   python skills_hook.py end --skill tdd --summary "<your summary description here>"
    ```

--- a/examples/claudecode-skills-memanto/skills_hook.py
+++ b/examples/claudecode-skills-memanto/skills_hook.py
@@ -20,13 +20,8 @@ try:
     from memanto.cli.client.sdk_client import SdkClient
     from memanto.app.utils.errors import AgentNotFoundError
 except ImportError:
-    # Fallback if python path doesn't resolve repo root directly
-    try:
-        from memanto.cli.client.sdk_client import SdkClient
-        from memanto.app.utils.errors import AgentNotFoundError
-    except ImportError:
-        print("[MEMANTO ERROR] SDK not found. Make sure the script is run inside the memanto workspace or 'memanto' is installed.")
-        sys.exit(1)
+    print("[MEMANTO ERROR] SDK not found. Make sure the script is run inside the memanto workspace or 'memanto' is installed.")
+    sys.exit(1)
 
 
 def get_client():

--- a/examples/claudecode-skills-memanto/skills_hook.py
+++ b/examples/claudecode-skills-memanto/skills_hook.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Memanto Integration Hook for Claude Code Skills
+Enables cross-skill active memory retrieval and storage.
+"""
+
+import os
+import sys
+import argparse
+from datetime import datetime
+
+# Add the parent directory of 'memanto' package to path to make sure we can import it
+# even if it's not installed in system site-packages yet.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.abspath(os.path.join(current_dir, "..", ".."))
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+try:
+    from memanto.cli.client.sdk_client import SdkClient
+    from memanto.app.utils.errors import AgentNotFoundError
+except ImportError:
+    # Fallback if python path doesn't resolve repo root directly
+    try:
+        from memanto.cli.client.sdk_client import SdkClient
+        from memanto.app.utils.errors import AgentNotFoundError
+    except ImportError:
+        print("[MEMANTO ERROR] SDK not found. Make sure the script is run inside the memanto workspace or 'memanto' is installed.")
+        sys.exit(1)
+
+
+def get_client():
+    api_key = os.environ.get("MOORCHEH_API_KEY")
+    if not api_key:
+        print("[MEMANTO WARNING] MOORCHEH_API_KEY environment variable is not set.")
+        print("                  Active memory companion will be bypassed. Setup your key at https://moorcheh.ai/")
+        return None
+    try:
+        return SdkClient(api_key=api_key)
+    except Exception as e:
+        print(f"[MEMANTO ERROR] Failed to initialize Memanto client: {e}")
+        return None
+
+
+def ensure_agent(client, agent_id):
+    try:
+        client.get_agent(agent_id)
+    except AgentNotFoundError:
+        print(f"[MEMANTO] Agent '{agent_id}' does not exist. Creating default developer profile...")
+        try:
+            client.create_agent(
+                agent_id=agent_id,
+                pattern="tool",
+                description="Global active memory agent for developer skills."
+            )
+            print(f"[MEMANTO] Created agent '{agent_id}' successfully.")
+        except Exception as e:
+            print(f"[MEMANTO ERROR] Failed to create agent '{agent_id}': {e}")
+            sys.exit(1)
+
+
+def handle_start(args):
+    client = get_client()
+    if not client:
+        return
+
+    agent_id = args.agent_id or "claudecode-developer"
+    ensure_agent(client, agent_id)
+
+    # Activate session
+    try:
+        client.activate_agent(agent_id)
+    except Exception as e:
+        print(f"[MEMANTO ERROR] Failed to activate agent session: {e}")
+        return
+
+    print(f"\n[MEMANTO] Querying active memory for task: '{args.task}' (Skill: {args.skill})...")
+
+    # Construct the query combining the skill context and the task
+    query = f"Engineering preferences, guidelines, architecture choices, coding conventions, or past decisions related to {args.task} and skill {args.skill}"
+    
+    try:
+        recall_result = client.recall(
+            agent_id=agent_id,
+            query=query,
+            limit=5
+        )
+        memories = recall_result.get("memories", [])
+
+        if not memories:
+            print("[MEMANTO] No existing relevant memories found for this task.")
+            return
+
+        print("\n========================================================")
+        print("🧠 MEMANTO ACTIVE SYSTEM CONSTRAINTS (INJECTED CONTEXT)")
+        print("========================================================")
+        print("Based on your past work, please adhere to these guidelines:")
+        for idx, mem in enumerate(memories, 1):
+            mtype = mem.get("type", "fact")
+            content = mem.get("content", "")
+            confidence = mem.get("confidence", 1.0)
+            print(f"  {idx}. [{mtype.upper()} - Conf: {confidence}] {content}")
+        print("========================================================\n")
+    except Exception as e:
+        print(f"[MEMANTO ERROR] Failed to retrieve memories: {e}")
+
+
+def handle_end(args):
+    client = get_client()
+    if not client:
+        return
+
+    agent_id = args.agent_id or "claudecode-developer"
+    
+    # Check if active session exists or activate
+    try:
+        client.activate_agent(agent_id)
+    except Exception as e:
+        print(f"[MEMANTO ERROR] Failed to activate agent session: {e}")
+        return
+
+    print(f"\n[MEMANTO] Extracted engineering patterns from skill '{args.skill}'. Storing to memory profile...")
+
+    summary_text = args.summary.strip()
+    if not summary_text:
+        print("[MEMANTO WARNING] Empty summary passed. Skipping memory capture.")
+        return
+
+    try:
+        # Save a general decision/learning memory
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        title = f"Skill {args.skill} completion on {timestamp}"
+        
+        # We classify memory_type dynamically or default to 'decision'
+        # If the summary mentions "preference", we use preference, otherwise decision
+        mtype = "decision"
+        if "prefer" in summary_text.lower() or "like" in summary_text.lower():
+            mtype = "preference"
+        elif "learn" in summary_text.lower() or "find out" in summary_text.lower():
+            mtype = "learning"
+
+        result = client.remember(
+            agent_id=agent_id,
+            memory_type=mtype,
+            title=title,
+            content=summary_text,
+            confidence=0.95,
+            provenance="inferred",
+            source="claude_code",
+            tags=["claudecode", args.skill, "interactive-session"]
+        )
+        
+        print(f"[MEMANTO] Captured new {mtype} memory successfully. (ID: {result.get('memory_id')})")
+    except Exception as e:
+        print(f"[MEMANTO ERROR] Failed to store memory: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Memanto Integration Hook for Claude Code Developer Skills")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Start command parser
+    start_parser = subparsers.add_parser("start", help="Retrieve relevant memories at skill startup")
+    start_parser.add_argument("--skill", required=True, help="Name of the skill being executed")
+    start_parser.add_argument("--task", required=True, help="The description of the task")
+    start_parser.add_argument("--agent-id", help="Custom Memanto agent ID")
+
+    # End command parser
+    end_parser = subparsers.add_parser("end", help="Persist architectural outcomes and preferences at skill completion")
+    end_parser.add_argument("--skill", required=True, help="Name of the skill that completed")
+    end_parser.add_argument("--summary", required=True, help="Summary of decisions, preferences or patterns to save")
+    end_parser.add_argument("--agent-id", help="Custom Memanto agent ID")
+
+    args = parser.parse_args()
+
+    if args.command == "start":
+        handle_start(args)
+    elif args.command == "end":
+        handle_end(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/claudecode-skills-memanto/skills_hook.py
+++ b/examples/claudecode-skills-memanto/skills_hook.py
@@ -125,14 +125,18 @@ def handle_end(args):
         # Save a general decision/learning memory
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         title = f"Skill {args.skill} completion on {timestamp}"
-        
-        # We classify memory_type dynamically or default to 'decision'
-        # If the summary mentions "preference", we use preference, otherwise decision
-        mtype = "decision"
-        if "prefer" in summary_text.lower() or "like" in summary_text.lower():
+        # Use explicitly provided type if given; otherwise infer from summary keywords.
+        # Known limitation: keyword inference is approximate — e.g. "I learned to prefer X"
+        # will match "prefer" and be stored as "preference" instead of "learning".
+        # Pass --memory-type to the CLI to override when the inferred type is wrong.
+        if args.memory_type:
+            mtype = args.memory_type
+        elif "prefer" in summary_text.lower() or "like" in summary_text.lower():
             mtype = "preference"
         elif "learn" in summary_text.lower() or "find out" in summary_text.lower():
             mtype = "learning"
+        else:
+            mtype = "decision"
 
         result = client.remember(
             agent_id=agent_id,
@@ -165,6 +169,12 @@ def main():
     end_parser.add_argument("--skill", required=True, help="Name of the skill that completed")
     end_parser.add_argument("--summary", required=True, help="Summary of decisions, preferences or patterns to save")
     end_parser.add_argument("--agent-id", help="Custom Memanto agent ID")
+    end_parser.add_argument(
+        "--memory-type",
+        choices=["decision", "preference", "learning"],
+        default=None,
+        help="Explicit memory type to store (default: inferred from summary keywords)"
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memanto active-memory integration for Claude Code developer skills with start/end lifecycle hooks and a CLI to inject and record session memories.
  * Two skill workflows: "grill-with-docs" (requirements-focused) and "tdd" (test-driven workflow).

* **Documentation**
  * Comprehensive example README and skill guides with setup, usage, sequence diagram, project layout, and CLI reference.

* **Chores**
  * Example environment now declares required packages for the Memanto integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->