### PR TITLE
Add research decision memory benchmark

### DIFF
--- a/examples/benchmarks/research-decision-memory/README.md
+++ b/examples/benchmarks/research-decision-memory/README.md
@@ -28,7 +28,7 @@ secrets.
 - Stale conflict rate when superseded assumptions appear in the answer.
 - Synthetic secret leak rate.
 - Retrieved token footprint.
-- p95 retrieval latency in milliseconds.
+- p95 retrieval latency in milliseconds for live stdout runs.
 - Signal/noise ratio over retrieved evidence.
 
 ## Run
@@ -40,6 +40,10 @@ python examples/benchmarks/research-decision-memory/run_benchmark.py
 python examples/benchmarks/research-decision-memory/run_benchmark.py --output examples/benchmarks/research-decision-memory/results/sample_results.json --markdown examples/benchmarks/research-decision-memory/results/sample_results.md
 python -m unittest discover -s examples/benchmarks/research-decision-memory -p "test_*.py"
 ```
+
+Saved JSON and Markdown outputs omit runtime-specific latency by default so
+committed sample artifacts are reproducible. Pass `--include-latency-output`
+when you need to save live p95 latency values.
 
 ## Expected Result
 

--- a/examples/benchmarks/research-decision-memory/README.md
+++ b/examples/benchmarks/research-decision-memory/README.md
@@ -1,0 +1,49 @@
+# Research Decision Memory Benchmark
+
+This benchmark evaluates long-running research and product agents that need to
+remember the current decision trail, cite the evidence that changed a decision,
+and suppress stale assumptions from earlier sessions.
+
+The scenario models a product-research agent over several planning sessions.
+Early assumptions about target users, pricing, launch readiness, data handling,
+and model routing are later corrected by new evidence. The benchmark asks
+golden probes about the final state and scores whether each memory strategy
+returns current facts without reintroducing superseded decisions or synthetic
+secrets.
+
+## Strategies
+
+- `active_decision_digest`: Memanto-style typed digest that stores current
+  decisions by slot, keeps evidence IDs, and redacts erased facts.
+- `passive_graph_history`: graph-style historical state memory that keeps all
+  known values unless a caller reconciles conflicts.
+- `append_only_log`: raw transcript retrieval over every historical note.
+- `recent_window_log`: sliding recent-window retrieval that avoids older stale
+  notes but forgets older still-valid decisions.
+
+## Metrics
+
+- Current-fact accuracy against the golden decision state.
+- Evidence coverage for required source IDs.
+- Stale conflict rate when superseded assumptions appear in the answer.
+- Synthetic secret leak rate.
+- Retrieved token footprint.
+- p95 retrieval latency in milliseconds.
+- Signal/noise ratio over retrieved evidence.
+
+## Run
+
+No third-party dependencies are required.
+
+```bash
+python examples/benchmarks/research-decision-memory/run_benchmark.py
+python examples/benchmarks/research-decision-memory/run_benchmark.py --output examples/benchmarks/research-decision-memory/results/sample_results.json --markdown examples/benchmarks/research-decision-memory/results/sample_results.md
+python -m unittest discover -s examples/benchmarks/research-decision-memory -p "test_*.py"
+```
+
+## Expected Result
+
+The active digest should retain current decisions with evidence, avoid stale
+assumptions, and retrieve less context than the append-only and graph-history
+baselines. The recent-window baseline should avoid many stale facts but miss
+older durable decisions that are still current.

--- a/examples/benchmarks/research-decision-memory/requirements.txt
+++ b/examples/benchmarks/research-decision-memory/requirements.txt
@@ -1,0 +1,1 @@
+# This benchmark uses only the Python standard library.

--- a/examples/benchmarks/research-decision-memory/results/sample_results.json
+++ b/examples/benchmarks/research-decision-memory/results/sample_results.json
@@ -132,7 +132,7 @@
       "stale_terms": [
         "raw support logs are safe"
       ],
-      "secret": "sk-test-123456"
+      "secret": "synthetic_secret_marker_123456"
     },
     {
       "turn": 8,
@@ -323,7 +323,7 @@
       ],
       "stale_terms": [
         "raw support logs are safe",
-        "sk-test-123456"
+        "synthetic_secret_marker_123456"
       ],
       "relevant_evidence": [
         "ev-008"
@@ -398,7 +398,7 @@
       "stale_conflict_rate": 0.0,
       "secret_leak_rate": 0.0,
       "avg_retrieved_tokens": 21.125,
-      "p95_latency_ms": 0.003584998194128275,
+      "p95_latency_ms": 0.0036200003705744166,
       "signal_noise_ratio": 1.0
     },
     {
@@ -408,7 +408,7 @@
       "stale_conflict_rate": 0.5,
       "secret_leak_rate": 0.125,
       "avg_retrieved_tokens": 30.5,
-      "p95_latency_ms": 0.007884982915129513,
+      "p95_latency_ms": 0.006479999728981056,
       "signal_noise_ratio": 0.6666666666666666
     },
     {
@@ -418,7 +418,7 @@
       "stale_conflict_rate": 0.5,
       "secret_leak_rate": 0.125,
       "avg_retrieved_tokens": 167.25,
-      "p95_latency_ms": 0.09810999181354418,
+      "p95_latency_ms": 0.08806000009826676,
       "signal_noise_ratio": 0.12307692307692308
     },
     {
@@ -428,7 +428,7 @@
       "stale_conflict_rate": 0.0,
       "secret_leak_rate": 0.0,
       "avg_retrieved_tokens": 10.625,
-      "p95_latency_ms": 0.003609998384490609,
+      "p95_latency_ms": 0.0024399999801971717,
       "signal_noise_ratio": 1.0
     }
   ],
@@ -452,7 +452,7 @@
           "ev-004"
         ],
         "retrieved_tokens": 21,
-        "latency_ms": 0.0029999937396496534
+        "latency_ms": 0.003099999958067201
       },
       {
         "backend": "active_decision_digest",
@@ -462,7 +462,7 @@
           "ev-005"
         ],
         "retrieved_tokens": 26,
-        "latency_ms": 0.0015999830793589354
+        "latency_ms": 0.001499999598308932
       },
       {
         "backend": "active_decision_digest",
@@ -472,7 +472,7 @@
           "ev-009"
         ],
         "retrieved_tokens": 24,
-        "latency_ms": 0.0009999785106629133
+        "latency_ms": 0.0008999995770864189
       },
       {
         "backend": "active_decision_digest",
@@ -482,7 +482,7 @@
           "ev-008"
         ],
         "retrieved_tokens": 19,
-        "latency_ms": 0.0011999800335615873
+        "latency_ms": 0.0009000004865811206
       },
       {
         "backend": "active_decision_digest",
@@ -492,7 +492,7 @@
           "ev-010"
         ],
         "retrieved_tokens": 22,
-        "latency_ms": 0.001200009137392044
+        "latency_ms": 0.0010000003385357559
       },
       {
         "backend": "active_decision_digest",
@@ -502,7 +502,7 @@
           "ev-011"
         ],
         "retrieved_tokens": 22,
-        "latency_ms": 0.00100000761449337
+        "latency_ms": 0.0008999995770864189
       },
       {
         "backend": "active_decision_digest",
@@ -512,7 +512,7 @@
           "ev-012"
         ],
         "retrieved_tokens": 17,
-        "latency_ms": 0.000900006853044033
+        "latency_ms": 0.0009000004865811206
       }
     ],
     "passive_graph_history": [
@@ -525,7 +525,7 @@
           "ev-003"
         ],
         "retrieved_tokens": 32,
-        "latency_ms": 0.009599985787644982
+        "latency_ms": 0.007599999662488699
       },
       {
         "backend": "passive_graph_history",
@@ -536,7 +536,7 @@
           "ev-004"
         ],
         "retrieved_tokens": 39,
-        "latency_ms": 0.004699977580457926
+        "latency_ms": 0.004399999852466863
       },
       {
         "backend": "passive_graph_history",
@@ -546,7 +546,7 @@
           "ev-005"
         ],
         "retrieved_tokens": 26,
-        "latency_ms": 0.0026999914553016424
+        "latency_ms": 0.0027999994927085936
       },
       {
         "backend": "passive_graph_history",
@@ -557,18 +557,18 @@
           "ev-009"
         ],
         "retrieved_tokens": 45,
-        "latency_ms": 0.0028999929782003164
+        "latency_ms": 0.003000000106112566
       },
       {
         "backend": "passive_graph_history",
         "probe": "data_handling",
-        "answer": "data_handling possible states: rejected: Rejected assumption: raw support logs are safe to store without redaction. sk-test-123456 (ev-007) | current: Current data handling requires redaction before logs enter memory. (ev-008).",
+        "answer": "data_handling possible states: rejected: Rejected assumption: raw support logs are safe to store without redaction. synthetic_secret_marker_123456 (ev-007) | current: Current data handling requires redaction before logs enter memory. (ev-008).",
         "evidence_ids": [
           "ev-007",
           "ev-008"
         ],
         "retrieved_tokens": 41,
-        "latency_ms": 0.0034999975468963385
+        "latency_ms": 0.0032999996619764715
       },
       {
         "backend": "passive_graph_history",
@@ -578,7 +578,7 @@
           "ev-010"
         ],
         "retrieved_tokens": 22,
-        "latency_ms": 0.0023999891709536314
+        "latency_ms": 0.0023000002329354174
       },
       {
         "backend": "passive_graph_history",
@@ -588,7 +588,7 @@
           "ev-011"
         ],
         "retrieved_tokens": 22,
-        "latency_ms": 0.0020999868866056204
+        "latency_ms": 0.00199999976757681
       },
       {
         "backend": "passive_graph_history",
@@ -598,7 +598,7 @@
           "ev-012"
         ],
         "retrieved_tokens": 17,
-        "latency_ms": 0.00200001522898674
+        "latency_ms": 0.002100000529026147
       }
     ],
     "append_only_log": [
@@ -619,7 +619,7 @@
           "ev-012"
         ],
         "retrieved_tokens": 200,
-        "latency_ms": 0.10209999163635075
+        "latency_ms": 0.09520000003249152
       },
       {
         "backend": "append_only_log",
@@ -638,7 +638,7 @@
           "ev-012"
         ],
         "retrieved_tokens": 200,
-        "latency_ms": 0.0906999921426177
+        "latency_ms": 0.07480000022042077
       },
       {
         "backend": "append_only_log",
@@ -657,7 +657,7 @@
           "ev-012"
         ],
         "retrieved_tokens": 203,
-        "latency_ms": 0.08329999400302768
+        "latency_ms": 0.07160000041039893
       },
       {
         "backend": "append_only_log",
@@ -670,12 +670,12 @@
           "ev-012"
         ],
         "retrieved_tokens": 88,
-        "latency_ms": 0.07360000745393336
+        "latency_ms": 0.07350000032602111
       },
       {
         "backend": "append_only_log",
         "probe": "data_handling",
-        "answer": "target_segment: Initial target segment is consumer creators. Evidence: ev-001. pricing: Initial pricing hypothesis is $49 per team per month. Evidence: ev-002. target_segment: Current target segment is support operations teams. Evidence: ev-003. pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004. deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. data_handling: Rejected assumption: raw support logs are safe to store without redaction. sk-test-123456 Evidence: ev-007. data_handling: Current data handling requires redaction before logs enter memory. Evidence: ev-008. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010. primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "answer": "target_segment: Initial target segment is consumer creators. Evidence: ev-001. pricing: Initial pricing hypothesis is $49 per team per month. Evidence: ev-002. target_segment: Current target segment is support operations teams. Evidence: ev-003. pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004. deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. data_handling: Rejected assumption: raw support logs are safe to store without redaction. synthetic_secret_marker_123456 Evidence: ev-007. data_handling: Current data handling requires redaction before logs enter memory. Evidence: ev-008. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010. primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
         "evidence_ids": [
           "ev-001",
           "ev-002",
@@ -690,7 +690,7 @@
           "ev-012"
         ],
         "retrieved_tokens": 222,
-        "latency_ms": 0.07550002192147076
+        "latency_ms": 0.07040000036795391
       },
       {
         "backend": "append_only_log",
@@ -706,7 +706,7 @@
           "ev-010"
         ],
         "retrieved_tokens": 151,
-        "latency_ms": 0.057199998991563916
+        "latency_ms": 0.07270000060088933
       },
       {
         "backend": "append_only_log",
@@ -719,7 +719,7 @@
           "ev-011"
         ],
         "retrieved_tokens": 93,
-        "latency_ms": 0.054899981478229165
+        "latency_ms": 0.05400000009103678
       },
       {
         "backend": "append_only_log",
@@ -737,7 +737,7 @@
           "ev-012"
         ],
         "retrieved_tokens": 181,
-        "latency_ms": 0.054800009820610285
+        "latency_ms": 0.054799999816168565
       }
     ],
     "recent_window_log": [
@@ -747,7 +747,7 @@
         "answer": "No decision found.",
         "evidence_ids": [],
         "retrieved_tokens": 0,
-        "latency_ms": 0.0048000074457377195
+        "latency_ms": 0.003000000106112566
       },
       {
         "backend": "recent_window_log",
@@ -755,7 +755,7 @@
         "answer": "No decision found.",
         "evidence_ids": [],
         "retrieved_tokens": 0,
-        "latency_ms": 0.0010999792721122503
+        "latency_ms": 0.001100000190490391
       },
       {
         "backend": "recent_window_log",
@@ -763,7 +763,7 @@
         "answer": "No decision found.",
         "evidence_ids": [],
         "retrieved_tokens": 0,
-        "latency_ms": 0.0007999769877642393
+        "latency_ms": 0.0006999998731771484
       },
       {
         "backend": "recent_window_log",
@@ -773,7 +773,7 @@
           "ev-009"
         ],
         "retrieved_tokens": 24,
-        "latency_ms": 0.0013999815564602613
+        "latency_ms": 0.0013999997463542968
       },
       {
         "backend": "recent_window_log",
@@ -781,7 +781,7 @@
         "answer": "No decision found.",
         "evidence_ids": [],
         "retrieved_tokens": 0,
-        "latency_ms": 0.000800006091594696
+        "latency_ms": 0.0006999998731771484
       },
       {
         "backend": "recent_window_log",
@@ -791,7 +791,7 @@
           "ev-010"
         ],
         "retrieved_tokens": 22,
-        "latency_ms": 0.001200009137392044
+        "latency_ms": 0.0012000000424450263
       },
       {
         "backend": "recent_window_log",
@@ -801,7 +801,7 @@
           "ev-011"
         ],
         "retrieved_tokens": 22,
-        "latency_ms": 0.0010999792721122503
+        "latency_ms": 0.0012000000424450263
       },
       {
         "backend": "recent_window_log",
@@ -811,7 +811,7 @@
           "ev-012"
         ],
         "retrieved_tokens": 17,
-        "latency_ms": 0.001100008375942707
+        "latency_ms": 0.0010000003385357559
       }
     ]
   }

--- a/examples/benchmarks/research-decision-memory/results/sample_results.json
+++ b/examples/benchmarks/research-decision-memory/results/sample_results.json
@@ -398,7 +398,6 @@
       "stale_conflict_rate": 0.0,
       "secret_leak_rate": 0.0,
       "avg_retrieved_tokens": 21.125,
-      "p95_latency_ms": 0.0036200003705744166,
       "signal_noise_ratio": 1.0
     },
     {
@@ -408,7 +407,6 @@
       "stale_conflict_rate": 0.5,
       "secret_leak_rate": 0.125,
       "avg_retrieved_tokens": 30.5,
-      "p95_latency_ms": 0.006479999728981056,
       "signal_noise_ratio": 0.6666666666666666
     },
     {
@@ -418,7 +416,6 @@
       "stale_conflict_rate": 0.5,
       "secret_leak_rate": 0.125,
       "avg_retrieved_tokens": 167.25,
-      "p95_latency_ms": 0.08806000009826676,
       "signal_noise_ratio": 0.12307692307692308
     },
     {
@@ -428,7 +425,6 @@
       "stale_conflict_rate": 0.0,
       "secret_leak_rate": 0.0,
       "avg_retrieved_tokens": 10.625,
-      "p95_latency_ms": 0.0024399999801971717,
       "signal_noise_ratio": 1.0
     }
   ],
@@ -441,8 +437,7 @@
         "evidence_ids": [
           "ev-003"
         ],
-        "retrieved_tokens": 18,
-        "latency_ms": 0.0039000005926936865
+        "retrieved_tokens": 18
       },
       {
         "backend": "active_decision_digest",
@@ -451,8 +446,7 @@
         "evidence_ids": [
           "ev-004"
         ],
-        "retrieved_tokens": 21,
-        "latency_ms": 0.003099999958067201
+        "retrieved_tokens": 21
       },
       {
         "backend": "active_decision_digest",
@@ -461,8 +455,7 @@
         "evidence_ids": [
           "ev-005"
         ],
-        "retrieved_tokens": 26,
-        "latency_ms": 0.001499999598308932
+        "retrieved_tokens": 26
       },
       {
         "backend": "active_decision_digest",
@@ -471,8 +464,7 @@
         "evidence_ids": [
           "ev-009"
         ],
-        "retrieved_tokens": 24,
-        "latency_ms": 0.0008999995770864189
+        "retrieved_tokens": 24
       },
       {
         "backend": "active_decision_digest",
@@ -481,8 +473,7 @@
         "evidence_ids": [
           "ev-008"
         ],
-        "retrieved_tokens": 19,
-        "latency_ms": 0.0009000004865811206
+        "retrieved_tokens": 19
       },
       {
         "backend": "active_decision_digest",
@@ -491,8 +482,7 @@
         "evidence_ids": [
           "ev-010"
         ],
-        "retrieved_tokens": 22,
-        "latency_ms": 0.0010000003385357559
+        "retrieved_tokens": 22
       },
       {
         "backend": "active_decision_digest",
@@ -501,8 +491,7 @@
         "evidence_ids": [
           "ev-011"
         ],
-        "retrieved_tokens": 22,
-        "latency_ms": 0.0008999995770864189
+        "retrieved_tokens": 22
       },
       {
         "backend": "active_decision_digest",
@@ -511,8 +500,7 @@
         "evidence_ids": [
           "ev-012"
         ],
-        "retrieved_tokens": 17,
-        "latency_ms": 0.0009000004865811206
+        "retrieved_tokens": 17
       }
     ],
     "passive_graph_history": [
@@ -524,8 +512,7 @@
           "ev-001",
           "ev-003"
         ],
-        "retrieved_tokens": 32,
-        "latency_ms": 0.007599999662488699
+        "retrieved_tokens": 32
       },
       {
         "backend": "passive_graph_history",
@@ -535,8 +522,7 @@
           "ev-002",
           "ev-004"
         ],
-        "retrieved_tokens": 39,
-        "latency_ms": 0.004399999852466863
+        "retrieved_tokens": 39
       },
       {
         "backend": "passive_graph_history",
@@ -545,8 +531,7 @@
         "evidence_ids": [
           "ev-005"
         ],
-        "retrieved_tokens": 26,
-        "latency_ms": 0.0027999994927085936
+        "retrieved_tokens": 26
       },
       {
         "backend": "passive_graph_history",
@@ -556,8 +541,7 @@
           "ev-006",
           "ev-009"
         ],
-        "retrieved_tokens": 45,
-        "latency_ms": 0.003000000106112566
+        "retrieved_tokens": 45
       },
       {
         "backend": "passive_graph_history",
@@ -567,8 +551,7 @@
           "ev-007",
           "ev-008"
         ],
-        "retrieved_tokens": 41,
-        "latency_ms": 0.0032999996619764715
+        "retrieved_tokens": 41
       },
       {
         "backend": "passive_graph_history",
@@ -577,8 +560,7 @@
         "evidence_ids": [
           "ev-010"
         ],
-        "retrieved_tokens": 22,
-        "latency_ms": 0.0023000002329354174
+        "retrieved_tokens": 22
       },
       {
         "backend": "passive_graph_history",
@@ -587,8 +569,7 @@
         "evidence_ids": [
           "ev-011"
         ],
-        "retrieved_tokens": 22,
-        "latency_ms": 0.00199999976757681
+        "retrieved_tokens": 22
       },
       {
         "backend": "passive_graph_history",
@@ -597,8 +578,7 @@
         "evidence_ids": [
           "ev-012"
         ],
-        "retrieved_tokens": 17,
-        "latency_ms": 0.002100000529026147
+        "retrieved_tokens": 17
       }
     ],
     "append_only_log": [
@@ -618,8 +598,7 @@
           "ev-010",
           "ev-012"
         ],
-        "retrieved_tokens": 200,
-        "latency_ms": 0.09520000003249152
+        "retrieved_tokens": 200
       },
       {
         "backend": "append_only_log",
@@ -637,8 +616,7 @@
           "ev-010",
           "ev-012"
         ],
-        "retrieved_tokens": 200,
-        "latency_ms": 0.07480000022042077
+        "retrieved_tokens": 200
       },
       {
         "backend": "append_only_log",
@@ -656,8 +634,7 @@
           "ev-011",
           "ev-012"
         ],
-        "retrieved_tokens": 203,
-        "latency_ms": 0.07160000041039893
+        "retrieved_tokens": 203
       },
       {
         "backend": "append_only_log",
@@ -669,8 +646,7 @@
           "ev-009",
           "ev-012"
         ],
-        "retrieved_tokens": 88,
-        "latency_ms": 0.07350000032602111
+        "retrieved_tokens": 88
       },
       {
         "backend": "append_only_log",
@@ -689,8 +665,7 @@
           "ev-010",
           "ev-012"
         ],
-        "retrieved_tokens": 222,
-        "latency_ms": 0.07040000036795391
+        "retrieved_tokens": 222
       },
       {
         "backend": "append_only_log",
@@ -705,8 +680,7 @@
           "ev-009",
           "ev-010"
         ],
-        "retrieved_tokens": 151,
-        "latency_ms": 0.07270000060088933
+        "retrieved_tokens": 151
       },
       {
         "backend": "append_only_log",
@@ -718,8 +692,7 @@
           "ev-009",
           "ev-011"
         ],
-        "retrieved_tokens": 93,
-        "latency_ms": 0.05400000009103678
+        "retrieved_tokens": 93
       },
       {
         "backend": "append_only_log",
@@ -736,8 +709,7 @@
           "ev-010",
           "ev-012"
         ],
-        "retrieved_tokens": 181,
-        "latency_ms": 0.054799999816168565
+        "retrieved_tokens": 181
       }
     ],
     "recent_window_log": [
@@ -746,24 +718,21 @@
         "probe": "target_segment",
         "answer": "No decision found.",
         "evidence_ids": [],
-        "retrieved_tokens": 0,
-        "latency_ms": 0.003000000106112566
+        "retrieved_tokens": 0
       },
       {
         "backend": "recent_window_log",
         "probe": "pricing",
         "answer": "No decision found.",
         "evidence_ids": [],
-        "retrieved_tokens": 0,
-        "latency_ms": 0.001100000190490391
+        "retrieved_tokens": 0
       },
       {
         "backend": "recent_window_log",
         "probe": "deployment",
         "answer": "No decision found.",
         "evidence_ids": [],
-        "retrieved_tokens": 0,
-        "latency_ms": 0.0006999998731771484
+        "retrieved_tokens": 0
       },
       {
         "backend": "recent_window_log",
@@ -772,16 +741,14 @@
         "evidence_ids": [
           "ev-009"
         ],
-        "retrieved_tokens": 24,
-        "latency_ms": 0.0013999997463542968
+        "retrieved_tokens": 24
       },
       {
         "backend": "recent_window_log",
         "probe": "data_handling",
         "answer": "No decision found.",
         "evidence_ids": [],
-        "retrieved_tokens": 0,
-        "latency_ms": 0.0006999998731771484
+        "retrieved_tokens": 0
       },
       {
         "backend": "recent_window_log",
@@ -790,8 +757,7 @@
         "evidence_ids": [
           "ev-010"
         ],
-        "retrieved_tokens": 22,
-        "latency_ms": 0.0012000000424450263
+        "retrieved_tokens": 22
       },
       {
         "backend": "recent_window_log",
@@ -800,8 +766,7 @@
         "evidence_ids": [
           "ev-011"
         ],
-        "retrieved_tokens": 22,
-        "latency_ms": 0.0012000000424450263
+        "retrieved_tokens": 22
       },
       {
         "backend": "recent_window_log",
@@ -810,8 +775,7 @@
         "evidence_ids": [
           "ev-012"
         ],
-        "retrieved_tokens": 17,
-        "latency_ms": 0.0010000003385357559
+        "retrieved_tokens": 17
       }
     ]
   }

--- a/examples/benchmarks/research-decision-memory/results/sample_results.json
+++ b/examples/benchmarks/research-decision-memory/results/sample_results.json
@@ -1,0 +1,818 @@
+{
+  "scenario": "research-decision-memory",
+  "records": [
+    {
+      "turn": 1,
+      "session": "s1-hypothesis",
+      "slot": "target_segment",
+      "value": "Initial target segment is consumer creators.",
+      "evidence_id": "ev-001",
+      "status": "superseded",
+      "rationale": "Founder hunch from an early market scan.",
+      "relevant_terms": [
+        "target",
+        "segment",
+        "consumer",
+        "creators"
+      ],
+      "stale_terms": [
+        "consumer creators"
+      ],
+      "secret": null
+    },
+    {
+      "turn": 2,
+      "session": "s1-hypothesis",
+      "slot": "pricing",
+      "value": "Initial pricing hypothesis is $49 per team per month.",
+      "evidence_id": "ev-002",
+      "status": "superseded",
+      "rationale": "Anchored on a competitor roundup, before support-team interviews.",
+      "relevant_terms": [
+        "pricing",
+        "$49",
+        "team",
+        "month"
+      ],
+      "stale_terms": [
+        "$49 per team per month"
+      ],
+      "secret": null
+    },
+    {
+      "turn": 3,
+      "session": "s2-interviews",
+      "slot": "target_segment",
+      "value": "Current target segment is support operations teams.",
+      "evidence_id": "ev-003",
+      "status": "current",
+      "rationale": "Nine of twelve interviews had an urgent cross-session handoff pain.",
+      "relevant_terms": [
+        "target",
+        "segment",
+        "support",
+        "operations",
+        "teams"
+      ],
+      "stale_terms": [],
+      "secret": null
+    },
+    {
+      "turn": 4,
+      "session": "s2-interviews",
+      "slot": "pricing",
+      "value": "Current pricing is a usage-based pilot at $0.08 per resolved ticket.",
+      "evidence_id": "ev-004",
+      "status": "current",
+      "rationale": "Budget owners preferred tying price to support resolution volume.",
+      "relevant_terms": [
+        "pricing",
+        "usage",
+        "$0.08",
+        "resolved",
+        "ticket"
+      ],
+      "stale_terms": [],
+      "secret": null
+    },
+    {
+      "turn": 5,
+      "session": "s3-architecture",
+      "slot": "deployment",
+      "value": "Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC.",
+      "evidence_id": "ev-005",
+      "status": "current",
+      "rationale": "Enterprise legal review rejected shared SaaS for the first pilot.",
+      "relevant_terms": [
+        "deployment",
+        "self-hosted",
+        "eu",
+        "vpc"
+      ],
+      "stale_terms": [
+        "shared SaaS"
+      ],
+      "secret": null
+    },
+    {
+      "turn": 6,
+      "session": "s3-architecture",
+      "slot": "launch_readiness",
+      "value": "Do not publish the public benchmark until the win-rate chart is reproduced.",
+      "evidence_id": "ev-006",
+      "status": "superseded",
+      "rationale": "The initial chart used a mixed judge prompt.",
+      "relevant_terms": [
+        "launch",
+        "benchmark",
+        "publish",
+        "win-rate",
+        "chart"
+      ],
+      "stale_terms": [
+        "do not publish"
+      ],
+      "secret": null
+    },
+    {
+      "turn": 7,
+      "session": "s3-architecture",
+      "slot": "data_handling",
+      "value": "Rejected assumption: raw support logs are safe to store without redaction.",
+      "evidence_id": "ev-007",
+      "status": "rejected",
+      "rationale": "Security review found synthetic keys in exported transcript fixtures.",
+      "relevant_terms": [
+        "data",
+        "logs",
+        "redaction",
+        "raw",
+        "safe"
+      ],
+      "stale_terms": [
+        "raw support logs are safe"
+      ],
+      "secret": "sk-test-123456"
+    },
+    {
+      "turn": 8,
+      "session": "s4-correction",
+      "slot": "data_handling",
+      "value": "Current data handling requires redaction before logs enter memory.",
+      "evidence_id": "ev-008",
+      "status": "current",
+      "rationale": "The fixture pipeline now strips synthetic tokens before ingestion.",
+      "relevant_terms": [
+        "data",
+        "logs",
+        "redaction",
+        "memory"
+      ],
+      "stale_terms": [],
+      "secret": null
+    },
+    {
+      "turn": 9,
+      "session": "s4-correction",
+      "slot": "launch_readiness",
+      "value": "Current launch decision is publish after the win-rate chart is reproduced.",
+      "evidence_id": "ev-009",
+      "status": "current",
+      "rationale": "The judge prompt was fixed and rerun on the frozen probe set.",
+      "relevant_terms": [
+        "launch",
+        "benchmark",
+        "publish",
+        "win-rate",
+        "chart"
+      ],
+      "stale_terms": [],
+      "secret": null
+    },
+    {
+      "turn": 10,
+      "session": "s5-pilot",
+      "slot": "customer_owner",
+      "value": "Acme pilot is blocked on DPA redlines; Lina owns it by June 18.",
+      "evidence_id": "ev-010",
+      "status": "current",
+      "rationale": "Customer success reassigned the owner after procurement escalation.",
+      "relevant_terms": [
+        "customer",
+        "owner",
+        "acme",
+        "dpa",
+        "lina",
+        "june"
+      ],
+      "stale_terms": [
+        "Mara owns"
+      ],
+      "secret": null
+    },
+    {
+      "turn": 11,
+      "session": "s5-pilot",
+      "slot": "model_routing",
+      "value": "Use a small local reranker for triage; GPT-4.1 only handles synthesis.",
+      "evidence_id": "ev-011",
+      "status": "current",
+      "rationale": "The local reranker kept cost down without hurting final synthesis.",
+      "relevant_terms": [
+        "model",
+        "routing",
+        "local",
+        "reranker",
+        "gpt-4.1"
+      ],
+      "stale_terms": [
+        "GPT-4.1 for every turn"
+      ],
+      "secret": null
+    },
+    {
+      "turn": 12,
+      "session": "s5-pilot",
+      "slot": "primary_metric",
+      "value": "Primary benchmark metric is decision freshness accuracy.",
+      "evidence_id": "ev-012",
+      "status": "current",
+      "rationale": "The team chose freshness over generic user satisfaction surveys.",
+      "relevant_terms": [
+        "primary",
+        "metric",
+        "decision",
+        "freshness",
+        "accuracy"
+      ],
+      "stale_terms": [
+        "user satisfaction"
+      ],
+      "secret": null
+    }
+  ],
+  "probes": [
+    {
+      "name": "target_segment",
+      "question": "Who is the current target segment?",
+      "slots": [
+        "target_segment"
+      ],
+      "expected_terms": [
+        "support operations teams"
+      ],
+      "expected_evidence": [
+        "ev-003"
+      ],
+      "stale_terms": [
+        "consumer creators"
+      ],
+      "relevant_evidence": [
+        "ev-003"
+      ]
+    },
+    {
+      "name": "pricing",
+      "question": "What is the current pricing decision?",
+      "slots": [
+        "pricing"
+      ],
+      "expected_terms": [
+        "$0.08 per resolved ticket"
+      ],
+      "expected_evidence": [
+        "ev-004"
+      ],
+      "stale_terms": [
+        "$49 per team per month"
+      ],
+      "relevant_evidence": [
+        "ev-004"
+      ]
+    },
+    {
+      "name": "deployment",
+      "question": "What deployment constraint is active for the beta?",
+      "slots": [
+        "deployment"
+      ],
+      "expected_terms": [
+        "self-hosted beta",
+        "no eu customer data leaves"
+      ],
+      "expected_evidence": [
+        "ev-005"
+      ],
+      "stale_terms": [
+        "shared saas"
+      ],
+      "relevant_evidence": [
+        "ev-005"
+      ]
+    },
+    {
+      "name": "launch_readiness",
+      "question": "When can the public benchmark be published?",
+      "slots": [
+        "launch_readiness"
+      ],
+      "expected_terms": [
+        "publish after the win-rate chart is reproduced"
+      ],
+      "expected_evidence": [
+        "ev-009"
+      ],
+      "stale_terms": [
+        "do not publish"
+      ],
+      "relevant_evidence": [
+        "ev-009"
+      ]
+    },
+    {
+      "name": "data_handling",
+      "question": "What is the current log-handling decision?",
+      "slots": [
+        "data_handling"
+      ],
+      "expected_terms": [
+        "redaction before logs enter memory"
+      ],
+      "expected_evidence": [
+        "ev-008"
+      ],
+      "stale_terms": [
+        "raw support logs are safe",
+        "sk-test-123456"
+      ],
+      "relevant_evidence": [
+        "ev-008"
+      ]
+    },
+    {
+      "name": "customer_owner",
+      "question": "Who owns the current Acme pilot blocker?",
+      "slots": [
+        "customer_owner"
+      ],
+      "expected_terms": [
+        "acme pilot is blocked",
+        "lina",
+        "june 18"
+      ],
+      "expected_evidence": [
+        "ev-010"
+      ],
+      "stale_terms": [
+        "mara owns"
+      ],
+      "relevant_evidence": [
+        "ev-010"
+      ]
+    },
+    {
+      "name": "model_routing",
+      "question": "How should the agent route model calls now?",
+      "slots": [
+        "model_routing"
+      ],
+      "expected_terms": [
+        "small local reranker",
+        "gpt-4.1 only handles synthesis"
+      ],
+      "expected_evidence": [
+        "ev-011"
+      ],
+      "stale_terms": [
+        "gpt-4.1 for every turn"
+      ],
+      "relevant_evidence": [
+        "ev-011"
+      ]
+    },
+    {
+      "name": "primary_metric",
+      "question": "What is the primary benchmark metric?",
+      "slots": [
+        "primary_metric"
+      ],
+      "expected_terms": [
+        "decision freshness accuracy"
+      ],
+      "expected_evidence": [
+        "ev-012"
+      ],
+      "stale_terms": [
+        "user satisfaction"
+      ],
+      "relevant_evidence": [
+        "ev-012"
+      ]
+    }
+  ],
+  "summaries": [
+    {
+      "backend": "active_decision_digest",
+      "accuracy": 1.0,
+      "evidence_coverage": 1.0,
+      "stale_conflict_rate": 0.0,
+      "secret_leak_rate": 0.0,
+      "avg_retrieved_tokens": 21.125,
+      "p95_latency_ms": 0.003584998194128275,
+      "signal_noise_ratio": 1.0
+    },
+    {
+      "backend": "passive_graph_history",
+      "accuracy": 0.5,
+      "evidence_coverage": 1.0,
+      "stale_conflict_rate": 0.5,
+      "secret_leak_rate": 0.125,
+      "avg_retrieved_tokens": 30.5,
+      "p95_latency_ms": 0.007884982915129513,
+      "signal_noise_ratio": 0.6666666666666666
+    },
+    {
+      "backend": "append_only_log",
+      "accuracy": 0.5,
+      "evidence_coverage": 1.0,
+      "stale_conflict_rate": 0.5,
+      "secret_leak_rate": 0.125,
+      "avg_retrieved_tokens": 167.25,
+      "p95_latency_ms": 0.09810999181354418,
+      "signal_noise_ratio": 0.12307692307692308
+    },
+    {
+      "backend": "recent_window_log",
+      "accuracy": 0.5,
+      "evidence_coverage": 0.5,
+      "stale_conflict_rate": 0.0,
+      "secret_leak_rate": 0.0,
+      "avg_retrieved_tokens": 10.625,
+      "p95_latency_ms": 0.003609998384490609,
+      "signal_noise_ratio": 1.0
+    }
+  ],
+  "answers": {
+    "active_decision_digest": [
+      {
+        "backend": "active_decision_digest",
+        "probe": "target_segment",
+        "answer": "target_segment: Current target segment is support operations teams. Evidence: ev-003.",
+        "evidence_ids": [
+          "ev-003"
+        ],
+        "retrieved_tokens": 18,
+        "latency_ms": 0.0039000005926936865
+      },
+      {
+        "backend": "active_decision_digest",
+        "probe": "pricing",
+        "answer": "pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004.",
+        "evidence_ids": [
+          "ev-004"
+        ],
+        "retrieved_tokens": 21,
+        "latency_ms": 0.0029999937396496534
+      },
+      {
+        "backend": "active_decision_digest",
+        "probe": "deployment",
+        "answer": "deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005.",
+        "evidence_ids": [
+          "ev-005"
+        ],
+        "retrieved_tokens": 26,
+        "latency_ms": 0.0015999830793589354
+      },
+      {
+        "backend": "active_decision_digest",
+        "probe": "launch_readiness",
+        "answer": "launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009.",
+        "evidence_ids": [
+          "ev-009"
+        ],
+        "retrieved_tokens": 24,
+        "latency_ms": 0.0009999785106629133
+      },
+      {
+        "backend": "active_decision_digest",
+        "probe": "data_handling",
+        "answer": "data_handling: Current data handling requires redaction before logs enter memory. Evidence: ev-008.",
+        "evidence_ids": [
+          "ev-008"
+        ],
+        "retrieved_tokens": 19,
+        "latency_ms": 0.0011999800335615873
+      },
+      {
+        "backend": "active_decision_digest",
+        "probe": "customer_owner",
+        "answer": "customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010.",
+        "evidence_ids": [
+          "ev-010"
+        ],
+        "retrieved_tokens": 22,
+        "latency_ms": 0.001200009137392044
+      },
+      {
+        "backend": "active_decision_digest",
+        "probe": "model_routing",
+        "answer": "model_routing: Use a small local reranker for triage; GPT-4.1 only handles synthesis. Evidence: ev-011.",
+        "evidence_ids": [
+          "ev-011"
+        ],
+        "retrieved_tokens": 22,
+        "latency_ms": 0.00100000761449337
+      },
+      {
+        "backend": "active_decision_digest",
+        "probe": "primary_metric",
+        "answer": "primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "evidence_ids": [
+          "ev-012"
+        ],
+        "retrieved_tokens": 17,
+        "latency_ms": 0.000900006853044033
+      }
+    ],
+    "passive_graph_history": [
+      {
+        "backend": "passive_graph_history",
+        "probe": "target_segment",
+        "answer": "target_segment possible states: superseded: Initial target segment is consumer creators. (ev-001) | current: Current target segment is support operations teams. (ev-003).",
+        "evidence_ids": [
+          "ev-001",
+          "ev-003"
+        ],
+        "retrieved_tokens": 32,
+        "latency_ms": 0.009599985787644982
+      },
+      {
+        "backend": "passive_graph_history",
+        "probe": "pricing",
+        "answer": "pricing possible states: superseded: Initial pricing hypothesis is $49 per team per month. (ev-002) | current: Current pricing is a usage-based pilot at $0.08 per resolved ticket. (ev-004).",
+        "evidence_ids": [
+          "ev-002",
+          "ev-004"
+        ],
+        "retrieved_tokens": 39,
+        "latency_ms": 0.004699977580457926
+      },
+      {
+        "backend": "passive_graph_history",
+        "probe": "deployment",
+        "answer": "deployment possible states: current: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. (ev-005).",
+        "evidence_ids": [
+          "ev-005"
+        ],
+        "retrieved_tokens": 26,
+        "latency_ms": 0.0026999914553016424
+      },
+      {
+        "backend": "passive_graph_history",
+        "probe": "launch_readiness",
+        "answer": "launch_readiness possible states: superseded: Do not publish the public benchmark until the win-rate chart is reproduced. (ev-006) | current: Current launch decision is publish after the win-rate chart is reproduced. (ev-009).",
+        "evidence_ids": [
+          "ev-006",
+          "ev-009"
+        ],
+        "retrieved_tokens": 45,
+        "latency_ms": 0.0028999929782003164
+      },
+      {
+        "backend": "passive_graph_history",
+        "probe": "data_handling",
+        "answer": "data_handling possible states: rejected: Rejected assumption: raw support logs are safe to store without redaction. sk-test-123456 (ev-007) | current: Current data handling requires redaction before logs enter memory. (ev-008).",
+        "evidence_ids": [
+          "ev-007",
+          "ev-008"
+        ],
+        "retrieved_tokens": 41,
+        "latency_ms": 0.0034999975468963385
+      },
+      {
+        "backend": "passive_graph_history",
+        "probe": "customer_owner",
+        "answer": "customer_owner possible states: current: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. (ev-010).",
+        "evidence_ids": [
+          "ev-010"
+        ],
+        "retrieved_tokens": 22,
+        "latency_ms": 0.0023999891709536314
+      },
+      {
+        "backend": "passive_graph_history",
+        "probe": "model_routing",
+        "answer": "model_routing possible states: current: Use a small local reranker for triage; GPT-4.1 only handles synthesis. (ev-011).",
+        "evidence_ids": [
+          "ev-011"
+        ],
+        "retrieved_tokens": 22,
+        "latency_ms": 0.0020999868866056204
+      },
+      {
+        "backend": "passive_graph_history",
+        "probe": "primary_metric",
+        "answer": "primary_metric possible states: current: Primary benchmark metric is decision freshness accuracy. (ev-012).",
+        "evidence_ids": [
+          "ev-012"
+        ],
+        "retrieved_tokens": 17,
+        "latency_ms": 0.00200001522898674
+      }
+    ],
+    "append_only_log": [
+      {
+        "backend": "append_only_log",
+        "probe": "target_segment",
+        "answer": "target_segment: Initial target segment is consumer creators. Evidence: ev-001. pricing: Initial pricing hypothesis is $49 per team per month. Evidence: ev-002. target_segment: Current target segment is support operations teams. Evidence: ev-003. pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004. deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. data_handling: Current data handling requires redaction before logs enter memory. Evidence: ev-008. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010. primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "evidence_ids": [
+          "ev-001",
+          "ev-002",
+          "ev-003",
+          "ev-004",
+          "ev-005",
+          "ev-006",
+          "ev-008",
+          "ev-009",
+          "ev-010",
+          "ev-012"
+        ],
+        "retrieved_tokens": 200,
+        "latency_ms": 0.10209999163635075
+      },
+      {
+        "backend": "append_only_log",
+        "probe": "pricing",
+        "answer": "target_segment: Initial target segment is consumer creators. Evidence: ev-001. pricing: Initial pricing hypothesis is $49 per team per month. Evidence: ev-002. target_segment: Current target segment is support operations teams. Evidence: ev-003. pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004. deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. data_handling: Current data handling requires redaction before logs enter memory. Evidence: ev-008. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010. primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "evidence_ids": [
+          "ev-001",
+          "ev-002",
+          "ev-003",
+          "ev-004",
+          "ev-005",
+          "ev-006",
+          "ev-008",
+          "ev-009",
+          "ev-010",
+          "ev-012"
+        ],
+        "retrieved_tokens": 200,
+        "latency_ms": 0.0906999921426177
+      },
+      {
+        "backend": "append_only_log",
+        "probe": "deployment",
+        "answer": "target_segment: Initial target segment is consumer creators. Evidence: ev-001. pricing: Initial pricing hypothesis is $49 per team per month. Evidence: ev-002. target_segment: Current target segment is support operations teams. Evidence: ev-003. pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004. deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010. model_routing: Use a small local reranker for triage; GPT-4.1 only handles synthesis. Evidence: ev-011. primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "evidence_ids": [
+          "ev-001",
+          "ev-002",
+          "ev-003",
+          "ev-004",
+          "ev-005",
+          "ev-006",
+          "ev-009",
+          "ev-010",
+          "ev-011",
+          "ev-012"
+        ],
+        "retrieved_tokens": 203,
+        "latency_ms": 0.08329999400302768
+      },
+      {
+        "backend": "append_only_log",
+        "probe": "launch_readiness",
+        "answer": "deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "evidence_ids": [
+          "ev-005",
+          "ev-006",
+          "ev-009",
+          "ev-012"
+        ],
+        "retrieved_tokens": 88,
+        "latency_ms": 0.07360000745393336
+      },
+      {
+        "backend": "append_only_log",
+        "probe": "data_handling",
+        "answer": "target_segment: Initial target segment is consumer creators. Evidence: ev-001. pricing: Initial pricing hypothesis is $49 per team per month. Evidence: ev-002. target_segment: Current target segment is support operations teams. Evidence: ev-003. pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004. deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. data_handling: Rejected assumption: raw support logs are safe to store without redaction. sk-test-123456 Evidence: ev-007. data_handling: Current data handling requires redaction before logs enter memory. Evidence: ev-008. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010. primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "evidence_ids": [
+          "ev-001",
+          "ev-002",
+          "ev-003",
+          "ev-004",
+          "ev-005",
+          "ev-006",
+          "ev-007",
+          "ev-008",
+          "ev-009",
+          "ev-010",
+          "ev-012"
+        ],
+        "retrieved_tokens": 222,
+        "latency_ms": 0.07550002192147076
+      },
+      {
+        "backend": "append_only_log",
+        "probe": "customer_owner",
+        "answer": "target_segment: Current target segment is support operations teams. Evidence: ev-003. pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004. deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. data_handling: Current data handling requires redaction before logs enter memory. Evidence: ev-008. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010.",
+        "evidence_ids": [
+          "ev-003",
+          "ev-004",
+          "ev-005",
+          "ev-006",
+          "ev-008",
+          "ev-009",
+          "ev-010"
+        ],
+        "retrieved_tokens": 151,
+        "latency_ms": 0.057199998991563916
+      },
+      {
+        "backend": "append_only_log",
+        "probe": "model_routing",
+        "answer": "deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. model_routing: Use a small local reranker for triage; GPT-4.1 only handles synthesis. Evidence: ev-011.",
+        "evidence_ids": [
+          "ev-005",
+          "ev-006",
+          "ev-009",
+          "ev-011"
+        ],
+        "retrieved_tokens": 93,
+        "latency_ms": 0.054899981478229165
+      },
+      {
+        "backend": "append_only_log",
+        "probe": "primary_metric",
+        "answer": "target_segment: Initial target segment is consumer creators. Evidence: ev-001. pricing: Initial pricing hypothesis is $49 per team per month. Evidence: ev-002. target_segment: Current target segment is support operations teams. Evidence: ev-003. pricing: Current pricing is a usage-based pilot at $0.08 per resolved ticket. Evidence: ev-004. deployment: Current deployment decision is self-hosted beta only; no EU customer data leaves the customer VPC. Evidence: ev-005. launch_readiness: Do not publish the public benchmark until the win-rate chart is reproduced. Evidence: ev-006. launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009. customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010. primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "evidence_ids": [
+          "ev-001",
+          "ev-002",
+          "ev-003",
+          "ev-004",
+          "ev-005",
+          "ev-006",
+          "ev-009",
+          "ev-010",
+          "ev-012"
+        ],
+        "retrieved_tokens": 181,
+        "latency_ms": 0.054800009820610285
+      }
+    ],
+    "recent_window_log": [
+      {
+        "backend": "recent_window_log",
+        "probe": "target_segment",
+        "answer": "No decision found.",
+        "evidence_ids": [],
+        "retrieved_tokens": 0,
+        "latency_ms": 0.0048000074457377195
+      },
+      {
+        "backend": "recent_window_log",
+        "probe": "pricing",
+        "answer": "No decision found.",
+        "evidence_ids": [],
+        "retrieved_tokens": 0,
+        "latency_ms": 0.0010999792721122503
+      },
+      {
+        "backend": "recent_window_log",
+        "probe": "deployment",
+        "answer": "No decision found.",
+        "evidence_ids": [],
+        "retrieved_tokens": 0,
+        "latency_ms": 0.0007999769877642393
+      },
+      {
+        "backend": "recent_window_log",
+        "probe": "launch_readiness",
+        "answer": "launch_readiness: Current launch decision is publish after the win-rate chart is reproduced. Evidence: ev-009.",
+        "evidence_ids": [
+          "ev-009"
+        ],
+        "retrieved_tokens": 24,
+        "latency_ms": 0.0013999815564602613
+      },
+      {
+        "backend": "recent_window_log",
+        "probe": "data_handling",
+        "answer": "No decision found.",
+        "evidence_ids": [],
+        "retrieved_tokens": 0,
+        "latency_ms": 0.000800006091594696
+      },
+      {
+        "backend": "recent_window_log",
+        "probe": "customer_owner",
+        "answer": "customer_owner: Acme pilot is blocked on DPA redlines; Lina owns it by June 18. Evidence: ev-010.",
+        "evidence_ids": [
+          "ev-010"
+        ],
+        "retrieved_tokens": 22,
+        "latency_ms": 0.001200009137392044
+      },
+      {
+        "backend": "recent_window_log",
+        "probe": "model_routing",
+        "answer": "model_routing: Use a small local reranker for triage; GPT-4.1 only handles synthesis. Evidence: ev-011.",
+        "evidence_ids": [
+          "ev-011"
+        ],
+        "retrieved_tokens": 22,
+        "latency_ms": 0.0010999792721122503
+      },
+      {
+        "backend": "recent_window_log",
+        "probe": "primary_metric",
+        "answer": "primary_metric: Primary benchmark metric is decision freshness accuracy. Evidence: ev-012.",
+        "evidence_ids": [
+          "ev-012"
+        ],
+        "retrieved_tokens": 17,
+        "latency_ms": 0.001100008375942707
+      }
+    ]
+  }
+}

--- a/examples/benchmarks/research-decision-memory/results/sample_results.md
+++ b/examples/benchmarks/research-decision-memory/results/sample_results.md
@@ -1,0 +1,10 @@
+# Research Decision Memory Results
+
+| Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | p95 ms | Signal/Noise |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| active_decision_digest | 100.00% | 100.00% | 0.00% | 0.00% | 21.12 | 0.0036 | 100.00% |
+| passive_graph_history | 50.00% | 100.00% | 50.00% | 12.50% | 30.50 | 0.0079 | 66.67% |
+| append_only_log | 50.00% | 100.00% | 50.00% | 12.50% | 167.25 | 0.0981 | 12.31% |
+| recent_window_log | 50.00% | 50.00% | 0.00% | 0.00% | 10.62 | 0.0036 | 100.00% |
+
+Generated with `run_benchmark.py` using only stdlib components.

--- a/examples/benchmarks/research-decision-memory/results/sample_results.md
+++ b/examples/benchmarks/research-decision-memory/results/sample_results.md
@@ -1,10 +1,12 @@
 # Research Decision Memory Results
 
-| Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | p95 ms | Signal/Noise |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| active_decision_digest | 100.00% | 100.00% | 0.00% | 0.00% | 21.12 | 0.0036 | 100.00% |
-| passive_graph_history | 50.00% | 100.00% | 50.00% | 12.50% | 30.50 | 0.0065 | 66.67% |
-| append_only_log | 50.00% | 100.00% | 50.00% | 12.50% | 167.25 | 0.0881 | 12.31% |
-| recent_window_log | 50.00% | 50.00% | 0.00% | 0.00% | 10.62 | 0.0024 | 100.00% |
+| Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | Signal/Noise |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| active_decision_digest | 100.00% | 100.00% | 0.00% | 0.00% | 21.12 | 100.00% |
+| passive_graph_history | 50.00% | 100.00% | 50.00% | 12.50% | 30.50 | 66.67% |
+| append_only_log | 50.00% | 100.00% | 50.00% | 12.50% | 167.25 | 12.31% |
+| recent_window_log | 50.00% | 50.00% | 0.00% | 0.00% | 10.62 | 100.00% |
+
+Runtime-specific latency is omitted from saved sample artifacts; run the benchmark without output flags for live p95 ms.
 
 Generated with `run_benchmark.py` using only stdlib components.

--- a/examples/benchmarks/research-decision-memory/results/sample_results.md
+++ b/examples/benchmarks/research-decision-memory/results/sample_results.md
@@ -3,8 +3,8 @@
 | Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | p95 ms | Signal/Noise |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | active_decision_digest | 100.00% | 100.00% | 0.00% | 0.00% | 21.12 | 0.0036 | 100.00% |
-| passive_graph_history | 50.00% | 100.00% | 50.00% | 12.50% | 30.50 | 0.0079 | 66.67% |
-| append_only_log | 50.00% | 100.00% | 50.00% | 12.50% | 167.25 | 0.0981 | 12.31% |
-| recent_window_log | 50.00% | 50.00% | 0.00% | 0.00% | 10.62 | 0.0036 | 100.00% |
+| passive_graph_history | 50.00% | 100.00% | 50.00% | 12.50% | 30.50 | 0.0065 | 66.67% |
+| append_only_log | 50.00% | 100.00% | 50.00% | 12.50% | 167.25 | 0.0881 | 12.31% |
+| recent_window_log | 50.00% | 50.00% | 0.00% | 0.00% | 10.62 | 0.0024 | 100.00% |
 
 Generated with `run_benchmark.py` using only stdlib components.

--- a/examples/benchmarks/research-decision-memory/run_benchmark.py
+++ b/examples/benchmarks/research-decision-memory/run_benchmark.py
@@ -8,14 +8,14 @@ only the Python standard library so reviewers can run it without credentials.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import re
 import statistics
 import time
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Iterable
-
 
 SECRET_MARKERS = (
     "synthetic_secret_marker_",
@@ -498,38 +498,79 @@ def run() -> dict[str, object]:
     }
 
 
-def write_json(path: Path, payload: dict[str, object]) -> None:
+def write_json(
+    path: Path, payload: dict[str, object], include_latency: bool = False
+) -> None:
+    output_payload = payload if include_latency else reproducible_payload(payload)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    path.write_text(json.dumps(output_payload, indent=2) + "\n", encoding="utf-8")
+
+
+def reproducible_payload(payload: dict[str, object]) -> dict[str, object]:
+    stable_payload = copy.deepcopy(payload)
+    for summary in stable_payload["summaries"]:
+        summary.pop("p95_latency_ms", None)
+    for answers in stable_payload["answers"].values():
+        for answer in answers:
+            answer.pop("latency_ms", None)
+    return stable_payload
 
 
 def summary_rows(payload: dict[str, object]) -> list[dict[str, object]]:
     return list(payload["summaries"])  # type: ignore[arg-type]
 
 
-def markdown_report(payload: dict[str, object]) -> str:
+def markdown_report(payload: dict[str, object], include_latency: bool = True) -> str:
     rows = summary_rows(payload)
-    lines = [
-        "# Research Decision Memory Results",
-        "",
-        "| Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | p95 ms | Signal/Noise |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
-    ]
-    for row in rows:
-        lines.append(
-            "| {backend} | {accuracy:.2%} | {evidence_coverage:.2%} | "
-            "{stale_conflict_rate:.2%} | {secret_leak_rate:.2%} | "
-            "{avg_retrieved_tokens:.2f} | {p95_latency_ms:.4f} | "
-            "{signal_noise_ratio:.2%} |".format(**row)
+    lines = ["# Research Decision Memory Results", ""]
+    if include_latency:
+        lines.extend(
+            [
+                "| Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | p95 ms | Signal/Noise |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+            ]
         )
+    else:
+        lines.extend(
+            [
+                "| Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | Signal/Noise |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+            ]
+        )
+    for row in rows:
+        if include_latency:
+            lines.append(
+                "| {backend} | {accuracy:.2%} | {evidence_coverage:.2%} | "
+                "{stale_conflict_rate:.2%} | {secret_leak_rate:.2%} | "
+                "{avg_retrieved_tokens:.2f} | {p95_latency_ms:.4f} | "
+                "{signal_noise_ratio:.2%} |".format(**row)
+            )
+        else:
+            lines.append(
+                "| {backend} | {accuracy:.2%} | {evidence_coverage:.2%} | "
+                "{stale_conflict_rate:.2%} | {secret_leak_rate:.2%} | "
+                "{avg_retrieved_tokens:.2f} | {signal_noise_ratio:.2%} |".format(
+                    **row
+                )
+            )
     lines.append("")
+    if not include_latency:
+        lines.append(
+            "Runtime-specific latency is omitted from saved sample artifacts; "
+            "run the benchmark without output flags for live p95 ms."
+        )
+        lines.append("")
     lines.append("Generated with `run_benchmark.py` using only stdlib components.")
     return "\n".join(lines) + "\n"
 
 
-def write_markdown(path: Path, payload: dict[str, object]) -> None:
+def write_markdown(
+    path: Path, payload: dict[str, object], include_latency: bool = False
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(markdown_report(payload), encoding="utf-8")
+    path.write_text(
+        markdown_report(payload, include_latency=include_latency), encoding="utf-8"
+    )
 
 
 def print_summary(payload: dict[str, object]) -> None:
@@ -550,6 +591,11 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Optional Markdown report path.",
     )
+    parser.add_argument(
+        "--include-latency-output",
+        action="store_true",
+        help="Include runtime-specific latency fields in JSON and Markdown outputs.",
+    )
     return parser.parse_args()
 
 
@@ -557,9 +603,11 @@ def main() -> None:
     args = parse_args()
     payload = run()
     if args.output:
-        write_json(args.output, payload)
+        write_json(args.output, payload, include_latency=args.include_latency_output)
     if args.markdown:
-        write_markdown(args.markdown, payload)
+        write_markdown(
+            args.markdown, payload, include_latency=args.include_latency_output
+        )
     print_summary(payload)
 
 

--- a/examples/benchmarks/research-decision-memory/run_benchmark.py
+++ b/examples/benchmarks/research-decision-memory/run_benchmark.py
@@ -1,0 +1,563 @@
+"""Deterministic research decision memory benchmark.
+
+The benchmark compares memory strategies on a product-research decision trail
+where early assumptions are superseded by later evidence. It intentionally uses
+only the Python standard library so reviewers can run it without credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+SECRET_MARKERS = ("sk-test-", "private_token_", "secret=")
+
+
+@dataclass(frozen=True)
+class DecisionRecord:
+    turn: int
+    session: str
+    slot: str
+    value: str
+    evidence_id: str
+    status: str
+    rationale: str
+    relevant_terms: tuple[str, ...]
+    stale_terms: tuple[str, ...] = ()
+    secret: str | None = None
+
+
+@dataclass(frozen=True)
+class Probe:
+    name: str
+    question: str
+    slots: tuple[str, ...]
+    expected_terms: tuple[str, ...]
+    expected_evidence: tuple[str, ...]
+    stale_terms: tuple[str, ...]
+    relevant_evidence: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Answer:
+    backend: str
+    probe: str
+    answer: str
+    evidence_ids: tuple[str, ...]
+    retrieved_tokens: int
+    latency_ms: float
+
+
+@dataclass(frozen=True)
+class BackendSummary:
+    backend: str
+    accuracy: float
+    evidence_coverage: float
+    stale_conflict_rate: float
+    secret_leak_rate: float
+    avg_retrieved_tokens: float
+    p95_latency_ms: float
+    signal_noise_ratio: float
+
+
+def tokenize(text: str) -> list[str]:
+    return re.findall(r"[a-zA-Z0-9_.:$-]+", text.lower())
+
+
+def token_count(text: str) -> int:
+    return len(tokenize(text))
+
+
+def contains_all(text: str, terms: Iterable[str]) -> bool:
+    lowered = text.lower()
+    return all(term.lower() in lowered for term in terms)
+
+
+def contains_any(text: str, terms: Iterable[str]) -> bool:
+    lowered = text.lower()
+    return any(term.lower() in lowered for term in terms)
+
+
+def percentile_95(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    return statistics.quantiles(values, n=20, method="inclusive")[18]
+
+
+def decision_records() -> list[DecisionRecord]:
+    return [
+        DecisionRecord(
+            turn=1,
+            session="s1-hypothesis",
+            slot="target_segment",
+            value="Initial target segment is consumer creators.",
+            evidence_id="ev-001",
+            status="superseded",
+            rationale="Founder hunch from an early market scan.",
+            relevant_terms=("target", "segment", "consumer", "creators"),
+            stale_terms=("consumer creators",),
+        ),
+        DecisionRecord(
+            turn=2,
+            session="s1-hypothesis",
+            slot="pricing",
+            value="Initial pricing hypothesis is $49 per team per month.",
+            evidence_id="ev-002",
+            status="superseded",
+            rationale="Anchored on a competitor roundup, before support-team interviews.",
+            relevant_terms=("pricing", "$49", "team", "month"),
+            stale_terms=("$49 per team per month",),
+        ),
+        DecisionRecord(
+            turn=3,
+            session="s2-interviews",
+            slot="target_segment",
+            value="Current target segment is support operations teams.",
+            evidence_id="ev-003",
+            status="current",
+            rationale="Nine of twelve interviews had an urgent cross-session handoff pain.",
+            relevant_terms=("target", "segment", "support", "operations", "teams"),
+        ),
+        DecisionRecord(
+            turn=4,
+            session="s2-interviews",
+            slot="pricing",
+            value="Current pricing is a usage-based pilot at $0.08 per resolved ticket.",
+            evidence_id="ev-004",
+            status="current",
+            rationale="Budget owners preferred tying price to support resolution volume.",
+            relevant_terms=("pricing", "usage", "$0.08", "resolved", "ticket"),
+        ),
+        DecisionRecord(
+            turn=5,
+            session="s3-architecture",
+            slot="deployment",
+            value=(
+                "Current deployment decision is self-hosted beta only; no EU "
+                "customer data leaves the customer VPC."
+            ),
+            evidence_id="ev-005",
+            status="current",
+            rationale="Enterprise legal review rejected shared SaaS for the first pilot.",
+            relevant_terms=("deployment", "self-hosted", "eu", "vpc"),
+            stale_terms=("shared SaaS",),
+        ),
+        DecisionRecord(
+            turn=6,
+            session="s3-architecture",
+            slot="launch_readiness",
+            value="Do not publish the public benchmark until the win-rate chart is reproduced.",
+            evidence_id="ev-006",
+            status="superseded",
+            rationale="The initial chart used a mixed judge prompt.",
+            relevant_terms=("launch", "benchmark", "publish", "win-rate", "chart"),
+            stale_terms=("do not publish",),
+        ),
+        DecisionRecord(
+            turn=7,
+            session="s3-architecture",
+            slot="data_handling",
+            value="Rejected assumption: raw support logs are safe to store without redaction.",
+            evidence_id="ev-007",
+            status="rejected",
+            rationale="Security review found synthetic keys in exported transcript fixtures.",
+            relevant_terms=("data", "logs", "redaction", "raw", "safe"),
+            stale_terms=("raw support logs are safe",),
+            secret="sk-test-123456",
+        ),
+        DecisionRecord(
+            turn=8,
+            session="s4-correction",
+            slot="data_handling",
+            value="Current data handling requires redaction before logs enter memory.",
+            evidence_id="ev-008",
+            status="current",
+            rationale="The fixture pipeline now strips synthetic tokens before ingestion.",
+            relevant_terms=("data", "logs", "redaction", "memory"),
+        ),
+        DecisionRecord(
+            turn=9,
+            session="s4-correction",
+            slot="launch_readiness",
+            value="Current launch decision is publish after the win-rate chart is reproduced.",
+            evidence_id="ev-009",
+            status="current",
+            rationale="The judge prompt was fixed and rerun on the frozen probe set.",
+            relevant_terms=("launch", "benchmark", "publish", "win-rate", "chart"),
+        ),
+        DecisionRecord(
+            turn=10,
+            session="s5-pilot",
+            slot="customer_owner",
+            value="Acme pilot is blocked on DPA redlines; Lina owns it by June 18.",
+            evidence_id="ev-010",
+            status="current",
+            rationale="Customer success reassigned the owner after procurement escalation.",
+            relevant_terms=("customer", "owner", "acme", "dpa", "lina", "june"),
+            stale_terms=("Mara owns",),
+        ),
+        DecisionRecord(
+            turn=11,
+            session="s5-pilot",
+            slot="model_routing",
+            value="Use a small local reranker for triage; GPT-4.1 only handles synthesis.",
+            evidence_id="ev-011",
+            status="current",
+            rationale="The local reranker kept cost down without hurting final synthesis.",
+            relevant_terms=("model", "routing", "local", "reranker", "gpt-4.1"),
+            stale_terms=("GPT-4.1 for every turn",),
+        ),
+        DecisionRecord(
+            turn=12,
+            session="s5-pilot",
+            slot="primary_metric",
+            value="Primary benchmark metric is decision freshness accuracy.",
+            evidence_id="ev-012",
+            status="current",
+            rationale="The team chose freshness over generic user satisfaction surveys.",
+            relevant_terms=("primary", "metric", "decision", "freshness", "accuracy"),
+            stale_terms=("user satisfaction",),
+        ),
+    ]
+
+
+def probes() -> list[Probe]:
+    return [
+        Probe(
+            name="target_segment",
+            question="Who is the current target segment?",
+            slots=("target_segment",),
+            expected_terms=("support operations teams",),
+            expected_evidence=("ev-003",),
+            stale_terms=("consumer creators",),
+            relevant_evidence=("ev-003",),
+        ),
+        Probe(
+            name="pricing",
+            question="What is the current pricing decision?",
+            slots=("pricing",),
+            expected_terms=("$0.08 per resolved ticket",),
+            expected_evidence=("ev-004",),
+            stale_terms=("$49 per team per month",),
+            relevant_evidence=("ev-004",),
+        ),
+        Probe(
+            name="deployment",
+            question="What deployment constraint is active for the beta?",
+            slots=("deployment",),
+            expected_terms=("self-hosted beta", "no eu customer data leaves"),
+            expected_evidence=("ev-005",),
+            stale_terms=("shared saas",),
+            relevant_evidence=("ev-005",),
+        ),
+        Probe(
+            name="launch_readiness",
+            question="When can the public benchmark be published?",
+            slots=("launch_readiness",),
+            expected_terms=("publish after the win-rate chart is reproduced",),
+            expected_evidence=("ev-009",),
+            stale_terms=("do not publish",),
+            relevant_evidence=("ev-009",),
+        ),
+        Probe(
+            name="data_handling",
+            question="What is the current log-handling decision?",
+            slots=("data_handling",),
+            expected_terms=("redaction before logs enter memory",),
+            expected_evidence=("ev-008",),
+            stale_terms=("raw support logs are safe", "sk-test-123456"),
+            relevant_evidence=("ev-008",),
+        ),
+        Probe(
+            name="customer_owner",
+            question="Who owns the current Acme pilot blocker?",
+            slots=("customer_owner",),
+            expected_terms=("acme pilot is blocked", "lina", "june 18"),
+            expected_evidence=("ev-010",),
+            stale_terms=("mara owns",),
+            relevant_evidence=("ev-010",),
+        ),
+        Probe(
+            name="model_routing",
+            question="How should the agent route model calls now?",
+            slots=("model_routing",),
+            expected_terms=("small local reranker", "gpt-4.1 only handles synthesis"),
+            expected_evidence=("ev-011",),
+            stale_terms=("gpt-4.1 for every turn",),
+            relevant_evidence=("ev-011",),
+        ),
+        Probe(
+            name="primary_metric",
+            question="What is the primary benchmark metric?",
+            slots=("primary_metric",),
+            expected_terms=("decision freshness accuracy",),
+            expected_evidence=("ev-012",),
+            stale_terms=("user satisfaction",),
+            relevant_evidence=("ev-012",),
+        ),
+    ]
+
+
+class MemoryBackend:
+    name = "base"
+
+    def __init__(self, records: list[DecisionRecord]) -> None:
+        self.records = records
+
+    def answer(self, probe: Probe) -> Answer:
+        start = time.perf_counter()
+        selected = self.retrieve(probe)
+        answer = self.render_answer(selected)
+        latency_ms = (time.perf_counter() - start) * 1000
+        return Answer(
+            backend=self.name,
+            probe=probe.name,
+            answer=answer,
+            evidence_ids=tuple(record.evidence_id for record in selected),
+            retrieved_tokens=sum(self.record_tokens(record) for record in selected),
+            latency_ms=latency_ms,
+        )
+
+    def retrieve(self, probe: Probe) -> list[DecisionRecord]:
+        raise NotImplementedError
+
+    def render_answer(self, records: list[DecisionRecord]) -> str:
+        if not records:
+            return "No decision found."
+        parts = []
+        for record in records:
+            value = record.value
+            if record.secret:
+                value = f"{value} {record.secret}"
+            parts.append(f"{record.slot}: {value} Evidence: {record.evidence_id}.")
+        return " ".join(parts)
+
+    @staticmethod
+    def record_tokens(record: DecisionRecord) -> int:
+        secret = f" {record.secret}" if record.secret else ""
+        return token_count(f"{record.slot} {record.value} {record.rationale}{secret}")
+
+
+class ActiveDecisionDigest(MemoryBackend):
+    name = "active_decision_digest"
+
+    def __init__(self, records: list[DecisionRecord]) -> None:
+        super().__init__(records)
+        self.current_by_slot: dict[str, DecisionRecord] = {}
+        for record in records:
+            if record.status == "current":
+                self.current_by_slot[record.slot] = record
+            elif record.status in {"superseded", "rejected"}:
+                self.current_by_slot.pop(record.slot, None)
+
+    def retrieve(self, probe: Probe) -> list[DecisionRecord]:
+        return [
+            self.current_by_slot[slot]
+            for slot in probe.slots
+            if slot in self.current_by_slot
+        ]
+
+
+class PassiveGraphHistory(MemoryBackend):
+    name = "passive_graph_history"
+
+    def retrieve(self, probe: Probe) -> list[DecisionRecord]:
+        return [record for record in self.records if record.slot in probe.slots]
+
+    def render_answer(self, records: list[DecisionRecord]) -> str:
+        if not records:
+            return "No decision node found."
+        grouped: dict[str, list[DecisionRecord]] = {}
+        for record in records:
+            grouped.setdefault(record.slot, []).append(record)
+        parts = []
+        for slot, slot_records in grouped.items():
+            states = []
+            for record in slot_records:
+                value = record.value
+                if record.secret:
+                    value = f"{value} {record.secret}"
+                states.append(f"{record.status}: {value} ({record.evidence_id})")
+            parts.append(f"{slot} possible states: {' | '.join(states)}.")
+        return " ".join(parts)
+
+
+class AppendOnlyLog(MemoryBackend):
+    name = "append_only_log"
+
+    def retrieve(self, probe: Probe) -> list[DecisionRecord]:
+        query_terms = set(tokenize(probe.question))
+        selected = []
+        for record in self.records:
+            record_terms = set(record.relevant_terms) | set(tokenize(record.value))
+            if record.slot in probe.slots or query_terms.intersection(record_terms):
+                selected.append(record)
+        return selected
+
+
+class RecentWindowLog(MemoryBackend):
+    name = "recent_window_log"
+
+    def __init__(self, records: list[DecisionRecord], window_size: int = 4) -> None:
+        super().__init__(records)
+        self.window_size = window_size
+
+    def retrieve(self, probe: Probe) -> list[DecisionRecord]:
+        window = self.records[-self.window_size :]
+        return [record for record in window if record.slot in probe.slots]
+
+
+def score_answers(answers: list[Answer], expected: list[Probe]) -> BackendSummary:
+    expected_by_name = {probe.name: probe for probe in expected}
+    correct = 0
+    evidence_hits = 0
+    evidence_total = 0
+    stale_conflicts = 0
+    secret_leaks = 0
+    relevant_evidence_hits = 0
+    retrieved_evidence_total = 0
+
+    for answer in answers:
+        probe = expected_by_name[answer.probe]
+        has_expected_terms = contains_all(answer.answer, probe.expected_terms)
+        has_expected_evidence = all(
+            evidence in answer.evidence_ids for evidence in probe.expected_evidence
+        )
+        has_stale = contains_any(answer.answer, probe.stale_terms)
+        leaked_secret = contains_any(answer.answer, SECRET_MARKERS)
+        if has_expected_terms and has_expected_evidence and not has_stale and not leaked_secret:
+            correct += 1
+        evidence_hits += sum(
+            evidence in answer.evidence_ids for evidence in probe.expected_evidence
+        )
+        evidence_total += len(probe.expected_evidence)
+        stale_conflicts += int(has_stale)
+        secret_leaks += int(leaked_secret)
+        relevant_evidence_hits += sum(
+            evidence in probe.relevant_evidence for evidence in answer.evidence_ids
+        )
+        retrieved_evidence_total += len(answer.evidence_ids)
+
+    total = len(answers)
+    tokens = [answer.retrieved_tokens for answer in answers]
+    latencies = [answer.latency_ms for answer in answers]
+    return BackendSummary(
+        backend=answers[0].backend if answers else "unknown",
+        accuracy=correct / total if total else 0.0,
+        evidence_coverage=evidence_hits / evidence_total if evidence_total else 0.0,
+        stale_conflict_rate=stale_conflicts / total if total else 0.0,
+        secret_leak_rate=secret_leaks / total if total else 0.0,
+        avg_retrieved_tokens=sum(tokens) / total if total else 0.0,
+        p95_latency_ms=percentile_95(latencies),
+        signal_noise_ratio=(
+            relevant_evidence_hits / retrieved_evidence_total
+            if retrieved_evidence_total
+            else 0.0
+        ),
+    )
+
+
+def run() -> dict[str, object]:
+    records = decision_records()
+    expected = probes()
+    backends: list[MemoryBackend] = [
+        ActiveDecisionDigest(records),
+        PassiveGraphHistory(records),
+        AppendOnlyLog(records),
+        RecentWindowLog(records),
+    ]
+    all_answers: dict[str, list[Answer]] = {}
+    summaries: list[BackendSummary] = []
+    for backend in backends:
+        answers = [backend.answer(probe) for probe in expected]
+        all_answers[backend.name] = answers
+        summaries.append(score_answers(answers, expected))
+
+    return {
+        "scenario": "research-decision-memory",
+        "records": [asdict(record) for record in records],
+        "probes": [asdict(probe) for probe in expected],
+        "summaries": [asdict(summary) for summary in summaries],
+        "answers": {
+            backend: [asdict(answer) for answer in answers]
+            for backend, answers in all_answers.items()
+        },
+    }
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def summary_rows(payload: dict[str, object]) -> list[dict[str, object]]:
+    return list(payload["summaries"])  # type: ignore[arg-type]
+
+
+def markdown_report(payload: dict[str, object]) -> str:
+    rows = summary_rows(payload)
+    lines = [
+        "# Research Decision Memory Results",
+        "",
+        "| Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | p95 ms | Signal/Noise |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in rows:
+        lines.append(
+            "| {backend} | {accuracy:.2%} | {evidence_coverage:.2%} | "
+            "{stale_conflict_rate:.2%} | {secret_leak_rate:.2%} | "
+            "{avg_retrieved_tokens:.2f} | {p95_latency_ms:.4f} | "
+            "{signal_noise_ratio:.2%} |".format(**row)
+        )
+    lines.append("")
+    lines.append("Generated with `run_benchmark.py` using only stdlib components.")
+    return "\n".join(lines) + "\n"
+
+
+def write_markdown(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(markdown_report(payload), encoding="utf-8")
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    print(markdown_report(payload))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional JSON output path.",
+    )
+    parser.add_argument(
+        "--markdown",
+        type=Path,
+        default=None,
+        help="Optional Markdown report path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    payload = run()
+    if args.output:
+        write_json(args.output, payload)
+    if args.markdown:
+        write_markdown(args.markdown, payload)
+    print_summary(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/research-decision-memory/run_benchmark.py
+++ b/examples/benchmarks/research-decision-memory/run_benchmark.py
@@ -17,7 +17,11 @@ from pathlib import Path
 from typing import Iterable
 
 
-SECRET_MARKERS = ("sk-test-", "private_token_", "secret=")
+SECRET_MARKERS = (
+    "synthetic_secret_marker_",
+    "fake_token_marker_",
+    "dummy_secret_marker=",
+)
 
 
 @dataclass(frozen=True)
@@ -172,7 +176,7 @@ def decision_records() -> list[DecisionRecord]:
             rationale="Security review found synthetic keys in exported transcript fixtures.",
             relevant_terms=("data", "logs", "redaction", "raw", "safe"),
             stale_terms=("raw support logs are safe",),
-            secret="sk-test-123456",
+            secret="synthetic_secret_marker_123456",
         ),
         DecisionRecord(
             turn=8,
@@ -274,7 +278,7 @@ def probes() -> list[Probe]:
             slots=("data_handling",),
             expected_terms=("redaction before logs enter memory",),
             expected_evidence=("ev-008",),
-            stale_terms=("raw support logs are safe", "sk-test-123456"),
+            stale_terms=("raw support logs are safe", "synthetic_secret_marker_123456"),
             relevant_evidence=("ev-008",),
         ),
         Probe(

--- a/examples/benchmarks/research-decision-memory/test_benchmark.py
+++ b/examples/benchmarks/research-decision-memory/test_benchmark.py
@@ -1,0 +1,71 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import run_benchmark
+
+
+class ResearchDecisionMemoryBenchmarkTest(unittest.TestCase):
+    def test_active_digest_keeps_current_decisions(self) -> None:
+        payload = run_benchmark.run()
+        summary = self._summary(payload, "active_decision_digest")
+
+        self.assertEqual(summary["accuracy"], 1.0)
+        self.assertEqual(summary["evidence_coverage"], 1.0)
+        self.assertEqual(summary["stale_conflict_rate"], 0.0)
+        self.assertEqual(summary["secret_leak_rate"], 0.0)
+
+    def test_append_only_log_retrieves_stale_context(self) -> None:
+        payload = run_benchmark.run()
+        active = self._summary(payload, "active_decision_digest")
+        append_only = self._summary(payload, "append_only_log")
+
+        self.assertGreater(
+            append_only["avg_retrieved_tokens"], active["avg_retrieved_tokens"]
+        )
+        self.assertGreater(append_only["stale_conflict_rate"], 0.0)
+        self.assertLess(append_only["accuracy"], active["accuracy"])
+
+    def test_recent_window_forgets_older_current_decisions(self) -> None:
+        payload = run_benchmark.run()
+        recent = self._summary(payload, "recent_window_log")
+
+        self.assertLess(recent["accuracy"], 1.0)
+        target_answer = self._answer(payload, "recent_window_log", "target_segment")
+        self.assertEqual(target_answer["answer"], "No decision found.")
+
+    def test_passive_graph_history_keeps_conflicting_states(self) -> None:
+        payload = run_benchmark.run()
+        graph = self._summary(payload, "passive_graph_history")
+
+        self.assertGreater(graph["stale_conflict_rate"], 0.0)
+        self.assertLess(graph["accuracy"], 1.0)
+
+    def test_writers_emit_json_and_markdown(self) -> None:
+        payload = run_benchmark.run()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_path = Path(tmpdir) / "results.json"
+            md_path = Path(tmpdir) / "results.md"
+            run_benchmark.write_json(json_path, payload)
+            run_benchmark.write_markdown(md_path, payload)
+
+            self.assertIn("active_decision_digest", json_path.read_text())
+            self.assertIn("Research Decision Memory Results", md_path.read_text())
+
+    @staticmethod
+    def _summary(payload: dict, backend: str) -> dict:
+        for summary in payload["summaries"]:
+            if summary["backend"] == backend:
+                return summary
+        raise AssertionError(f"Missing summary for {backend}")
+
+    @staticmethod
+    def _answer(payload: dict, backend: str, probe: str) -> dict:
+        for answer in payload["answers"][backend]:
+            if answer["probe"] == probe:
+                return answer
+        raise AssertionError(f"Missing answer for {backend}:{probe}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/benchmarks/research-decision-memory/test_benchmark.py
+++ b/examples/benchmarks/research-decision-memory/test_benchmark.py
@@ -41,7 +41,7 @@ class ResearchDecisionMemoryBenchmarkTest(unittest.TestCase):
         self.assertGreater(graph["stale_conflict_rate"], 0.0)
         self.assertLess(graph["accuracy"], 1.0)
 
-    def test_writers_emit_json_and_markdown(self) -> None:
+    def test_writers_emit_reproducible_json_and_markdown(self) -> None:
         payload = run_benchmark.run()
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "results.json"
@@ -49,8 +49,20 @@ class ResearchDecisionMemoryBenchmarkTest(unittest.TestCase):
             run_benchmark.write_json(json_path, payload)
             run_benchmark.write_markdown(md_path, payload)
 
-            self.assertIn("active_decision_digest", json_path.read_text())
-            self.assertIn("Research Decision Memory Results", md_path.read_text())
+            json_text = json_path.read_text()
+            markdown_text = md_path.read_text()
+            self.assertIn("active_decision_digest", json_text)
+            self.assertNotIn("p95_latency_ms", json_text)
+            self.assertNotIn("latency_ms", json_text)
+            self.assertIn("Research Decision Memory Results", markdown_text)
+            self.assertNotIn("| p95 ms |", markdown_text)
+
+    def test_live_markdown_keeps_latency_metric(self) -> None:
+        payload = run_benchmark.run()
+
+        report = run_benchmark.markdown_report(payload)
+
+        self.assertIn("p95 ms", report)
 
     @staticmethod
     def _summary(payload: dict, backend: str) -> dict:


### PR DESCRIPTION
/claim #639

BountyHub bounty: https://www.bountyhub.dev/bounty/view/ec58c800-823e-4134-b027-99838e096d4b

## Summary

Adds `examples/benchmarks/research-decision-memory`, a credential-free benchmark for issue #639 focused on long-running research and product agents that must preserve the current decision trail while suppressing superseded assumptions.

The scenario tracks target segment, pricing, deployment constraints, launch readiness, data handling, customer ownership, model routing, and the primary benchmark metric across multiple sessions where early hypotheses are corrected by later evidence.

## Strategies compared

- `active_decision_digest`: Memanto-style typed digest with current decision slots, evidence IDs, and redaction of erased facts
- `passive_graph_history`: graph-style historical state memory that keeps conflicting states unless reconciled by the caller
- `append_only_log`: raw transcript retrieval that brings back stale assumptions and synthetic secrets
- `recent_window_log`: sliding recent-window baseline that avoids old stale facts but forgets older still-valid decisions

## Sample results

| Backend | Accuracy | Evidence | Stale Conflicts | Secret Leaks | Avg Tokens | Signal/Noise |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| active_decision_digest | 100.00% | 100.00% | 0.00% | 0.00% | 21.12 | 100.00% |
| passive_graph_history | 50.00% | 100.00% | 50.00% | 12.50% | 30.50 | 66.67% |
| append_only_log | 50.00% | 100.00% | 50.00% | 12.50% | 167.25 | 12.31% |
| recent_window_log | 50.00% | 50.00% | 0.00% | 0.00% | 10.62 | 100.00% |

## Validation

```bash
py -3 examples/benchmarks/research-decision-memory/run_benchmark.py --output examples/benchmarks/research-decision-memory/results/sample_results.json --markdown examples/benchmarks/research-decision-memory/results/sample_results.md
py -3 -m unittest discover -s examples/benchmarks/research-decision-memory -p test_*.py
py -3 -m py_compile examples/benchmarks/research-decision-memory/run_benchmark.py examples/benchmarks/research-decision-memory/test_benchmark.py
git diff --check
```

Local validation passed: report generation, 5 unittest tests, py_compile, and git diff --check.

Social showcase: pending. I did not fabricate a Reddit/X link from this environment.

No private payout details or real secrets are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Research Decision Memory benchmark with a runnable, deterministic script that evaluates multiple memory strategies and reports per-backend metrics (accuracy, evidence coverage, stale conflict rate, secret leak rate, token footprint, latency, signal/noise).

* **Documentation**
  * Added README describing scenario, strategies, metrics, and CLI usage.
  * Added reproducible sample results in JSON and Markdown; notes that the benchmark uses only the Python standard library.

* **Tests**
  * Added unit tests validating benchmark behavior, metrics, and output generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->