### PR TITLE
[BOUNTY $100] Add tool-call audit memory benchmark

### DIFF
--- a/examples/benchmarks/tool_call_audit_memory/README.md
+++ b/examples/benchmarks/tool_call_audit_memory/README.md
@@ -1,0 +1,45 @@
+# Tool-Call Audit Memory Benchmark
+
+This example is a submission for issue #639, "The Great Agentic Memory Showdown."
+
+It benchmarks a failure mode that appears in long-running coding agents: the model has to remember user constraints, review feedback, current test commands, feature-flag renames, payout state, and secret-handling rules while its raw tool-call transcript keeps growing. A naive append-only log has plenty of recall but injects stale decisions and secret-shaped values. A recent-window log is cheap but forgets older durable constraints. The active digest acts like a Memanto companion: it stores typed current facts, supersedes stale keys, redacts secrets, and injects only relevant evidence.
+
+## What It Measures
+
+- Retrieval accuracy across current engineering facts.
+- Average retrieved token footprint.
+- p95 retrieval latency.
+- Stale conflict rate.
+- Secret leak rate.
+
+## Run
+
+```bash
+python examples/benchmarks/tool_call_audit_memory/run_benchmark.py
+```
+
+Generate sample reports:
+
+```bash
+python examples/benchmarks/tool_call_audit_memory/run_benchmark.py \
+  --output examples/benchmarks/tool_call_audit_memory/results/sample_results.json \
+  --markdown examples/benchmarks/tool_call_audit_memory/results/sample_results.md
+```
+
+Run tests:
+
+```bash
+python -m unittest examples.benchmarks.tool_call_audit_memory.test_benchmark -q
+```
+
+## Backends Compared
+
+| Backend | Description |
+| --- | --- |
+| `append_only_log` | Stores every audit event and retrieves matching raw text. It recalls facts but also surfaces stale decisions and secrets. |
+| `windowed_recent_log` | Only retrieves recent audit text. It is compact but loses older durable constraints. |
+| `active_audit_digest` | Keeps one current fact per memory key, redacts secret-shaped values, and retrieves typed facts by question relevance. |
+
+## Why This Is Useful
+
+The benchmark focuses on a production coding-agent behavior that raw vector or graph dumps often handle poorly: operational memory needs to be current, compact, scoped, and safe. The same query may need a newer feature flag while suppressing the stale flag, or a payment-state fact while avoiding sensitive payout details. The active digest demonstrates how a memory companion can win on accuracy and safety while reducing context tokens.

--- a/examples/benchmarks/tool_call_audit_memory/__init__.py
+++ b/examples/benchmarks/tool_call_audit_memory/__init__.py
@@ -1,0 +1,1 @@
+"""Tool-call audit memory benchmark example."""

--- a/examples/benchmarks/tool_call_audit_memory/results/sample_results.json
+++ b/examples/benchmarks/tool_call_audit_memory/results/sample_results.json
@@ -1,0 +1,254 @@
+{
+  "benchmark": "tool_call_audit_memory",
+  "description": "Offline benchmark for long-lived coding agents that must compact tool-call audit logs into current, secret-safe memory.",
+  "event_count": 12,
+  "query_count": 9,
+  "results": [
+    {
+      "backend": "append_only_log",
+      "accuracy": 0.1111,
+      "avg_retrieved_tokens": 40.22,
+      "p95_latency_ms": 0.0671,
+      "stale_conflict_rate": 0.5556,
+      "secret_leak_rate": 0.1111,
+      "rows": [
+        {
+          "question": "Which feature flag should the benchmark docs tell users to set?",
+          "retrieved_tokens": 27,
+          "correct": false,
+          "stale_conflict": true,
+          "secret_leak": false,
+          "context_preview": "Feature flag renamed for the benchmark docs: MEMANTO_AUDIT_MEMORY replaces MEMANTO_USE_MEMORY_V1.\nOld feature flag name documented as MEMANTO_USE_MEMORY_V1.\nEarly test habit: run pytest -q for quick benchmark checks."
+        },
+        {
+          "question": "What payout currency and account state has the monetization sprint configured?",
+          "retrieved_tokens": 27,
+          "correct": false,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "Algora payout setup is active through Stripe Connect Express, country New Zealand, payout currency NZD, bank account masked as **** 9000. No reward has been paid yet."
+        },
+        {
+          "question": "Should public bounty comments include the payment QR or sensitive payout details?",
+          "retrieved_tokens": 48,
+          "correct": false,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "User allowed revenue-related Gmail review only. They also asked to avoid posting sensitive payment details unless confirmed for a specific platform.\nAlgora payout setup is active through Stripe Connect Express, country New Zealand, payout c"
+        },
+        {
+          "question": "Which SQL approach should a new patch use after review feedback?",
+          "retrieved_tokens": 94,
+          "correct": false,
+          "stale_conflict": true,
+          "secret_leak": false,
+          "context_preview": "Reviewer feedback superseded the raw SQL shortcut: use QueryBuilder for new data access changes so the code stays portable and testable.\nAlgora payout setup is active through Stripe Connect Express, country New Zealand, payout currency NZD,"
+        },
+        {
+          "question": "Which test command is current for this benchmark example?",
+          "retrieved_tokens": 46,
+          "correct": false,
+          "stale_conflict": true,
+          "secret_leak": false,
+          "context_preview": "Current focused test command for this example: python -m unittest examples.benchmarks.tool_call_audit_memory.test_benchmark -q.\nEarly test habit: run pytest -q for quick benchmark checks.\nFeature flag renamed for the benchmark docs: MEMANTO"
+        },
+        {
+          "question": "What should be injected about the observed Stripe secret?",
+          "retrieved_tokens": 43,
+          "correct": false,
+          "stale_conflict": true,
+          "secret_leak": true,
+          "context_preview": "Audit found a Stripe secret in .env: STRIPE_SECRET_KEY=stripe_live_secret_FAKE_TOOL_AUDIT_0000. The value was removed from logs before sharing.\nAlgora payout setup is active through Stripe Connect Express, country New Zealand, payout curren"
+        },
+        {
+          "question": "Which deployment target is current?",
+          "retrieved_tokens": 35,
+          "correct": false,
+          "stale_conflict": true,
+          "secret_leak": false,
+          "context_preview": "Platform decision changed after Railway credit limits: Fly.io is now the current deploy target.\nInitial deployment note: Railway is the expected hosting target.\nCurrent focused test command for this example: python -m unittest examples.benc"
+        },
+        {
+          "question": "Which auth claim validation rule should be remembered?",
+          "retrieved_tokens": 21,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "Auth middleware decision: verified JWT payloads must contain a non-empty string sub claim and a supported role before protected routes proceed."
+        },
+        {
+          "question": "What Gmail scope is permitted for this sprint?",
+          "retrieved_tokens": 21,
+          "correct": false,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "User allowed revenue-related Gmail review only. They also asked to avoid posting sensitive payment details unless confirmed for a specific platform."
+        }
+      ]
+    },
+    {
+      "backend": "windowed_recent_log",
+      "accuracy": 0.2222,
+      "avg_retrieved_tokens": 23.89,
+      "p95_latency_ms": 0.0154,
+      "stale_conflict_rate": 0.2222,
+      "secret_leak_rate": 0.0,
+      "rows": [
+        {
+          "question": "Which feature flag should the benchmark docs tell users to set?",
+          "retrieved_tokens": 10,
+          "correct": false,
+          "stale_conflict": true,
+          "secret_leak": false,
+          "context_preview": "Feature flag renamed for the benchmark docs: MEMANTO_AUDIT_MEMORY replaces MEMANTO_USE_MEMORY_V1."
+        },
+        {
+          "question": "What payout currency and account state has the monetization sprint configured?",
+          "retrieved_tokens": 27,
+          "correct": false,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "Algora payout setup is active through Stripe Connect Express, country New Zealand, payout currency NZD, bank account masked as **** 9000. No reward has been paid yet."
+        },
+        {
+          "question": "Should public bounty comments include the payment QR or sensitive payout details?",
+          "retrieved_tokens": 27,
+          "correct": false,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "Algora payout setup is active through Stripe Connect Express, country New Zealand, payout currency NZD, bank account masked as **** 9000. No reward has been paid yet."
+        },
+        {
+          "question": "Which SQL approach should a new patch use after review feedback?",
+          "retrieved_tokens": 62,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "Reviewer feedback superseded the raw SQL shortcut: use QueryBuilder for new data access changes so the code stays portable and testable.\nPlatform decision changed after Railway credit limits: Fly.io is now the current deploy target.\nAlgora "
+        },
+        {
+          "question": "Which test command is current for this benchmark example?",
+          "retrieved_tokens": 36,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "Platform decision changed after Railway credit limits: Fly.io is now the current deploy target.\nFeature flag renamed for the benchmark docs: MEMANTO_AUDIT_MEMORY replaces MEMANTO_USE_MEMORY_V1.\nCurrent focused test command for this example:"
+        },
+        {
+          "question": "What should be injected about the observed Stripe secret?",
+          "retrieved_tokens": 27,
+          "correct": false,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "Algora payout setup is active through Stripe Connect Express, country New Zealand, payout currency NZD, bank account masked as **** 9000. No reward has been paid yet."
+        },
+        {
+          "question": "Which deployment target is current?",
+          "retrieved_tokens": 26,
+          "correct": false,
+          "stale_conflict": true,
+          "secret_leak": false,
+          "context_preview": "Platform decision changed after Railway credit limits: Fly.io is now the current deploy target.\nCurrent focused test command for this example: python -m unittest examples.benchmarks.tool_call_audit_memory.test_benchmark -q."
+        },
+        {
+          "question": "Which auth claim validation rule should be remembered?",
+          "retrieved_tokens": 0,
+          "correct": false,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": ""
+        },
+        {
+          "question": "What Gmail scope is permitted for this sprint?",
+          "retrieved_tokens": 0,
+          "correct": false,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": ""
+        }
+      ]
+    },
+    {
+      "backend": "active_audit_digest",
+      "accuracy": 1.0,
+      "avg_retrieved_tokens": 32.67,
+      "p95_latency_ms": 0.0406,
+      "stale_conflict_rate": 0.0,
+      "secret_leak_rate": 0.0,
+      "rows": [
+        {
+          "question": "Which feature flag should the benchmark docs tell users to set?",
+          "retrieved_tokens": 25,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "feature.flag: MEMANTO_AUDIT_MEMORY Evidence: Current docs should use the audit-memory flag name.\nbenchmark.test_command: python -m unittest examples.benchmarks.tool_call_audit_memory.test_benchmark -q Evidence: Focused standard-library test"
+        },
+        {
+          "question": "What payout currency and account state has the monetization sprint configured?",
+          "retrieved_tokens": 52,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "payout.state: Algora/Stripe Connect Express active; payout currency NZD; no paid reward yet. Evidence: Payout setup is active but balances remain zero until a bounty is awarded.\npayment.public_qr: Do not post payment QR or sensitive payout "
+        },
+        {
+          "question": "Should public bounty comments include the payment QR or sensitive payout details?",
+          "retrieved_tokens": 52,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "payment.public_qr: Do not post payment QR or sensitive payout details to third-party platforms without explicit confirmation. Evidence: Payment details must stay private unless confirmed per platform.\npayout.state: Algora/Stripe Connect Exp"
+        },
+        {
+          "question": "Which SQL approach should a new patch use after review feedback?",
+          "retrieved_tokens": 28,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "data.sql_style: Use QueryBuilder for new data access changes. Evidence: Reviewer explicitly replaced the earlier raw SQL shortcut.\nfeature.flag: MEMANTO_AUDIT_MEMORY Evidence: Current docs should use the audit-memory flag name."
+        },
+        {
+          "question": "Which test command is current for this benchmark example?",
+          "retrieved_tokens": 25,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "benchmark.test_command: python -m unittest examples.benchmarks.tool_call_audit_memory.test_benchmark -q Evidence: Focused standard-library test command for this benchmark.\nfeature.flag: MEMANTO_AUDIT_MEMORY Evidence: Current docs should use"
+        },
+        {
+          "question": "What should be injected about the observed Stripe secret?",
+          "retrieved_tokens": 47,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "secret.stripe: A Stripe secret was observed and must be represented only as <redacted>. Evidence: Secret-shaped values must never be injected verbatim.\npayout.state: Algora/Stripe Connect Express active; payout currency NZD; no paid reward "
+        },
+        {
+          "question": "Which deployment target is current?",
+          "retrieved_tokens": 21,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "deploy.target: Fly.io Evidence: Current deploy target after platform constraints changed.\nfeature.flag: MEMANTO_AUDIT_MEMORY Evidence: Current docs should use the audit-memory flag name."
+        },
+        {
+          "question": "Which auth claim validation rule should be remembered?",
+          "retrieved_tokens": 25,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "auth.claim_rule: Require a non-empty string sub claim and a supported role in JWT payloads. Evidence: Protected routes must reject blank sub values and unsupported roles."
+        },
+        {
+          "question": "What Gmail scope is permitted for this sprint?",
+          "retrieved_tokens": 19,
+          "correct": true,
+          "stale_conflict": false,
+          "secret_leak": false,
+          "context_preview": "gmail.scope: Read only revenue-related Gmail threads; do not inspect unrelated mail. Evidence: User constrained mailbox access to revenue-related messages."
+        }
+      ]
+    }
+  ]
+}

--- a/examples/benchmarks/tool_call_audit_memory/results/sample_results.md
+++ b/examples/benchmarks/tool_call_audit_memory/results/sample_results.md
@@ -1,0 +1,9 @@
+# Tool-Call Audit Memory Results
+
+| Backend | Accuracy | Avg retrieved tokens | p95 latency ms | Stale conflict rate | Secret leak rate |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| append_only_log | 11.1% | 40.22 | 0.0671 | 55.6% | 11.1% |
+| windowed_recent_log | 22.2% | 23.89 | 0.0154 | 22.2% | 0.0% |
+| active_audit_digest | 100.0% | 32.67 | 0.0406 | 0.0% | 0.0% |
+
+The active digest keeps one current fact per memory key, redacts secret-shaped values, and retrieves only facts relevant to each question. The append-only and recent-window baselines demonstrate the tradeoff between stale context bloat and lost long-term recall.

--- a/examples/benchmarks/tool_call_audit_memory/run_benchmark.py
+++ b/examples/benchmarks/tool_call_audit_memory/run_benchmark.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Tool-call audit memory benchmark for the Memanto showdown.
+
+The benchmark is intentionally offline and deterministic. It models a coding
+agent that accumulates noisy tool output, user constraints, stale decisions,
+review feedback, payout state, and secret-shaped values over a long session.
+The active memory backend is a small Memanto-style digest that keeps typed,
+current facts and redacts secrets before retrieval.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+SECRET_PATTERNS = [
+    re.compile(r"stripe_live_secret_[A-Za-z0-9_]{12,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{12,}"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+]
+
+
+def redact(text: str) -> str:
+    for pattern in SECRET_PATTERNS:
+        text = pattern.sub("<redacted>", text)
+    return text
+
+
+def leaks_secret(text: str) -> bool:
+    return any(pattern.search(text) for pattern in SECRET_PATTERNS)
+
+
+def tokenize(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-zA-Z0-9_]{3,}", text.lower())
+        if token
+        not in {
+            "the",
+            "and",
+            "for",
+            "with",
+            "that",
+            "this",
+            "from",
+            "should",
+            "which",
+            "what",
+        }
+    }
+
+
+def token_count(text: str) -> int:
+    return len(re.findall(r"\S+", text))
+
+
+@dataclass(frozen=True)
+class Fact:
+    key: str
+    value: str
+    tags: tuple[str, ...]
+    evidence: str
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    session: str
+    source: str
+    text: str
+    facts: tuple[Fact, ...] = ()
+
+
+@dataclass(frozen=True)
+class Query:
+    question: str
+    must_have: tuple[str, ...]
+    must_not_have: tuple[str, ...] = ()
+
+
+EVENTS: tuple[AuditEvent, ...] = (
+    AuditEvent(
+        "s01",
+        "user",
+        "User allowed revenue-related Gmail review only. They also asked to avoid "
+        "posting sensitive payment details unless confirmed for a specific platform.",
+        (
+            Fact(
+                "gmail.scope",
+                "Read only revenue-related Gmail threads; do not inspect unrelated mail.",
+                ("gmail", "permission", "privacy"),
+                "User constrained mailbox access to revenue-related messages.",
+            ),
+            Fact(
+                "payment.public_qr",
+                "Do not post payment QR or sensitive payout details to third-party platforms without explicit confirmation.",
+                ("payment", "privacy", "bounty"),
+                "Payment details must stay private unless confirmed per platform.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s02",
+        "tool",
+        "Audit found a Stripe secret in .env: STRIPE_SECRET_KEY=stripe_live_secret_FAKE_TOOL_AUDIT_0000. "
+        "The value was removed from logs before sharing.",
+        (
+            Fact(
+                "secret.stripe",
+                "A Stripe secret was observed and must be represented only as <redacted>.",
+                ("secret", "audit", "stripe"),
+                "Secret-shaped values must never be injected verbatim.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s03",
+        "implementation",
+        "Auth middleware decision: verified JWT payloads must contain a non-empty string sub "
+        "claim and a supported role before protected routes proceed.",
+        (
+            Fact(
+                "auth.claim_rule",
+                "Require a non-empty string sub claim and a supported role in JWT payloads.",
+                ("auth", "claims", "security"),
+                "Protected routes must reject blank sub values and unsupported roles.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s04",
+        "test",
+        "Early test habit: run pytest -q for quick benchmark checks.",
+        (
+            Fact(
+                "benchmark.test_command",
+                "pytest -q",
+                ("tests", "stale"),
+                "Initial test command before the example was split out.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s05",
+        "review",
+        "Old data-layer note: raw SQL snippets are acceptable for quick prototypes.",
+        (
+            Fact(
+                "data.sql_style",
+                "raw SQL snippets are acceptable for quick prototypes.",
+                ("sql", "stale", "review"),
+                "This was later superseded by reviewer feedback.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s06",
+        "deploy",
+        "Initial deployment note: Railway is the expected hosting target.",
+        (
+            Fact(
+                "deploy.target",
+                "Railway",
+                ("deploy", "stale"),
+                "Initial target before platform constraints changed.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s07",
+        "implementation",
+        "Old feature flag name documented as MEMANTO_USE_MEMORY_V1.",
+        (
+            Fact(
+                "feature.flag",
+                "MEMANTO_USE_MEMORY_V1",
+                ("flag", "docs", "stale"),
+                "Initial flag name before audit-memory naming.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s08",
+        "review",
+        "Reviewer feedback superseded the raw SQL shortcut: use QueryBuilder for new data access "
+        "changes so the code stays portable and testable.",
+        (
+            Fact(
+                "data.sql_style",
+                "Use QueryBuilder for new data access changes.",
+                ("sql", "review", "current"),
+                "Reviewer explicitly replaced the earlier raw SQL shortcut.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s09",
+        "deployment",
+        "Platform decision changed after Railway credit limits: Fly.io is now the current deploy target.",
+        (
+            Fact(
+                "deploy.target",
+                "Fly.io",
+                ("deploy", "current"),
+                "Current deploy target after platform constraints changed.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s10",
+        "payout",
+        "Algora payout setup is active through Stripe Connect Express, country New Zealand, "
+        "payout currency NZD, bank account masked as **** 9000. No reward has been paid yet.",
+        (
+            Fact(
+                "payout.state",
+                "Algora/Stripe Connect Express active; payout currency NZD; no paid reward yet.",
+                ("payment", "algora", "stripe", "nzd"),
+                "Payout setup is active but balances remain zero until a bounty is awarded.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s11",
+        "implementation",
+        "Feature flag renamed for the benchmark docs: MEMANTO_AUDIT_MEMORY replaces MEMANTO_USE_MEMORY_V1.",
+        (
+            Fact(
+                "feature.flag",
+                "MEMANTO_AUDIT_MEMORY",
+                ("flag", "docs", "current"),
+                "Current docs should use the audit-memory flag name.",
+            ),
+        ),
+    ),
+    AuditEvent(
+        "s12",
+        "test",
+        "Current focused test command for this example: python -m unittest "
+        "examples.benchmarks.tool_call_audit_memory.test_benchmark -q.",
+        (
+            Fact(
+                "benchmark.test_command",
+                "python -m unittest examples.benchmarks.tool_call_audit_memory.test_benchmark -q",
+                ("tests", "current"),
+                "Focused standard-library test command for this benchmark.",
+            ),
+        ),
+    ),
+)
+
+
+QUERIES: tuple[Query, ...] = (
+    Query(
+        "Which feature flag should the benchmark docs tell users to set?",
+        ("MEMANTO_AUDIT_MEMORY",),
+        ("MEMANTO_USE_MEMORY_V1",),
+    ),
+    Query(
+        "What payout currency and account state has the monetization sprint configured?",
+        ("NZD", "Stripe Connect Express", "no paid reward yet"),
+    ),
+    Query(
+        "Should public bounty comments include the payment QR or sensitive payout details?",
+        ("Do not post payment QR", "explicit confirmation"),
+    ),
+    Query(
+        "Which SQL approach should a new patch use after review feedback?",
+        ("QueryBuilder",),
+        ("raw SQL snippets are acceptable",),
+    ),
+    Query(
+        "Which test command is current for this benchmark example?",
+        ("python -m unittest", "tool_call_audit_memory.test_benchmark"),
+        ("pytest -q",),
+    ),
+    Query(
+        "What should be injected about the observed Stripe secret?",
+        ("<redacted>",),
+        ("stripe_live_secret_FAKE_TOOL_AUDIT_0000",),
+    ),
+    Query(
+        "Which deployment target is current?",
+        ("Fly.io",),
+        ("Railway",),
+    ),
+    Query(
+        "Which auth claim validation rule should be remembered?",
+        ("non-empty string sub", "supported role"),
+    ),
+    Query(
+        "What Gmail scope is permitted for this sprint?",
+        ("revenue-related Gmail", "unrelated mail"),
+    ),
+)
+
+
+class Backend:
+    name = "backend"
+
+    def retrieve(self, question: str) -> str:
+        raise NotImplementedError
+
+
+class AppendOnlyLog(Backend):
+    name = "append_only_log"
+
+    def __init__(self, events: Iterable[AuditEvent]) -> None:
+        self.events = list(events)
+
+    def retrieve(self, question: str) -> str:
+        query_terms = tokenize(question)
+        ranked = []
+        for event in self.events:
+            overlap = len(query_terms & tokenize(event.text))
+            if overlap:
+                ranked.append((overlap, event.session, event))
+        ranked.sort(reverse=True, key=lambda item: (item[0], item[1]))
+        return "\n".join(event.text for _, _, event in ranked[:8])
+
+
+class WindowedLog(Backend):
+    name = "windowed_recent_log"
+
+    def __init__(self, events: Iterable[AuditEvent], window_size: int = 5) -> None:
+        self.events = list(events)[-window_size:]
+
+    def retrieve(self, question: str) -> str:
+        query_terms = tokenize(question)
+        hits = [
+            event.text
+            for event in self.events
+            if query_terms & tokenize(event.text)
+        ]
+        return "\n".join(hits)
+
+
+class ActiveAuditDigest(Backend):
+    name = "active_audit_digest"
+
+    def __init__(self, events: Iterable[AuditEvent]) -> None:
+        facts: dict[str, Fact] = {}
+        for event in events:
+            for fact in event.facts:
+                facts[fact.key] = fact
+        self.facts = facts
+
+    def retrieve(self, question: str) -> str:
+        query_terms = tokenize(question)
+        ranked = []
+        for fact in self.facts.values():
+            haystack = " ".join((fact.key, fact.value, " ".join(fact.tags), fact.evidence))
+            score = len(query_terms & tokenize(haystack))
+            if score:
+                ranked.append((score, fact.key, fact))
+        ranked.sort(reverse=True, key=lambda item: (item[0], item[1]))
+        lines = [
+            f"{fact.key}: {redact(fact.value)} Evidence: {redact(fact.evidence)}"
+            for _, _, fact in ranked[:2]
+        ]
+        return "\n".join(lines)
+
+
+def evaluate_backend(backend: Backend, queries: Iterable[Query]) -> dict[str, object]:
+    rows = []
+    latencies_ms = []
+    total_tokens = 0
+    correct = 0
+    stale_conflicts = 0
+    secret_leaks = 0
+
+    for query in queries:
+        start = time.perf_counter()
+        context = backend.retrieve(query.question)
+        latencies_ms.append((time.perf_counter() - start) * 1000)
+        normalized = context.lower()
+        has_expected = all(value.lower() in normalized for value in query.must_have)
+        has_stale = any(value.lower() in normalized for value in query.must_not_have)
+        leaked = leaks_secret(context)
+        ok = has_expected and not has_stale and not leaked
+
+        if ok:
+            correct += 1
+        if has_stale:
+            stale_conflicts += 1
+        if leaked:
+            secret_leaks += 1
+
+        retrieved_tokens = token_count(context)
+        total_tokens += retrieved_tokens
+        rows.append(
+            {
+                "question": query.question,
+                "retrieved_tokens": retrieved_tokens,
+                "correct": ok,
+                "stale_conflict": has_stale,
+                "secret_leak": leaked,
+                "context_preview": context[:240],
+            }
+        )
+
+    query_count = len(rows)
+    return {
+        "backend": backend.name,
+        "accuracy": round(correct / query_count, 4),
+        "avg_retrieved_tokens": round(total_tokens / query_count, 2),
+        "p95_latency_ms": round(
+            statistics.quantiles(latencies_ms, n=20, method="inclusive")[18],
+            4,
+        ),
+        "stale_conflict_rate": round(stale_conflicts / query_count, 4),
+        "secret_leak_rate": round(secret_leaks / query_count, 4),
+        "rows": rows,
+    }
+
+
+def run() -> dict[str, object]:
+    backends: tuple[Backend, ...] = (
+        AppendOnlyLog(EVENTS),
+        WindowedLog(EVENTS),
+        ActiveAuditDigest(EVENTS),
+    )
+    results = [evaluate_backend(backend, QUERIES) for backend in backends]
+    return {
+        "benchmark": "tool_call_audit_memory",
+        "description": (
+            "Offline benchmark for long-lived coding agents that must compact tool-call "
+            "audit logs into current, secret-safe memory."
+        ),
+        "event_count": len(EVENTS),
+        "query_count": len(QUERIES),
+        "results": results,
+    }
+
+
+def to_markdown(report: dict[str, object]) -> str:
+    lines = [
+        "# Tool-Call Audit Memory Results",
+        "",
+        "| Backend | Accuracy | Avg retrieved tokens | p95 latency ms | Stale conflict rate | Secret leak rate |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for item in report["results"]:
+        lines.append(
+            "| {backend} | {accuracy:.1%} | {avg_retrieved_tokens} | {p95_latency_ms} | {stale_conflict_rate:.1%} | {secret_leak_rate:.1%} |".format(
+                **item
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "The active digest keeps one current fact per memory key, redacts secret-shaped values, and retrieves only facts relevant to each question. The append-only and recent-window baselines demonstrate the tradeoff between stale context bloat and lost long-term recall.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSON output path.",
+    )
+    parser.add_argument(
+        "--markdown",
+        type=Path,
+        help="Optional Markdown summary output path.",
+    )
+    args = parser.parse_args()
+
+    report = run()
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.markdown:
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text(to_markdown(report), encoding="utf-8")
+    if not args.output and not args.markdown:
+        print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/tool_call_audit_memory/run_benchmark.py
+++ b/examples/benchmarks/tool_call_audit_memory/run_benchmark.py
@@ -37,6 +37,10 @@ def leaks_secret(text: str) -> bool:
     return any(pattern.search(text) for pattern in SECRET_PATTERNS)
 
 
+def safe_context_preview(text: str, limit: int = 240) -> str:
+    return redact(text)[:limit]
+
+
 def tokenize(text: str) -> set[str]:
     return {
         token
@@ -401,11 +405,22 @@ def evaluate_backend(backend: Backend, queries: Iterable[Query]) -> dict[str, ob
                 "correct": ok,
                 "stale_conflict": has_stale,
                 "secret_leak": leaked,
-                "context_preview": context[:240],
+                "context_preview": safe_context_preview(context),
             }
         )
 
     query_count = len(rows)
+    if query_count == 0:
+        return {
+            "backend": backend.name,
+            "accuracy": 0.0,
+            "avg_retrieved_tokens": 0.0,
+            "p95_latency_ms": 0.0,
+            "stale_conflict_rate": 0.0,
+            "secret_leak_rate": 0.0,
+            "rows": rows,
+        }
+
     return {
         "backend": backend.name,
         "accuracy": round(correct / query_count, 4),

--- a/examples/benchmarks/tool_call_audit_memory/test_benchmark.py
+++ b/examples/benchmarks/tool_call_audit_memory/test_benchmark.py
@@ -1,6 +1,13 @@
 import unittest
 
-from .run_benchmark import ActiveAuditDigest, EVENTS, QUERIES, leaks_secret, run
+from .run_benchmark import (
+    ActiveAuditDigest,
+    EVENTS,
+    QUERIES,
+    evaluate_backend,
+    leaks_secret,
+    run,
+)
 
 
 class ToolCallAuditMemoryBenchmarkTests(unittest.TestCase):
@@ -33,8 +40,27 @@ class ToolCallAuditMemoryBenchmarkTests(unittest.TestCase):
         self.assertFalse(leaks_secret(context))
 
     def test_all_queries_have_expected_answers(self) -> None:
+        backend = ActiveAuditDigest(EVENTS)
         for query in QUERIES:
-            self.assertTrue(query.must_have, query.question)
+            context = backend.retrieve(query.question)
+            normalized = context.lower()
+
+            for expected in query.must_have:
+                self.assertIn(expected.lower(), normalized, query.question)
+            for stale in query.must_not_have:
+                self.assertNotIn(stale.lower(), normalized, query.question)
+
+    def test_empty_query_set_returns_zero_metrics(self) -> None:
+        backend = ActiveAuditDigest(EVENTS)
+        result = evaluate_backend(backend, ())
+
+        self.assertEqual(result["backend"], "active_audit_digest")
+        self.assertEqual(result["accuracy"], 0.0)
+        self.assertEqual(result["avg_retrieved_tokens"], 0.0)
+        self.assertEqual(result["p95_latency_ms"], 0.0)
+        self.assertEqual(result["stale_conflict_rate"], 0.0)
+        self.assertEqual(result["secret_leak_rate"], 0.0)
+        self.assertEqual(result["rows"], [])
 
 
 if __name__ == "__main__":

--- a/examples/benchmarks/tool_call_audit_memory/test_benchmark.py
+++ b/examples/benchmarks/tool_call_audit_memory/test_benchmark.py
@@ -1,0 +1,41 @@
+import unittest
+
+from .run_benchmark import ActiveAuditDigest, EVENTS, QUERIES, leaks_secret, run
+
+
+class ToolCallAuditMemoryBenchmarkTests(unittest.TestCase):
+    def test_active_digest_beats_append_only_accuracy(self) -> None:
+        report = run()
+        results = {item["backend"]: item for item in report["results"]}
+
+        self.assertGreater(
+            results["active_audit_digest"]["accuracy"],
+            results["append_only_log"]["accuracy"],
+        )
+        self.assertEqual(results["active_audit_digest"]["secret_leak_rate"], 0)
+        self.assertLess(
+            results["active_audit_digest"]["avg_retrieved_tokens"],
+            results["append_only_log"]["avg_retrieved_tokens"],
+        )
+
+    def test_active_digest_suppresses_stale_flag(self) -> None:
+        backend = ActiveAuditDigest(EVENTS)
+        context = backend.retrieve("Which feature flag should the benchmark docs tell users to set?")
+
+        self.assertIn("MEMANTO_AUDIT_MEMORY", context)
+        self.assertNotIn("MEMANTO_USE_MEMORY_V1", context)
+
+    def test_secret_context_is_redacted(self) -> None:
+        backend = ActiveAuditDigest(EVENTS)
+        context = backend.retrieve("What should be injected about the observed Stripe secret?")
+
+        self.assertIn("<redacted>", context)
+        self.assertFalse(leaks_secret(context))
+
+    def test_all_queries_have_expected_answers(self) -> None:
+        for query in QUERIES:
+            self.assertTrue(query.must_have, query.question)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/benchmarks/tool_call_audit_memory/test_benchmark.py
+++ b/examples/benchmarks/tool_call_audit_memory/test_benchmark.py
@@ -46,9 +46,17 @@ class ToolCallAuditMemoryBenchmarkTests(unittest.TestCase):
             normalized = context.lower()
 
             for expected in query.must_have:
-                self.assertIn(expected.lower(), normalized, query.question)
+                self.assertIn(
+                    expected.lower(),
+                    normalized,
+                    f"Expected value {expected!r} not found for query: {query.question}",
+                )
             for stale in query.must_not_have:
-                self.assertNotIn(stale.lower(), normalized, query.question)
+                self.assertNotIn(
+                    stale.lower(),
+                    normalized,
+                    f"Stale value {stale!r} found for query: {query.question}",
+                )
 
     def test_empty_query_set_returns_zero_metrics(self) -> None:
         backend = ActiveAuditDigest(EVENTS)


### PR DESCRIPTION
Refs #639

BountyHub: https://www.bountyhub.dev/bounty/view/ec58c800-823e-4134-b027-99838e096d4b

## Summary

This PR adds `examples/benchmarks/tool_call_audit_memory`, a credential-free benchmark for long-lived coding agents that must compact noisy tool-call audit logs into current, scoped, secret-safe memory.

It is intentionally different from the existing #639 submissions: instead of preference drift, incident response, or multi-agent handoff, this benchmark stresses audit-trail memory for code work:

- current facts must supersede stale facts, including feature flags, deploy targets, test commands, and reviewer SQL guidance
- payment and mailbox constraints must be recalled without exposing sensitive payout details
- secret-shaped tool output must be redacted before context injection
- baselines show the tradeoff between append-only context bloat and recent-window forgetfulness

## Included

- `run_benchmark.py`: dependency-free benchmark runner with append-only, recent-window, and active digest backends
- `test_benchmark.py`: standard-library tests for accuracy, stale suppression, and redaction
- `results/sample_results.json` and `.md`: reproducible sample report
- README with run commands and metric definitions

## Sample result

| Backend | Accuracy | Avg retrieved tokens | p95 latency ms | Stale conflict rate | Secret leak rate |
| --- | ---: | ---: | ---: | ---: | ---: |
| append_only_log | 11.1% | 40.22 | ~0.07 | 55.6% | 11.1% |
| windowed_recent_log | 22.2% | 23.89 | ~0.02 | 22.2% | 0.0% |
| active_audit_digest | 100.0% | 32.67 | ~0.04 | 0.0% | 0.0% |

## Validation

- `python examples/benchmarks/tool_call_audit_memory/run_benchmark.py`
- `python examples/benchmarks/tool_call_audit_memory/run_benchmark.py --output examples/benchmarks/tool_call_audit_memory/results/sample_results.json --markdown examples/benchmarks/tool_call_audit_memory/results/sample_results.md`
- `python -m unittest examples.benchmarks.tool_call_audit_memory.test_benchmark -q`
- `python -m py_compile examples/benchmarks/tool_call_audit_memory/run_benchmark.py examples/benchmarks/tool_call_audit_memory/test_benchmark.py`
- `git diff --check`

Note: `python -m ruff ...` was attempted locally, but `ruff` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tool-Call Audit Memory Benchmark example to evaluate long-running agent memory strategies with three offline backends.
  * Benchmark reports retrieval accuracy, token footprint, p95 latency, stale-conflict rate, and secret leak rate, including deterministic simulation of audit events.
  * Added sample benchmark outputs (JSON and Markdown) to illustrate backend tradeoffs.

* **Documentation**
  * Added a README explaining what’s measured and how to run the benchmark and unit tests.

* **Tests**
  * Added unit tests for backend comparison, stale-suppression behavior, secret redaction, query coverage, and zero-metric defaults on empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->