### PR TITLE
fix: update pyproject for new langgraph release

### DIFF
--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-memanto"
-version = "0.1.0"
+version = "0.1.1"
 description = "LangGraph tools and integration for Memanto's persistent memory"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
- Update pyproject to version 0.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.1.1 for the LangGraph integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->