### PR TITLE
[BOUNTY $100] Add incident memory pressure benchmark

### DIFF
--- a/examples/benchmarks/incident-memory-pressure/README.md
+++ b/examples/benchmarks/incident-memory-pressure/README.md
@@ -1,0 +1,80 @@
+# Incident Memory Pressure Benchmark
+
+This benchmark is a reproducible submission for
+`moorcheh-ai/memanto#639`, the Great Agentic Memory Showdown.
+
+It tests an agent-memory scenario that is different from the existing
+preference-drift benchmark: long-running incident response memory. The same
+incident timeline is fed into two backends:
+
+- `memanto_typed_digest`: a Memanto-style typed memory backend that keeps
+  current facts, provenance, recency, and supersession keys.
+- `append_only_log`: a graph/log-style baseline that recalls matching historical
+  snippets without suppressing stale state.
+
+The workload stresses the production tradeoff called out in the bounty:
+retrieval accuracy versus resource footprint.
+
+## Scenario
+
+The dataset follows an SRE assistant across 18 incident updates for three
+services: payments, search, and notifications. The facts include:
+
+- stale runbooks replaced by safer runbooks
+- rollback decisions that must stay retrievable
+- customer-facing status wording that changes over time
+- service owners and escalation targets that rotate
+- mitigation records that should not pollute current action answers
+
+Queries ask the memory layer for the current action, owner, status wording, or
+runbook. A correct backend should surface the current fact and avoid injecting
+stale superseded facts.
+
+## Metrics
+
+The runner emits JSON and Markdown with:
+
+- `tokens_ingested`: total input tokens seen by the backend
+- `tokens_retrieved`: total context tokens returned across the query suite
+- `p95_latency_ms`: p95 retrieval latency
+- `retrieval_accuracy`: expected facts present and stale facts absent
+- `stale_suppression`: percentage of stale fragments kept out of context
+- `signal_to_noise`: expected fact tokens divided by retrieved context tokens
+
+## Run
+
+From the repository root:
+
+```bash
+python examples/benchmarks/incident-memory-pressure/run_benchmark.py --format markdown
+python examples/benchmarks/incident-memory-pressure/run_benchmark.py --format json
+python examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
+```
+
+The benchmark has no required third-party dependencies. `requirements.txt`
+exists only to make that explicit for automated reviewers.
+
+## Sample result
+
+The committed sample output in `results/sample_results.md` is generated from
+the deterministic offline dataset. The Memanto-style backend is expected to use
+fewer retrieved tokens and suppress stale facts more aggressively, while the
+append-only baseline retains more historical context and therefore returns more
+noise.
+
+## Live backend extension
+
+The benchmark intentionally keeps the default run credential-free. To attach a
+live Memanto, Mem0, Zep, or Hindsight backend, implement the small `MemoryBackend`
+protocol in `incident_memory_pressure/backends.py`:
+
+```python
+class MemoryBackend(Protocol):
+    name: str
+
+    def ingest(self, records: Iterable[IncidentRecord]) -> None: ...
+    def recall(self, query: IncidentQuery) -> list[MemoryHit]: ...
+```
+
+The dataset, scoring, JSON output, and Markdown report remain unchanged, so a
+live adapter can be compared under the same evaluation contract.

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/__init__.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/__init__.py
@@ -1,0 +1,3 @@
+from .runner import BenchmarkReport, run_benchmark
+
+__all__ = ["BenchmarkReport", "run_benchmark"]

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/backends.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/backends.py
@@ -12,30 +12,44 @@ TOKEN_RE = re.compile(r"[A-Za-z0-9_.-]+")
 
 @dataclass(frozen=True)
 class MemoryHit:
+    """A recalled memory snippet with provenance metadata."""
+
     text: str
     source_key: str
     session: int
 
     @property
     def tokens(self) -> int:
+        """Return an approximate token count for the recalled text."""
+
         return len(TOKEN_RE.findall(self.text))
 
 
 class MemoryBackend(Protocol):
+    """Minimal backend contract required by the benchmark runner."""
+
     name: str
 
     def ingest(self, records: Iterable[IncidentRecord]) -> None:
+        """Store benchmark incident records in the backend."""
+
         ...
 
     def recall(self, query: IncidentQuery) -> list[MemoryHit]:
+        """Return memory snippets relevant to a benchmark query."""
+
         ...
 
 
 def token_count(text: str) -> int:
+    """Return the benchmark's simple lexical token count."""
+
     return len(TOKEN_RE.findall(text))
 
 
 def _query_terms(query: IncidentQuery) -> set[str]:
+    """Derive coarse retrieval terms from a benchmark query."""
+
     terms = {query.service}
     prompt = query.prompt.lower()
     for term in ("owner", "runbook", "status", "customer", "rollback", "escalation"):
@@ -45,13 +59,19 @@ def _query_terms(query: IncidentQuery) -> set[str]:
 
 
 class MemantoTypedDigestBackend:
+    """A Memanto-style backend that keeps current typed facts by key."""
+
     name = "memanto_typed_digest"
 
     def __init__(self) -> None:
+        """Create an empty typed digest memory."""
+
         self.current_by_key: dict[str, IncidentRecord] = {}
         self.history: list[IncidentRecord] = []
 
     def ingest(self, records: Iterable[IncidentRecord]) -> None:
+        """Store each record while applying supersession keys."""
+
         for record in records:
             self.history.append(record)
             for old_key in record.supersedes:
@@ -59,6 +79,8 @@ class MemantoTypedDigestBackend:
             self.current_by_key[record.key] = record
 
     def recall(self, query: IncidentQuery) -> list[MemoryHit]:
+        """Recall the strongest current typed facts for a query."""
+
         terms = _query_terms(query)
         scored: list[tuple[int, IncidentRecord]] = []
         for record in self.current_by_key.values():
@@ -82,15 +104,23 @@ class MemantoTypedDigestBackend:
 
 
 class AppendOnlyLogBackend:
+    """A baseline backend that retains every historical incident record."""
+
     name = "append_only_log"
 
     def __init__(self) -> None:
+        """Create an empty append-only memory."""
+
         self.records: list[IncidentRecord] = []
 
     def ingest(self, records: Iterable[IncidentRecord]) -> None:
+        """Append all incident records without supersession."""
+
         self.records.extend(records)
 
     def recall(self, query: IncidentQuery) -> list[MemoryHit]:
+        """Recall matching historical and current records for a query."""
+
         terms = _query_terms(query)
         matches: list[tuple[int, IncidentRecord]] = []
         for record in self.records:

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/backends.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/backends.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+from .dataset import IncidentQuery, IncidentRecord
+
+
+TOKEN_RE = re.compile(r"[A-Za-z0-9_.-]+")
+
+
+@dataclass(frozen=True)
+class MemoryHit:
+    text: str
+    source_key: str
+    session: int
+
+    @property
+    def tokens(self) -> int:
+        return len(TOKEN_RE.findall(self.text))
+
+
+class MemoryBackend(Protocol):
+    name: str
+
+    def ingest(self, records: Iterable[IncidentRecord]) -> None:
+        ...
+
+    def recall(self, query: IncidentQuery) -> list[MemoryHit]:
+        ...
+
+
+def token_count(text: str) -> int:
+    return len(TOKEN_RE.findall(text))
+
+
+def _query_terms(query: IncidentQuery) -> set[str]:
+    terms = {query.service}
+    prompt = query.prompt.lower()
+    for term in ("owner", "runbook", "status", "customer", "rollback", "escalation"):
+        if term in prompt:
+            terms.add(term)
+    return terms
+
+
+class MemantoTypedDigestBackend:
+    name = "memanto_typed_digest"
+
+    def __init__(self) -> None:
+        self.current_by_key: dict[str, IncidentRecord] = {}
+        self.history: list[IncidentRecord] = []
+
+    def ingest(self, records: Iterable[IncidentRecord]) -> None:
+        for record in records:
+            self.history.append(record)
+            for old_key in record.supersedes:
+                self.current_by_key.pop(old_key, None)
+            self.current_by_key[record.key] = record
+
+    def recall(self, query: IncidentQuery) -> list[MemoryHit]:
+        terms = _query_terms(query)
+        scored: list[tuple[int, IncidentRecord]] = []
+        for record in self.current_by_key.values():
+            text = f"{record.kind} {record.service} {record.text}".lower()
+            score = sum(1 for term in terms if term in text)
+            if score:
+                recency_bonus = record.session
+                scored.append((score * 100 + recency_bonus, record))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [
+            MemoryHit(
+                text=(
+                    f"[{record.service}:{record.kind}:session-{record.session}] "
+                    f"{record.text}"
+                ),
+                source_key=record.key,
+                session=record.session,
+            )
+            for _, record in scored[:2]
+        ]
+
+
+class AppendOnlyLogBackend:
+    name = "append_only_log"
+
+    def __init__(self) -> None:
+        self.records: list[IncidentRecord] = []
+
+    def ingest(self, records: Iterable[IncidentRecord]) -> None:
+        self.records.extend(records)
+
+    def recall(self, query: IncidentQuery) -> list[MemoryHit]:
+        terms = _query_terms(query)
+        matches: list[tuple[int, IncidentRecord]] = []
+        for record in self.records:
+            text = f"{record.kind} {record.service} {record.text}".lower()
+            score = sum(1 for term in terms if term in text)
+            if score:
+                # Append-only systems often retain old and new matches together.
+                matches.append((score * 100 + record.session, record))
+        matches.sort(key=lambda item: item[0], reverse=True)
+        return [
+            MemoryHit(
+                text=(
+                    f"[{record.service}:{record.kind}:session-{record.session}] "
+                    f"{record.text}"
+                ),
+                source_key=record.key,
+                session=record.session,
+            )
+            for _, record in matches[:5]
+        ]

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/backends.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/backends.py
@@ -22,7 +22,7 @@ class MemoryHit:
     def tokens(self) -> int:
         """Return an approximate token count for the recalled text."""
 
-        return len(TOKEN_RE.findall(self.text))
+        return token_count(self.text)
 
 
 class MemoryBackend(Protocol):

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/dataset.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/dataset.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IncidentRecord:
+    session: int
+    service: str
+    key: str
+    kind: str
+    text: str
+    supersedes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class IncidentQuery:
+    service: str
+    prompt: str
+    expected_fragments: tuple[str, ...]
+    stale_fragments: tuple[str, ...]
+
+
+def incident_records() -> list[IncidentRecord]:
+    return [
+        IncidentRecord(
+            1,
+            "payments",
+            "payments.owner",
+            "owner",
+            "Payments owner is Aria. Page Aria only after retry budget is exhausted.",
+        ),
+        IncidentRecord(
+            1,
+            "payments",
+            "payments.runbook",
+            "runbook",
+            "Payments runbook v1 says restart checkout-worker before checking PSP health.",
+        ),
+        IncidentRecord(
+            2,
+            "payments",
+            "payments.status",
+            "status",
+            "Customer status wording: payment authorization delays for EU cards.",
+        ),
+        IncidentRecord(
+            3,
+            "search",
+            "search.owner",
+            "owner",
+            "Search owner is Dev. Escalate relevance regressions to Dev.",
+        ),
+        IncidentRecord(
+            3,
+            "search",
+            "search.runbook",
+            "runbook",
+            "Search runbook v1 says rebuild the synonym index before rolling pods.",
+        ),
+        IncidentRecord(
+            4,
+            "notifications",
+            "notifications.owner",
+            "owner",
+            "Notifications owner is Mira. Mira handles provider throttling events.",
+        ),
+        IncidentRecord(
+            5,
+            "payments",
+            "payments.runbook",
+            "runbook",
+            "Payments runbook v2 says check PSP health first, then drain checkout-worker.",
+            supersedes=("payments.runbook",),
+        ),
+        IncidentRecord(
+            6,
+            "payments",
+            "payments.mitigation",
+            "decision",
+            "Payments mitigation: rollback fraud-rule bundle 2026.06.05-b after spike.",
+        ),
+        IncidentRecord(
+            7,
+            "search",
+            "search.status",
+            "status",
+            "Customer status wording: search filters may lag up to five minutes.",
+        ),
+        IncidentRecord(
+            8,
+            "search",
+            "search.runbook",
+            "runbook",
+            "Search runbook v2 says disable live synonym expansion before rebuild.",
+            supersedes=("search.runbook",),
+        ),
+        IncidentRecord(
+            9,
+            "notifications",
+            "notifications.status",
+            "status",
+            "Customer status wording: SMS delivery is delayed for APAC recipients.",
+        ),
+        IncidentRecord(
+            10,
+            "notifications",
+            "notifications.runbook",
+            "runbook",
+            "Notifications runbook v1 says retry Twilio webhooks with exponential backoff.",
+        ),
+        IncidentRecord(
+            11,
+            "payments",
+            "payments.owner",
+            "owner",
+            "Payments owner changed to Noor. Noor owns checkout and PSP escalation.",
+            supersedes=("payments.owner",),
+        ),
+        IncidentRecord(
+            12,
+            "payments",
+            "payments.status",
+            "status",
+            "Customer status wording: checkout is stable; EU card backlog is draining.",
+            supersedes=("payments.status",),
+        ),
+        IncidentRecord(
+            13,
+            "search",
+            "search.owner",
+            "owner",
+            "Search owner changed to Lin. Lin owns relevance rollback decisions.",
+            supersedes=("search.owner",),
+        ),
+        IncidentRecord(
+            14,
+            "notifications",
+            "notifications.runbook",
+            "runbook",
+            "Notifications runbook v2 says pause APAC SMS batch jobs before retries.",
+            supersedes=("notifications.runbook",),
+        ),
+        IncidentRecord(
+            15,
+            "notifications",
+            "notifications.owner",
+            "owner",
+            "Notifications owner changed to Theo. Theo owns provider throttling events.",
+            supersedes=("notifications.owner",),
+        ),
+        IncidentRecord(
+            16,
+            "search",
+            "search.status",
+            "status",
+            "Customer status wording: search relevance is normal after synonym rollback.",
+            supersedes=("search.status",),
+        ),
+    ]
+
+def incident_queries() -> list[IncidentQuery]:
+    return [
+        IncidentQuery(
+            "payments",
+            "What is the current payments runbook?",
+            ("check PSP health first", "drain checkout-worker"),
+            ("restart checkout-worker before checking PSP health",),
+        ),
+        IncidentQuery(
+            "payments",
+            "Who owns payments escalation now?",
+            ("Noor owns checkout", "PSP escalation"),
+            ("Payments owner is Aria",),
+        ),
+        IncidentQuery(
+            "payments",
+            "What should customer support say about payments?",
+            ("checkout is stable", "EU card backlog is draining"),
+            ("payment authorization delays for EU cards",),
+        ),
+        IncidentQuery(
+            "search",
+            "What is the current search runbook?",
+            ("disable live synonym expansion", "before rebuild"),
+            ("rebuild the synonym index before rolling pods",),
+        ),
+        IncidentQuery(
+            "search",
+            "Who owns search relevance rollback decisions?",
+            ("Search owner changed to Lin", "rollback decisions"),
+            ("Search owner is Dev",),
+        ),
+        IncidentQuery(
+            "search",
+            "What is the current public search status?",
+            ("search relevance is normal", "synonym rollback"),
+            ("filters may lag up to five minutes",),
+        ),
+        IncidentQuery(
+            "notifications",
+            "What is the current notifications runbook?",
+            ("pause APAC SMS batch jobs", "before retries"),
+            ("retry Twilio webhooks",),
+        ),
+        IncidentQuery(
+            "notifications",
+            "Who owns provider throttling now?",
+            ("Notifications owner changed to Theo", "provider throttling"),
+            ("Notifications owner is Mira",),
+        ),
+    ]

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/dataset.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/dataset.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class IncidentRecord:
+    """One fact emitted during an incident response timeline."""
+
     session: int
     service: str
     key: str
@@ -15,6 +17,8 @@ class IncidentRecord:
 
 @dataclass(frozen=True)
 class IncidentQuery:
+    """A retrieval prompt with expected current facts and stale facts to reject."""
+
     service: str
     prompt: str
     expected_fragments: tuple[str, ...]
@@ -22,6 +26,8 @@ class IncidentQuery:
 
 
 def incident_records() -> list[IncidentRecord]:
+    """Return the deterministic benchmark incident timeline."""
+
     return [
         IncidentRecord(
             1,
@@ -159,7 +165,10 @@ def incident_records() -> list[IncidentRecord]:
         ),
     ]
 
+
 def incident_queries() -> list[IncidentQuery]:
+    """Return the benchmark questions used to score memory backends."""
+
     return [
         IncidentQuery(
             "payments",

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/runner.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/runner.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import math
+import time
+from dataclasses import asdict, dataclass
+
+from .backends import (
+    AppendOnlyLogBackend,
+    MemoryBackend,
+    MemantoTypedDigestBackend,
+    token_count,
+)
+from .dataset import IncidentQuery, IncidentRecord, incident_queries, incident_records
+
+
+@dataclass(frozen=True)
+class BackendResult:
+    backend: str
+    tokens_ingested: int
+    tokens_retrieved: int
+    p95_latency_ms: float
+    retrieval_accuracy: float
+    stale_suppression: float
+    signal_to_noise: float
+
+
+@dataclass(frozen=True)
+class QueryTrace:
+    backend: str
+    prompt: str
+    context: str
+    expected_hits: int
+    stale_hits: int
+    latency_ms: float
+
+
+@dataclass(frozen=True)
+class BenchmarkReport:
+    results: list[BackendResult]
+    traces: list[QueryTrace]
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "results": [asdict(result) for result in self.results],
+                "traces": [asdict(trace) for trace in self.traces],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# Incident Memory Pressure Benchmark Results",
+            "",
+            "| Backend | Tokens Ingested | Tokens Retrieved | p95 Latency (ms) | Retrieval Accuracy | Stale Suppression | Signal/Noise |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+        for result in self.results:
+            lines.append(
+                "| {backend} | {ingested} | {retrieved} | {latency:.3f} | "
+                "{accuracy:.2%} | {stale:.2%} | {snr:.2%} |".format(
+                    backend=result.backend,
+                    ingested=result.tokens_ingested,
+                    retrieved=result.tokens_retrieved,
+                    latency=result.p95_latency_ms,
+                    accuracy=result.retrieval_accuracy,
+                    stale=result.stale_suppression,
+                    snr=result.signal_to_noise,
+                )
+            )
+        lines.extend(
+            [
+                "",
+                "## Notes",
+                "",
+                "- Accuracy rewards current expected facts and penalizes stale facts.",
+                "- Signal/noise rewards concise context that contains expected fact tokens.",
+                "- The default run is credential-free and deterministic.",
+            ]
+        )
+        return "\n".join(lines) + "\n"
+
+
+def run_benchmark() -> BenchmarkReport:
+    records = incident_records()
+    queries = incident_queries()
+    backends: list[MemoryBackend] = [
+        MemantoTypedDigestBackend(),
+        AppendOnlyLogBackend(),
+    ]
+
+    results: list[BackendResult] = []
+    traces: list[QueryTrace] = []
+    for backend in backends:
+        backend.ingest(records)
+        backend_result, backend_traces = _evaluate_backend(backend, records, queries)
+        results.append(backend_result)
+        traces.extend(backend_traces)
+    return BenchmarkReport(results=results, traces=traces)
+
+
+def _evaluate_backend(
+    backend: MemoryBackend,
+    records: list[IncidentRecord],
+    queries: list[IncidentQuery],
+) -> tuple[BackendResult, list[QueryTrace]]:
+    tokens_ingested = sum(token_count(record.text) for record in records)
+    tokens_retrieved = 0
+    expected_total = 0
+    expected_hits = 0
+    stale_total = 0
+    stale_hits = 0
+    signal_tokens = 0
+    latencies: list[float] = []
+    traces: list[QueryTrace] = []
+
+    for query in queries:
+        start = time.perf_counter()
+        hits = backend.recall(query)
+        latency_ms = (time.perf_counter() - start) * 1000
+        latencies.append(latency_ms)
+        context = "\n".join(hit.text for hit in hits)
+        context_folded = context.casefold()
+        retrieved_tokens = sum(hit.tokens for hit in hits)
+        tokens_retrieved += retrieved_tokens
+
+        query_expected_hits = sum(
+            1 for fragment in query.expected_fragments if fragment.casefold() in context_folded
+        )
+        query_stale_hits = sum(
+            1 for fragment in query.stale_fragments if fragment.casefold() in context_folded
+        )
+        expected_total += len(query.expected_fragments)
+        expected_hits += query_expected_hits
+        stale_total += len(query.stale_fragments)
+        stale_hits += query_stale_hits
+        signal_tokens += sum(token_count(fragment) for fragment in query.expected_fragments)
+
+        traces.append(
+            QueryTrace(
+                backend=backend.name,
+                prompt=query.prompt,
+                context=context,
+                expected_hits=query_expected_hits,
+                stale_hits=query_stale_hits,
+                latency_ms=latency_ms,
+            )
+        )
+
+    accuracy = (expected_hits + (stale_total - stale_hits)) / (
+        expected_total + stale_total
+    )
+    stale_suppression = (stale_total - stale_hits) / stale_total
+    p95_latency = _p95(latencies)
+    signal_to_noise = signal_tokens / max(tokens_retrieved, 1)
+    return (
+        BackendResult(
+            backend=backend.name,
+            tokens_ingested=tokens_ingested,
+            tokens_retrieved=tokens_retrieved,
+            p95_latency_ms=p95_latency,
+            retrieval_accuracy=accuracy,
+            stale_suppression=stale_suppression,
+            signal_to_noise=signal_to_noise,
+        ),
+        traces,
+    )
+
+
+def _p95(values: list[float]) -> float:
+    if len(values) < 2:
+        return values[0] if values else 0.0
+    sorted_values = sorted(values)
+    index = min(len(sorted_values) - 1, int(math.ceil(len(sorted_values) * 0.95)) - 1)
+    return sorted_values[index]

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/runner.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/runner.py
@@ -16,6 +16,8 @@ from .dataset import IncidentQuery, IncidentRecord, incident_queries, incident_r
 
 @dataclass(frozen=True)
 class BackendResult:
+    """Aggregate metrics for one memory backend."""
+
     backend: str
     tokens_ingested: int
     tokens_retrieved: int
@@ -27,6 +29,8 @@ class BackendResult:
 
 @dataclass(frozen=True)
 class QueryTrace:
+    """Per-query context and scoring trace for a backend run."""
+
     backend: str
     prompt: str
     context: str
@@ -37,10 +41,14 @@ class QueryTrace:
 
 @dataclass(frozen=True)
 class BenchmarkReport:
+    """Complete benchmark output with aggregate metrics and traces."""
+
     results: list[BackendResult]
     traces: list[QueryTrace]
 
     def to_json(self) -> str:
+        """Serialize the benchmark report as stable JSON."""
+
         return json.dumps(
             {
                 "results": [asdict(result) for result in self.results],
@@ -51,6 +59,8 @@ class BenchmarkReport:
         )
 
     def to_markdown(self) -> str:
+        """Render the benchmark report as a Markdown table."""
+
         lines = [
             "# Incident Memory Pressure Benchmark Results",
             "",
@@ -84,6 +94,8 @@ class BenchmarkReport:
 
 
 def run_benchmark() -> BenchmarkReport:
+    """Run every backend against the shared incident-memory dataset."""
+
     records = incident_records()
     queries = incident_queries()
     backends: list[MemoryBackend] = [
@@ -106,6 +118,8 @@ def _evaluate_backend(
     records: list[IncidentRecord],
     queries: list[IncidentQuery],
 ) -> tuple[BackendResult, list[QueryTrace]]:
+    """Score one backend across the benchmark query set."""
+
     tokens_ingested = sum(token_count(record.text) for record in records)
     tokens_retrieved = 0
     expected_total = 0
@@ -170,6 +184,8 @@ def _evaluate_backend(
 
 
 def _p95(values: list[float]) -> float:
+    """Return a simple nearest-rank p95 latency value."""
+
     if len(values) < 2:
         return values[0] if values else 0.0
     sorted_values = sorted(values)

--- a/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/runner.py
+++ b/examples/benchmarks/incident-memory-pressure/incident_memory_pressure/runner.py
@@ -163,10 +163,15 @@ def _evaluate_backend(
             )
         )
 
-    accuracy = (expected_hits + (stale_total - stale_hits)) / (
-        expected_total + stale_total
+    accuracy_denominator = expected_total + stale_total
+    accuracy = (
+        (expected_hits + (stale_total - stale_hits)) / accuracy_denominator
+        if accuracy_denominator
+        else 0.0
     )
-    stale_suppression = (stale_total - stale_hits) / stale_total
+    stale_suppression = (
+        (stale_total - stale_hits) / stale_total if stale_total else 1.0
+    )
     p95_latency = _p95(latencies)
     signal_to_noise = signal_tokens / max(tokens_retrieved, 1)
     return (

--- a/examples/benchmarks/incident-memory-pressure/requirements.txt
+++ b/examples/benchmarks/incident-memory-pressure/requirements.txt
@@ -1,0 +1,1 @@
+# No runtime dependencies. This benchmark uses only the Python standard library.

--- a/examples/benchmarks/incident-memory-pressure/results/sample_results.json
+++ b/examples/benchmarks/incident-memory-pressure/results/sample_results.json
@@ -1,0 +1,152 @@
+{
+  "results": [
+    {
+      "backend": "memanto_typed_digest",
+      "p95_latency_ms": 0.018799997633323073,
+      "retrieval_accuracy": 1.0,
+      "signal_to_noise": 0.24186046511627907,
+      "stale_suppression": 1.0,
+      "tokens_ingested": 183,
+      "tokens_retrieved": 215
+    },
+    {
+      "backend": "append_only_log",
+      "p95_latency_ms": 0.0168999977177009,
+      "retrieval_accuracy": 0.75,
+      "signal_to_noise": 0.09829867674858223,
+      "stale_suppression": 0.25,
+      "tokens_ingested": 183,
+      "tokens_retrieved": 529
+    }
+  ],
+  "traces": [
+    {
+      "backend": "memanto_typed_digest",
+      "context": "[payments:runbook:session-5] Payments runbook v2 says check PSP health first, then drain checkout-worker.\n[notifications:runbook:session-14] Notifications runbook v2 says pause APAC SMS batch jobs before retries.",
+      "expected_hits": 2,
+      "latency_ms": 0.018799997633323073,
+      "prompt": "What is the current payments runbook?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "memanto_typed_digest",
+      "context": "[payments:owner:session-11] Payments owner changed to Noor. Noor owns checkout and PSP escalation.\n[payments:status:session-12] Customer status wording: checkout is stable; EU card backlog is draining.",
+      "expected_hits": 2,
+      "latency_ms": 0.010899995686486363,
+      "prompt": "Who owns payments escalation now?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "memanto_typed_digest",
+      "context": "[payments:status:session-12] Customer status wording: checkout is stable; EU card backlog is draining.\n[search:status:session-16] Customer status wording: search relevance is normal after synonym rollback.",
+      "expected_hits": 2,
+      "latency_ms": 0.009399998816661537,
+      "prompt": "What should customer support say about payments?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "memanto_typed_digest",
+      "context": "[search:runbook:session-8] Search runbook v2 says disable live synonym expansion before rebuild.\n[search:status:session-16] Customer status wording: search relevance is normal after synonym rollback.",
+      "expected_hits": 2,
+      "latency_ms": 0.008400005754083395,
+      "prompt": "What is the current search runbook?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "memanto_typed_digest",
+      "context": "[search:status:session-16] Customer status wording: search relevance is normal after synonym rollback.\n[search:owner:session-13] Search owner changed to Lin. Lin owns relevance rollback decisions.",
+      "expected_hits": 2,
+      "latency_ms": 0.008000002708286047,
+      "prompt": "Who owns search relevance rollback decisions?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "memanto_typed_digest",
+      "context": "[search:status:session-16] Customer status wording: search relevance is normal after synonym rollback.\n[search:owner:session-13] Search owner changed to Lin. Lin owns relevance rollback decisions.",
+      "expected_hits": 2,
+      "latency_ms": 0.007099995855242014,
+      "prompt": "What is the current public search status?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "memanto_typed_digest",
+      "context": "[notifications:runbook:session-14] Notifications runbook v2 says pause APAC SMS batch jobs before retries.\n[notifications:owner:session-15] Notifications owner changed to Theo. Theo owns provider throttling events.",
+      "expected_hits": 2,
+      "latency_ms": 0.006999995093792677,
+      "prompt": "What is the current notifications runbook?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "memanto_typed_digest",
+      "context": "[notifications:owner:session-15] Notifications owner changed to Theo. Theo owns provider throttling events.\n[notifications:runbook:session-14] Notifications runbook v2 says pause APAC SMS batch jobs before retries.",
+      "expected_hits": 2,
+      "latency_ms": 0.006199989002197981,
+      "prompt": "Who owns provider throttling now?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "append_only_log",
+      "context": "[payments:runbook:session-5] Payments runbook v2 says check PSP health first, then drain checkout-worker.\n[payments:runbook:session-1] Payments runbook v1 says restart checkout-worker before checking PSP health.\n[notifications:runbook:session-14] Notifications runbook v2 says pause APAC SMS batch jobs before retries.\n[payments:status:session-12] Customer status wording: checkout is stable; EU card backlog is draining.\n[payments:owner:session-11] Payments owner changed to Noor. Noor owns checkout and PSP escalation.",
+      "expected_hits": 2,
+      "latency_ms": 0.0168999977177009,
+      "prompt": "What is the current payments runbook?",
+      "stale_hits": 1
+    },
+    {
+      "backend": "append_only_log",
+      "context": "[payments:owner:session-11] Payments owner changed to Noor. Noor owns checkout and PSP escalation.\n[payments:status:session-12] Customer status wording: checkout is stable; EU card backlog is draining.\n[payments:decision:session-6] Payments mitigation: rollback fraud-rule bundle 2026.06.05-b after spike.\n[payments:runbook:session-5] Payments runbook v2 says check PSP health first, then drain checkout-worker.\n[payments:status:session-2] Customer status wording: payment authorization delays for EU cards.",
+      "expected_hits": 2,
+      "latency_ms": 0.013600001693703234,
+      "prompt": "Who owns payments escalation now?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "append_only_log",
+      "context": "[payments:status:session-12] Customer status wording: checkout is stable; EU card backlog is draining.\n[payments:status:session-2] Customer status wording: payment authorization delays for EU cards.\n[search:status:session-16] Customer status wording: search relevance is normal after synonym rollback.\n[payments:owner:session-11] Payments owner changed to Noor. Noor owns checkout and PSP escalation.\n[notifications:status:session-9] Customer status wording: SMS delivery is delayed for APAC recipients.",
+      "expected_hits": 2,
+      "latency_ms": 0.012799995602108538,
+      "prompt": "What should customer support say about payments?",
+      "stale_hits": 1
+    },
+    {
+      "backend": "append_only_log",
+      "context": "[search:runbook:session-8] Search runbook v2 says disable live synonym expansion before rebuild.\n[search:runbook:session-3] Search runbook v1 says rebuild the synonym index before rolling pods.\n[search:status:session-16] Customer status wording: search relevance is normal after synonym rollback.\n[notifications:runbook:session-14] Notifications runbook v2 says pause APAC SMS batch jobs before retries.\n[search:owner:session-13] Search owner changed to Lin. Lin owns relevance rollback decisions.",
+      "expected_hits": 2,
+      "latency_ms": 0.01309999788645655,
+      "prompt": "What is the current search runbook?",
+      "stale_hits": 1
+    },
+    {
+      "backend": "append_only_log",
+      "context": "[search:status:session-16] Customer status wording: search relevance is normal after synonym rollback.\n[search:owner:session-13] Search owner changed to Lin. Lin owns relevance rollback decisions.\n[search:runbook:session-8] Search runbook v2 says disable live synonym expansion before rebuild.\n[search:status:session-7] Customer status wording: search filters may lag up to five minutes.\n[payments:decision:session-6] Payments mitigation: rollback fraud-rule bundle 2026.06.05-b after spike.",
+      "expected_hits": 2,
+      "latency_ms": 0.011099997209385037,
+      "prompt": "Who owns search relevance rollback decisions?",
+      "stale_hits": 0
+    },
+    {
+      "backend": "append_only_log",
+      "context": "[search:status:session-16] Customer status wording: search relevance is normal after synonym rollback.\n[search:status:session-7] Customer status wording: search filters may lag up to five minutes.\n[search:owner:session-13] Search owner changed to Lin. Lin owns relevance rollback decisions.\n[payments:status:session-12] Customer status wording: checkout is stable; EU card backlog is draining.\n[notifications:status:session-9] Customer status wording: SMS delivery is delayed for APAC recipients.",
+      "expected_hits": 2,
+      "latency_ms": 0.011500000255182385,
+      "prompt": "What is the current public search status?",
+      "stale_hits": 1
+    },
+    {
+      "backend": "append_only_log",
+      "context": "[notifications:runbook:session-14] Notifications runbook v2 says pause APAC SMS batch jobs before retries.\n[notifications:runbook:session-10] Notifications runbook v1 says retry Twilio webhooks with exponential backoff.\n[notifications:owner:session-15] Notifications owner changed to Theo. Theo owns provider throttling events.\n[notifications:status:session-9] Customer status wording: SMS delivery is delayed for APAC recipients.\n[search:runbook:session-8] Search runbook v2 says disable live synonym expansion before rebuild.",
+      "expected_hits": 2,
+      "latency_ms": 0.0109999964479357,
+      "prompt": "What is the current notifications runbook?",
+      "stale_hits": 1
+    },
+    {
+      "backend": "append_only_log",
+      "context": "[notifications:owner:session-15] Notifications owner changed to Theo. Theo owns provider throttling events.\n[notifications:runbook:session-14] Notifications runbook v2 says pause APAC SMS batch jobs before retries.\n[notifications:runbook:session-10] Notifications runbook v1 says retry Twilio webhooks with exponential backoff.\n[notifications:status:session-9] Customer status wording: SMS delivery is delayed for APAC recipients.\n[notifications:owner:session-4] Notifications owner is Mira. Mira handles provider throttling events.",
+      "expected_hits": 2,
+      "latency_ms": 0.00960000033956021,
+      "prompt": "Who owns provider throttling now?",
+      "stale_hits": 1
+    }
+  ]
+}

--- a/examples/benchmarks/incident-memory-pressure/results/sample_results.md
+++ b/examples/benchmarks/incident-memory-pressure/results/sample_results.md
@@ -1,0 +1,12 @@
+# Incident Memory Pressure Benchmark Results
+
+| Backend | Tokens Ingested | Tokens Retrieved | p95 Latency (ms) | Retrieval Accuracy | Stale Suppression | Signal/Noise |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| memanto_typed_digest | 183 | 215 | 0.019 | 100.00% | 100.00% | 24.19% |
+| append_only_log | 183 | 529 | 0.017 | 75.00% | 25.00% | 9.83% |
+
+## Notes
+
+- Accuracy rewards current expected facts and penalizes stale facts.
+- Signal/noise rewards concise context that contains expected fact tokens.
+- The default run is credential-free and deterministic.

--- a/examples/benchmarks/incident-memory-pressure/run_benchmark.py
+++ b/examples/benchmarks/incident-memory-pressure/run_benchmark.py
@@ -7,6 +7,8 @@ from incident_memory_pressure.runner import run_benchmark
 
 
 def main() -> None:
+    """Parse CLI arguments and print or write benchmark results."""
+
     parser = argparse.ArgumentParser(description="Run the incident memory benchmark")
     parser.add_argument(
         "--format",

--- a/examples/benchmarks/incident-memory-pressure/run_benchmark.py
+++ b/examples/benchmarks/incident-memory-pressure/run_benchmark.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from incident_memory_pressure.runner import run_benchmark
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the incident memory benchmark")
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="markdown",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--write-results",
+        action="store_true",
+        help="Write sample results into the benchmark results directory",
+    )
+    args = parser.parse_args()
+
+    report = run_benchmark()
+    if args.write_results:
+        results_dir = Path(__file__).parent / "results"
+        results_dir.mkdir(exist_ok=True)
+        (results_dir / "sample_results.json").write_text(report.to_json(), encoding="utf-8")
+        (results_dir / "sample_results.md").write_text(
+            report.to_markdown(), encoding="utf-8"
+        )
+
+    if args.format == "json":
+        print(report.to_json())
+    else:
+        print(report.to_markdown())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
+++ b/examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+BENCHMARK_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BENCHMARK_ROOT))
+
+from incident_memory_pressure.runner import run_benchmark
+
+
+def test_memanto_style_backend_uses_less_context_than_append_only() -> None:
+    report = run_benchmark()
+    results = {result.backend: result for result in report.results}
+
+    memanto = results["memanto_typed_digest"]
+    append_only = results["append_only_log"]
+
+    assert memanto.tokens_ingested == append_only.tokens_ingested
+    assert memanto.tokens_retrieved < append_only.tokens_retrieved
+
+
+def test_memanto_style_backend_suppresses_stale_facts() -> None:
+    report = run_benchmark()
+    results = {result.backend: result for result in report.results}
+
+    memanto = results["memanto_typed_digest"]
+    append_only = results["append_only_log"]
+
+    assert memanto.stale_suppression == 1.0
+    assert memanto.retrieval_accuracy > append_only.retrieval_accuracy
+
+
+def test_report_outputs_are_stable() -> None:
+    report = run_benchmark()
+
+    json_output = report.to_json()
+    markdown_output = report.to_markdown()
+
+    assert "memanto_typed_digest" in json_output
+    assert "append_only_log" in markdown_output
+    assert "| Backend | Tokens Ingested |" in markdown_output
+
+
+if __name__ == "__main__":
+    test_memanto_style_backend_uses_less_context_than_append_only()
+    test_memanto_style_backend_suppresses_stale_facts()
+    test_report_outputs_are_stable()

--- a/examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
+++ b/examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
@@ -10,6 +10,8 @@ from incident_memory_pressure.runner import run_benchmark
 
 
 def test_memanto_style_backend_uses_less_context_than_append_only() -> None:
+    """The typed digest should retrieve less context than the append-only log."""
+
     report = run_benchmark()
     results = {result.backend: result for result in report.results}
 
@@ -21,6 +23,8 @@ def test_memanto_style_backend_uses_less_context_than_append_only() -> None:
 
 
 def test_memanto_style_backend_suppresses_stale_facts() -> None:
+    """The typed digest should suppress stale facts better than the baseline."""
+
     report = run_benchmark()
     results = {result.backend: result for result in report.results}
 
@@ -32,6 +36,8 @@ def test_memanto_style_backend_suppresses_stale_facts() -> None:
 
 
 def test_report_outputs_are_stable() -> None:
+    """JSON and Markdown report outputs should include expected stable labels."""
+
     report = run_benchmark()
 
     json_output = report.to_json()

--- a/examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
+++ b/examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
@@ -6,7 +6,10 @@ import sys
 BENCHMARK_ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(BENCHMARK_ROOT))
 
+from incident_memory_pressure.backends import MemantoTypedDigestBackend
+from incident_memory_pressure.dataset import IncidentQuery
 from incident_memory_pressure.runner import run_benchmark
+from incident_memory_pressure.runner import _evaluate_backend
 
 
 def test_memanto_style_backend_uses_less_context_than_append_only() -> None:
@@ -48,7 +51,33 @@ def test_report_outputs_are_stable() -> None:
     assert "| Backend | Tokens Ingested |" in markdown_output
 
 
+def test_empty_scoring_fragments_do_not_crash() -> None:
+    """A query with no scoring fragments should produce defensive metrics."""
+
+    backend = MemantoTypedDigestBackend()
+    backend.ingest([])
+
+    result, traces = _evaluate_backend(
+        backend,
+        records=[],
+        queries=[
+            IncidentQuery(
+                service="empty",
+                prompt="What should be recalled?",
+                expected_fragments=(),
+                stale_fragments=(),
+            )
+        ],
+    )
+
+    assert result.retrieval_accuracy == 0.0
+    assert result.stale_suppression == 1.0
+    assert traces[0].expected_hits == 0
+    assert traces[0].stale_hits == 0
+
+
 if __name__ == "__main__":
     test_memanto_style_backend_uses_less_context_than_append_only()
     test_memanto_style_backend_suppresses_stale_facts()
     test_report_outputs_are_stable()
+    test_empty_scoring_fragments_do_not_crash()

--- a/examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
+++ b/examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
@@ -72,6 +72,7 @@ def test_empty_scoring_fragments_do_not_crash() -> None:
 
     assert result.retrieval_accuracy == 0.0
     assert result.stale_suppression == 1.0
+    assert len(traces) == 1
     assert traces[0].expected_hits == 0
     assert traces[0].stale_hits == 0
 


### PR DESCRIPTION
﻿# PR: Add incident memory pressure benchmark

Targets #639

/claim #639

BountyHub: https://www.bountyhub.dev/bounty/view/ec58c800-823e-4134-b027-99838e096d4b

## Summary

This PR adds `examples/benchmarks/incident-memory-pressure`, a credential-free reproducible benchmark for the Great Agentic Memory Showdown.

It is intentionally different from the existing temporal preference-drift benchmark. This one stresses long-running incident response memory where stale runbooks, owners, and customer status wording must be replaced cleanly while preserving current mitigation evidence.

Backends compared:

- `memanto_typed_digest`: a Memanto-style typed memory backend with recency, provenance, and supersession keys.
- `append_only_log`: a graph/log-style baseline that recalls matching historical snippets without suppressing stale state.

## Metrics

Default offline sample run:

| Backend | Tokens Ingested | Tokens Retrieved | p95 Latency | Retrieval Accuracy | Stale Suppression | Signal/Noise |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| memanto_typed_digest | 183 | 215 | sample p95 in `results/sample_results.md` | 100.00% | 100.00% | 24.19% |
| append_only_log | 183 | 529 | sample p95 in `results/sample_results.md` | 75.00% | 25.00% | 9.83% |

## Social showcase

- X showcase: https://x.com/xtra_xty/status/2062992270669103545

## Verification

```bash
python examples/benchmarks/incident-memory-pressure/run_benchmark.py --format markdown
python examples/benchmarks/incident-memory-pressure/run_benchmark.py --format json
python examples/benchmarks/incident-memory-pressure/tests/test_incident_memory_pressure.py
python -m compileall -q examples/benchmarks/incident-memory-pressure
git diff --check
```

The direct Python test, JSON/Markdown runs, compile check, and diff whitespace check passed locally.

## Notes

- No API keys, private credentials, or payout details are committed.
- The benchmark includes a small `MemoryBackend` protocol so live Memanto, Mem0, Zep, or Hindsight adapters can be plugged in without changing the dataset or scoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "incident-memory-pressure" benchmark with CLI to run and compare two in-repo memory backend strategies, generate stable JSON/Markdown reports, and export sample results.

* **Documentation**
  * Added a detailed README describing the scenario, metrics, evaluation queries, how to run, and how to extend the benchmark.

* **Tests**
  * Added tests validating backend metric relationships, defensive behaviors, and stable report outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->