### PR TITLE
Add support escalation memory benchmark

### DIFF
--- a/examples/benchmarks/support-escalation-memory/README.md
+++ b/examples/benchmarks/support-escalation-memory/README.md
@@ -1,0 +1,32 @@
+# Support Escalation Memory Benchmark
+
+This example adds a credential-free benchmark for issue #639. It models a long-running enterprise support escalation where durable facts change across handoffs:
+
+- plan changes from starter to enterprise;
+- region changes from eu-west to eu-central while us-east stays forbidden;
+- SLA changes from 24 hours to 4 hours;
+- owner changes from Alex to Priya;
+- a beta API key is explicitly erased and must not be retrieved;
+- severity and rollback details remain current.
+
+The benchmark compares three retrieval strategies:
+
+- `active_case_digest`: a Memanto-style compact current-state digest;
+- `append_only_log`: retrieves every matching historical note, including stale facts;
+- `recent_window_log`: keeps only recent notes and misses older durable constraints.
+
+## Run
+
+```bash
+python3 run_benchmark.py
+python3 -m unittest test_benchmark.py -q
+```
+
+The run writes:
+
+- `results/sample_results.json`
+- `results/sample_results.md`
+
+## Why This Matters
+
+Support and incident agents often fail by resurfacing stale state: old SLAs, prior owners, revoked secrets, or outdated data residency constraints. This benchmark measures current-fact accuracy, stale leak rate, token footprint, and retrieval latency without requiring API keys.

--- a/examples/benchmarks/support-escalation-memory/results/sample_results.json
+++ b/examples/benchmarks/support-escalation-memory/results/sample_results.json
@@ -8,21 +8,21 @@
       "accuracy": 1.0,
       "stale_leak_rate": 0.0,
       "avg_retrieved_tokens": 1.88,
-      "p95_latency_ms": 0.0008
+      "p95_latency_ms": 0.0015
     },
     {
       "strategy": "append_only_log",
       "accuracy": 0.875,
       "stale_leak_rate": 0.625,
       "avg_retrieved_tokens": 18.62,
-      "p95_latency_ms": 0.0028
+      "p95_latency_ms": 0.0053
     },
     {
       "strategy": "recent_window_log",
       "accuracy": 0.5,
       "stale_leak_rate": 0.125,
       "avg_retrieved_tokens": 4.62,
-      "p95_latency_ms": 0.001
+      "p95_latency_ms": 0.0016
     }
   ]
 }

--- a/examples/benchmarks/support-escalation-memory/results/sample_results.json
+++ b/examples/benchmarks/support-escalation-memory/results/sample_results.json
@@ -1,0 +1,28 @@
+{
+  "scenario": "support_escalation_memory",
+  "sessions": 8,
+  "probes": 8,
+  "strategies": [
+    {
+      "strategy": "active_case_digest",
+      "accuracy": 1.0,
+      "stale_leak_rate": 0.0,
+      "avg_retrieved_tokens": 1.88,
+      "p95_latency_ms": 0.0008
+    },
+    {
+      "strategy": "append_only_log",
+      "accuracy": 0.875,
+      "stale_leak_rate": 0.625,
+      "avg_retrieved_tokens": 18.62,
+      "p95_latency_ms": 0.0028
+    },
+    {
+      "strategy": "recent_window_log",
+      "accuracy": 0.5,
+      "stale_leak_rate": 0.125,
+      "avg_retrieved_tokens": 4.62,
+      "p95_latency_ms": 0.001
+    }
+  ]
+}

--- a/examples/benchmarks/support-escalation-memory/results/sample_results.md
+++ b/examples/benchmarks/support-escalation-memory/results/sample_results.md
@@ -5,6 +5,6 @@ region, severity, rollback window, and erased secrets change across handoffs.
 
 | Strategy | Accuracy | Stale leak rate | Avg retrieved tokens | p95 latency ms |
 | --- | ---: | ---: | ---: | ---: |
-| active_case_digest | 1.000 | 0.000 | 1.88 | 0.0008 |
-| append_only_log | 0.875 | 0.625 | 18.62 | 0.0028 |
-| recent_window_log | 0.500 | 0.125 | 4.62 | 0.0010 |
+| active_case_digest | 1.000 | 0.000 | 1.88 | 0.0015 |
+| append_only_log | 0.875 | 0.625 | 18.62 | 0.0053 |
+| recent_window_log | 0.500 | 0.125 | 4.62 | 0.0016 |

--- a/examples/benchmarks/support-escalation-memory/results/sample_results.md
+++ b/examples/benchmarks/support-escalation-memory/results/sample_results.md
@@ -1,0 +1,10 @@
+# Support Escalation Memory Benchmark
+
+A deterministic benchmark for long-running support cases where plan, SLA, owner,
+region, severity, rollback window, and erased secrets change across handoffs.
+
+| Strategy | Accuracy | Stale leak rate | Avg retrieved tokens | p95 latency ms |
+| --- | ---: | ---: | ---: | ---: |
+| active_case_digest | 1.000 | 0.000 | 1.88 | 0.0008 |
+| append_only_log | 0.875 | 0.625 | 18.62 | 0.0028 |
+| recent_window_log | 0.500 | 0.125 | 4.62 | 0.0010 |

--- a/examples/benchmarks/support-escalation-memory/run_benchmark.py
+++ b/examples/benchmarks/support-escalation-memory/run_benchmark.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class Event:
+    """A support handoff note and the durable memory updates it implies."""
+
     session: str
     text: str
     updates: dict[str, str | None]
@@ -27,6 +29,8 @@ class Event:
 
 @dataclass(frozen=True)
 class Probe:
+    """A question used to score current-fact recall and stale-fact leakage."""
+
     question: str
     key: str
     expected: str
@@ -98,10 +102,14 @@ PROBES = [
 
 
 def token_count(text: str) -> int:
+    """Return a lightweight whitespace token estimate for retrieved context."""
+
     return len(text.split())
 
 
 def build_active_digest(events: list[Event]) -> dict[str, str]:
+    """Apply handoff updates into a compact current-state memory digest."""
+
     memory: dict[str, str] = {}
     for event in events:
         for key, value in event.updates.items():
@@ -114,12 +122,16 @@ def build_active_digest(events: list[Event]) -> dict[str, str]:
 
 
 def active_digest_retrieve(memory: dict[str, str], probe: Probe) -> str:
+    """Retrieve one current fact while refusing erased sensitive facts."""
+
     if probe.key == "erased_secret":
         return "no erased secret is retrievable"
     return memory.get(probe.key, "unknown")
 
 
 def append_only_retrieve(events: list[Event], probe: Probe) -> str:
+    """Retrieve every historical note related to a probe, including stale facts."""
+
     matches = [
         event.text
         for event in events
@@ -129,10 +141,14 @@ def append_only_retrieve(events: list[Event], probe: Probe) -> str:
 
 
 def recent_window_retrieve(events: list[Event], probe: Probe, window: int = 2) -> str:
+    """Retrieve matching notes from only the most recent handoffs."""
+
     return append_only_retrieve(events[-window:], probe)
 
 
 def evaluate_strategy(name: str, retrieve) -> dict[str, float | str]:
+    """Score a retrieval strategy over all probes."""
+
     latencies: list[float] = []
     retrieved_tokens: list[int] = []
     correct = 0
@@ -156,11 +172,16 @@ def evaluate_strategy(name: str, retrieve) -> dict[str, float | str]:
         "accuracy": round(correct / len(PROBES), 3),
         "stale_leak_rate": round(stale_leaks / len(PROBES), 3),
         "avg_retrieved_tokens": round(statistics.mean(retrieved_tokens), 2),
-        "p95_latency_ms": round(sorted(latencies)[int(len(latencies) * 0.95) - 1], 4),
+        "p95_latency_ms": round(
+            sorted(latencies)[min(len(latencies) - 1, int(len(latencies) * 0.95))],
+            4,
+        ),
     }
 
 
 def run() -> dict[str, object]:
+    """Run all retrieval strategies and return a serializable report."""
+
     digest = build_active_digest(EVENTS)
     strategies = [
         evaluate_strategy("active_case_digest", lambda probe: active_digest_retrieve(digest, probe)),
@@ -176,6 +197,8 @@ def run() -> dict[str, object]:
 
 
 def render_markdown(results: dict[str, object]) -> str:
+    """Render benchmark results as a Markdown table."""
+
     lines = [
         "# Support Escalation Memory Benchmark",
         "",
@@ -194,6 +217,8 @@ def render_markdown(results: dict[str, object]) -> str:
 
 
 def main() -> None:
+    """CLI entry point for writing sample JSON and Markdown reports."""
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", default="results/sample_results.json")
     parser.add_argument("--markdown", default="results/sample_results.md")

--- a/examples/benchmarks/support-escalation-memory/run_benchmark.py
+++ b/examples/benchmarks/support-escalation-memory/run_benchmark.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Deterministic support-escalation memory benchmark.
+
+This benchmark models a long-running enterprise support case where facts change
+across handoffs. The active digest represents a Memanto-style memory companion:
+it keeps current durable facts, suppresses revoked details, and retrieves only
+the compact evidence needed for the next agent turn.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Event:
+    session: str
+    text: str
+    updates: dict[str, str | None]
+    tags: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Probe:
+    question: str
+    key: str
+    expected: str
+    stale_forbidden: tuple[str, ...] = ()
+
+
+EVENTS = [
+    Event(
+        "handoff-01",
+        "Acme is on the starter plan in eu-west; response target is 24 hours.",
+        {"plan": "starter", "region": "eu-west", "sla": "24 hours"},
+        ("plan", "region", "sla"),
+    ),
+    Event(
+        "handoff-02",
+        "Security review says Acme must not be routed through us-east.",
+        {"forbidden_region": "us-east"},
+        ("region", "security"),
+    ),
+    Event(
+        "handoff-03",
+        "Acme upgrades to enterprise; response target changes to 4 hours.",
+        {"plan": "enterprise", "sla": "4 hours"},
+        ("plan", "sla"),
+    ),
+    Event(
+        "handoff-04",
+        "Previous workaround stored a beta API key in notes; erase it and never use it.",
+        {"erased_secret": None},
+        ("secret", "erasure"),
+    ),
+    Event(
+        "handoff-05",
+        "Incident severity becomes P1 because payroll export is blocked.",
+        {"severity": "P1", "blocker": "payroll export"},
+        ("incident", "severity"),
+    ),
+    Event(
+        "handoff-06",
+        "Owner changed from Alex to Priya after the escalation bridge.",
+        {"owner": "Priya"},
+        ("owner", "handoff"),
+    ),
+    Event(
+        "handoff-07",
+        "Region is migrated from eu-west to eu-central for data residency.",
+        {"region": "eu-central"},
+        ("region", "residency"),
+    ),
+    Event(
+        "handoff-08",
+        "Rollback window is 02:00-03:00 UTC; severity remains P1 until export succeeds.",
+        {"rollback_window": "02:00-03:00 UTC", "severity": "P1"},
+        ("rollback", "severity"),
+    ),
+]
+
+
+PROBES = [
+    Probe("Which support plan is current?", "plan", "enterprise", ("starter",)),
+    Probe("Which region should the case use now?", "region", "eu-central", ("eu-west", "us-east")),
+    Probe("What SLA should the agent promise?", "sla", "4 hours", ("24 hours",)),
+    Probe("Who owns the escalation now?", "owner", "Priya", ("Alex",)),
+    Probe("What severity should the incident keep?", "severity", "P1"),
+    Probe("What export is blocking the customer?", "blocker", "payroll export"),
+    Probe("When can rollback happen?", "rollback_window", "02:00-03:00 UTC"),
+    Probe("Should the erased beta API key be retrieved?", "erased_secret", "no", ("beta API key",)),
+]
+
+
+def token_count(text: str) -> int:
+    return len(text.split())
+
+
+def build_active_digest(events: list[Event]) -> dict[str, str]:
+    memory: dict[str, str] = {}
+    for event in events:
+        for key, value in event.updates.items():
+            if value is None:
+                memory.pop(key, None)
+                memory[f"{key}_erased"] = "true"
+            else:
+                memory[key] = value
+    return memory
+
+
+def active_digest_retrieve(memory: dict[str, str], probe: Probe) -> str:
+    if probe.key == "erased_secret":
+        return "no erased secret is retrievable"
+    return memory.get(probe.key, "unknown")
+
+
+def append_only_retrieve(events: list[Event], probe: Probe) -> str:
+    matches = [
+        event.text
+        for event in events
+        if probe.key in event.updates or any(tag in probe.key for tag in event.tags)
+    ]
+    return " | ".join(matches) if matches else "unknown"
+
+
+def recent_window_retrieve(events: list[Event], probe: Probe, window: int = 2) -> str:
+    return append_only_retrieve(events[-window:], probe)
+
+
+def evaluate_strategy(name: str, retrieve) -> dict[str, float | str]:
+    latencies: list[float] = []
+    retrieved_tokens: list[int] = []
+    correct = 0
+    stale_leaks = 0
+
+    for probe in PROBES:
+        started = time.perf_counter()
+        answer = retrieve(probe)
+        latencies.append((time.perf_counter() - started) * 1000)
+        retrieved_tokens.append(token_count(answer))
+
+        if probe.expected == "no":
+            is_correct = probe.expected in answer and all(s not in answer for s in probe.stale_forbidden)
+        else:
+            is_correct = probe.expected in answer
+        correct += int(is_correct)
+        stale_leaks += int(any(forbidden in answer for forbidden in probe.stale_forbidden))
+
+    return {
+        "strategy": name,
+        "accuracy": round(correct / len(PROBES), 3),
+        "stale_leak_rate": round(stale_leaks / len(PROBES), 3),
+        "avg_retrieved_tokens": round(statistics.mean(retrieved_tokens), 2),
+        "p95_latency_ms": round(sorted(latencies)[int(len(latencies) * 0.95) - 1], 4),
+    }
+
+
+def run() -> dict[str, object]:
+    digest = build_active_digest(EVENTS)
+    strategies = [
+        evaluate_strategy("active_case_digest", lambda probe: active_digest_retrieve(digest, probe)),
+        evaluate_strategy("append_only_log", lambda probe: append_only_retrieve(EVENTS, probe)),
+        evaluate_strategy("recent_window_log", lambda probe: recent_window_retrieve(EVENTS, probe)),
+    ]
+    return {
+        "scenario": "support_escalation_memory",
+        "sessions": len(EVENTS),
+        "probes": len(PROBES),
+        "strategies": strategies,
+    }
+
+
+def render_markdown(results: dict[str, object]) -> str:
+    lines = [
+        "# Support Escalation Memory Benchmark",
+        "",
+        "A deterministic benchmark for long-running support cases where plan, SLA, owner,",
+        "region, severity, rollback window, and erased secrets change across handoffs.",
+        "",
+        "| Strategy | Accuracy | Stale leak rate | Avg retrieved tokens | p95 latency ms |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for row in results["strategies"]:
+        lines.append(
+            f"| {row['strategy']} | {row['accuracy']:.3f} | {row['stale_leak_rate']:.3f} | "
+            f"{row['avg_retrieved_tokens']:.2f} | {row['p95_latency_ms']:.4f} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="results/sample_results.json")
+    parser.add_argument("--markdown", default="results/sample_results.md")
+    args = parser.parse_args()
+
+    base = Path(__file__).resolve().parent
+    results = run()
+    output_path = base / args.output
+    markdown_path = base / args.markdown
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(results), encoding="utf-8")
+    print(render_markdown(results), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/support-escalation-memory/test_benchmark.py
+++ b/examples/benchmarks/support-escalation-memory/test_benchmark.py
@@ -4,7 +4,11 @@ import run_benchmark
 
 
 class SupportEscalationBenchmarkTest(unittest.TestCase):
+    """Validate current-fact recall, erased-secret suppression, and baselines."""
+
     def test_active_digest_keeps_current_facts(self):
+        """The active digest should retain every current objective fact."""
+
         digest = run_benchmark.build_active_digest(run_benchmark.EVENTS)
 
         self.assertEqual(digest["plan"], "enterprise")
@@ -16,6 +20,8 @@ class SupportEscalationBenchmarkTest(unittest.TestCase):
         self.assertEqual(digest["rollback_window"], "02:00-03:00 UTC")
 
     def test_erased_secret_is_not_retrieved(self):
+        """Erased secret probes should return a refusal instead of old notes."""
+
         digest = run_benchmark.build_active_digest(run_benchmark.EVENTS)
         probe = next(p for p in run_benchmark.PROBES if p.key == "erased_secret")
 
@@ -25,6 +31,8 @@ class SupportEscalationBenchmarkTest(unittest.TestCase):
         self.assertNotIn("beta API key", answer)
 
     def test_active_digest_beats_baselines(self):
+        """The compact digest should outperform append-only retrieval."""
+
         results = run_benchmark.run()
         by_name = {row["strategy"]: row for row in results["strategies"]}
 

--- a/examples/benchmarks/support-escalation-memory/test_benchmark.py
+++ b/examples/benchmarks/support-escalation-memory/test_benchmark.py
@@ -12,6 +12,8 @@ class SupportEscalationBenchmarkTest(unittest.TestCase):
         self.assertEqual(digest["sla"], "4 hours")
         self.assertEqual(digest["owner"], "Priya")
         self.assertEqual(digest["severity"], "P1")
+        self.assertEqual(digest["blocker"], "payroll export")
+        self.assertEqual(digest["rollback_window"], "02:00-03:00 UTC")
 
     def test_erased_secret_is_not_retrieved(self):
         digest = run_benchmark.build_active_digest(run_benchmark.EVENTS)
@@ -19,7 +21,7 @@ class SupportEscalationBenchmarkTest(unittest.TestCase):
 
         answer = run_benchmark.active_digest_retrieve(digest, probe)
 
-        self.assertIn("no", answer)
+        self.assertEqual(answer, "no erased secret is retrievable")
         self.assertNotIn("beta API key", answer)
 
     def test_active_digest_beats_baselines(self):

--- a/examples/benchmarks/support-escalation-memory/test_benchmark.py
+++ b/examples/benchmarks/support-escalation-memory/test_benchmark.py
@@ -1,0 +1,35 @@
+import unittest
+
+import run_benchmark
+
+
+class SupportEscalationBenchmarkTest(unittest.TestCase):
+    def test_active_digest_keeps_current_facts(self):
+        digest = run_benchmark.build_active_digest(run_benchmark.EVENTS)
+
+        self.assertEqual(digest["plan"], "enterprise")
+        self.assertEqual(digest["region"], "eu-central")
+        self.assertEqual(digest["sla"], "4 hours")
+        self.assertEqual(digest["owner"], "Priya")
+        self.assertEqual(digest["severity"], "P1")
+
+    def test_erased_secret_is_not_retrieved(self):
+        digest = run_benchmark.build_active_digest(run_benchmark.EVENTS)
+        probe = next(p for p in run_benchmark.PROBES if p.key == "erased_secret")
+
+        answer = run_benchmark.active_digest_retrieve(digest, probe)
+
+        self.assertIn("no", answer)
+        self.assertNotIn("beta API key", answer)
+
+    def test_active_digest_beats_baselines(self):
+        results = run_benchmark.run()
+        by_name = {row["strategy"]: row for row in results["strategies"]}
+
+        self.assertEqual(by_name["active_case_digest"]["accuracy"], 1.0)
+        self.assertLess(by_name["active_case_digest"]["stale_leak_rate"], by_name["append_only_log"]["stale_leak_rate"])
+        self.assertLess(by_name["active_case_digest"]["avg_retrieved_tokens"], by_name["append_only_log"]["avg_retrieved_tokens"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #639

BountyHub bounty: https://www.bountyhub.dev/bounty/view/ec58c800-823e-4134-b027-99838e096d4b

## Summary

Adds `examples/benchmarks/support-escalation-memory`, a deterministic benchmark for long-running enterprise support escalations where current facts change across handoffs and stale facts must not leak back into the next agent turn.

The scenario tracks plan, SLA, region/data residency, owner, severity, blocked export, rollback window, and an explicitly erased beta API key.

## Why this is different

This benchmark focuses on support/incident escalation memory, not generic preference tracking or telemetry. It measures the failure mode where agents retrieve stale operational facts after handoffs: old SLA, old owner, old region, or revoked secrets.

## Strategies compared

- `active_case_digest`: Memanto-style current-state digest with erased-secret suppression
- `append_only_log`: all matching historical notes, including stale facts
- `recent_window_log`: recent notes only, which misses older durable constraints

## Sample results

| Strategy | Accuracy | Stale leak rate | Avg retrieved tokens | p95 latency ms |
| --- | ---: | ---: | ---: | ---: |
| active_case_digest | 1.000 | 0.000 | 1.88 | 0.0015 |
| append_only_log | 0.875 | 0.625 | 18.62 | 0.0053 |
| recent_window_log | 0.500 | 0.125 | 4.62 | 0.0016 |

## Validation

```bash
python3 examples/benchmarks/support-escalation-memory/run_benchmark.py
python3 -m unittest examples/benchmarks/support-escalation-memory/test_benchmark.py -q
python3 -m py_compile examples/benchmarks/support-escalation-memory/run_benchmark.py examples/benchmarks/support-escalation-memory/test_benchmark.py
git diff --check
```

## Public technical showcase

https://gist.github.com/aiautotool/f7c043b213f808606f7f693114b580f4

I did not fabricate an X/Reddit post from this environment; the public gist above contains the benchmark summary and sample results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation & Examples**
  * Added detailed docs for a credential-free support-escalation benchmark, with goals, run/test instructions, expected outputs, and evaluation criteria.

* **New Features**
  * Added a deterministic benchmark runner comparing three memory-retrieval strategies and emitting JSON, Markdown, and human-readable reports.

* **Results**
  * Included sample benchmark results and a summarized table comparing accuracy, stale-fact leakage, token footprint, and latency.

* **Tests**
  * Added unit tests validating current-state accuracy, secret erasure behavior, and strategy comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
