### PR TITLE
[BOUNTY $100] Add privacy consent memory benchmark

### DIFF
--- a/examples/benchmarks/privacy-consent-memory/README.md
+++ b/examples/benchmarks/privacy-consent-memory/README.md
@@ -1,0 +1,33 @@
+# Privacy Consent Memory Benchmark
+
+This benchmark evaluates agent memory behavior when users change consent,
+revoke permissions, correct sensitive preferences, or request erasure. It is a
+credential-free control-group benchmark for issue #639.
+
+The suite compares three deterministic memory strategies:
+
+- `active_consent_digest`: a Memanto-style typed digest that keeps current
+  facts, honors revocations, and suppresses superseded or erased memories.
+- `append_only_log`: a naive memory log that retrieves every matching event,
+  including stale consent and deleted facts.
+- `recent_window_log`: a small recent-history baseline that reduces token
+  footprint but can miss older still-valid constraints.
+
+Metrics:
+
+- retrieval accuracy against a golden current-state dataset
+- stale consent leak rate
+- erased fact leak rate
+- average retrieved tokens
+- p95 retrieval latency in milliseconds
+- signal-to-noise ratio
+
+Run:
+
+```bash
+python3 examples/benchmarks/privacy-consent-memory/run_benchmark.py
+python3 -m unittest examples/benchmarks/privacy-consent-memory/test_benchmark.py
+```
+
+The committed sample output is in `results/sample_results.md` and
+`results/sample_results.json`.

--- a/examples/benchmarks/privacy-consent-memory/README.md
+++ b/examples/benchmarks/privacy-consent-memory/README.md
@@ -2,7 +2,7 @@
 
 This benchmark evaluates agent memory behavior when users change consent,
 revoke permissions, correct sensitive preferences, or request erasure. It is a
-credential-free control-group benchmark for issue #639.
+credential-free control-group benchmark for PR #650.
 
 The suite compares three deterministic memory strategies:
 

--- a/examples/benchmarks/privacy-consent-memory/results/sample_results.json
+++ b/examples/benchmarks/privacy-consent-memory/results/sample_results.json
@@ -10,7 +10,7 @@
       "stale_leak_rate": 0.0,
       "erased_leak_rate": 0.0,
       "avg_retrieved_tokens": 1.2857142857142858,
-      "p95_latency_ms": 0.0009295414201915264,
+      "p95_latency_ms": 0.000816071406006813,
       "signal_to_noise": 0.7777777777777778
     },
     {
@@ -19,7 +19,7 @@
       "stale_leak_rate": 0.5714285714285714,
       "erased_leak_rate": 0.2857142857142857,
       "avg_retrieved_tokens": 17.714285714285715,
-      "p95_latency_ms": 0.0018711201846599579,
+      "p95_latency_ms": 0.0013124197721481323,
       "signal_to_noise": 0.0
     },
     {
@@ -28,7 +28,7 @@
       "stale_leak_rate": 0.14285714285714285,
       "erased_leak_rate": 0.0,
       "avg_retrieved_tokens": 3.2857142857142856,
-      "p95_latency_ms": 0.0008624047040939331,
+      "p95_latency_ms": 0.000787700992077589,
       "signal_to_noise": 0.08695652173913043
     }
   ],
@@ -39,7 +39,7 @@
       "expected_value": "denied",
       "answer": "denied",
       "retrieved_tokens": 1,
-      "latency_ms": 0.0010420335456728935,
+      "latency_ms": 0.0009159557521343231,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -50,7 +50,7 @@
       "expected_value": null,
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.0006670597940683365,
+      "latency_ms": 0.0005409820005297661,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -72,7 +72,7 @@
       "expected_value": "denied",
       "answer": "denied",
       "retrieved_tokens": 1,
-      "latency_ms": 0.00037497375160455704,
+      "latency_ms": 0.0003330642357468605,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -83,7 +83,7 @@
       "expected_value": null,
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.000250060111284256,
+      "latency_ms": 0.00016693957149982452,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -94,7 +94,7 @@
       "expected_value": "company billing portal",
       "answer": "company billing portal",
       "retrieved_tokens": 3,
-      "latency_ms": 0.0003330642357468605,
+      "latency_ms": 0.000333995558321476,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -105,7 +105,7 @@
       "expected_value": "7 days",
       "answer": "7 days",
       "retrieved_tokens": 2,
-      "latency_ms": 0.000250060111284256,
+      "latency_ms": 0.00024994369596242905,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -116,7 +116,7 @@
       "expected_value": "denied",
       "answer": "Maya opts into weekly product marketing emails. | Maya revokes marketing email consent after a privacy review.",
       "retrieved_tokens": 16,
-      "latency_ms": 0.002334010787308216,
+      "latency_ms": 0.0014998950064182281,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -127,7 +127,7 @@
       "expected_value": null,
       "answer": "Maya says her support profile may store a peanut allergy note. | Maya asks to erase the health note from future memory retrieval.",
       "retrieved_tokens": 22,
-      "latency_ms": 0.0007910421118140221,
+      "latency_ms": 0.0008749775588512421,
       "correct": false,
       "stale_leak": true,
       "erased_leak": true
@@ -138,7 +138,7 @@
       "expected_value": "email only",
       "answer": "Maya prefers support followups by email only.",
       "retrieved_tokens": 7,
-      "latency_ms": 0.000500003807246685,
+      "latency_ms": 0.0005409820005297661,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -149,7 +149,7 @@
       "expected_value": "denied",
       "answer": "Noah allows temporary location sharing during travel. | Noah turns off location sharing after arriving.",
       "retrieved_tokens": 14,
-      "latency_ms": 0.000583939254283905,
+      "latency_ms": 0.0005420297384262085,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -160,7 +160,7 @@
       "expected_value": null,
       "answer": "Noah is traveling in Berlin this week. | Noah updates his current travel city to Lisbon. | Noah requests deletion of travel city memory after the trip.",
       "retrieved_tokens": 25,
-      "latency_ms": 0.00045797787606716156,
+      "latency_ms": 0.00045890919864177704,
       "correct": false,
       "stale_leak": true,
       "erased_leak": true
@@ -171,7 +171,7 @@
       "expected_value": "company billing portal",
       "answer": "Rhea accidentally shares a personal card ending 4242. | Rhea asks to erase the personal card detail immediately. | Rhea says invoices should use the company billing portal.",
       "retrieved_tokens": 26,
-      "latency_ms": 0.0005420297384262085,
+      "latency_ms": 0.000583939254283905,
       "correct": false,
       "stale_leak": true,
       "erased_leak": false
@@ -182,7 +182,7 @@
       "expected_value": "7 days",
       "answer": "Rhea sets data retention to 30 days. | Rhea changes data retention to 7 days.",
       "retrieved_tokens": 14,
-      "latency_ms": 0.000625033862888813,
+      "latency_ms": 0.00045797787606716156,
       "correct": false,
       "stale_leak": true,
       "erased_leak": false
@@ -193,7 +193,7 @@
       "expected_value": "denied",
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.0008330680429935455,
+      "latency_ms": 0.0008749775588512421,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -215,7 +215,7 @@
       "expected_value": "email only",
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.00024994369596242905,
+      "latency_ms": 0.000208965502679348,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -226,7 +226,7 @@
       "expected_value": "denied",
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.00016705598682165146,
+      "latency_ms": 0.00016693957149982452,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -237,7 +237,7 @@
       "expected_value": null,
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.00016600824892520905,
+      "latency_ms": 0.00016693957149982452,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -248,7 +248,7 @@
       "expected_value": "company billing portal",
       "answer": "Rhea says invoices should use the company billing portal.",
       "retrieved_tokens": 9,
-      "latency_ms": 0.000500003807246685,
+      "latency_ms": 0.000584055669605732,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -259,7 +259,7 @@
       "expected_value": "7 days",
       "answer": "Rhea changes data retention to 7 days.",
       "retrieved_tokens": 14,
-      "latency_ms": 0.0008749775588512421,
+      "latency_ms": 0.0005420297384262085,
       "correct": false,
       "stale_leak": true,
       "erased_leak": false

--- a/examples/benchmarks/privacy-consent-memory/results/sample_results.json
+++ b/examples/benchmarks/privacy-consent-memory/results/sample_results.json
@@ -1,0 +1,268 @@
+{
+  "benchmark": "privacy-consent-memory",
+  "description": "Current consent, erasure, and sensitive preference retrieval under memory pressure.",
+  "queries": 7,
+  "events": 15,
+  "summaries": [
+    {
+      "backend": "active_consent_digest",
+      "accuracy": 1.0,
+      "stale_leak_rate": 0.0,
+      "erased_leak_rate": 0.0,
+      "avg_retrieved_tokens": 1.2857142857142858,
+      "p95_latency_ms": 0.001078553032130003,
+      "signal_to_noise": 0.7777777777777778
+    },
+    {
+      "backend": "append_only_log",
+      "accuracy": 0.14285714285714285,
+      "stale_leak_rate": 0.5714285714285714,
+      "erased_leak_rate": 0.2857142857142857,
+      "avg_retrieved_tokens": 17.714285714285715,
+      "p95_latency_ms": 0.0020000035874545574,
+      "signal_to_noise": 0.008064516129032258
+    },
+    {
+      "backend": "recent_window_log",
+      "accuracy": 0.42857142857142855,
+      "stale_leak_rate": 0.14285714285714285,
+      "erased_leak_rate": 0.0,
+      "avg_retrieved_tokens": 3.2857142857142856,
+      "p95_latency_ms": 0.0008170842193067074,
+      "signal_to_noise": 0.13043478260869565
+    }
+  ],
+  "results": [
+    {
+      "backend": "active_consent_digest",
+      "prompt": "Can Maya receive marketing email?",
+      "expected_value": "denied",
+      "answer": "denied",
+      "retrieved_tokens": 1,
+      "latency_ms": 0.0012909295037388802,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "active_consent_digest",
+      "prompt": "What health note should be retrieved for Maya?",
+      "expected_value": null,
+      "answer": null,
+      "retrieved_tokens": 0,
+      "latency_ms": 0.0005830079317092896,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "active_consent_digest",
+      "prompt": "How should support follow up with Maya?",
+      "expected_value": "email only",
+      "answer": "email only",
+      "retrieved_tokens": 2,
+      "latency_ms": 0.0005830079317092896,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "active_consent_digest",
+      "prompt": "Can Noah's location be used now?",
+      "expected_value": "denied",
+      "answer": "denied",
+      "retrieved_tokens": 1,
+      "latency_ms": 0.0003330642357468605,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "active_consent_digest",
+      "prompt": "What travel city should be recalled for Noah?",
+      "expected_value": null,
+      "answer": null,
+      "retrieved_tokens": 0,
+      "latency_ms": 0.00020791776478290558,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "active_consent_digest",
+      "prompt": "How should Rhea be invoiced?",
+      "expected_value": "company billing portal",
+      "answer": "company billing portal",
+      "retrieved_tokens": 3,
+      "latency_ms": 0.000333995558321476,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "active_consent_digest",
+      "prompt": "What is Rhea's current retention period?",
+      "expected_value": "7 days",
+      "answer": "7 days",
+      "retrieved_tokens": 2,
+      "latency_ms": 0.00033294782042503357,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "append_only_log",
+      "prompt": "Can Maya receive marketing email?",
+      "expected_value": "denied",
+      "answer": "Maya opts into weekly product marketing emails. | Maya revokes marketing email consent after a privacy review.",
+      "retrieved_tokens": 16,
+      "latency_ms": 0.002374988980591297,
+      "correct": false,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "append_only_log",
+      "prompt": "What health note should be retrieved for Maya?",
+      "expected_value": null,
+      "answer": "Maya says her support profile may store a peanut allergy note. | Maya asks to erase the health note from future memory retrieval.",
+      "retrieved_tokens": 22,
+      "latency_ms": 0.001125037670135498,
+      "correct": false,
+      "stale_leak": true,
+      "erased_leak": true
+    },
+    {
+      "backend": "append_only_log",
+      "prompt": "How should support follow up with Maya?",
+      "expected_value": "email only",
+      "answer": "Maya prefers support followups by email only.",
+      "retrieved_tokens": 7,
+      "latency_ms": 0.0005830079317092896,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "append_only_log",
+      "prompt": "Can Noah's location be used now?",
+      "expected_value": "denied",
+      "answer": "Noah allows temporary location sharing during travel. | Noah turns off location sharing after arriving.",
+      "retrieved_tokens": 14,
+      "latency_ms": 0.000750063918530941,
+      "correct": false,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "append_only_log",
+      "prompt": "What travel city should be recalled for Noah?",
+      "expected_value": null,
+      "answer": "Noah is traveling in Berlin this week. | Noah updates his current travel city to Lisbon. | Noah requests deletion of travel city memory after the trip.",
+      "retrieved_tokens": 25,
+      "latency_ms": 0.0005830079317092896,
+      "correct": false,
+      "stale_leak": true,
+      "erased_leak": true
+    },
+    {
+      "backend": "append_only_log",
+      "prompt": "How should Rhea be invoiced?",
+      "expected_value": "company billing portal",
+      "answer": "Rhea accidentally shares a personal card ending 4242. | Rhea asks to erase the personal card detail immediately. | Rhea says invoices should use the company billing portal.",
+      "retrieved_tokens": 26,
+      "latency_ms": 0.0004580942913889885,
+      "correct": false,
+      "stale_leak": true,
+      "erased_leak": false
+    },
+    {
+      "backend": "append_only_log",
+      "prompt": "What is Rhea's current retention period?",
+      "expected_value": "7 days",
+      "answer": "Rhea sets data retention to 30 days. | Rhea changes data retention to 7 days.",
+      "retrieved_tokens": 14,
+      "latency_ms": 0.0005420297384262085,
+      "correct": false,
+      "stale_leak": true,
+      "erased_leak": false
+    },
+    {
+      "backend": "recent_window_log",
+      "prompt": "Can Maya receive marketing email?",
+      "expected_value": "denied",
+      "answer": null,
+      "retrieved_tokens": 0,
+      "latency_ms": 0.0009170034900307655,
+      "correct": false,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "recent_window_log",
+      "prompt": "What health note should be retrieved for Maya?",
+      "expected_value": null,
+      "answer": null,
+      "retrieved_tokens": 0,
+      "latency_ms": 0.00045797787606716156,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "recent_window_log",
+      "prompt": "How should support follow up with Maya?",
+      "expected_value": "email only",
+      "answer": null,
+      "retrieved_tokens": 0,
+      "latency_ms": 0.000250060111284256,
+      "correct": false,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "recent_window_log",
+      "prompt": "Can Noah's location be used now?",
+      "expected_value": "denied",
+      "answer": null,
+      "retrieved_tokens": 0,
+      "latency_ms": 0.00016705598682165146,
+      "correct": false,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "recent_window_log",
+      "prompt": "What travel city should be recalled for Noah?",
+      "expected_value": null,
+      "answer": null,
+      "retrieved_tokens": 0,
+      "latency_ms": 0.00012491364032030106,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "recent_window_log",
+      "prompt": "How should Rhea be invoiced?",
+      "expected_value": "company billing portal",
+      "answer": "Rhea says invoices should use the company billing portal.",
+      "retrieved_tokens": 9,
+      "latency_ms": 0.000583939254283905,
+      "correct": true,
+      "stale_leak": false,
+      "erased_leak": false
+    },
+    {
+      "backend": "recent_window_log",
+      "prompt": "What is Rhea's current retention period?",
+      "expected_value": "7 days",
+      "answer": "Rhea changes data retention to 7 days.",
+      "retrieved_tokens": 14,
+      "latency_ms": 0.0005409820005297661,
+      "correct": false,
+      "stale_leak": true,
+      "erased_leak": false
+    }
+  ]
+}

--- a/examples/benchmarks/privacy-consent-memory/results/sample_results.json
+++ b/examples/benchmarks/privacy-consent-memory/results/sample_results.json
@@ -10,26 +10,26 @@
       "stale_leak_rate": 0.0,
       "erased_leak_rate": 0.0,
       "avg_retrieved_tokens": 1.2857142857142858,
-      "p95_latency_ms": 0.001078553032130003,
+      "p95_latency_ms": 0.0009295414201915264,
       "signal_to_noise": 0.7777777777777778
     },
     {
       "backend": "append_only_log",
-      "accuracy": 0.14285714285714285,
+      "accuracy": 0.0,
       "stale_leak_rate": 0.5714285714285714,
       "erased_leak_rate": 0.2857142857142857,
       "avg_retrieved_tokens": 17.714285714285715,
-      "p95_latency_ms": 0.0020000035874545574,
-      "signal_to_noise": 0.008064516129032258
+      "p95_latency_ms": 0.0018711201846599579,
+      "signal_to_noise": 0.0
     },
     {
       "backend": "recent_window_log",
-      "accuracy": 0.42857142857142855,
+      "accuracy": 0.2857142857142857,
       "stale_leak_rate": 0.14285714285714285,
       "erased_leak_rate": 0.0,
       "avg_retrieved_tokens": 3.2857142857142856,
-      "p95_latency_ms": 0.0008170842193067074,
-      "signal_to_noise": 0.13043478260869565
+      "p95_latency_ms": 0.0008624047040939331,
+      "signal_to_noise": 0.08695652173913043
     }
   ],
   "results": [
@@ -39,7 +39,7 @@
       "expected_value": "denied",
       "answer": "denied",
       "retrieved_tokens": 1,
-      "latency_ms": 0.0012909295037388802,
+      "latency_ms": 0.0010420335456728935,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -50,7 +50,7 @@
       "expected_value": null,
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.0005830079317092896,
+      "latency_ms": 0.0006670597940683365,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -72,7 +72,7 @@
       "expected_value": "denied",
       "answer": "denied",
       "retrieved_tokens": 1,
-      "latency_ms": 0.0003330642357468605,
+      "latency_ms": 0.00037497375160455704,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -83,7 +83,7 @@
       "expected_value": null,
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.00020791776478290558,
+      "latency_ms": 0.000250060111284256,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -94,7 +94,7 @@
       "expected_value": "company billing portal",
       "answer": "company billing portal",
       "retrieved_tokens": 3,
-      "latency_ms": 0.000333995558321476,
+      "latency_ms": 0.0003330642357468605,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -105,7 +105,7 @@
       "expected_value": "7 days",
       "answer": "7 days",
       "retrieved_tokens": 2,
-      "latency_ms": 0.00033294782042503357,
+      "latency_ms": 0.000250060111284256,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -116,7 +116,7 @@
       "expected_value": "denied",
       "answer": "Maya opts into weekly product marketing emails. | Maya revokes marketing email consent after a privacy review.",
       "retrieved_tokens": 16,
-      "latency_ms": 0.002374988980591297,
+      "latency_ms": 0.002334010787308216,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -127,7 +127,7 @@
       "expected_value": null,
       "answer": "Maya says her support profile may store a peanut allergy note. | Maya asks to erase the health note from future memory retrieval.",
       "retrieved_tokens": 22,
-      "latency_ms": 0.001125037670135498,
+      "latency_ms": 0.0007910421118140221,
       "correct": false,
       "stale_leak": true,
       "erased_leak": true
@@ -138,8 +138,8 @@
       "expected_value": "email only",
       "answer": "Maya prefers support followups by email only.",
       "retrieved_tokens": 7,
-      "latency_ms": 0.0005830079317092896,
-      "correct": true,
+      "latency_ms": 0.000500003807246685,
+      "correct": false,
       "stale_leak": false,
       "erased_leak": false
     },
@@ -149,7 +149,7 @@
       "expected_value": "denied",
       "answer": "Noah allows temporary location sharing during travel. | Noah turns off location sharing after arriving.",
       "retrieved_tokens": 14,
-      "latency_ms": 0.000750063918530941,
+      "latency_ms": 0.000583939254283905,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -160,7 +160,7 @@
       "expected_value": null,
       "answer": "Noah is traveling in Berlin this week. | Noah updates his current travel city to Lisbon. | Noah requests deletion of travel city memory after the trip.",
       "retrieved_tokens": 25,
-      "latency_ms": 0.0005830079317092896,
+      "latency_ms": 0.00045797787606716156,
       "correct": false,
       "stale_leak": true,
       "erased_leak": true
@@ -171,7 +171,7 @@
       "expected_value": "company billing portal",
       "answer": "Rhea accidentally shares a personal card ending 4242. | Rhea asks to erase the personal card detail immediately. | Rhea says invoices should use the company billing portal.",
       "retrieved_tokens": 26,
-      "latency_ms": 0.0004580942913889885,
+      "latency_ms": 0.0005420297384262085,
       "correct": false,
       "stale_leak": true,
       "erased_leak": false
@@ -182,7 +182,7 @@
       "expected_value": "7 days",
       "answer": "Rhea sets data retention to 30 days. | Rhea changes data retention to 7 days.",
       "retrieved_tokens": 14,
-      "latency_ms": 0.0005420297384262085,
+      "latency_ms": 0.000625033862888813,
       "correct": false,
       "stale_leak": true,
       "erased_leak": false
@@ -193,7 +193,7 @@
       "expected_value": "denied",
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.0009170034900307655,
+      "latency_ms": 0.0008330680429935455,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -204,7 +204,7 @@
       "expected_value": null,
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.00045797787606716156,
+      "latency_ms": 0.0004169996827840805,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -215,7 +215,7 @@
       "expected_value": "email only",
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.000250060111284256,
+      "latency_ms": 0.00024994369596242905,
       "correct": false,
       "stale_leak": false,
       "erased_leak": false
@@ -237,7 +237,7 @@
       "expected_value": null,
       "answer": null,
       "retrieved_tokens": 0,
-      "latency_ms": 0.00012491364032030106,
+      "latency_ms": 0.00016600824892520905,
       "correct": true,
       "stale_leak": false,
       "erased_leak": false
@@ -248,8 +248,8 @@
       "expected_value": "company billing portal",
       "answer": "Rhea says invoices should use the company billing portal.",
       "retrieved_tokens": 9,
-      "latency_ms": 0.000583939254283905,
-      "correct": true,
+      "latency_ms": 0.000500003807246685,
+      "correct": false,
       "stale_leak": false,
       "erased_leak": false
     },
@@ -259,7 +259,7 @@
       "expected_value": "7 days",
       "answer": "Rhea changes data retention to 7 days.",
       "retrieved_tokens": 14,
-      "latency_ms": 0.0005409820005297661,
+      "latency_ms": 0.0008749775588512421,
       "correct": false,
       "stale_leak": true,
       "erased_leak": false

--- a/examples/benchmarks/privacy-consent-memory/results/sample_results.md
+++ b/examples/benchmarks/privacy-consent-memory/results/sample_results.md
@@ -3,5 +3,5 @@
 | Backend | Accuracy | Stale Leak | Erased Leak | Avg Tokens | p95 Latency | Signal/Noise |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
 | active_consent_digest | 100.0% | 0.0% | 0.0% | 1.3 | 0.001 ms | 0.7778 |
-| append_only_log | 0.0% | 57.1% | 28.6% | 17.7 | 0.002 ms | 0.0000 |
+| append_only_log | 0.0% | 57.1% | 28.6% | 17.7 | 0.001 ms | 0.0000 |
 | recent_window_log | 28.6% | 14.3% | 0.0% | 3.3 | 0.001 ms | 0.0870 |

--- a/examples/benchmarks/privacy-consent-memory/results/sample_results.md
+++ b/examples/benchmarks/privacy-consent-memory/results/sample_results.md
@@ -3,5 +3,5 @@
 | Backend | Accuracy | Stale Leak | Erased Leak | Avg Tokens | p95 Latency | Signal/Noise |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
 | active_consent_digest | 100.0% | 0.0% | 0.0% | 1.3 | 0.001 ms | 0.7778 |
-| append_only_log | 14.3% | 57.1% | 28.6% | 17.7 | 0.002 ms | 0.0081 |
-| recent_window_log | 42.9% | 14.3% | 0.0% | 3.3 | 0.001 ms | 0.1304 |
+| append_only_log | 0.0% | 57.1% | 28.6% | 17.7 | 0.002 ms | 0.0000 |
+| recent_window_log | 28.6% | 14.3% | 0.0% | 3.3 | 0.001 ms | 0.0870 |

--- a/examples/benchmarks/privacy-consent-memory/results/sample_results.md
+++ b/examples/benchmarks/privacy-consent-memory/results/sample_results.md
@@ -1,0 +1,7 @@
+# Privacy Consent Memory Benchmark Results
+
+| Backend | Accuracy | Stale Leak | Erased Leak | Avg Tokens | p95 Latency | Signal/Noise |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| active_consent_digest | 100.0% | 0.0% | 0.0% | 1.3 | 0.001 ms | 0.7778 |
+| append_only_log | 14.3% | 57.1% | 28.6% | 17.7 | 0.002 ms | 0.0081 |
+| recent_window_log | 42.9% | 14.3% | 0.0% | 3.3 | 0.001 ms | 0.1304 |

--- a/examples/benchmarks/privacy-consent-memory/run_benchmark.py
+++ b/examples/benchmarks/privacy-consent-memory/run_benchmark.py
@@ -22,6 +22,8 @@ ROOT = Path(__file__).resolve().parent
 
 @dataclass(frozen=True)
 class MemoryEvent:
+    """Single timeline event that can set, revoke, or erase a memory fact."""
+
     turn: int
     user: str
     kind: str
@@ -32,6 +34,8 @@ class MemoryEvent:
 
 @dataclass(frozen=True)
 class QueryCase:
+    """Golden query used to evaluate current memory retrieval behavior."""
+
     user: str
     key: str
     prompt: str
@@ -41,6 +45,8 @@ class QueryCase:
 
 @dataclass(frozen=True)
 class QueryResult:
+    """Per-backend result for one golden query."""
+
     backend: str
     prompt: str
     expected_value: str | None
@@ -54,6 +60,8 @@ class QueryResult:
 
 @dataclass(frozen=True)
 class BackendSummary:
+    """Aggregate metrics for one benchmark backend."""
+
     backend: str
     accuracy: float
     stale_leak_rate: float
@@ -94,19 +102,26 @@ QUERIES = [
 
 
 class Backend:
+    """Minimal interface shared by deterministic memory backends."""
+
     name = "backend"
 
     def __init__(self, events: Iterable[MemoryEvent]) -> None:
+        """Store the event timeline used by this backend."""
         self.events = list(events)
 
     def answer(self, query: QueryCase) -> tuple[str | None, list[str]]:
+        """Return an answer and retrieved context snippets for a query."""
         raise NotImplementedError
 
 
 class ActiveConsentDigest(Backend):
+    """Memanto-style active digest that keeps only current allowed facts."""
+
     name = "active_consent_digest"
 
     def __init__(self, events: Iterable[MemoryEvent]) -> None:
+        """Build current consent state while tracking erased keys."""
         super().__init__(events)
         self.current: dict[tuple[str, str], str] = {}
         self.erased: set[tuple[str, str]] = set()
@@ -120,6 +135,7 @@ class ActiveConsentDigest(Backend):
                 self.erased.discard(key)
 
     def answer(self, query: QueryCase) -> tuple[str | None, list[str]]:
+        """Answer from the current digest without surfacing erased facts."""
         key = (query.user, query.key)
         if key in self.erased:
             return None, []
@@ -130,9 +146,12 @@ class ActiveConsentDigest(Backend):
 
 
 class AppendOnlyLog(Backend):
+    """Naive baseline that retrieves every matching historical event."""
+
     name = "append_only_log"
 
     def answer(self, query: QueryCase) -> tuple[str | None, list[str]]:
+        """Return all historical matches, including stale or erased facts."""
         matches = [
             event.text
             for event in self.events
@@ -145,15 +164,19 @@ class AppendOnlyLog(Backend):
 
 
 class RecentWindowLog(Backend):
+    """Low-token baseline that searches only the last N events."""
+
     name = "recent_window_log"
 
     def __init__(self, events: Iterable[MemoryEvent], window: int = 3) -> None:
+        """Create a recent-window backend with a positive window size."""
         if not isinstance(window, int) or window <= 0:
             raise ValueError("window must be a positive integer")
         super().__init__(events)
         self.window = window
 
     def answer(self, query: QueryCase) -> tuple[str | None, list[str]]:
+        """Return matching facts from the recent event window only."""
         recent = self.events[-self.window :]
         matches = [
             event.text
@@ -167,10 +190,12 @@ class RecentWindowLog(Backend):
 
 
 def token_count(items: Iterable[str]) -> int:
+    """Approximate retrieved context size with whitespace token counts."""
     return sum(len(item.split()) for item in items)
 
 
 def evaluate_backend(backend: Backend, queries: Iterable[QueryCase]) -> list[QueryResult]:
+    """Run all queries against one backend and score leaks and correctness."""
     rows: list[QueryResult] = []
     for query in queries:
         started = time.perf_counter()
@@ -199,6 +224,7 @@ def evaluate_backend(backend: Backend, queries: Iterable[QueryCase]) -> list[Que
 
 
 def p95(values: list[float]) -> float:
+    """Return inclusive p95 for a short deterministic latency sample."""
     if not values:
         return 0.0
     if len(values) == 1:
@@ -207,6 +233,7 @@ def p95(values: list[float]) -> float:
 
 
 def summarize(rows: list[QueryResult]) -> BackendSummary:
+    """Aggregate per-query results into the challenge success metrics."""
     if not rows:
         raise ValueError("cannot summarize empty query results")
     total = len(rows)
@@ -227,6 +254,7 @@ def summarize(rows: list[QueryResult]) -> BackendSummary:
 
 
 def run() -> dict[str, object]:
+    """Execute the full benchmark and return a serializable report."""
     backends: list[Backend] = [
         ActiveConsentDigest(EVENTS),
         AppendOnlyLog(EVENTS),
@@ -249,6 +277,7 @@ def run() -> dict[str, object]:
 
 
 def write_markdown(report: dict[str, object], path: Path) -> None:
+    """Write the benchmark summary table as Markdown."""
     summaries = report["summaries"]
     assert isinstance(summaries, list)
     lines = [
@@ -269,6 +298,7 @@ def write_markdown(report: dict[str, object], path: Path) -> None:
 
 
 def main() -> int:
+    """CLI entry point for generating JSON and Markdown benchmark reports."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", default=str(ROOT / "results" / "sample_results.json"))
     parser.add_argument("--markdown", default=str(ROOT / "results" / "sample_results.md"))

--- a/examples/benchmarks/privacy-consent-memory/run_benchmark.py
+++ b/examples/benchmarks/privacy-consent-memory/run_benchmark.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Deterministic privacy/consent memory benchmark.
+
+The benchmark is intentionally offline and dependency-free so reviewers can run
+it without API keys. It models the core production risk for long-lived memory:
+retrieving stale consent, superseded preferences, or erased sensitive facts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class MemoryEvent:
+    turn: int
+    user: str
+    kind: str
+    key: str
+    value: str
+    text: str
+
+
+@dataclass(frozen=True)
+class QueryCase:
+    user: str
+    key: str
+    prompt: str
+    expected_value: str | None
+    forbidden_terms: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class QueryResult:
+    backend: str
+    prompt: str
+    expected_value: str | None
+    answer: str | None
+    retrieved_tokens: int
+    latency_ms: float
+    correct: bool
+    stale_leak: bool
+    erased_leak: bool
+
+
+@dataclass(frozen=True)
+class BackendSummary:
+    backend: str
+    accuracy: float
+    stale_leak_rate: float
+    erased_leak_rate: float
+    avg_retrieved_tokens: float
+    p95_latency_ms: float
+    signal_to_noise: float
+
+
+EVENTS = [
+    MemoryEvent(1, "maya", "set", "marketing_email", "allowed", "Maya opts into weekly product marketing emails."),
+    MemoryEvent(2, "maya", "set", "health_note", "peanut allergy", "Maya says her support profile may store a peanut allergy note."),
+    MemoryEvent(3, "maya", "revoke", "marketing_email", "denied", "Maya revokes marketing email consent after a privacy review."),
+    MemoryEvent(4, "maya", "erase", "health_note", "", "Maya asks to erase the health note from future memory retrieval."),
+    MemoryEvent(5, "maya", "set", "support_channel", "email only", "Maya prefers support followups by email only."),
+    MemoryEvent(6, "noah", "set", "location_sharing", "allowed", "Noah allows temporary location sharing during travel."),
+    MemoryEvent(7, "noah", "set", "travel_city", "Berlin", "Noah is traveling in Berlin this week."),
+    MemoryEvent(8, "noah", "revoke", "location_sharing", "denied", "Noah turns off location sharing after arriving."),
+    MemoryEvent(9, "noah", "set", "travel_city", "Lisbon", "Noah updates his current travel city to Lisbon."),
+    MemoryEvent(10, "noah", "erase", "travel_city", "", "Noah requests deletion of travel city memory after the trip."),
+    MemoryEvent(11, "rhea", "set", "invoice_detail", "personal card ending 4242", "Rhea accidentally shares a personal card ending 4242."),
+    MemoryEvent(12, "rhea", "erase", "invoice_detail", "", "Rhea asks to erase the personal card detail immediately."),
+    MemoryEvent(13, "rhea", "set", "invoice_detail", "company billing portal", "Rhea says invoices should use the company billing portal."),
+    MemoryEvent(14, "rhea", "set", "retention_period", "30 days", "Rhea sets data retention to 30 days."),
+    MemoryEvent(15, "rhea", "set", "retention_period", "7 days", "Rhea changes data retention to 7 days."),
+]
+
+
+QUERIES = [
+    QueryCase("maya", "marketing_email", "Can Maya receive marketing email?", "denied", ("allowed",)),
+    QueryCase("maya", "health_note", "What health note should be retrieved for Maya?", None, ("peanut allergy",)),
+    QueryCase("maya", "support_channel", "How should support follow up with Maya?", "email only", ()),
+    QueryCase("noah", "location_sharing", "Can Noah's location be used now?", "denied", ("allowed",)),
+    QueryCase("noah", "travel_city", "What travel city should be recalled for Noah?", None, ("Berlin", "Lisbon")),
+    QueryCase("rhea", "invoice_detail", "How should Rhea be invoiced?", "company billing portal", ("personal card ending 4242",)),
+    QueryCase("rhea", "retention_period", "What is Rhea's current retention period?", "7 days", ("30 days",)),
+]
+
+
+class Backend:
+    name = "backend"
+
+    def __init__(self, events: Iterable[MemoryEvent]) -> None:
+        self.events = list(events)
+
+    def answer(self, query: QueryCase) -> tuple[str | None, list[str]]:
+        raise NotImplementedError
+
+
+class ActiveConsentDigest(Backend):
+    name = "active_consent_digest"
+
+    def __init__(self, events: Iterable[MemoryEvent]) -> None:
+        super().__init__(events)
+        self.current: dict[tuple[str, str], str] = {}
+        self.erased: set[tuple[str, str]] = set()
+        for event in self.events:
+            key = (event.user, event.key)
+            if event.kind == "erase":
+                self.current.pop(key, None)
+                self.erased.add(key)
+            elif event.kind in {"set", "revoke"}:
+                self.current[key] = event.value
+                self.erased.discard(key)
+
+    def answer(self, query: QueryCase) -> tuple[str | None, list[str]]:
+        key = (query.user, query.key)
+        if key in self.erased:
+            return None, []
+        value = self.current.get(key)
+        if value is None:
+            return None, []
+        return value, [f"{query.user}:{query.key}={value}"]
+
+
+class AppendOnlyLog(Backend):
+    name = "append_only_log"
+
+    def answer(self, query: QueryCase) -> tuple[str | None, list[str]]:
+        matches = [
+            event.text
+            for event in self.events
+            if event.user == query.user and event.key == query.key
+        ]
+        if not matches:
+            return None, []
+        answer = " | ".join(matches)
+        return answer, matches
+
+
+class RecentWindowLog(Backend):
+    name = "recent_window_log"
+
+    def __init__(self, events: Iterable[MemoryEvent], window: int = 3) -> None:
+        super().__init__(events)
+        self.window = window
+
+    def answer(self, query: QueryCase) -> tuple[str | None, list[str]]:
+        recent = self.events[-self.window :]
+        matches = [
+            event.text
+            for event in recent
+            if event.user == query.user and event.key == query.key
+        ]
+        if not matches:
+            return None, []
+        latest = matches[-1]
+        return latest, matches
+
+
+def token_count(items: Iterable[str]) -> int:
+    return sum(len(item.split()) for item in items)
+
+
+def evaluate_backend(backend: Backend, queries: Iterable[QueryCase]) -> list[QueryResult]:
+    rows: list[QueryResult] = []
+    for query in queries:
+        started = time.perf_counter()
+        answer, retrieved = backend.answer(query)
+        latency_ms = (time.perf_counter() - started) * 1000
+        text = " ".join([answer or "", *retrieved]).lower()
+        expected = query.expected_value.lower() if query.expected_value else None
+        correct = (answer is None) if expected is None else expected in (answer or "").lower()
+        stale_leak = any(term.lower() in text for term in query.forbidden_terms)
+        erased_leak = query.expected_value is None and bool(answer)
+        rows.append(
+            QueryResult(
+                backend=backend.name,
+                prompt=query.prompt,
+                expected_value=query.expected_value,
+                answer=answer,
+                retrieved_tokens=token_count(retrieved),
+                latency_ms=latency_ms,
+                correct=correct and not stale_leak and not erased_leak,
+                stale_leak=stale_leak,
+                erased_leak=erased_leak,
+            )
+        )
+    return rows
+
+
+def p95(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    return statistics.quantiles(values, n=20, method="inclusive")[18]
+
+
+def summarize(rows: list[QueryResult]) -> BackendSummary:
+    total = len(rows)
+    accurate = sum(1 for row in rows if row.correct)
+    stale = sum(1 for row in rows if row.stale_leak)
+    erased = sum(1 for row in rows if row.erased_leak)
+    avg_tokens = sum(row.retrieved_tokens for row in rows) / total
+    signal = accurate / max(1, sum(row.retrieved_tokens for row in rows))
+    return BackendSummary(
+        backend=rows[0].backend,
+        accuracy=accurate / total,
+        stale_leak_rate=stale / total,
+        erased_leak_rate=erased / total,
+        avg_retrieved_tokens=avg_tokens,
+        p95_latency_ms=p95([row.latency_ms for row in rows]),
+        signal_to_noise=signal,
+    )
+
+
+def run() -> dict[str, object]:
+    backends: list[Backend] = [
+        ActiveConsentDigest(EVENTS),
+        AppendOnlyLog(EVENTS),
+        RecentWindowLog(EVENTS),
+    ]
+    all_results = []
+    summaries = []
+    for backend in backends:
+        rows = evaluate_backend(backend, QUERIES)
+        all_results.extend(rows)
+        summaries.append(summarize(rows))
+    return {
+        "benchmark": "privacy-consent-memory",
+        "description": "Current consent, erasure, and sensitive preference retrieval under memory pressure.",
+        "queries": len(QUERIES),
+        "events": len(EVENTS),
+        "summaries": [asdict(summary) for summary in summaries],
+        "results": [asdict(row) for row in all_results],
+    }
+
+
+def write_markdown(report: dict[str, object], path: Path) -> None:
+    summaries = report["summaries"]
+    assert isinstance(summaries, list)
+    lines = [
+        "# Privacy Consent Memory Benchmark Results",
+        "",
+        "| Backend | Accuracy | Stale Leak | Erased Leak | Avg Tokens | p95 Latency | Signal/Noise |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for item in summaries:
+        assert isinstance(item, dict)
+        lines.append(
+            "| {backend} | {accuracy:.1%} | {stale_leak_rate:.1%} | {erased_leak_rate:.1%} | "
+            "{avg_retrieved_tokens:.1f} | {p95_latency_ms:.3f} ms | {signal_to_noise:.4f} |".format(
+                **item
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default=str(ROOT / "results" / "sample_results.json"))
+    parser.add_argument("--markdown", default=str(ROOT / "results" / "sample_results.md"))
+    args = parser.parse_args()
+    report = run()
+    output_path = Path(args.output)
+    markdown_path = Path(args.markdown)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    write_markdown(report, markdown_path)
+    print(json.dumps(report["summaries"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmarks/privacy-consent-memory/run_benchmark.py
+++ b/examples/benchmarks/privacy-consent-memory/run_benchmark.py
@@ -148,6 +148,8 @@ class RecentWindowLog(Backend):
     name = "recent_window_log"
 
     def __init__(self, events: Iterable[MemoryEvent], window: int = 3) -> None:
+        if not isinstance(window, int) or window <= 0:
+            raise ValueError("window must be a positive integer")
         super().__init__(events)
         self.window = window
 
@@ -175,8 +177,9 @@ def evaluate_backend(backend: Backend, queries: Iterable[QueryCase]) -> list[Que
         answer, retrieved = backend.answer(query)
         latency_ms = (time.perf_counter() - started) * 1000
         text = " ".join([answer or "", *retrieved]).lower()
-        expected = query.expected_value.lower() if query.expected_value else None
-        correct = (answer is None) if expected is None else expected in (answer or "").lower()
+        expected = query.expected_value.strip().lower() if query.expected_value else None
+        normalized_answer = str(answer).strip().lower() if answer is not None else None
+        correct = (answer is None) if expected is None else expected == normalized_answer
         stale_leak = any(term.lower() in text for term in query.forbidden_terms)
         erased_leak = query.expected_value is None and bool(answer)
         rows.append(
@@ -204,6 +207,8 @@ def p95(values: list[float]) -> float:
 
 
 def summarize(rows: list[QueryResult]) -> BackendSummary:
+    if not rows:
+        raise ValueError("cannot summarize empty query results")
     total = len(rows)
     accurate = sum(1 for row in rows if row.correct)
     stale = sum(1 for row in rows if row.stale_leak)

--- a/examples/benchmarks/privacy-consent-memory/test_benchmark.py
+++ b/examples/benchmarks/privacy-consent-memory/test_benchmark.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("run_benchmark.py")
+spec = importlib.util.spec_from_file_location("privacy_consent_benchmark", MODULE_PATH)
+benchmark = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules["privacy_consent_benchmark"] = benchmark
+spec.loader.exec_module(benchmark)
+
+
+class PrivacyConsentBenchmarkTest(unittest.TestCase):
+    def test_active_digest_honors_erasure_and_revocation(self) -> None:
+        report = benchmark.run()
+        summaries = {item["backend"]: item for item in report["summaries"]}
+
+        active = summaries["active_consent_digest"]
+        self.assertEqual(active["accuracy"], 1.0)
+        self.assertEqual(active["stale_leak_rate"], 0.0)
+        self.assertEqual(active["erased_leak_rate"], 0.0)
+
+    def test_append_only_log_leaks_stale_or_erased_memory(self) -> None:
+        report = benchmark.run()
+        summaries = {item["backend"]: item for item in report["summaries"]}
+
+        append_only = summaries["append_only_log"]
+        self.assertLess(append_only["accuracy"], 0.5)
+        self.assertGreater(append_only["stale_leak_rate"], 0.0)
+        self.assertGreater(append_only["erased_leak_rate"], 0.0)
+
+    def test_recent_window_loses_older_valid_constraints(self) -> None:
+        report = benchmark.run()
+        summaries = {item["backend"]: item for item in report["summaries"]}
+
+        recent = summaries["recent_window_log"]
+        self.assertLess(recent["accuracy"], 1.0)
+        self.assertLess(recent["avg_retrieved_tokens"], summaries["append_only_log"]["avg_retrieved_tokens"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/benchmarks/privacy-consent-memory/test_benchmark.py
+++ b/examples/benchmarks/privacy-consent-memory/test_benchmark.py
@@ -8,8 +8,9 @@ import unittest
 
 MODULE_PATH = Path(__file__).with_name("run_benchmark.py")
 spec = importlib.util.spec_from_file_location("privacy_consent_benchmark", MODULE_PATH)
+if spec is None or spec.loader is None:
+    raise ImportError(f"Could not load benchmark module from {MODULE_PATH}")
 benchmark = importlib.util.module_from_spec(spec)
-assert spec is not None and spec.loader is not None
 sys.modules["privacy_consent_benchmark"] = benchmark
 spec.loader.exec_module(benchmark)
 


### PR DESCRIPTION
/claim #639

BountyHub bounty: https://www.bountyhub.dev/bounty/view/ec58c800-823e-4134-b027-99838e096d4b

This submission adds `examples/benchmarks/privacy-consent-memory`, a credential-free reproducible benchmark for the Memanto showdown challenge. It focuses on a privacy/consent pressure scenario where long-lived agents must honor consent revocations, erased sensitive facts, and corrected retention preferences instead of retrieving stale memory.

It compares three deterministic memory strategies:
- `active_consent_digest`: a Memanto-style typed digest that keeps current consent state and suppresses erased facts.
- `append_only_log`: a naive baseline that retrieves stale consent and erased sensitive details.
- `recent_window_log`: a low-token baseline that can miss older still-valid constraints.

Sample metrics from the committed report:
- active_consent_digest: 100.0% accuracy, 0.0% stale leaks, 0.0% erased leaks, 1.3 average retrieved tokens
- append_only_log: 0.0% accuracy, 57.1% stale leaks, 28.6% erased leaks, 17.7 average retrieved tokens
- recent_window_log: 28.6% accuracy, 14.3% stale leaks, 0.0% erased leaks, 3.3 average retrieved tokens

Public technical showcase: https://gist.github.com/catcherintheroad-hub/3ce8556cbac05971ee0beb2b64c1e184

I did not fabricate a Reddit/X link from this environment. The gist above is a real public technical showcase; if a real Reddit/X post becomes available before final scoring, I can add it.

Validation:
- `python3 examples/benchmarks/privacy-consent-memory/run_benchmark.py --output examples/benchmarks/privacy-consent-memory/results/sample_results.json --markdown examples/benchmarks/privacy-consent-memory/results/sample_results.md`
- `python3 -m unittest examples/benchmarks/privacy-consent-memory/test_benchmark.py -q`
- `python3 -m py_compile examples/benchmarks/privacy-consent-memory/run_benchmark.py examples/benchmarks/privacy-consent-memory/test_benchmark.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deterministic privacy-consent-memory benchmark CLI to simulate consent events and compare three memory strategies (active consent digest, append-only log, recent-window log) and emit JSON/Markdown reports.

* **Documentation**
  * Added README describing scenarios, metrics, and run commands.
  * Included sample JSON and Markdown result outputs illustrating summaries and per-case results.

* **Tests**
  * Added integration tests validating backend accuracy, stale/erased leak detection, and comparative token/latency behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->