### PR TITLE
Add Claude Code skills + Memanto integration example

### DIFF
--- a/examples/claudecode-skills-memanto/.claude/settings.json
+++ b/examples/claudecode-skills-memanto/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py hook-inject",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py hook-capture --dry-run-output .memanto/skill-candidates.jsonl",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/claudecode-skills-memanto/.claude/settings.json
+++ b/examples/claudecode-skills-memanto/.claude/settings.json
@@ -1,8 +1,8 @@
 {
   "hooks": {
-    "UserPromptSubmit": [
+    "UserPromptExpansion": [
       {
-        "matcher": "",
+        "matcher": "^[a-z][a-z0-9-]*$",
         "hooks": [
           {
             "type": "command",

--- a/examples/claudecode-skills-memanto/.claude/skills/memanto-skill-companion/SKILL.md
+++ b/examples/claudecode-skills-memanto/.claude/skills/memanto-skill-companion/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: memanto-skill-companion
+description: Use when running Claude Code slash skills that should preserve decisions, preferences, project facts, or lessons across future skill executions.
+---
+
+# MEMANTO Skill Companion
+
+MEMANTO should sit around slash-skill work, not inside one isolated command.
+Before executing a skill, read the injected `<memanto-skill-context>` block and
+apply those memories as prior engineering context. After the skill finishes,
+make important outcomes explicit in the transcript so the stop hook can capture
+them.
+
+## Memory-Friendly Transcript Markers
+
+Use these labels for durable outcomes:
+
+| Marker | MEMANTO type |
+| --- | --- |
+| `Decision:` | `decision` |
+| `User preference:` | `preference` |
+| `Codebase fact:` | `fact` |
+
+## Example
+
+```text
+Decision: keep token refresh inside the auth service because it owns retry policy.
+User preference: prefer concise error messages in UI copy.
+Codebase fact: API routes live under src/server/routes and use zod schemas.
+```
+
+Only label durable engineering context. Do not label routine progress updates,
+scratch thoughts, or facts that will be stale by the next session.

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -62,6 +62,8 @@ For the checked-in Claude Code hook, `UserPromptExpansion` uses a slash-command
 matcher so recall only runs for skill-like commands. The `Stop` hook does not
 support matchers in Claude Code, so capture stays dry-run by default and should
 only be switched to `--commit` after inspecting `.memanto/skill-candidates.jsonl`.
+`UserPromptSubmit` is intentionally not configured for recall because it cannot
+be filtered by slash command name and would spawn the bridge for every prompt.
 
 ## Live MEMANTO Mode
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -4,8 +4,8 @@ This example wires MEMANTO into the `mattpocock/skills` style of Claude Code
 slash-skill workflows. It turns MEMANTO into an active memory companion around
 skill execution:
 
-1. `UserPromptSubmit` recalls relevant prior engineering context when a prompt
-   invokes a slash skill such as `/grill-with-docs`, `/tdd`, or `/handoff`.
+1. `UserPromptExpansion` recalls relevant prior engineering context when a
+   slash skill such as `/grill-with-docs`, `/tdd`, or `/handoff` expands.
 2. Claude Code receives a `<memanto-skill-context>` block before the skill runs.
 3. `Stop` reads the transcript after the run and captures high-signal decisions,
    preferences, and codebase facts back into MEMANTO.
@@ -52,11 +52,16 @@ python examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py \
 Inject those memories into a later slash-skill prompt:
 
 ```bash
-echo '{"hook_event_name":"UserPromptSubmit","prompt":"/tdd implement auth retry tests"}' \
+echo '{"hook_event_name":"UserPromptExpansion","command_name":"tdd","command_args":"implement auth retry tests"}' \
   | python examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py \
       hook-inject \
       --memories .memanto/skill-candidates.jsonl
 ```
+
+For the checked-in Claude Code hook, `UserPromptExpansion` uses a slash-command
+matcher so recall only runs for skill-like commands. The `Stop` hook does not
+support matchers in Claude Code, so capture stays dry-run by default and should
+only be switched to `--commit` after inspecting `.memanto/skill-candidates.jsonl`.
 
 ## Live MEMANTO Mode
 

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,77 @@
+# Claude Code Skills + MEMANTO
+
+This example wires MEMANTO into the `mattpocock/skills` style of Claude Code
+slash-skill workflows. It turns MEMANTO into an active memory companion around
+skill execution:
+
+1. `UserPromptSubmit` recalls relevant prior engineering context when a prompt
+   invokes a slash skill such as `/grill-with-docs`, `/tdd`, or `/handoff`.
+2. Claude Code receives a `<memanto-skill-context>` block before the skill runs.
+3. `Stop` reads the transcript after the run and captures high-signal decisions,
+   preferences, and codebase facts back into MEMANTO.
+
+The bridge is dependency-free and has a dry-run path, so it can be tested without
+a Moorcheh API key. When `memanto` is configured, pass `--commit` on capture to
+store memories through the normal CLI.
+
+## Layout
+
+```text
+examples/claudecode-skills-memanto/
+  .claude/settings.json
+  .claude/skills/memanto-skill-companion/SKILL.md
+  claudecode_skills_memanto/bridge.py
+  tests/test_bridge.py
+```
+
+## Install
+
+Copy the example into the root of a Claude Code project that already uses
+slash skills.
+
+```bash
+cp -R examples/claudecode-skills-memanto/.claude .
+```
+
+Then adjust the `python examples/claudecode-skills-memanto/...` paths in
+`.claude/settings.json` if your copy lives somewhere else.
+
+## Dry Run
+
+Capture candidate memories from a transcript:
+
+```bash
+python examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py \
+  capture \
+  --transcript ~/.claude/projects/example/transcript.jsonl \
+  --skill grill-with-docs \
+  --project checkout-api \
+  --dry-run-output .memanto/skill-candidates.jsonl
+```
+
+Inject those memories into a later slash-skill prompt:
+
+```bash
+echo '{"hook_event_name":"UserPromptSubmit","prompt":"/tdd implement auth retry tests"}' \
+  | python examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py \
+      hook-inject \
+      --memories .memanto/skill-candidates.jsonl
+```
+
+## Live MEMANTO Mode
+
+For prompt injection, `hook-inject` calls:
+
+```bash
+memanto recall "<skill> <prompt>" --limit 8
+```
+
+For post-run capture, add `--commit` to the `Stop` hook command. Each candidate
+is stored with explicit `--type`, `--confidence`, `--provenance`, `--source`,
+and `--tags` metadata.
+
+## Offline Verification
+
+```bash
+python examples/claudecode-skills-memanto/tests/test_bridge.py
+```

--- a/examples/claudecode-skills-memanto/claudecode_skills_memanto/__init__.py
+++ b/examples/claudecode-skills-memanto/claudecode_skills_memanto/__init__.py
@@ -1,0 +1,1 @@
+"""Claude Code skills integration example for MEMANTO."""

--- a/examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py
+++ b/examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py
@@ -17,8 +17,13 @@ from pathlib import Path
 from typing import Iterable, Sequence
 
 
+DEFAULT_DRY_RUN_OUTPUT = Path(".memanto/skill-candidates.jsonl")
+
+
 @dataclass(frozen=True)
 class MemoryCandidate:
+    """One durable memory candidate extracted from a Claude Code skill run."""
+
     content: str
     memory_type: str
     confidence: float
@@ -142,6 +147,8 @@ def build_raw_context(
     skill_name: str,
     prompt: str,
 ) -> str:
+    """Wrap raw `memanto recall` output as Claude Code hook context."""
+
     return "\n".join(
         [
             f'<memanto-skill-context skill="{skill_name}">',
@@ -178,6 +185,8 @@ def load_transcript_text(path: Path) -> str:
 
 
 def write_jsonl(path: Path, memories: Iterable[MemoryCandidate]) -> None:
+    """Write memory candidates in JSONL for dry-run inspection."""
+
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
         for memory in memories:
@@ -187,6 +196,7 @@ def write_jsonl(path: Path, memories: Iterable[MemoryCandidate]) -> None:
 def remember_with_memanto(memories: Sequence[MemoryCandidate]) -> int:
     """Persist candidates through the installed MEMANTO CLI."""
 
+    stored = 0
     for memory in memories:
         command = [
             "memanto",
@@ -203,11 +213,21 @@ def remember_with_memanto(memories: Sequence[MemoryCandidate]) -> int:
             "--tags",
             ",".join(memory.tags),
         ]
-        subprocess.run(command, check=True)
-    return len(memories)
+        try:
+            subprocess.run(command, check=True)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            print(
+                f"memanto remember failed for {memory.memory_type} memory: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        stored += 1
+    return stored
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """Run the command-line bridge used by examples and Claude Code hooks."""
+
     parser = argparse.ArgumentParser(
         description="Bridge Claude Code skill transcripts into MEMANTO."
     )
@@ -248,7 +268,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     hook_capture.add_argument(
         "--dry-run-output",
         type=Path,
-        default=Path(".memanto/skill-candidates.jsonl"),
+        default=DEFAULT_DRY_RUN_OUTPUT,
     )
     hook_capture.add_argument("--commit", action="store_true")
 
@@ -260,13 +280,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             skill_name=args.skill,
             project_slug=args.project,
         )
+        stored = None
         if args.commit:
-            remember_with_memanto(memories)
+            stored = remember_with_memanto(memories)
         else:
             output = args.dry_run_output or Path(".memanto-skill-candidates.jsonl")
             write_jsonl(output, memories)
         noun = "candidate" if len(memories) == 1 else "candidates"
-        print(f"captured {len(memories)} memory {noun}")
+        message = f"captured {len(memories)} memory {noun}"
+        if stored is not None:
+            message = f"{message}; stored {stored} with memanto"
+        print(message)
         return 0
 
     if args.command == "inject":
@@ -283,20 +307,23 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "hook-inject":
         payload = _read_hook_payload()
-        prompt = str(payload.get("prompt") or "")
-        skill_name = args.skill or detect_skill_name(prompt)
+        prompt = _payload_prompt(payload)
+        skill_name = (
+            args.skill or _payload_skill_name(payload) or detect_skill_name(prompt)
+        )
         if not skill_name:
             return 0
 
         if args.memories:
             memories = _load_memory_candidates(args.memories)
-            print(
+            _print_hook_context(
+                payload,
                 build_additional_context(
                     memories,
                     skill_name=skill_name,
                     prompt=prompt,
                     max_items=args.max_items,
-                )
+                ),
             )
             return 0
 
@@ -305,7 +332,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             limit=args.max_items,
         )
         if recall_output:
-            print(build_raw_context(recall_output, skill_name=skill_name, prompt=prompt))
+            _print_hook_context(
+                payload,
+                build_raw_context(recall_output, skill_name=skill_name, prompt=prompt),
+            )
         return 0
 
     if args.command == "hook-capture":
@@ -332,6 +362,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 def _load_memory_candidates(path: Path) -> list[MemoryCandidate]:
+    """Load dry-run JSONL candidates back into typed memory objects."""
+
     memories: list[MemoryCandidate] = []
     for line in path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
@@ -343,6 +375,8 @@ def _load_memory_candidates(path: Path) -> list[MemoryCandidate]:
 
 
 def _read_hook_payload() -> dict[str, object]:
+    """Read and validate a Claude Code hook JSON payload from stdin."""
+
     raw = sys.stdin.read()
     if not raw.strip():
         return {}
@@ -354,12 +388,16 @@ def _read_hook_payload() -> dict[str, object]:
 
 
 def _optional_path(value: object) -> Path | None:
+    """Convert an optional hook payload path field to `Path`."""
+
     if not isinstance(value, str) or not value:
         return None
     return Path(value)
 
 
 def _recall_with_memanto(query: str, *, limit: int) -> str:
+    """Run `memanto recall` and return empty text on unavailable CLI/errors."""
+
     command = ["memanto", "recall", query, "--limit", str(limit)]
     try:
         completed = subprocess.run(
@@ -377,33 +415,97 @@ def _recall_with_memanto(query: str, *, limit: int) -> str:
 
 
 def _strip_speaker(line: str) -> str:
+    """Remove common transcript speaker prefixes before pattern matching."""
+
     stripped = line.strip()
     return re.sub(r"^(?:User|Assistant|System|Tool)\s*:\s*", "", stripped, flags=re.I)
 
 
 def _clean_content(content: str) -> str:
+    """Trim wrapper punctuation around captured memory content."""
+
     return content.strip().strip("\"'` ")
 
 
 def _event_text(event: object) -> list[str]:
+    """Extract text chunks from common Claude transcript JSONL event shapes."""
+
     if not isinstance(event, dict):
         return []
 
+    texts: list[str] = []
     message = event.get("message")
     if isinstance(message, dict):
-        content = message.get("content")
-        if isinstance(content, str):
-            return [content]
-        if isinstance(content, list):
-            texts: list[str] = []
-            for item in content:
-                if isinstance(item, dict) and isinstance(item.get("text"), str):
-                    texts.append(item["text"])
-            return texts
+        texts.extend(_content_text(message.get("content")))
+
+    texts.extend(_content_text(event.get("content")))
 
     if isinstance(event.get("text"), str):
-        return [event["text"]]
+        texts.append(event["text"])
+    return texts
+
+
+def _content_text(content: object) -> list[str]:
+    """Normalize Claude text content blocks into strings."""
+
+    if isinstance(content, str):
+        return [content]
+    if isinstance(content, list):
+        texts: list[str] = []
+        for item in content:
+            texts.extend(_content_text(item))
+        return texts
+    if isinstance(content, dict):
+        texts: list[str] = []
+        if isinstance(content.get("text"), str):
+            texts.append(content["text"])
+        texts.extend(_content_text(content.get("content")))
+        return texts
     return []
+
+
+def _payload_prompt(payload: dict[str, object]) -> str:
+    """Return a usable prompt string from hook payload variants."""
+
+    prompt = payload.get("prompt")
+    if isinstance(prompt, str) and prompt:
+        return prompt
+
+    skill_name = _payload_skill_name(payload)
+    command_args = payload.get("command_args")
+    if skill_name and isinstance(command_args, str) and command_args:
+        return f"/{skill_name} {command_args}"
+    if skill_name:
+        return f"/{skill_name}"
+    return ""
+
+
+def _payload_skill_name(payload: dict[str, object]) -> str | None:
+    """Detect a slash skill name from Claude Code hook payload fields."""
+
+    command_name = payload.get("command_name")
+    if isinstance(command_name, str) and command_name:
+        return command_name.lstrip("/")
+    return None
+
+
+def _print_hook_context(payload: dict[str, object], context: str) -> None:
+    """Emit context using the output format expected by the hook event."""
+
+    event_name = payload.get("hook_event_name")
+    if event_name == "UserPromptExpansion":
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptExpansion",
+                        "additionalContext": context,
+                    }
+                }
+            )
+        )
+        return
+    print(context)
 
 
 if __name__ == "__main__":

--- a/examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py
+++ b/examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py
@@ -214,8 +214,12 @@ def remember_with_memanto(memories: Sequence[MemoryCandidate]) -> int:
             ",".join(memory.tags),
         ]
         try:
-            subprocess.run(command, check=True)
-        except (OSError, subprocess.CalledProcessError) as exc:
+            subprocess.run(command, check=True, timeout=30)
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ) as exc:
             print(
                 f"memanto remember failed for {memory.memory_type} memory: {exc}",
                 file=sys.stderr,
@@ -284,7 +288,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.commit:
             stored = remember_with_memanto(memories)
         else:
-            output = args.dry_run_output or Path(".memanto-skill-candidates.jsonl")
+            output = args.dry_run_output or DEFAULT_DRY_RUN_OUTPUT
             write_jsonl(output, memories)
         noun = "candidate" if len(memories) == 1 else "candidates"
         message = f"captured {len(memories)} memory {noun}"

--- a/examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py
+++ b/examples/claudecode-skills-memanto/claudecode_skills_memanto/bridge.py
@@ -1,0 +1,410 @@
+"""Bridge Claude Code skill runs into MEMANTO memories.
+
+The module is intentionally dependency-free so the example can run before users
+configure a Moorcheh API key. Dry-run mode writes memory candidates to JSONL;
+production mode can pipe those candidates into the `memanto` CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class MemoryCandidate:
+    content: str
+    memory_type: str
+    confidence: float
+    provenance: str
+    source: str
+    tags: tuple[str, ...]
+
+
+SIGNAL_PATTERNS: tuple[tuple[re.Pattern[str], str, float, str], ...] = (
+    (
+        re.compile(r"^(?:architecture\s+)?decision:\s*(?P<content>.+)$", re.I),
+        "decision",
+        0.95,
+        "observed",
+    ),
+    (
+        re.compile(r"^user\s+preference:\s*(?P<content>.+)$", re.I),
+        "preference",
+        0.90,
+        "explicit_statement",
+    ),
+    (
+        re.compile(r"^preference:\s*(?P<content>.+)$", re.I),
+        "preference",
+        0.85,
+        "observed",
+    ),
+    (
+        re.compile(r"^codebase\s+fact:\s*(?P<content>.+)$", re.I),
+        "fact",
+        0.90,
+        "observed",
+    ),
+    (
+        re.compile(r"^project\s+fact:\s*(?P<content>.+)$", re.I),
+        "fact",
+        0.90,
+        "observed",
+    ),
+    (
+        re.compile(r"^fact:\s*(?P<content>.+)$", re.I),
+        "fact",
+        0.85,
+        "observed",
+    ),
+)
+
+
+def distill_memories(
+    transcript_text: str,
+    *,
+    skill_name: str,
+    project_slug: str,
+) -> list[MemoryCandidate]:
+    """Extract high-signal memory candidates from a skill transcript."""
+
+    candidates: list[MemoryCandidate] = []
+    seen: set[tuple[str, str]] = set()
+    for raw_line in transcript_text.splitlines():
+        line = _strip_speaker(raw_line)
+        if not line:
+            continue
+
+        for pattern, memory_type, confidence, provenance in SIGNAL_PATTERNS:
+            match = pattern.match(line)
+            if not match:
+                continue
+            content = _clean_content(match.group("content"))
+            if not content:
+                break
+            key = (memory_type, content.lower())
+            if key in seen:
+                break
+            seen.add(key)
+            candidates.append(
+                MemoryCandidate(
+                    content=content,
+                    memory_type=memory_type,
+                    confidence=confidence,
+                    provenance=provenance,
+                    source=f"claude_code:{skill_name}",
+                    tags=(project_slug, f"skill-{skill_name}", memory_type),
+                )
+            )
+            break
+
+    return candidates
+
+
+def build_additional_context(
+    memories: Sequence[MemoryCandidate],
+    *,
+    skill_name: str,
+    prompt: str,
+    max_items: int = 8,
+) -> str:
+    """Format memories for Claude Code UserPromptSubmit hook stdout."""
+
+    if not memories:
+        return (
+            f'<memanto-skill-context skill="{skill_name}">\n'
+            f"Prompt: {prompt}\n"
+            "No relevant MEMANTO memories were found for this skill run.\n"
+            "</memanto-skill-context>"
+        )
+
+    lines = [
+        f'<memanto-skill-context skill="{skill_name}">',
+        f"Prompt: {prompt}",
+        "Use these memories as prior engineering context before executing the skill:",
+    ]
+    for memory in memories[:max_items]:
+        lines.append(f"- [{memory.memory_type}] {memory.content}")
+    lines.append("</memanto-skill-context>")
+    return "\n".join(lines)
+
+
+def build_raw_context(
+    recall_output: str,
+    *,
+    skill_name: str,
+    prompt: str,
+) -> str:
+    return "\n".join(
+        [
+            f'<memanto-skill-context skill="{skill_name}">',
+            f"Prompt: {prompt}",
+            "Use this MEMANTO recall output as prior engineering context:",
+            recall_output.strip(),
+            "</memanto-skill-context>",
+        ]
+    )
+
+
+def detect_skill_name(prompt: str) -> str | None:
+    """Return the first slash skill name in a Claude Code user prompt."""
+
+    match = re.search(r"(?<!\S)/([a-z][a-z0-9-]*)\b", prompt)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def load_transcript_text(path: Path) -> str:
+    """Read Claude transcript JSONL or plain text into one text stream."""
+
+    raw = path.read_text(encoding="utf-8")
+    text_parts: list[str] = []
+    for line in raw.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            text_parts.append(line)
+            continue
+        text_parts.extend(_event_text(event))
+    return "\n".join(text_parts)
+
+
+def write_jsonl(path: Path, memories: Iterable[MemoryCandidate]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for memory in memories:
+            handle.write(json.dumps(asdict(memory), sort_keys=True) + "\n")
+
+
+def remember_with_memanto(memories: Sequence[MemoryCandidate]) -> int:
+    """Persist candidates through the installed MEMANTO CLI."""
+
+    for memory in memories:
+        command = [
+            "memanto",
+            "remember",
+            memory.content,
+            "--type",
+            memory.memory_type,
+            "--confidence",
+            str(memory.confidence),
+            "--provenance",
+            memory.provenance,
+            "--source",
+            memory.source,
+            "--tags",
+            ",".join(memory.tags),
+        ]
+        subprocess.run(command, check=True)
+    return len(memories)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bridge Claude Code skill transcripts into MEMANTO."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    capture = subparsers.add_parser("capture", help="Capture memories after a skill run")
+    capture.add_argument("--transcript", type=Path, required=True)
+    capture.add_argument("--skill", required=True)
+    capture.add_argument("--project", required=True)
+    capture.add_argument("--dry-run-output", type=Path)
+    capture.add_argument(
+        "--commit",
+        action="store_true",
+        help="Call `memanto remember` instead of only writing dry-run output.",
+    )
+
+    inject = subparsers.add_parser("inject", help="Format recalled memories for a skill")
+    inject.add_argument("--memories", type=Path, required=True)
+    inject.add_argument("--skill", required=True)
+    inject.add_argument("--prompt", required=True)
+    inject.add_argument("--max-items", type=int, default=8)
+
+    hook_inject = subparsers.add_parser(
+        "hook-inject",
+        help="Read Claude Code hook JSON from stdin and emit prompt context",
+    )
+    hook_inject.add_argument("--memories", type=Path)
+    hook_inject.add_argument("--skill")
+    hook_inject.add_argument("--max-items", type=int, default=8)
+
+    hook_capture = subparsers.add_parser(
+        "hook-capture",
+        help="Read Claude Code stop-hook JSON from stdin and capture memories",
+    )
+    hook_capture.add_argument("--transcript", type=Path)
+    hook_capture.add_argument("--skill")
+    hook_capture.add_argument("--project")
+    hook_capture.add_argument(
+        "--dry-run-output",
+        type=Path,
+        default=Path(".memanto/skill-candidates.jsonl"),
+    )
+    hook_capture.add_argument("--commit", action="store_true")
+
+    args = parser.parse_args(argv)
+    if args.command == "capture":
+        transcript_text = load_transcript_text(args.transcript)
+        memories = distill_memories(
+            transcript_text,
+            skill_name=args.skill,
+            project_slug=args.project,
+        )
+        if args.commit:
+            remember_with_memanto(memories)
+        else:
+            output = args.dry_run_output or Path(".memanto-skill-candidates.jsonl")
+            write_jsonl(output, memories)
+        noun = "candidate" if len(memories) == 1 else "candidates"
+        print(f"captured {len(memories)} memory {noun}")
+        return 0
+
+    if args.command == "inject":
+        memories = _load_memory_candidates(args.memories)
+        print(
+            build_additional_context(
+                memories,
+                skill_name=args.skill,
+                prompt=args.prompt,
+                max_items=args.max_items,
+            )
+        )
+        return 0
+
+    if args.command == "hook-inject":
+        payload = _read_hook_payload()
+        prompt = str(payload.get("prompt") or "")
+        skill_name = args.skill or detect_skill_name(prompt)
+        if not skill_name:
+            return 0
+
+        if args.memories:
+            memories = _load_memory_candidates(args.memories)
+            print(
+                build_additional_context(
+                    memories,
+                    skill_name=skill_name,
+                    prompt=prompt,
+                    max_items=args.max_items,
+                )
+            )
+            return 0
+
+        recall_output = _recall_with_memanto(
+            query=f"{skill_name} {prompt}",
+            limit=args.max_items,
+        )
+        if recall_output:
+            print(build_raw_context(recall_output, skill_name=skill_name, prompt=prompt))
+        return 0
+
+    if args.command == "hook-capture":
+        payload = _read_hook_payload()
+        transcript_path = args.transcript or _optional_path(payload.get("transcript_path"))
+        if not transcript_path or not transcript_path.exists():
+            return 0
+        prompt = str(payload.get("prompt") or "")
+        skill_name = args.skill or detect_skill_name(prompt) or "unknown-skill"
+        project_slug = args.project or Path.cwd().name
+        memories = distill_memories(
+            load_transcript_text(transcript_path),
+            skill_name=skill_name,
+            project_slug=project_slug,
+        )
+        if args.commit:
+            remember_with_memanto(memories)
+        else:
+            write_jsonl(args.dry_run_output, memories)
+        return 0
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2
+
+
+def _load_memory_candidates(path: Path) -> list[MemoryCandidate]:
+    memories: list[MemoryCandidate] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        payload["tags"] = tuple(payload.get("tags", ()))
+        memories.append(MemoryCandidate(**payload))
+    return memories
+
+
+def _read_hook_payload() -> dict[str, object]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _optional_path(value: object) -> Path | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return Path(value)
+
+
+def _recall_with_memanto(query: str, *, limit: int) -> str:
+    command = ["memanto", "recall", query, "--limit", str(limit)]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+def _strip_speaker(line: str) -> str:
+    stripped = line.strip()
+    return re.sub(r"^(?:User|Assistant|System|Tool)\s*:\s*", "", stripped, flags=re.I)
+
+
+def _clean_content(content: str) -> str:
+    return content.strip().strip("\"'` ")
+
+
+def _event_text(event: object) -> list[str]:
+    if not isinstance(event, dict):
+        return []
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        content = message.get("content")
+        if isinstance(content, str):
+            return [content]
+        if isinstance(content, list):
+            texts: list[str] = []
+            for item in content:
+                if isinstance(item, dict) and isinstance(item.get("text"), str):
+                    texts.append(item["text"])
+            return texts
+
+    if isinstance(event.get("text"), str):
+        return [event["text"]]
+    return []
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -22,9 +22,13 @@ from claudecode_skills_memanto.bridge import (  # noqa: E402
 
 
 class BridgeTests(unittest.TestCase):
+    """Regression tests for the Claude Code skills MEMANTO bridge."""
+
     def test_distills_decisions_preferences_and_project_facts_from_skill_transcript(
         self,
     ):
+        """Extract labeled durable facts from transcript text."""
+
         transcript = """
         User: /grill-with-docs auth refactor
         Assistant: Decision: keep token refresh inside the auth service because it owns retry policy.
@@ -70,6 +74,8 @@ class BridgeTests(unittest.TestCase):
         )
 
     def test_builds_user_prompt_expansion_context_for_next_skill(self):
+        """Format recalled memories as Claude Code prompt context."""
+
         memories = [
             MemoryCandidate(
                 content="keep token refresh inside the auth service because it owns retry policy.",
@@ -106,6 +112,8 @@ class BridgeTests(unittest.TestCase):
         self.assertIn("Use these memories as prior engineering context", context)
 
     def test_cli_supports_dry_run_capture_without_memanto_binary(self):
+        """Capture memories to JSONL without requiring a live memanto CLI."""
+
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             transcript = temp_path / "transcript.jsonl"
@@ -138,6 +146,8 @@ class BridgeTests(unittest.TestCase):
             )
 
     def test_detects_slash_skill_name_from_user_prompt(self):
+        """Detect slash-skill names embedded in user prompts."""
+
         self.assertEqual(
             detect_skill_name("/grill-with-docs design the auth cache"),
             "grill-with-docs",
@@ -149,6 +159,8 @@ class BridgeTests(unittest.TestCase):
         self.assertIsNone(detect_skill_name("plain prompt without a slash skill"))
 
     def test_cli_hook_inject_reads_claude_hook_json_from_stdin(self):
+        """Read UserPromptSubmit hook JSON and emit plain context."""
+
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             memories = temp_path / "memories.jsonl"
@@ -178,6 +190,8 @@ class BridgeTests(unittest.TestCase):
             self.assertIn("use zod output schemas", stdout.getvalue())
 
     def test_cli_hook_inject_supports_user_prompt_expansion_payloads(self):
+        """Emit structured additional context for UserPromptExpansion hooks."""
+
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             memories = temp_path / "memories.jsonl"
@@ -216,6 +230,8 @@ class BridgeTests(unittest.TestCase):
             self.assertIn("Prompt: /handoff billing rules", output["additionalContext"])
 
     def test_load_transcript_text_reads_common_claude_jsonl_content_shapes(self):
+        """Handle Claude transcript JSONL text fields in common locations."""
+
         with tempfile.TemporaryDirectory() as temp_dir:
             transcript = Path(temp_dir) / "transcript.jsonl"
             transcript.write_text(
@@ -256,6 +272,8 @@ class BridgeTests(unittest.TestCase):
             self.assertIn("User preference: concise summaries.", text)
 
     def test_remember_with_memanto_logs_failures_and_continues(self):
+        """Keep storing later memories when one memanto call fails."""
+
         memories = [
             MemoryCandidate(
                 content="first",
@@ -292,6 +310,8 @@ class BridgeTests(unittest.TestCase):
         self.assertEqual(run.call_args_list[1].kwargs["timeout"], 30)
 
     def test_example_artifacts_exist_and_settings_json_is_valid(self):
+        """Verify the checked-in example files and hook keys are present."""
+
         root = Path(__file__).resolve().parents[1]
         self.assertTrue((root / "README.md").exists())
         self.assertTrue(
@@ -306,6 +326,8 @@ class BridgeTests(unittest.TestCase):
 
 
 def json_line(memory: MemoryCandidate) -> str:
+    """Serialize a memory candidate as one JSONL record."""
+
     from dataclasses import asdict
     import json
 

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -1,9 +1,10 @@
 import io
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -14,7 +15,9 @@ from claudecode_skills_memanto.bridge import (  # noqa: E402
     build_additional_context,
     detect_skill_name,
     distill_memories,
+    load_transcript_text,
     main,
+    remember_with_memanto,
 )
 
 
@@ -174,6 +177,118 @@ class BridgeTests(unittest.TestCase):
             self.assertIn('<memanto-skill-context skill="tdd">', stdout.getvalue())
             self.assertIn("use zod output schemas", stdout.getvalue())
 
+    def test_cli_hook_inject_supports_user_prompt_expansion_payloads(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            memories = temp_path / "memories.jsonl"
+            memories.write_text(
+                json_line(
+                    MemoryCandidate(
+                        content="keep checkout tax logic in billing service.",
+                        memory_type="decision",
+                        confidence=0.95,
+                        provenance="observed",
+                        source="claude_code:handoff",
+                        tags=("checkout-api", "skill-handoff", "decision"),
+                    )
+                ),
+                encoding="utf-8",
+            )
+            hook_input = io.StringIO(
+                json.dumps(
+                    {
+                        "hook_event_name": "UserPromptExpansion",
+                        "command_name": "handoff",
+                        "command_args": "billing rules",
+                    }
+                )
+            )
+            stdout = io.StringIO()
+            with mock.patch("sys.stdin", hook_input):
+                with redirect_stdout(stdout):
+                    exit_code = main(["hook-inject", "--memories", str(memories)])
+
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(stdout.getvalue())
+            output = payload["hookSpecificOutput"]
+            self.assertEqual(output["hookEventName"], "UserPromptExpansion")
+            self.assertIn("keep checkout tax logic", output["additionalContext"])
+            self.assertIn("Prompt: /handoff billing rules", output["additionalContext"])
+
+    def test_load_transcript_text_reads_common_claude_jsonl_content_shapes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transcript = Path(temp_dir) / "transcript.jsonl"
+            transcript.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "message": {
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Decision: keep cache local.",
+                                        }
+                                    ]
+                                }
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": "Codebase fact: hooks live in .claude.",
+                                    }
+                                ]
+                            }
+                        ),
+                        json.dumps({"text": "User preference: concise summaries."}),
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            text = load_transcript_text(transcript)
+
+            self.assertIn("Decision: keep cache local.", text)
+            self.assertIn("Codebase fact: hooks live in .claude.", text)
+            self.assertIn("User preference: concise summaries.", text)
+
+    def test_remember_with_memanto_logs_failures_and_continues(self):
+        memories = [
+            MemoryCandidate(
+                content="first",
+                memory_type="decision",
+                confidence=0.95,
+                provenance="observed",
+                source="claude_code:tdd",
+                tags=("demo", "skill-tdd", "decision"),
+            ),
+            MemoryCandidate(
+                content="second",
+                memory_type="fact",
+                confidence=0.9,
+                provenance="observed",
+                source="claude_code:tdd",
+                tags=("demo", "skill-tdd", "fact"),
+            ),
+        ]
+        stderr = io.StringIO()
+        completed = subprocess.CompletedProcess(args=["memanto"], returncode=0)
+        with mock.patch(
+            "subprocess.run",
+            side_effect=[
+                subprocess.CalledProcessError(1, ["memanto", "remember", "first"]),
+                completed,
+            ],
+        ):
+            with redirect_stderr(stderr):
+                stored = remember_with_memanto(memories)
+
+        self.assertEqual(stored, 1)
+        self.assertIn("memanto remember failed", stderr.getvalue())
+
     def test_example_artifacts_exist_and_settings_json_is_valid(self):
         root = Path(__file__).resolve().parents[1]
         self.assertTrue((root / "README.md").exists())
@@ -184,7 +299,7 @@ class BridgeTests(unittest.TestCase):
         settings_path = root / ".claude" / "settings.json"
         payload = json.loads(settings_path.read_text(encoding="utf-8"))
         hooks = payload["hooks"]
-        self.assertIn("UserPromptSubmit", hooks)
+        self.assertIn("UserPromptExpansion", hooks)
         self.assertIn("Stop", hooks)
 
 

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -322,6 +322,7 @@ class BridgeTests(unittest.TestCase):
         payload = json.loads(settings_path.read_text(encoding="utf-8"))
         hooks = payload["hooks"]
         self.assertIn("UserPromptExpansion", hooks)
+        self.assertNotIn("UserPromptSubmit", hooks)
         self.assertIn("Stop", hooks)
 
 

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -282,12 +282,14 @@ class BridgeTests(unittest.TestCase):
                 subprocess.CalledProcessError(1, ["memanto", "remember", "first"]),
                 completed,
             ],
-        ):
+        ) as run:
             with redirect_stderr(stderr):
                 stored = remember_with_memanto(memories)
 
         self.assertEqual(stored, 1)
         self.assertIn("memanto remember failed", stderr.getvalue())
+        self.assertEqual(run.call_args_list[0].kwargs["timeout"], 30)
+        self.assertEqual(run.call_args_list[1].kwargs["timeout"], 30)
 
     def test_example_artifacts_exist_and_settings_json_is_valid(self):
         root = Path(__file__).resolve().parents[1]

--- a/examples/claudecode-skills-memanto/tests/test_bridge.py
+++ b/examples/claudecode-skills-memanto/tests/test_bridge.py
@@ -1,0 +1,199 @@
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from claudecode_skills_memanto.bridge import (  # noqa: E402
+    MemoryCandidate,
+    build_additional_context,
+    detect_skill_name,
+    distill_memories,
+    main,
+)
+
+
+class BridgeTests(unittest.TestCase):
+    def test_distills_decisions_preferences_and_project_facts_from_skill_transcript(
+        self,
+    ):
+        transcript = """
+        User: /grill-with-docs auth refactor
+        Assistant: Decision: keep token refresh inside the auth service because it owns retry policy.
+        Assistant: User preference: prefer concise error messages in UI copy.
+        Assistant: Codebase fact: API routes live under src/server/routes and use zod schemas.
+        Assistant: Random progress chatter that should not become a memory.
+        """
+
+        memories = distill_memories(
+            transcript,
+            skill_name="grill-with-docs",
+            project_slug="checkout-api",
+        )
+
+        self.assertEqual(
+            memories,
+            [
+                MemoryCandidate(
+                    content="keep token refresh inside the auth service because it owns retry policy.",
+                    memory_type="decision",
+                    confidence=0.95,
+                    provenance="observed",
+                    source="claude_code:grill-with-docs",
+                    tags=("checkout-api", "skill-grill-with-docs", "decision"),
+                ),
+                MemoryCandidate(
+                    content="prefer concise error messages in UI copy.",
+                    memory_type="preference",
+                    confidence=0.9,
+                    provenance="explicit_statement",
+                    source="claude_code:grill-with-docs",
+                    tags=("checkout-api", "skill-grill-with-docs", "preference"),
+                ),
+                MemoryCandidate(
+                    content="API routes live under src/server/routes and use zod schemas.",
+                    memory_type="fact",
+                    confidence=0.9,
+                    provenance="observed",
+                    source="claude_code:grill-with-docs",
+                    tags=("checkout-api", "skill-grill-with-docs", "fact"),
+                ),
+            ],
+        )
+
+    def test_builds_user_prompt_expansion_context_for_next_skill(self):
+        memories = [
+            MemoryCandidate(
+                content="keep token refresh inside the auth service because it owns retry policy.",
+                memory_type="decision",
+                confidence=0.95,
+                provenance="observed",
+                source="claude_code:grill-with-docs",
+                tags=("checkout-api", "skill-grill-with-docs", "decision"),
+            ),
+            MemoryCandidate(
+                content="prefer concise error messages in UI copy.",
+                memory_type="preference",
+                confidence=0.9,
+                provenance="explicit_statement",
+                source="claude_code:grill-with-docs",
+                tags=("checkout-api", "skill-grill-with-docs", "preference"),
+            ),
+        ]
+
+        context = build_additional_context(
+            memories,
+            skill_name="tdd",
+            prompt="/tdd implement auth retry tests",
+        )
+
+        self.assertIn('<memanto-skill-context skill="tdd">', context)
+        self.assertIn("Prompt: /tdd implement auth retry tests", context)
+        self.assertIn(
+            "- [decision] keep token refresh inside the auth service", context
+        )
+        self.assertIn(
+            "- [preference] prefer concise error messages in UI copy.", context
+        )
+        self.assertIn("Use these memories as prior engineering context", context)
+
+    def test_cli_supports_dry_run_capture_without_memanto_binary(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            transcript = temp_path / "transcript.jsonl"
+            transcript.write_text(
+                '{"type":"assistant","message":{"content":[{"type":"text","text":"Decision: use SQLite for the local cache."}]}}\n',
+                encoding="utf-8",
+            )
+            output = temp_path / "memories.jsonl"
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "capture",
+                        "--transcript",
+                        str(transcript),
+                        "--skill",
+                        "prototype",
+                        "--project",
+                        "demo-app",
+                        "--dry-run-output",
+                        str(output),
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("captured 1 memory candidate", stdout.getvalue())
+            self.assertIn(
+                '"memory_type": "decision"', output.read_text(encoding="utf-8")
+            )
+
+    def test_detects_slash_skill_name_from_user_prompt(self):
+        self.assertEqual(
+            detect_skill_name("/grill-with-docs design the auth cache"),
+            "grill-with-docs",
+        )
+        self.assertEqual(
+            detect_skill_name("please run /tdd on the retry behavior"),
+            "tdd",
+        )
+        self.assertIsNone(detect_skill_name("plain prompt without a slash skill"))
+
+    def test_cli_hook_inject_reads_claude_hook_json_from_stdin(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            memories = temp_path / "memories.jsonl"
+            memories.write_text(
+                json_line(
+                    MemoryCandidate(
+                        content="use zod output schemas for API responses.",
+                        memory_type="decision",
+                        confidence=0.95,
+                        provenance="observed",
+                        source="claude_code:grill-with-docs",
+                        tags=("checkout-api", "skill-grill-with-docs", "decision"),
+                    )
+                ),
+                encoding="utf-8",
+            )
+            hook_input = io.StringIO(
+                '{"hook_event_name":"UserPromptSubmit","prompt":"/tdd add bounty endpoint tests"}'
+            )
+            stdout = io.StringIO()
+            with mock.patch("sys.stdin", hook_input):
+                with redirect_stdout(stdout):
+                    exit_code = main(["hook-inject", "--memories", str(memories)])
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn('<memanto-skill-context skill="tdd">', stdout.getvalue())
+            self.assertIn("use zod output schemas", stdout.getvalue())
+
+    def test_example_artifacts_exist_and_settings_json_is_valid(self):
+        root = Path(__file__).resolve().parents[1]
+        self.assertTrue((root / "README.md").exists())
+        self.assertTrue(
+            (root / ".claude" / "skills" / "memanto-skill-companion" / "SKILL.md").exists()
+        )
+
+        settings_path = root / ".claude" / "settings.json"
+        payload = json.loads(settings_path.read_text(encoding="utf-8"))
+        hooks = payload["hooks"]
+        self.assertIn("UserPromptSubmit", hooks)
+        self.assertIn("Stop", hooks)
+
+
+def json_line(memory: MemoryCandidate) -> str:
+    from dataclasses import asdict
+    import json
+
+    return json.dumps(asdict(memory), sort_keys=True) + "\n"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `examples/claudecode-skills-memanto`, a Claude Code slash-skill integration example for the Memanto + mattpocock/skills bounty.
- Uses `UserPromptExpansion` to recall prior Memanto context only when a slash skill expands, then injects a `<memanto-skill-context>` block before the skill runs.
- Uses a `Stop` hook after the skill run to capture durable `Decision:`, `User preference:`, and `Codebase fact:` transcript markers back into Memanto.
- Includes a dependency-free Python bridge, dry-run JSONL mode, live `memanto remember` mode, a companion skill, `.claude/settings.json`, and offline tests.
- Handles common Claude transcript JSONL shapes, per-memory Memanto CLI failures/timeouts, and a single consistent dry-run output path.

## Showcase

- Public GitHub PR showcase/discussion: https://github.com/moorcheh-ai/memanto/pull/638

## Bounty Claim

- `/claim #508`
- BountyHub: https://www.bountyhub.dev/bounty/view/3a63800c-7c18-41d2-870f-c62344f8a3fe

## Verification

- `python examples/claudecode-skills-memanto/tests/test_bridge.py`
- `python -m compileall -q examples/claudecode-skills-memanto/claudecode_skills_memanto`
- `git diff --check`

Refs #508