### PR TITLE
[BOUNTY $100] Add multi-agent code handoff benchmark

### DIFF
--- a/examples/benchmarks/multi-agent-code-handoff/README.md
+++ b/examples/benchmarks/multi-agent-code-handoff/README.md
@@ -1,0 +1,87 @@
+# Multi-Agent Codebase Handoff Benchmark
+
+This benchmark evaluates how a shared, active memory layer handles a realistic
+multi-agent software release handoff compared with a per-agent append-only log
+baseline.
+
+The workload models a team of specialized coding agents shipping an imports API:
+
+- planner
+- implementer
+- reviewer
+- qa-agent
+- docs-agent
+- release-manager
+
+Facts intentionally change over time. The benchmark asks each agent for the
+current state of facts that were often created or corrected by another agent.
+This stresses the multi-agent memory sharing problem: the best memory layer must
+surface the latest cross-agent fact without bloating the prompt with stale logs.
+
+## What It Measures
+
+The output includes:
+
+- retrieval accuracy using golden dataset matching
+- cross-agent retrieval accuracy
+- total ingested tokens
+- total retrieved tokens
+- p95 retrieval latency
+- stale conflict rate
+- signal-to-noise ratio for retrieved context
+
+## Backends
+
+The default benchmark is dependency-free and deterministic:
+
+- `shared_active_digest`: an offline control that mirrors Memanto's intended
+  active shared memory behavior, typed facts, latest-state supersession, and
+  compact retrieval.
+- `shared_append_log`: a shared transcript baseline with cross-agent access but
+  no active supersession, so stale facts remain in retrieved context.
+- `per_agent_append_log`: a siloed append-only log baseline where each agent
+  mainly searches its own transcript, causing missed handoffs and stale
+  contradictions.
+
+The harness isolates benchmark design from service availability. A real Memanto
+or competitor adapter can replace either backend as long as it implements the
+same `ingest(event)` and `retrieve(question)` interface in `run_benchmark.py`.
+
+## Scientific Controls
+
+- Backend LLM: none by default. The run is offline and uses golden exact-match
+  scoring rather than LLM-as-a-judge.
+- Dataset: `dataset/codebase_handoff.json`
+- Prompt/system instructions: none. Retrieval queries are the exact `query`
+  strings in the dataset.
+- Engine toggles:
+  - `shared_active_digest`: global shared namespace, one active fact per key,
+    latest event supersedes older values, max 1 fact retrieved.
+  - `shared_append_log`: global shared namespace, append-only transcript, no
+    supersession, max 6 log entries retrieved.
+  - `per_agent_append_log`: per-agent silo, append-only transcript, no
+    supersession, max 6 log entries retrieved.
+- Host environment: captured in each JSON result under `host_environment`.
+
+## Run
+
+```bash
+python run_benchmark.py \
+  --output results/latest.json \
+  --markdown results/latest.md
+```
+
+Run tests:
+
+```bash
+python -m unittest discover -s . -p "test_*.py"
+```
+
+No external packages are required.
+
+## Expected Result
+
+The shared active digest should retrieve fewer tokens, avoid stale conflicts,
+and score higher on cross-agent handoff questions. This is the production
+tension the bounty asks for: accuracy versus resource footprint under changing
+state.

--- a/examples/benchmarks/multi-agent-code-handoff/dataset/codebase_handoff.json
+++ b/examples/benchmarks/multi-agent-code-handoff/dataset/codebase_handoff.json
@@ -1,0 +1,262 @@
+{
+  "name": "multi_agent_codebase_handoff_v1",
+  "description": "A deterministic benchmark for shared memory in multi-agent coding workflows. Facts mutate across planning, implementation, review, QA, docs, and release handoff turns.",
+  "controls": {
+    "backend_llm": "none; offline golden dataset matching",
+    "judge": "exact key/value matching with stale conflict detection",
+    "prompt_system_instructions": "none",
+    "memanto_style_toggles": {
+      "namespace": "shared project memory",
+      "fact_model": "typed latest-state digest",
+      "supersession": "newer event with the same key replaces the active fact",
+      "max_retrieved_facts": 1
+    },
+    "baseline_toggles": {
+      "shared_append_log": "global transcript with no supersession and max 6 retrieved events",
+      "namespace": "per-agent transcript silo",
+      "fact_model": "append-only log",
+      "supersession": "disabled",
+      "max_retrieved_events": 6
+    }
+  },
+  "events": [
+    {
+      "turn": 1,
+      "timestamp": "2026-06-01T09:00:00Z",
+      "agent": "planner",
+      "memory_type": "decision",
+      "key": "imports.api.contract",
+      "value": "POST /v2/imports accepts csv_url and dry_run",
+      "content": "Initial imports API contract: POST /v2/imports accepts csv_url and dry_run. This is a planning draft for implementer handoff.",
+      "tags": ["imports", "api", "contract", "draft"]
+    },
+    {
+      "turn": 2,
+      "timestamp": "2026-06-01T09:12:00Z",
+      "agent": "implementer",
+      "memory_type": "fact",
+      "key": "imports.auth.scope",
+      "value": "imports:write",
+      "content": "Implementation note: imports endpoint currently checks the imports:write scope before enqueueing a job.",
+      "tags": ["imports", "auth", "scope"]
+    },
+    {
+      "turn": 3,
+      "timestamp": "2026-06-01T09:30:00Z",
+      "agent": "qa-agent",
+      "memory_type": "observation",
+      "key": "test.blocker",
+      "value": "CSV parser newline bug blocks the import smoke test",
+      "content": "QA blocker: CSV parser newline bug blocks the import smoke test on Windows generated files.",
+      "tags": ["qa", "test", "blocker", "csv"]
+    },
+    {
+      "turn": 4,
+      "timestamp": "2026-06-01T10:05:00Z",
+      "agent": "release-manager",
+      "memory_type": "decision",
+      "key": "rollout.region",
+      "value": "all production tenants after reviewer approval",
+      "content": "Draft rollout region: all production tenants after reviewer approval. This is only a release draft.",
+      "tags": ["rollout", "region", "draft"]
+    },
+    {
+      "turn": 5,
+      "timestamp": "2026-06-01T10:18:00Z",
+      "agent": "planner",
+      "memory_type": "decision",
+      "key": "imports.api.contract",
+      "value": "POST /v2/imports accepts source_url, preview_only, and idempotency_key",
+      "content": "Superseding API contract: POST /v2/imports now accepts source_url, preview_only, and idempotency_key. Replace the older csv_url and dry_run draft.",
+      "tags": ["imports", "api", "contract", "current"],
+      "supersedes": ["imports.api.contract"]
+    },
+    {
+      "turn": 6,
+      "timestamp": "2026-06-01T10:26:00Z",
+      "agent": "reviewer",
+      "memory_type": "constraint",
+      "key": "imports.auth.scope",
+      "value": "imports:admin",
+      "content": "Review security correction: imports must require imports:admin because source_url can point at customer-controlled storage. Supersede imports:write.",
+      "tags": ["imports", "auth", "scope", "security"],
+      "supersedes": ["imports.auth.scope"]
+    },
+    {
+      "turn": 7,
+      "timestamp": "2026-06-01T10:33:00Z",
+      "agent": "implementer",
+      "memory_type": "fact",
+      "key": "feature.flag",
+      "value": "imports_v2_beta",
+      "content": "Implementation branch still uses feature flag imports_v2_beta around the new import worker.",
+      "tags": ["feature", "flag", "implementation"]
+    },
+    {
+      "turn": 8,
+      "timestamp": "2026-06-01T11:02:00Z",
+      "agent": "planner",
+      "memory_type": "decision",
+      "key": "feature.flag",
+      "value": "bulk_import_v2",
+      "content": "Release naming decision: the current feature flag is bulk_import_v2. Replace imports_v2_beta in docs, code comments, and rollout notes.",
+      "tags": ["feature", "flag", "current"],
+      "supersedes": ["feature.flag"]
+    },
+    {
+      "turn": 9,
+      "timestamp": "2026-06-01T11:20:00Z",
+      "agent": "qa-agent",
+      "memory_type": "observation",
+      "key": "test.blocker",
+      "value": "retry idempotency conflict on duplicate idempotency_key",
+      "content": "QA update: newline parser issue is fixed. Current blocker is a retry idempotency conflict when the same idempotency_key is submitted twice.",
+      "tags": ["qa", "test", "blocker", "idempotency"],
+      "supersedes": ["test.blocker"]
+    },
+    {
+      "turn": 10,
+      "timestamp": "2026-06-01T11:45:00Z",
+      "agent": "implementer",
+      "memory_type": "fact",
+      "key": "database.migration",
+      "value": "20260605_add_import_jobs_retry_state",
+      "content": "Database migration to review: 20260605_add_import_jobs_retry_state adds retry_state and idempotency_key columns to import_jobs.",
+      "tags": ["database", "migration", "retry", "idempotency"]
+    },
+    {
+      "turn": 11,
+      "timestamp": "2026-06-01T12:00:00Z",
+      "agent": "docs-agent",
+      "memory_type": "fact",
+      "key": "docs.warning",
+      "value": "preview_only defaults true in sandbox and false in production",
+      "content": "Docs warning: preview_only defaults true in sandbox and false in production. The public guide must call this out before examples.",
+      "tags": ["docs", "preview_only", "sandbox", "production"]
+    },
+    {
+      "turn": 12,
+      "timestamp": "2026-06-01T12:18:00Z",
+      "agent": "release-manager",
+      "memory_type": "decision",
+      "key": "rollout.region",
+      "value": "us-east-1 internal tenants only",
+      "content": "Release decision: rollout region is us-east-1 internal tenants only for the first 24 hours. Do not use the earlier all-tenant rollout draft.",
+      "tags": ["rollout", "region", "current"],
+      "supersedes": ["rollout.region"]
+    },
+    {
+      "turn": 13,
+      "timestamp": "2026-06-01T12:36:00Z",
+      "agent": "release-manager",
+      "memory_type": "procedure",
+      "key": "rollback.plan",
+      "value": "disable bulk_import_v2 and route jobs to legacy_import_worker",
+      "content": "Rollback plan: disable bulk_import_v2 and route jobs to legacy_import_worker. Keep import_jobs rows for forensic review.",
+      "tags": ["rollback", "feature", "worker"]
+    },
+    {
+      "turn": 14,
+      "timestamp": "2026-06-01T12:52:00Z",
+      "agent": "planner",
+      "memory_type": "relationship",
+      "key": "owner.oncall",
+      "value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
+      "content": "Ownership update: Mina owns backend until 18:00 UTC; Ravi owns QA signoff. Replace Leo as the release contact.",
+      "tags": ["owner", "oncall", "backend", "qa"],
+      "supersedes": ["owner.oncall"]
+    },
+    {
+      "turn": 15,
+      "timestamp": "2026-06-01T13:05:00Z",
+      "agent": "docs-agent",
+      "memory_type": "fact",
+      "key": "customer.message",
+      "value": "release is delayed by validation hardening; no customer data loss",
+      "content": "Customer message: release is delayed by validation hardening; no customer data loss. Avoid saying the API is generally unavailable.",
+      "tags": ["customer", "message", "release"]
+    }
+  ],
+  "questions": [
+    {
+      "id": "q1",
+      "asker": "reviewer",
+      "query": "For code review, what is the current imports API contract and endpoint arguments?",
+      "expected_key": "imports.api.contract",
+      "expected_value": "POST /v2/imports accepts source_url, preview_only, and idempotency_key",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q2",
+      "asker": "implementer",
+      "query": "What auth scope should the import endpoint enforce now?",
+      "expected_key": "imports.auth.scope",
+      "expected_value": "imports:admin",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q3",
+      "asker": "docs-agent",
+      "query": "Which feature flag name should docs and examples use for the import worker?",
+      "expected_key": "feature.flag",
+      "expected_value": "bulk_import_v2",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q4",
+      "asker": "release-manager",
+      "query": "What is the current QA test blocker for release readiness?",
+      "expected_key": "test.blocker",
+      "expected_value": "retry idempotency conflict on duplicate idempotency_key",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q5",
+      "asker": "qa-agent",
+      "query": "Which database migration should QA verify for retry state?",
+      "expected_key": "database.migration",
+      "expected_value": "20260605_add_import_jobs_retry_state",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q6",
+      "asker": "implementer",
+      "query": "What warning should be reflected around preview_only behavior?",
+      "expected_key": "docs.warning",
+      "expected_value": "preview_only defaults true in sandbox and false in production",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q7",
+      "asker": "reviewer",
+      "query": "What is the current rollout region and tenant scope?",
+      "expected_key": "rollout.region",
+      "expected_value": "us-east-1 internal tenants only",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q8",
+      "asker": "docs-agent",
+      "query": "Who owns backend and QA signoff during the release handoff?",
+      "expected_key": "owner.oncall",
+      "expected_value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q9",
+      "asker": "qa-agent",
+      "query": "What rollback plan should be used if the import release fails?",
+      "expected_key": "rollback.plan",
+      "expected_value": "disable bulk_import_v2 and route jobs to legacy_import_worker",
+      "requires_cross_agent_memory": true
+    },
+    {
+      "id": "q10",
+      "asker": "release-manager",
+      "query": "What customer message should we use for the release delay?",
+      "expected_key": "customer.message",
+      "expected_value": "release is delayed by validation hardening; no customer data loss",
+      "requires_cross_agent_memory": true
+    }
+  ]
+}

--- a/examples/benchmarks/multi-agent-code-handoff/dataset/codebase_handoff.json
+++ b/examples/benchmarks/multi-agent-code-handoff/dataset/codebase_handoff.json
@@ -163,8 +163,7 @@
       "key": "owner.oncall",
       "value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
       "content": "Ownership update: Mina owns backend until 18:00 UTC; Ravi owns QA signoff. Replace Leo as the release contact.",
-      "tags": ["owner", "oncall", "backend", "qa"],
-      "supersedes": ["owner.oncall"]
+      "tags": ["owner", "oncall", "backend", "qa"]
     },
     {
       "turn": 15,

--- a/examples/benchmarks/multi-agent-code-handoff/requirements.txt
+++ b/examples/benchmarks/multi-agent-code-handoff/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party packages are required.

--- a/examples/benchmarks/multi-agent-code-handoff/results/sample_results.json
+++ b/examples/benchmarks/multi-agent-code-handoff/results/sample_results.json
@@ -32,7 +32,7 @@
       "cross_agent_accuracy": 1.0,
       "cross_agent_correct": 10,
       "ingested_tokens": 252,
-      "p95_latency_seconds": 0.00018279999494552612,
+      "p95_latency_seconds": 0.000276199949439615,
       "questions": [
         {
           "id": "q1",
@@ -41,7 +41,7 @@
           "expected_key": "imports.api.contract",
           "expected_value": "POST /v2/imports accepts source_url, preview_only, and idempotency_key",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00018279999494552612,
+          "latency_seconds": 0.000276199949439615,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -58,7 +58,7 @@
           "expected_key": "imports.auth.scope",
           "expected_value": "imports:admin",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00017740001203492284,
+          "latency_seconds": 9.929999941959977e-05,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -75,7 +75,7 @@
           "expected_key": "feature.flag",
           "expected_value": "bulk_import_v2",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00016739999409765005,
+          "latency_seconds": 0.00010549998842179775,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -92,7 +92,7 @@
           "expected_key": "test.blocker",
           "expected_value": "retry idempotency conflict on duplicate idempotency_key",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.0001647999742999673,
+          "latency_seconds": 9.319995297119021e-05,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -109,7 +109,7 @@
           "expected_key": "database.migration",
           "expected_value": "20260605_add_import_jobs_retry_state",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00011030002497136593,
+          "latency_seconds": 6.78999931551516e-05,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -126,7 +126,7 @@
           "expected_key": "docs.warning",
           "expected_value": "preview_only defaults true in sandbox and false in production",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00010250002378597856,
+          "latency_seconds": 8.289999095723033e-05,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -143,7 +143,7 @@
           "expected_key": "rollout.region",
           "expected_value": "us-east-1 internal tenants only",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.0001357999863103032,
+          "latency_seconds": 0.0001373999984934926,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -160,7 +160,7 @@
           "expected_key": "owner.oncall",
           "expected_value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00011369999265298247,
+          "latency_seconds": 0.00011560000712051988,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -177,7 +177,7 @@
           "expected_key": "rollback.plan",
           "expected_value": "disable bulk_import_v2 and route jobs to legacy_import_worker",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00014379998901858926,
+          "latency_seconds": 0.00012199999764561653,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -194,7 +194,7 @@
           "expected_key": "customer.message",
           "expected_value": "release is delayed by validation hardening; no customer data loss",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00013969995779916644,
+          "latency_seconds": 0.00011319998884573579,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -217,7 +217,7 @@
       "cross_agent_accuracy": 0.8,
       "cross_agent_correct": 8,
       "ingested_tokens": 252,
-      "p95_latency_seconds": 0.00043479999294504523,
+      "p95_latency_seconds": 0.000291300006210804,
       "questions": [
         {
           "id": "q1",
@@ -226,7 +226,7 @@
           "expected_key": "imports.api.contract",
           "expected_value": "POST /v2/imports accepts source_url, preview_only, and idempotency_key",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00020150002092123032,
+          "latency_seconds": 0.00022709998302161694,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -248,7 +248,7 @@
           "expected_key": "imports.auth.scope",
           "expected_value": "imports:admin",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.0001564000267535448,
+          "latency_seconds": 0.00015460001304745674,
           "correct": false,
           "first_exact_rank": 2,
           "retrieved_keys": [
@@ -270,7 +270,7 @@
           "expected_key": "feature.flag",
           "expected_value": "bulk_import_v2",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00014590000500902534,
+          "latency_seconds": 0.0001582999830134213,
           "correct": false,
           "first_exact_rank": 2,
           "retrieved_keys": [
@@ -292,7 +292,7 @@
           "expected_key": "test.blocker",
           "expected_value": "retry idempotency conflict on duplicate idempotency_key",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 9.99000039882958e-05,
+          "latency_seconds": 0.00010000000474974513,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -314,7 +314,7 @@
           "expected_key": "database.migration",
           "expected_value": "20260605_add_import_jobs_retry_state",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.000146100006531924,
+          "latency_seconds": 0.00010979996295645833,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -336,7 +336,7 @@
           "expected_key": "docs.warning",
           "expected_value": "preview_only defaults true in sandbox and false in production",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.0001466000103391707,
+          "latency_seconds": 0.00011990003986284137,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -358,7 +358,7 @@
           "expected_key": "rollout.region",
           "expected_value": "us-east-1 internal tenants only",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00014899997040629387,
+          "latency_seconds": 9.460002183914185e-05,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -380,7 +380,7 @@
           "expected_key": "owner.oncall",
           "expected_value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00015569996321573853,
+          "latency_seconds": 0.00017279997700825334,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -402,7 +402,7 @@
           "expected_key": "rollback.plan",
           "expected_value": "disable bulk_import_v2 and route jobs to legacy_import_worker",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00015480001457035542,
+          "latency_seconds": 0.000291300006210804,
           "correct": true,
           "first_exact_rank": 2,
           "retrieved_keys": [
@@ -424,7 +424,7 @@
           "expected_key": "customer.message",
           "expected_value": "release is delayed by validation hardening; no customer data loss",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 0.00043479999294504523,
+          "latency_seconds": 0.0001750999945215881,
           "correct": true,
           "first_exact_rank": 1,
           "retrieved_keys": [
@@ -452,7 +452,7 @@
       "cross_agent_accuracy": 0.0,
       "cross_agent_correct": 0,
       "ingested_tokens": 252,
-      "p95_latency_seconds": 3.539997851476073e-05,
+      "p95_latency_seconds": 3.809999907389283e-05,
       "questions": [
         {
           "id": "q1",
@@ -461,7 +461,7 @@
           "expected_key": "imports.api.contract",
           "expected_value": "POST /v2/imports accepts source_url, preview_only, and idempotency_key",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 2.3100001271814108e-05,
+          "latency_seconds": 1.580000389367342e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -478,7 +478,7 @@
           "expected_key": "imports.auth.scope",
           "expected_value": "imports:admin",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 3.239995567128062e-05,
+          "latency_seconds": 2.8399983420968056e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -497,7 +497,7 @@
           "expected_key": "feature.flag",
           "expected_value": "bulk_import_v2",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 2.929999027401209e-05,
+          "latency_seconds": 2.829998265951872e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -515,7 +515,7 @@
           "expected_key": "test.blocker",
           "expected_value": "retry idempotency conflict on duplicate idempotency_key",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 3.539997851476073e-05,
+          "latency_seconds": 3.809999907389283e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -534,7 +534,7 @@
           "expected_key": "database.migration",
           "expected_value": "20260605_add_import_jobs_retry_state",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 2.5600020308047533e-05,
+          "latency_seconds": 2.5300018023699522e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -552,7 +552,7 @@
           "expected_key": "docs.warning",
           "expected_value": "preview_only defaults true in sandbox and false in production",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 2.7099973522126675e-05,
+          "latency_seconds": 2.5499961338937283e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -571,7 +571,7 @@
           "expected_key": "rollout.region",
           "expected_value": "us-east-1 internal tenants only",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 1.1299969628453255e-05,
+          "latency_seconds": 2.9999995604157448e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -588,7 +588,7 @@
           "expected_key": "owner.oncall",
           "expected_value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 2.6099965907633305e-05,
+          "latency_seconds": 3.309996100142598e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -606,7 +606,7 @@
           "expected_key": "rollback.plan",
           "expected_value": "disable bulk_import_v2 and route jobs to legacy_import_worker",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 2.4300010409206152e-05,
+          "latency_seconds": 2.800003858283162e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [
@@ -624,7 +624,7 @@
           "expected_key": "customer.message",
           "expected_value": "release is delayed by validation hardening; no customer data loss",
           "requires_cross_agent_memory": true,
-          "latency_seconds": 3.300001844763756e-05,
+          "latency_seconds": 3.649998689070344e-05,
           "correct": false,
           "first_exact_rank": null,
           "retrieved_keys": [

--- a/examples/benchmarks/multi-agent-code-handoff/results/sample_results.json
+++ b/examples/benchmarks/multi-agent-code-handoff/results/sample_results.json
@@ -1,0 +1,646 @@
+{
+  "benchmark": "multi_agent_codebase_handoff_v1",
+  "description": "A deterministic benchmark for shared memory in multi-agent coding workflows. Facts mutate across planning, implementation, review, QA, docs, and release handoff turns.",
+  "controls": {
+    "backend_llm": "none; offline golden dataset matching",
+    "judge": "exact key/value matching with stale conflict detection",
+    "prompt_system_instructions": "none",
+    "memanto_style_toggles": {
+      "namespace": "shared project memory",
+      "fact_model": "typed latest-state digest",
+      "supersession": "newer event with the same key replaces the active fact",
+      "max_retrieved_facts": 1
+    },
+    "baseline_toggles": {
+      "shared_append_log": "global transcript with no supersession and max 6 retrieved events",
+      "namespace": "per-agent transcript silo",
+      "fact_model": "append-only log",
+      "supersession": "disabled",
+      "max_retrieved_events": 6
+    }
+  },
+  "host_environment": {
+    "platform": "Windows-11-10.0.26200-SP0",
+    "python": "3.12.10 (tags/v3.12.10:0cc8128, Apr  8 2025, 12:21:36) [MSC v.1943 64 bit (AMD64)]",
+    "implementation": "CPython"
+  },
+  "results": [
+    {
+      "backend": "shared_active_digest",
+      "accuracy": 1.0,
+      "correct": 10,
+      "cross_agent_accuracy": 1.0,
+      "cross_agent_correct": 10,
+      "ingested_tokens": 252,
+      "p95_latency_seconds": 0.00018279999494552612,
+      "questions": [
+        {
+          "id": "q1",
+          "asker": "reviewer",
+          "query": "For code review, what is the current imports API contract and endpoint arguments?",
+          "expected_key": "imports.api.contract",
+          "expected_value": "POST /v2/imports accepts source_url, preview_only, and idempotency_key",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00018279999494552612,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "imports.api.contract"
+          ],
+          "retrieved_tokens": 31,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q2",
+          "asker": "implementer",
+          "query": "What auth scope should the import endpoint enforce now?",
+          "expected_key": "imports.auth.scope",
+          "expected_value": "imports:admin",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00017740001203492284,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "imports.auth.scope"
+          ],
+          "retrieved_tokens": 23,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q3",
+          "asker": "docs-agent",
+          "query": "Which feature flag name should docs and examples use for the import worker?",
+          "expected_key": "feature.flag",
+          "expected_value": "bulk_import_v2",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00016739999409765005,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "feature.flag"
+          ],
+          "retrieved_tokens": 24,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q4",
+          "asker": "release-manager",
+          "query": "What is the current QA test blocker for release readiness?",
+          "expected_key": "test.blocker",
+          "expected_value": "retry idempotency conflict on duplicate idempotency_key",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.0001647999742999673,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "test.blocker"
+          ],
+          "retrieved_tokens": 33,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q5",
+          "asker": "qa-agent",
+          "query": "Which database migration should QA verify for retry state?",
+          "expected_key": "database.migration",
+          "expected_value": "20260605_add_import_jobs_retry_state",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00011030002497136593,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "database.migration"
+          ],
+          "retrieved_tokens": 19,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q6",
+          "asker": "implementer",
+          "query": "What warning should be reflected around preview_only behavior?",
+          "expected_key": "docs.warning",
+          "expected_value": "preview_only defaults true in sandbox and false in production",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00010250002378597856,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "docs.warning"
+          ],
+          "retrieved_tokens": 35,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q7",
+          "asker": "reviewer",
+          "query": "What is the current rollout region and tenant scope?",
+          "expected_key": "rollout.region",
+          "expected_value": "us-east-1 internal tenants only",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.0001357999863103032,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "rollout.region"
+          ],
+          "retrieved_tokens": 31,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q8",
+          "asker": "docs-agent",
+          "query": "Who owns backend and QA signoff during the release handoff?",
+          "expected_key": "owner.oncall",
+          "expected_value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00011369999265298247,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "owner.oncall"
+          ],
+          "retrieved_tokens": 34,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q9",
+          "asker": "qa-agent",
+          "query": "What rollback plan should be used if the import release fails?",
+          "expected_key": "rollback.plan",
+          "expected_value": "disable bulk_import_v2 and route jobs to legacy_import_worker",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00014379998901858926,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "rollback.plan"
+          ],
+          "retrieved_tokens": 27,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q10",
+          "asker": "release-manager",
+          "query": "What customer message should we use for the release delay?",
+          "expected_key": "customer.message",
+          "expected_value": "release is delayed by validation hardening; no customer data loss",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00013969995779916644,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "customer.message"
+          ],
+          "retrieved_tokens": 34,
+          "signal_noise_ratio": 1.0,
+          "stale_conflict": false
+        }
+      ],
+      "retrieved_tokens": 291,
+      "signal_noise_ratio": 1.0,
+      "stale_conflict_rate": 0.0,
+      "total_questions": 10
+    },
+    {
+      "backend": "shared_append_log",
+      "accuracy": 0.8,
+      "correct": 8,
+      "cross_agent_accuracy": 0.8,
+      "cross_agent_correct": 8,
+      "ingested_tokens": 252,
+      "p95_latency_seconds": 0.00043479999294504523,
+      "questions": [
+        {
+          "id": "q1",
+          "asker": "reviewer",
+          "query": "For code review, what is the current imports API contract and endpoint arguments?",
+          "expected_key": "imports.api.contract",
+          "expected_value": "POST /v2/imports accepts source_url, preview_only, and idempotency_key",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00020150002092123032,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "imports.api.contract",
+            "imports.api.contract",
+            "imports.auth.scope",
+            "feature.flag",
+            "imports.auth.scope",
+            "customer.message"
+          ],
+          "retrieved_tokens": 161,
+          "signal_noise_ratio": 0.3333333333333333,
+          "stale_conflict": true
+        },
+        {
+          "id": "q2",
+          "asker": "implementer",
+          "query": "What auth scope should the import endpoint enforce now?",
+          "expected_key": "imports.auth.scope",
+          "expected_value": "imports:admin",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.0001564000267535448,
+          "correct": false,
+          "first_exact_rank": 2,
+          "retrieved_keys": [
+            "imports.auth.scope",
+            "imports.auth.scope",
+            "feature.flag",
+            "test.blocker",
+            "customer.message",
+            "owner.oncall"
+          ],
+          "retrieved_tokens": 158,
+          "signal_noise_ratio": 0.3333333333333333,
+          "stale_conflict": true
+        },
+        {
+          "id": "q3",
+          "asker": "docs-agent",
+          "query": "Which feature flag name should docs and examples use for the import worker?",
+          "expected_key": "feature.flag",
+          "expected_value": "bulk_import_v2",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00014590000500902534,
+          "correct": false,
+          "first_exact_rank": 2,
+          "retrieved_keys": [
+            "feature.flag",
+            "feature.flag",
+            "rollback.plan",
+            "test.blocker",
+            "docs.warning",
+            "customer.message"
+          ],
+          "retrieved_tokens": 168,
+          "signal_noise_ratio": 0.3333333333333333,
+          "stale_conflict": true
+        },
+        {
+          "id": "q4",
+          "asker": "release-manager",
+          "query": "What is the current QA test blocker for release readiness?",
+          "expected_key": "test.blocker",
+          "expected_value": "retry idempotency conflict on duplicate idempotency_key",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 9.99000039882958e-05,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "test.blocker",
+            "test.blocker",
+            "feature.flag",
+            "rollout.region",
+            "owner.oncall",
+            "rollout.region"
+          ],
+          "retrieved_tokens": 178,
+          "signal_noise_ratio": 0.3333333333333333,
+          "stale_conflict": true
+        },
+        {
+          "id": "q5",
+          "asker": "qa-agent",
+          "query": "Which database migration should QA verify for retry state?",
+          "expected_key": "database.migration",
+          "expected_value": "20260605_add_import_jobs_retry_state",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.000146100006531924,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "database.migration",
+            "test.blocker",
+            "test.blocker",
+            "owner.oncall",
+            "customer.message",
+            "rollback.plan"
+          ],
+          "retrieved_tokens": 177,
+          "signal_noise_ratio": 0.16666666666666666,
+          "stale_conflict": false
+        },
+        {
+          "id": "q6",
+          "asker": "implementer",
+          "query": "What warning should be reflected around preview_only behavior?",
+          "expected_key": "docs.warning",
+          "expected_value": "preview_only defaults true in sandbox and false in production",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.0001466000103391707,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "docs.warning",
+            "imports.api.contract",
+            "customer.message",
+            "owner.oncall",
+            "rollback.plan",
+            "rollout.region"
+          ],
+          "retrieved_tokens": 192,
+          "signal_noise_ratio": 0.16666666666666666,
+          "stale_conflict": false
+        },
+        {
+          "id": "q7",
+          "asker": "reviewer",
+          "query": "What is the current rollout region and tenant scope?",
+          "expected_key": "rollout.region",
+          "expected_value": "us-east-1 internal tenants only",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00014899997040629387,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "rollout.region",
+            "feature.flag",
+            "rollout.region",
+            "imports.auth.scope",
+            "test.blocker",
+            "imports.auth.scope"
+          ],
+          "retrieved_tokens": 156,
+          "signal_noise_ratio": 0.3333333333333333,
+          "stale_conflict": true
+        },
+        {
+          "id": "q8",
+          "asker": "docs-agent",
+          "query": "Who owns backend and QA signoff during the release handoff?",
+          "expected_key": "owner.oncall",
+          "expected_value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00015569996321573853,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "owner.oncall",
+            "test.blocker",
+            "feature.flag",
+            "rollout.region",
+            "customer.message",
+            "rollout.region"
+          ],
+          "retrieved_tokens": 179,
+          "signal_noise_ratio": 0.16666666666666666,
+          "stale_conflict": false
+        },
+        {
+          "id": "q9",
+          "asker": "qa-agent",
+          "query": "What rollback plan should be used if the import release fails?",
+          "expected_key": "rollback.plan",
+          "expected_value": "disable bulk_import_v2 and route jobs to legacy_import_worker",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00015480001457035542,
+          "correct": true,
+          "first_exact_rank": 2,
+          "retrieved_keys": [
+            "feature.flag",
+            "rollback.plan",
+            "test.blocker",
+            "feature.flag",
+            "rollout.region",
+            "customer.message"
+          ],
+          "retrieved_tokens": 159,
+          "signal_noise_ratio": 0.16666666666666666,
+          "stale_conflict": false
+        },
+        {
+          "id": "q10",
+          "asker": "release-manager",
+          "query": "What customer message should we use for the release delay?",
+          "expected_key": "customer.message",
+          "expected_value": "release is delayed by validation hardening; no customer data loss",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 0.00043479999294504523,
+          "correct": true,
+          "first_exact_rank": 1,
+          "retrieved_keys": [
+            "customer.message",
+            "feature.flag",
+            "rollout.region",
+            "rollout.region",
+            "owner.oncall",
+            "rollback.plan"
+          ],
+          "retrieved_tokens": 176,
+          "signal_noise_ratio": 0.16666666666666666,
+          "stale_conflict": false
+        }
+      ],
+      "retrieved_tokens": 1704,
+      "signal_noise_ratio": 0.25,
+      "stale_conflict_rate": 0.5,
+      "total_questions": 10
+    },
+    {
+      "backend": "per_agent_append_log",
+      "accuracy": 0.0,
+      "correct": 0,
+      "cross_agent_accuracy": 0.0,
+      "cross_agent_correct": 0,
+      "ingested_tokens": 252,
+      "p95_latency_seconds": 3.539997851476073e-05,
+      "questions": [
+        {
+          "id": "q1",
+          "asker": "reviewer",
+          "query": "For code review, what is the current imports API contract and endpoint arguments?",
+          "expected_key": "imports.api.contract",
+          "expected_value": "POST /v2/imports accepts source_url, preview_only, and idempotency_key",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 2.3100001271814108e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "imports.auth.scope"
+          ],
+          "retrieved_tokens": 23,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q2",
+          "asker": "implementer",
+          "query": "What auth scope should the import endpoint enforce now?",
+          "expected_key": "imports.auth.scope",
+          "expected_value": "imports:admin",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 3.239995567128062e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "imports.auth.scope",
+            "feature.flag",
+            "database.migration"
+          ],
+          "retrieved_tokens": 56,
+          "signal_noise_ratio": 0.3333333333333333,
+          "stale_conflict": true
+        },
+        {
+          "id": "q3",
+          "asker": "docs-agent",
+          "query": "Which feature flag name should docs and examples use for the import worker?",
+          "expected_key": "feature.flag",
+          "expected_value": "bulk_import_v2",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 2.929999027401209e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "docs.warning",
+            "customer.message"
+          ],
+          "retrieved_tokens": 69,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q4",
+          "asker": "release-manager",
+          "query": "What is the current QA test blocker for release readiness?",
+          "expected_key": "test.blocker",
+          "expected_value": "retry idempotency conflict on duplicate idempotency_key",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 3.539997851476073e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "rollout.region",
+            "rollout.region",
+            "rollback.plan"
+          ],
+          "retrieved_tokens": 84,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q5",
+          "asker": "qa-agent",
+          "query": "Which database migration should QA verify for retry state?",
+          "expected_key": "database.migration",
+          "expected_value": "20260605_add_import_jobs_retry_state",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 2.5600020308047533e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "test.blocker",
+            "test.blocker"
+          ],
+          "retrieved_tokens": 63,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q6",
+          "asker": "implementer",
+          "query": "What warning should be reflected around preview_only behavior?",
+          "expected_key": "docs.warning",
+          "expected_value": "preview_only defaults true in sandbox and false in production",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 2.7099973522126675e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "database.migration",
+            "feature.flag",
+            "imports.auth.scope"
+          ],
+          "retrieved_tokens": 56,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q7",
+          "asker": "reviewer",
+          "query": "What is the current rollout region and tenant scope?",
+          "expected_key": "rollout.region",
+          "expected_value": "us-east-1 internal tenants only",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 1.1299969628453255e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "imports.auth.scope"
+          ],
+          "retrieved_tokens": 23,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q8",
+          "asker": "docs-agent",
+          "query": "Who owns backend and QA signoff during the release handoff?",
+          "expected_key": "owner.oncall",
+          "expected_value": "Mina owns backend until 18:00 UTC; Ravi owns QA signoff",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 2.6099965907633305e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "customer.message",
+            "docs.warning"
+          ],
+          "retrieved_tokens": 69,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q9",
+          "asker": "qa-agent",
+          "query": "What rollback plan should be used if the import release fails?",
+          "expected_key": "rollback.plan",
+          "expected_value": "disable bulk_import_v2 and route jobs to legacy_import_worker",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 2.4300010409206152e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "test.blocker",
+            "test.blocker"
+          ],
+          "retrieved_tokens": 63,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        },
+        {
+          "id": "q10",
+          "asker": "release-manager",
+          "query": "What customer message should we use for the release delay?",
+          "expected_key": "customer.message",
+          "expected_value": "release is delayed by validation hardening; no customer data loss",
+          "requires_cross_agent_memory": true,
+          "latency_seconds": 3.300001844763756e-05,
+          "correct": false,
+          "first_exact_rank": null,
+          "retrieved_keys": [
+            "rollout.region",
+            "rollout.region",
+            "rollback.plan"
+          ],
+          "retrieved_tokens": 84,
+          "signal_noise_ratio": 0.0,
+          "stale_conflict": false
+        }
+      ],
+      "retrieved_tokens": 590,
+      "signal_noise_ratio": 0.03333333333333333,
+      "stale_conflict_rate": 0.1,
+      "total_questions": 10
+    }
+  ]
+}

--- a/examples/benchmarks/multi-agent-code-handoff/results/sample_results.md
+++ b/examples/benchmarks/multi-agent-code-handoff/results/sample_results.md
@@ -6,9 +6,9 @@ A deterministic benchmark for shared memory in multi-agent coding workflows. Fac
 
 | Backend | Accuracy | Cross-Agent Accuracy | Ingested Tokens | Retrieved Tokens | p95 Latency (s) | Stale Conflict Rate | Signal/Noise |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| shared_active_digest | 100.0% | 100.0% | 252 | 291 | 0.000183 | 0.0% | 1.00 |
-| shared_append_log | 80.0% | 80.0% | 252 | 1704 | 0.000435 | 50.0% | 0.25 |
-| per_agent_append_log | 0.0% | 0.0% | 252 | 590 | 0.000035 | 10.0% | 0.03 |
+| shared_active_digest | 100.0% | 100.0% | 252 | 291 | 0.000276 | 0.0% | 1.00 |
+| shared_append_log | 80.0% | 80.0% | 252 | 1704 | 0.000291 | 50.0% | 0.25 |
+| per_agent_append_log | 0.0% | 0.0% | 252 | 590 | 0.000038 | 10.0% | 0.03 |
 
 ## Per-Question Accuracy
 

--- a/examples/benchmarks/multi-agent-code-handoff/results/sample_results.md
+++ b/examples/benchmarks/multi-agent-code-handoff/results/sample_results.md
@@ -1,0 +1,53 @@
+# multi_agent_codebase_handoff_v1
+
+A deterministic benchmark for shared memory in multi-agent coding workflows. Facts mutate across planning, implementation, review, QA, docs, and release handoff turns.
+
+## Summary
+
+| Backend | Accuracy | Cross-Agent Accuracy | Ingested Tokens | Retrieved Tokens | p95 Latency (s) | Stale Conflict Rate | Signal/Noise |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| shared_active_digest | 100.0% | 100.0% | 252 | 291 | 0.000183 | 0.0% | 1.00 |
+| shared_append_log | 80.0% | 80.0% | 252 | 1704 | 0.000435 | 50.0% | 0.25 |
+| per_agent_append_log | 0.0% | 0.0% | 252 | 590 | 0.000035 | 10.0% | 0.03 |
+
+## Per-Question Accuracy
+
+| Question | Backend | Correct | Retrieved Tokens | Retrieved Keys |
+| --- | --- | ---: | ---: | --- |
+| q1 | shared_active_digest | yes | 31 | imports.api.contract |
+| q2 | shared_active_digest | yes | 23 | imports.auth.scope |
+| q3 | shared_active_digest | yes | 24 | feature.flag |
+| q4 | shared_active_digest | yes | 33 | test.blocker |
+| q5 | shared_active_digest | yes | 19 | database.migration |
+| q6 | shared_active_digest | yes | 35 | docs.warning |
+| q7 | shared_active_digest | yes | 31 | rollout.region |
+| q8 | shared_active_digest | yes | 34 | owner.oncall |
+| q9 | shared_active_digest | yes | 27 | rollback.plan |
+| q10 | shared_active_digest | yes | 34 | customer.message |
+| q1 | shared_append_log | yes | 161 | imports.api.contract, imports.api.contract, imports.auth.scope, feature.flag, imports.auth.scope, customer.message |
+| q2 | shared_append_log | no | 158 | imports.auth.scope, imports.auth.scope, feature.flag, test.blocker, customer.message, owner.oncall |
+| q3 | shared_append_log | no | 168 | feature.flag, feature.flag, rollback.plan, test.blocker, docs.warning, customer.message |
+| q4 | shared_append_log | yes | 178 | test.blocker, test.blocker, feature.flag, rollout.region, owner.oncall, rollout.region |
+| q5 | shared_append_log | yes | 177 | database.migration, test.blocker, test.blocker, owner.oncall, customer.message, rollback.plan |
+| q6 | shared_append_log | yes | 192 | docs.warning, imports.api.contract, customer.message, owner.oncall, rollback.plan, rollout.region |
+| q7 | shared_append_log | yes | 156 | rollout.region, feature.flag, rollout.region, imports.auth.scope, test.blocker, imports.auth.scope |
+| q8 | shared_append_log | yes | 179 | owner.oncall, test.blocker, feature.flag, rollout.region, customer.message, rollout.region |
+| q9 | shared_append_log | yes | 159 | feature.flag, rollback.plan, test.blocker, feature.flag, rollout.region, customer.message |
+| q10 | shared_append_log | yes | 176 | customer.message, feature.flag, rollout.region, rollout.region, owner.oncall, rollback.plan |
+| q1 | per_agent_append_log | no | 23 | imports.auth.scope |
+| q2 | per_agent_append_log | no | 56 | imports.auth.scope, feature.flag, database.migration |
+| q3 | per_agent_append_log | no | 69 | docs.warning, customer.message |
+| q4 | per_agent_append_log | no | 84 | rollout.region, rollout.region, rollback.plan |
+| q5 | per_agent_append_log | no | 63 | test.blocker, test.blocker |
+| q6 | per_agent_append_log | no | 56 | database.migration, feature.flag, imports.auth.scope |
+| q7 | per_agent_append_log | no | 23 | imports.auth.scope |
+| q8 | per_agent_append_log | no | 69 | customer.message, docs.warning |
+| q9 | per_agent_append_log | no | 63 | test.blocker, test.blocker |
+| q10 | per_agent_append_log | no | 84 | rollout.region, rollout.region, rollback.plan |
+
+## Controls
+
+- Backend LLM: none; offline golden dataset matching
+- Judge: exact key/value matching with stale conflict detection
+- Prompt/system instructions: none
+- Host: Windows-11-10.0.26200-SP0 / CPython

--- a/examples/benchmarks/multi-agent-code-handoff/run_benchmark.py
+++ b/examples/benchmarks/multi-agent-code-handoff/run_benchmark.py
@@ -50,6 +50,8 @@ STOPWORDS = {
 
 @dataclass(frozen=True)
 class Event:
+    """One timestamped memory write from an agent in the handoff dataset."""
+
     turn: int
     timestamp: str
     agent: str
@@ -61,6 +63,8 @@ class Event:
 
     @classmethod
     def from_raw(cls, raw: dict[str, Any]) -> "Event":
+        """Build an event from a JSON dataset entry."""
+
         return cls(
             turn=int(raw["turn"]),
             timestamp=str(raw["timestamp"]),
@@ -75,6 +79,8 @@ class Event:
 
 @dataclass(frozen=True)
 class Question:
+    """One golden retrieval probe used to score a memory backend."""
+
     id: str
     asker: str
     query: str
@@ -84,6 +90,8 @@ class Question:
 
     @classmethod
     def from_raw(cls, raw: dict[str, Any]) -> "Question":
+        """Build a retrieval question from a JSON dataset entry."""
+
         return cls(
             id=str(raw["id"]),
             asker=str(raw["asker"]),
@@ -95,6 +103,8 @@ class Question:
 
 
 def tokenize(text: str) -> list[str]:
+    """Return normalized non-stopword tokens for lightweight scoring."""
+
     return [
         token.lower()
         for token in TOKEN_RE.findall(text)
@@ -103,10 +113,14 @@ def tokenize(text: str) -> list[str]:
 
 
 def token_count(text: str) -> int:
+    """Count tokenizer-sized words in a text field."""
+
     return len(TOKEN_RE.findall(text))
 
 
 def p95(values: list[float]) -> float:
+    """Return the nearest-rank p95 value for a small latency sample."""
+
     if not values:
         return 0.0
     ordered = sorted(values)
@@ -115,6 +129,8 @@ def p95(values: list[float]) -> float:
 
 
 def load_dataset(path: Path) -> tuple[dict[str, Any], list[Event], list[Question]]:
+    """Load benchmark metadata, memory events, and golden questions."""
+
     data = json.loads(path.read_text(encoding="utf-8"))
     events = [Event.from_raw(event) for event in data["events"]]
     questions = [Question.from_raw(question) for question in data["questions"]]
@@ -122,6 +138,8 @@ def load_dataset(path: Path) -> tuple[dict[str, Any], list[Event], list[Question
 
 
 def record_text(record: dict[str, Any]) -> str:
+    """Flatten a backend record into text used by token and keyword scoring."""
+
     return " ".join(
         [
             str(record.get("key", "")),
@@ -134,6 +152,8 @@ def record_text(record: dict[str, Any]) -> str:
 
 
 def keyword_score(query: str, record: dict[str, Any]) -> float:
+    """Score a record by query overlap with a small recency tiebreaker."""
+
     query_terms = set(tokenize(query))
     record_terms = set(tokenize(record_text(record)))
     if not query_terms:
@@ -145,14 +165,20 @@ def keyword_score(query: str, record: dict[str, Any]) -> float:
 
 
 class SharedActiveDigestBackend:
+    """Memanto-style shared memory that keeps only the latest fact per key."""
+
     name = "shared_active_digest"
 
     def __init__(self, max_retrieved_facts: int = 1) -> None:
+        """Create a bounded active digest backend."""
+
         self.max_retrieved_facts = max_retrieved_facts
         self.active_by_key: dict[str, dict[str, Any]] = {}
         self.ingested_tokens = 0
 
     def ingest(self, event: Event) -> None:
+        """Apply one event, replacing any prior fact with the same key."""
+
         self.ingested_tokens += token_count(event.content)
         self.active_by_key[event.key] = {
             "agent": event.agent,
@@ -165,6 +191,8 @@ class SharedActiveDigestBackend:
         }
 
     def retrieve(self, question: Question) -> tuple[list[dict[str, Any]], float]:
+        """Return top matching active facts and measured retrieval latency."""
+
         start = time.perf_counter()
         scored = [
             (keyword_score(question.query, record), record)
@@ -181,14 +209,20 @@ class SharedActiveDigestBackend:
 
 
 class PerAgentAppendLogBackend:
+    """Baseline where each agent can only search its own append-only log."""
+
     name = "per_agent_append_log"
 
     def __init__(self, max_retrieved_events: int = 6) -> None:
+        """Create a per-agent transcript backend."""
+
         self.max_retrieved_events = max_retrieved_events
         self.logs_by_agent: dict[str, list[dict[str, Any]]] = {}
         self.ingested_tokens = 0
 
     def ingest(self, event: Event) -> None:
+        """Append one event to the writing agent's private log."""
+
         self.ingested_tokens += token_count(event.content)
         self.logs_by_agent.setdefault(event.agent, []).append(
             {
@@ -203,6 +237,8 @@ class PerAgentAppendLogBackend:
         )
 
     def retrieve(self, question: Question) -> tuple[list[dict[str, Any]], float]:
+        """Search only the asker's local transcript and return latency."""
+
         start = time.perf_counter()
         local_log = self.logs_by_agent.get(question.asker, [])
         scored = [
@@ -220,14 +256,20 @@ class PerAgentAppendLogBackend:
 
 
 class SharedAppendLogBackend:
+    """Baseline where all agents search a shared append-only transcript."""
+
     name = "shared_append_log"
 
     def __init__(self, max_retrieved_events: int = 6) -> None:
+        """Create a shared transcript backend."""
+
         self.max_retrieved_events = max_retrieved_events
         self.log: list[dict[str, Any]] = []
         self.ingested_tokens = 0
 
     def ingest(self, event: Event) -> None:
+        """Append one event without replacing stale facts."""
+
         self.ingested_tokens += token_count(event.content)
         self.log.append(
             {
@@ -242,6 +284,8 @@ class SharedAppendLogBackend:
         )
 
     def retrieve(self, question: Question) -> tuple[list[dict[str, Any]], float]:
+        """Search the shared transcript and return matching events."""
+
         start = time.perf_counter()
         scored = [
             (keyword_score(question.query, record), record)
@@ -260,6 +304,8 @@ class SharedAppendLogBackend:
 def score_retrieval(
     question: Question, records: list[dict[str, Any]]
 ) -> dict[str, Any]:
+    """Score one retrieval result against the expected current fact."""
+
     same_key = [
         (index, record)
         for index, record in enumerate(records)
@@ -303,6 +349,8 @@ def evaluate_backend(
     events: list[Event],
     questions: list[Question],
 ) -> dict[str, Any]:
+    """Ingest all events, score all questions, and aggregate backend metrics."""
+
     for event in events:
         backend.ingest(event)
 
@@ -359,6 +407,8 @@ def evaluate_backend(
 
 
 def run(dataset_path: Path) -> dict[str, Any]:
+    """Run the full benchmark suite for every backend."""
+
     data, events, questions = load_dataset(dataset_path)
     backend_results = [
         evaluate_backend(SharedActiveDigestBackend(), events, questions),
@@ -379,10 +429,14 @@ def run(dataset_path: Path) -> dict[str, Any]:
 
 
 def format_percent(value: float) -> str:
+    """Format a ratio as a one-decimal percentage string."""
+
     return f"{value * 100:.1f}%"
 
 
 def markdown_report(result: dict[str, Any]) -> str:
+    """Render a benchmark result object as a Markdown report."""
+
     lines = [
         f"# {result['benchmark']}",
         "",
@@ -452,6 +506,8 @@ def markdown_report(result: dict[str, Any]) -> str:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the benchmark runner."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dataset", type=Path, default=DEFAULT_DATASET)
     parser.add_argument("--output", type=Path)
@@ -460,6 +516,8 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    """Run the benchmark and write JSON and/or Markdown outputs."""
+
     args = parse_args()
     result = run(args.dataset)
 

--- a/examples/benchmarks/multi-agent-code-handoff/run_benchmark.py
+++ b/examples/benchmarks/multi-agent-code-handoff/run_benchmark.py
@@ -1,0 +1,479 @@
+"""Multi-agent codebase handoff benchmark.
+
+The harness is intentionally dependency-free so reviewers can run it before
+configuring hosted memory services. Backends are small adapters with a shared
+interface, which keeps the dataset and scoring reusable for real Memanto or
+competitor integrations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import re
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_DATASET = ROOT / "dataset" / "codebase_handoff.json"
+TOKEN_RE = re.compile(r"[A-Za-z0-9_:/.-]+")
+STOPWORDS = {
+    "a",
+    "and",
+    "around",
+    "be",
+    "for",
+    "if",
+    "in",
+    "is",
+    "it",
+    "now",
+    "of",
+    "on",
+    "or",
+    "should",
+    "the",
+    "to",
+    "use",
+    "what",
+    "which",
+    "who",
+}
+
+
+@dataclass(frozen=True)
+class Event:
+    turn: int
+    timestamp: str
+    agent: str
+    memory_type: str
+    key: str
+    value: str
+    content: str
+    tags: tuple[str, ...]
+
+    @classmethod
+    def from_raw(cls, raw: dict[str, Any]) -> "Event":
+        return cls(
+            turn=int(raw["turn"]),
+            timestamp=str(raw["timestamp"]),
+            agent=str(raw["agent"]),
+            memory_type=str(raw["memory_type"]),
+            key=str(raw["key"]),
+            value=str(raw["value"]),
+            content=str(raw["content"]),
+            tags=tuple(str(tag) for tag in raw.get("tags", [])),
+        )
+
+
+@dataclass(frozen=True)
+class Question:
+    id: str
+    asker: str
+    query: str
+    expected_key: str
+    expected_value: str
+    requires_cross_agent_memory: bool
+
+    @classmethod
+    def from_raw(cls, raw: dict[str, Any]) -> "Question":
+        return cls(
+            id=str(raw["id"]),
+            asker=str(raw["asker"]),
+            query=str(raw["query"]),
+            expected_key=str(raw["expected_key"]),
+            expected_value=str(raw["expected_value"]),
+            requires_cross_agent_memory=bool(raw["requires_cross_agent_memory"]),
+        )
+
+
+def tokenize(text: str) -> list[str]:
+    return [
+        token.lower()
+        for token in TOKEN_RE.findall(text)
+        if token.lower() not in STOPWORDS
+    ]
+
+
+def token_count(text: str) -> int:
+    return len(TOKEN_RE.findall(text))
+
+
+def p95(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = max(0, math.ceil(0.95 * len(ordered)) - 1)
+    return ordered[index]
+
+
+def load_dataset(path: Path) -> tuple[dict[str, Any], list[Event], list[Question]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    events = [Event.from_raw(event) for event in data["events"]]
+    questions = [Question.from_raw(question) for question in data["questions"]]
+    return data, events, questions
+
+
+def record_text(record: dict[str, Any]) -> str:
+    return " ".join(
+        [
+            str(record.get("key", "")),
+            str(record.get("value", "")),
+            str(record.get("content", "")),
+            " ".join(str(tag) for tag in record.get("tags", [])),
+            str(record.get("memory_type", "")),
+        ]
+    )
+
+
+def keyword_score(query: str, record: dict[str, Any]) -> float:
+    query_terms = set(tokenize(query))
+    record_terms = set(tokenize(record_text(record)))
+    if not query_terms:
+        return 0.0
+    overlap = len(query_terms & record_terms)
+    normalized = overlap / math.sqrt(max(len(record_terms), 1))
+    recency = float(record.get("turn", 0)) / 1000.0
+    return normalized + recency
+
+
+class SharedActiveDigestBackend:
+    name = "shared_active_digest"
+
+    def __init__(self, max_retrieved_facts: int = 1) -> None:
+        self.max_retrieved_facts = max_retrieved_facts
+        self.active_by_key: dict[str, dict[str, Any]] = {}
+        self.ingested_tokens = 0
+
+    def ingest(self, event: Event) -> None:
+        self.ingested_tokens += token_count(event.content)
+        self.active_by_key[event.key] = {
+            "agent": event.agent,
+            "content": event.content,
+            "key": event.key,
+            "memory_type": event.memory_type,
+            "tags": list(event.tags),
+            "turn": event.turn,
+            "value": event.value,
+        }
+
+    def retrieve(self, question: Question) -> tuple[list[dict[str, Any]], float]:
+        start = time.perf_counter()
+        scored = [
+            (keyword_score(question.query, record), record)
+            for record in self.active_by_key.values()
+        ]
+        ranked = [
+            record
+            for score, record in sorted(scored, key=lambda item: item[0], reverse=True)
+            if score > 0
+        ]
+        records = ranked[: self.max_retrieved_facts]
+        elapsed = time.perf_counter() - start
+        return records, elapsed
+
+
+class PerAgentAppendLogBackend:
+    name = "per_agent_append_log"
+
+    def __init__(self, max_retrieved_events: int = 6) -> None:
+        self.max_retrieved_events = max_retrieved_events
+        self.logs_by_agent: dict[str, list[dict[str, Any]]] = {}
+        self.ingested_tokens = 0
+
+    def ingest(self, event: Event) -> None:
+        self.ingested_tokens += token_count(event.content)
+        self.logs_by_agent.setdefault(event.agent, []).append(
+            {
+                "agent": event.agent,
+                "content": event.content,
+                "key": event.key,
+                "memory_type": event.memory_type,
+                "tags": list(event.tags),
+                "turn": event.turn,
+                "value": event.value,
+            }
+        )
+
+    def retrieve(self, question: Question) -> tuple[list[dict[str, Any]], float]:
+        start = time.perf_counter()
+        local_log = self.logs_by_agent.get(question.asker, [])
+        scored = [
+            (keyword_score(question.query, record), record)
+            for record in local_log
+        ]
+        ranked = [
+            record
+            for score, record in sorted(scored, key=lambda item: item[0], reverse=True)
+            if score > 0
+        ]
+        records = ranked[: self.max_retrieved_events]
+        elapsed = time.perf_counter() - start
+        return records, elapsed
+
+
+class SharedAppendLogBackend:
+    name = "shared_append_log"
+
+    def __init__(self, max_retrieved_events: int = 6) -> None:
+        self.max_retrieved_events = max_retrieved_events
+        self.log: list[dict[str, Any]] = []
+        self.ingested_tokens = 0
+
+    def ingest(self, event: Event) -> None:
+        self.ingested_tokens += token_count(event.content)
+        self.log.append(
+            {
+                "agent": event.agent,
+                "content": event.content,
+                "key": event.key,
+                "memory_type": event.memory_type,
+                "tags": list(event.tags),
+                "turn": event.turn,
+                "value": event.value,
+            }
+        )
+
+    def retrieve(self, question: Question) -> tuple[list[dict[str, Any]], float]:
+        start = time.perf_counter()
+        scored = [
+            (keyword_score(question.query, record), record)
+            for record in self.log
+        ]
+        ranked = [
+            record
+            for score, record in sorted(scored, key=lambda item: item[0], reverse=True)
+            if score > 0
+        ]
+        records = ranked[: self.max_retrieved_events]
+        elapsed = time.perf_counter() - start
+        return records, elapsed
+
+
+def score_retrieval(
+    question: Question, records: list[dict[str, Any]]
+) -> dict[str, Any]:
+    same_key = [
+        (index, record)
+        for index, record in enumerate(records)
+        if record.get("key") == question.expected_key
+    ]
+    exact_indexes = [
+        index
+        for index, record in same_key
+        if record.get("value") == question.expected_value
+    ]
+    first_exact_index = exact_indexes[0] if exact_indexes else None
+    stale_before_exact = any(
+        record.get("value") != question.expected_value
+        and (first_exact_index is None or index <= first_exact_index)
+        for index, record in same_key
+    )
+    stale_retrieved = any(
+        record.get("value") != question.expected_value
+        for _, record in same_key
+    )
+    correct = first_exact_index is not None and not stale_before_exact
+    retrieved_tokens = sum(token_count(record_text(record)) for record in records)
+    signal_records = sum(
+        1 for record in records if record.get("key") == question.expected_key
+    )
+    signal_noise_ratio = signal_records / len(records) if records else 0.0
+    return {
+        "correct": correct,
+        "first_exact_rank": (
+            first_exact_index + 1 if first_exact_index is not None else None
+        ),
+        "retrieved_keys": [record.get("key") for record in records],
+        "retrieved_tokens": retrieved_tokens,
+        "signal_noise_ratio": signal_noise_ratio,
+        "stale_conflict": stale_retrieved,
+    }
+
+
+def evaluate_backend(
+    backend: SharedActiveDigestBackend | SharedAppendLogBackend | PerAgentAppendLogBackend,
+    events: list[Event],
+    questions: list[Question],
+) -> dict[str, Any]:
+    for event in events:
+        backend.ingest(event)
+
+    per_question: list[dict[str, Any]] = []
+    latencies: list[float] = []
+    for question in questions:
+        records, latency = backend.retrieve(question)
+        latencies.append(latency)
+        scored = score_retrieval(question, records)
+        per_question.append(
+            {
+                "id": question.id,
+                "asker": question.asker,
+                "query": question.query,
+                "expected_key": question.expected_key,
+                "expected_value": question.expected_value,
+                "requires_cross_agent_memory": question.requires_cross_agent_memory,
+                "latency_seconds": latency,
+                **scored,
+            }
+        )
+
+    total_questions = len(per_question)
+    correct = sum(1 for item in per_question if item["correct"])
+    cross_agent = [
+        item for item in per_question if item["requires_cross_agent_memory"]
+    ]
+    cross_agent_correct = sum(1 for item in cross_agent if item["correct"])
+    retrieved_tokens = sum(int(item["retrieved_tokens"]) for item in per_question)
+    stale_conflicts = sum(1 for item in per_question if item["stale_conflict"])
+    signal_noise_values = [
+        float(item["signal_noise_ratio"]) for item in per_question
+    ]
+    return {
+        "backend": backend.name,
+        "accuracy": correct / total_questions if total_questions else 0.0,
+        "correct": correct,
+        "cross_agent_accuracy": (
+            cross_agent_correct / len(cross_agent) if cross_agent else 0.0
+        ),
+        "cross_agent_correct": cross_agent_correct,
+        "ingested_tokens": backend.ingested_tokens,
+        "p95_latency_seconds": p95(latencies),
+        "questions": per_question,
+        "retrieved_tokens": retrieved_tokens,
+        "signal_noise_ratio": (
+            statistics.fmean(signal_noise_values) if signal_noise_values else 0.0
+        ),
+        "stale_conflict_rate": (
+            stale_conflicts / total_questions if total_questions else 0.0
+        ),
+        "total_questions": total_questions,
+    }
+
+
+def run(dataset_path: Path) -> dict[str, Any]:
+    data, events, questions = load_dataset(dataset_path)
+    backend_results = [
+        evaluate_backend(SharedActiveDigestBackend(), events, questions),
+        evaluate_backend(SharedAppendLogBackend(), events, questions),
+        evaluate_backend(PerAgentAppendLogBackend(), events, questions),
+    ]
+    return {
+        "benchmark": data["name"],
+        "description": data["description"],
+        "controls": data["controls"],
+        "host_environment": {
+            "platform": platform.platform(),
+            "python": sys.version,
+            "implementation": platform.python_implementation(),
+        },
+        "results": backend_results,
+    }
+
+
+def format_percent(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def markdown_report(result: dict[str, Any]) -> str:
+    lines = [
+        f"# {result['benchmark']}",
+        "",
+        result["description"],
+        "",
+        "## Summary",
+        "",
+        (
+            "| Backend | Accuracy | Cross-Agent Accuracy | Ingested Tokens | "
+            "Retrieved Tokens | p95 Latency (s) | Stale Conflict Rate | "
+            "Signal/Noise |"
+        ),
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for backend in result["results"]:
+        lines.append(
+            "| {backend} | {accuracy} | {cross_accuracy} | {ingested} | "
+            "{retrieved} | {latency:.6f} | {stale} | {snr:.2f} |".format(
+                backend=backend["backend"],
+                accuracy=format_percent(float(backend["accuracy"])),
+                cross_accuracy=format_percent(
+                    float(backend["cross_agent_accuracy"])
+                ),
+                ingested=backend["ingested_tokens"],
+                retrieved=backend["retrieved_tokens"],
+                latency=float(backend["p95_latency_seconds"]),
+                stale=format_percent(float(backend["stale_conflict_rate"])),
+                snr=float(backend["signal_noise_ratio"]),
+            )
+        )
+
+    lines.extend(["", "## Per-Question Accuracy", ""])
+    lines.append("| Question | Backend | Correct | Retrieved Tokens | Retrieved Keys |")
+    lines.append("| --- | --- | ---: | ---: | --- |")
+    for backend in result["results"]:
+        for item in backend["questions"]:
+            lines.append(
+                "| {qid} | {backend} | {correct} | {tokens} | {keys} |".format(
+                    qid=item["id"],
+                    backend=backend["backend"],
+                    correct="yes" if item["correct"] else "no",
+                    tokens=item["retrieved_tokens"],
+                    keys=", ".join(str(key) for key in item["retrieved_keys"]),
+                )
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Controls",
+            "",
+            f"- Backend LLM: {result['controls']['backend_llm']}",
+            f"- Judge: {result['controls']['judge']}",
+            (
+                "- Prompt/system instructions: "
+                f"{result['controls']['prompt_system_instructions']}"
+            ),
+            (
+                "- Host: "
+                f"{result['host_environment']['platform']} / "
+                f"{result['host_environment']['implementation']}"
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", type=Path, default=DEFAULT_DATASET)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--markdown", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = run(args.dataset)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+
+    report = markdown_report(result)
+    if args.markdown:
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text(report, encoding="utf-8")
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/multi-agent-code-handoff/test_benchmark.py
+++ b/examples/benchmarks/multi-agent-code-handoff/test_benchmark.py
@@ -9,7 +9,11 @@ import run_benchmark
 
 
 class MultiAgentCodeHandoffBenchmarkTests(unittest.TestCase):
+    """Regression tests for the multi-agent handoff benchmark harness."""
+
     def test_dataset_loads_with_cross_agent_questions(self) -> None:
+        """Verify the bundled dataset has enough cross-agent probes."""
+
         _, events, questions = run_benchmark.load_dataset(
             run_benchmark.DEFAULT_DATASET
         )
@@ -21,6 +25,8 @@ class MultiAgentCodeHandoffBenchmarkTests(unittest.TestCase):
         )
 
     def test_shared_digest_beats_append_only_baseline(self) -> None:
+        """Verify the active digest beats both append-only baselines."""
+
         result = run_benchmark.run(run_benchmark.DEFAULT_DATASET)
         by_backend = {item["backend"]: item for item in result["results"]}
         shared = by_backend["shared_active_digest"]
@@ -37,6 +43,8 @@ class MultiAgentCodeHandoffBenchmarkTests(unittest.TestCase):
         self.assertEqual(shared["stale_conflict_rate"], 0.0)
 
     def test_reports_are_written(self) -> None:
+        """Verify JSON and Markdown reports can be generated and read."""
+
         with tempfile.TemporaryDirectory() as tmpdir:
             output = Path(tmpdir) / "latest.json"
             markdown = Path(tmpdir) / "latest.md"

--- a/examples/benchmarks/multi-agent-code-handoff/test_benchmark.py
+++ b/examples/benchmarks/multi-agent-code-handoff/test_benchmark.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import run_benchmark
+
+
+class MultiAgentCodeHandoffBenchmarkTests(unittest.TestCase):
+    def test_dataset_loads_with_cross_agent_questions(self) -> None:
+        _, events, questions = run_benchmark.load_dataset(
+            run_benchmark.DEFAULT_DATASET
+        )
+
+        self.assertGreaterEqual(len(events), 10)
+        self.assertGreaterEqual(len(questions), 8)
+        self.assertTrue(
+            all(question.requires_cross_agent_memory for question in questions)
+        )
+
+    def test_shared_digest_beats_append_only_baseline(self) -> None:
+        result = run_benchmark.run(run_benchmark.DEFAULT_DATASET)
+        by_backend = {item["backend"]: item for item in result["results"]}
+        shared = by_backend["shared_active_digest"]
+        shared_log = by_backend["shared_append_log"]
+        baseline = by_backend["per_agent_append_log"]
+
+        self.assertGreaterEqual(shared["accuracy"], shared_log["accuracy"])
+        self.assertGreater(shared["accuracy"], baseline["accuracy"])
+        self.assertLess(shared["retrieved_tokens"], shared_log["retrieved_tokens"])
+        self.assertGreater(
+            shared["cross_agent_accuracy"], baseline["cross_agent_accuracy"]
+        )
+        self.assertLess(shared["retrieved_tokens"], baseline["retrieved_tokens"])
+        self.assertEqual(shared["stale_conflict_rate"], 0.0)
+
+    def test_reports_are_written(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "latest.json"
+            markdown = Path(tmpdir) / "latest.md"
+            result = run_benchmark.run(run_benchmark.DEFAULT_DATASET)
+
+            output.write_text(json.dumps(result), encoding="utf-8")
+            markdown.write_text(
+                run_benchmark.markdown_report(result), encoding="utf-8"
+            )
+
+            self.assertIn("shared_active_digest", output.read_text())
+            self.assertIn("| Backend | Accuracy |", markdown.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #639

BountyHub: https://www.bountyhub.dev/bounty/view/ec58c800-823e-4134-b027-99838e096d4b

## Summary

This submission adds `examples/benchmarks/multi-agent-code-handoff`, a reproducible multi-agent memory sharing benchmark for a coding team handoff. It focuses on the scenario suggested in the issue comments: shared memory across specialized agents working on the same codebase.

The benchmark includes:

- a deterministic codebase handoff dataset with mutable facts across planner, implementer, reviewer, QA, docs, and release agents
- `shared_active_digest`, an offline Memanto-style active shared memory control with latest-state supersession
- `shared_append_log`, a shared append-only transcript baseline with stale context bloat
- `per_agent_append_log`, a siloed per-agent transcript baseline
- golden dataset scoring for retrieval accuracy, cross-agent accuracy, stale conflict rate, retrieved tokens, p95 latency, and signal/noise
- sample JSON and Markdown reports
- unittest coverage and a dependency-free runner

## Sample Metrics

From `results/sample_results.md`:

| Backend | Accuracy | Cross-Agent Accuracy | Ingested Tokens | Retrieved Tokens | p95 Latency (s) | Stale Conflict Rate | Signal/Noise |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| shared_active_digest | 100.0% | 100.0% | 252 | 291 | 0.000183 | 0.0% | 1.00 |
| shared_append_log | 80.0% | 80.0% | 252 | 1704 | 0.000435 | 50.0% | 0.25 |
| per_agent_append_log | 0.0% | 0.0% | 252 | 590 | 0.000035 | 10.0% | 0.03 |

## Reproduction

```bash
python examples/benchmarks/multi-agent-code-handoff/run_benchmark.py \
  --output examples/benchmarks/multi-agent-code-handoff/results/latest.json \
  --markdown examples/benchmarks/multi-agent-code-handoff/results/latest.md

python -m unittest discover -s examples/benchmarks/multi-agent-code-handoff -p test_*.py
python -m py_compile examples/benchmarks/multi-agent-code-handoff/run_benchmark.py examples/benchmarks/multi-agent-code-handoff/test_benchmark.py
git diff --check
```

## Social Showcase

Public technical showcase: https://gist.github.com/modelsbridgeaicom-ship-it/630000176ac9caf55f6b0357f1aba012

I did not fabricate Reddit/X metrics from this environment; this link is a real public GitHub showcase for the benchmark design and reproduction steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Multi‑Agent Code Handoff benchmark comparing three memory-backend modes with metrics for retrieval accuracy, token efficiency, latency, staleness/conflict, and signal‑to‑noise.

* **Documentation**
  * Added README, dataset description, and deterministic sample results (JSON + Markdown) with controls and run instructions.

* **Tests**
  * Added tests validating dataset loading, benchmark execution, comparative metrics, and report generation.

* **Chores**
  * Benchmark harness is dependency‑free for easy local runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
