### PR TITLE
Feat/ans onprem

### DIFF
--- a/memanto/app/clients/backend.py
+++ b/memanto/app/clients/backend.py
@@ -4,23 +4,20 @@ Backend selection and protocol for Memanto's Moorcheh client.
 Memanto can talk to two backends:
 - ``cloud``   - Moorcheh Cloud via the ``moorcheh_sdk`` package (API key).
 - ``on-prem`` - A local ``moorcheh`` server (Docker) via the ``moorcheh-client``
-  package. No Moorcheh API key needed. Does not support ``answer.generate``.
+  package. No Moorcheh API key needed.
 
-Both clients are expected to expose the same attribute shape used across
-``memanto/app/`` (namespaces/documents/answer with method names matching the
-cloud SDK), so service code never branches on backend.
+Both clients expose the same ``namespaces / documents / similarity_search /
+answer / files / vectors`` shape, so service code never branches on backend.
 """
 
+import json
 from enum import Enum
+from pathlib import Path
 
 
 class Backend(str, Enum):
     CLOUD = "cloud"
     ON_PREM = "on-prem"
-
-
-class OnPremFeatureUnavailable(Exception):
-    """Raised when on-prem hits a feature that only Moorcheh Cloud supports."""
 
 
 def parse_backend(value: str | None) -> Backend:
@@ -31,3 +28,31 @@ def parse_backend(value: str | None) -> Backend:
         return Backend(value.strip().lower())
     except ValueError:
         return Backend.CLOUD
+
+
+def get_active_llm_model(cloud_default: str) -> str | None:
+    """Active LLM model identifier for ``answer.generate`` / summary.
+
+    Cloud: returns ``cloud_default`` (i.e. ``settings.ANSWER_MODEL`` or
+    ``settings.SUMMARY_MODEL`` — caller picks the right one).
+
+    On-prem: returns ``llm_model`` from ``~/.memanto/on-prem/state.json`` (set
+    during onboarding). Returns ``None`` when state is missing/empty so the
+    caller can omit ``ai_model`` and let the on-prem server fall back to its
+    ``~/.moorcheh/config.json`` LLM. No coercion magic happens elsewhere in
+    the stack — what this returns is what gets sent.
+    """
+    # Local import to avoid circular dependency with ``app.config``.
+    from memanto.app.config import settings
+
+    if parse_backend(settings.MEMANTO_BACKEND) == Backend.CLOUD:
+        return cloud_default
+
+    state_path = Path.home() / ".memanto" / "on-prem" / "state.json"
+    if not state_path.exists():
+        return None
+    try:
+        state = json.loads(state_path.read_text())
+    except Exception:
+        return None
+    return state.get("llm_model") or None

--- a/memanto/app/clients/moorcheh.py
+++ b/memanto/app/clients/moorcheh.py
@@ -53,7 +53,10 @@ class MoorchehClientSingleton:
             if self._client is None:
                 from memanto.app.clients.onprem import OnPremClient
 
-                self._client = OnPremClient(base_url=settings.MOORCHEH_ONPREM_URL)
+                self._client = OnPremClient(
+                    base_url=settings.MOORCHEH_ONPREM_URL,
+                    timeout=settings.MOORCHEH_ONPREM_TIMEOUT,
+                )
             return self._client
 
         # Cloud path
@@ -71,7 +74,8 @@ class MoorchehClientSingleton:
                 from memanto.app.clients.onprem import AsyncOnPremClient
 
                 self._async_client = AsyncOnPremClient(
-                    base_url=settings.MOORCHEH_ONPREM_URL
+                    base_url=settings.MOORCHEH_ONPREM_URL,
+                    timeout=settings.MOORCHEH_ONPREM_TIMEOUT,
                 )
             return self._async_client
 

--- a/memanto/app/clients/onprem.py
+++ b/memanto/app/clients/onprem.py
@@ -1,203 +1,142 @@
 """
 On-prem Moorcheh client.
 
-Wraps ``moorcheh.MoorchehApiClient`` (from the ``moorcheh-client`` PyPI package)
-and exposes the same ``client.namespaces.*`` / ``client.documents.*`` /
-``client.similarity_search.*`` / ``client.answer.*`` shape that Memanto's
-services use against the cloud SDK, so no service code branches on backend.
+Wraps ``moorcheh.MoorchehClient`` (``moorcheh-client>=0.1.3``) and exposes the
+same ``namespaces / documents / similarity_search / answer / files / vectors``
+shape that the cloud SDK does, so Memanto's service layer never branches on
+backend. Only one thin adapter is needed: ``_DocumentsAdapter`` adds cloud's
+``documents.upload_file(namespace, path)`` on top of on-prem's
+``files.upload(namespace, files=[{path: container_path}])`` (copies into
+``~/.moorcheh/uploads`` and converts the host path).
 
-Real on-prem method signatures (verified against docs):
-
-    client.create_namespace(payload: dict) -> dict
-        payload = {"namespace_name": str, "type": "text"|"vector",
-                   "vector_dimension": int (vector only)}
-
-    client.list_namespaces() -> dict
-        returns {"namespaces": [{"namespace_name", "type",
-                 "vector_dimension", "item_count", "created_at"}, ...]}
-
-    client.delete_namespace(namespace_name: str) -> dict
-        returns {"job_id": ...}
-
-    client.upload_namespace_documents(namespace_name: str, payload: dict) -> dict
-        payload = {"documents": [{"id": str, "text": str, ...metadata}, ...]}
-
-    client.get_namespace_items(namespace_name: str, payload: dict) -> dict
-        payload = {"ids": [str, ...]}  # <= 100 ids
-
-    client.delete_namespace_items(namespace_name: str, payload: dict) -> dict
-        payload = {"ids": [str, ...]}
-
-    client.search(payload: dict) -> dict
-        payload = {"query": str|list, "namespaces": [str, ...],
-                   "top_k": int, "threshold": float, "metadata": dict,
-                   "kiosk_mode": bool}
-
-    client.health() -> dict
-
-Cloud-only surface Memanto uses that on-prem does not expose - we surface a
-clear ``OnPremFeatureUnavailable`` instead of silently failing:
-    - documents.upload_file (no server-side file chunking on on-prem)
-    - answer.generate (cloud-only LLM RAG)
+The ``ai_model`` value passed to ``answer.generate`` is the caller's
+responsibility — on-prem callers must source it from
+``~/.memanto/on-prem/state.json`` via ``config_manager.get_answer_config()``,
+which is backend-aware. No silent model coercion happens here.
 """
 
+from pathlib import Path
 from typing import Any
 
-from memanto.app.clients.backend import OnPremFeatureUnavailable
-
 _DEFAULT_URL = "http://localhost:8080"
-_ANSWER_DISABLED_MSG = (
-    "answer is not available on the on-prem backend. "
-    "Switch with: memanto config backend cloud"
-)
-_FEATURE_DISABLED_MSG = (
-    "{feature} is not available on the on-prem backend. "
-    "Switch with: memanto config backend cloud"
-)
 
 
 def _import_raw_client() -> Any:
     """Lazy import so the cloud path doesn't require ``moorcheh-client``."""
     try:
-        from moorcheh import MoorchehApiClient  # type: ignore[import-not-found]
+        from moorcheh import MoorchehClient  # type: ignore[import-not-found]
     except ImportError as e:  # pragma: no cover - exercised at runtime only
         raise RuntimeError(
             "moorcheh-client is not installed. Run: pip install moorcheh-client"
         ) from e
-    return MoorchehApiClient
+    return MoorchehClient
 
 
-class _NamespacesAdapter:
-    def __init__(self, raw: Any) -> None:
-        self._raw = raw
-
-    def create(self, namespace_name: str, type: str = "text") -> Any:
-        return self._raw.create_namespace(
-            {"namespace_name": namespace_name, "type": type}
+def _import_docker_runtime_helpers() -> tuple[Any, Any]:
+    """Lazy import of upload-dir helpers; only needed for ``upload_file``."""
+    try:
+        from moorcheh.docker_runtime import (  # type: ignore[import-not-found]
+            ensure_upload_dir,
+            host_path_to_container_upload_path,
         )
-
-    def list(self) -> Any:
-        return self._raw.list_namespaces()
-
-    def delete(self, namespace_name: str) -> Any:
-        return self._raw.delete_namespace(namespace_name)
+    except ImportError as e:  # pragma: no cover - exercised at runtime only
+        raise RuntimeError(
+            "moorcheh.docker_runtime helpers are unavailable. "
+            "Upgrade with: pip install -U moorcheh-client"
+        ) from e
+    return ensure_upload_dir, host_path_to_container_upload_path
 
 
 class _DocumentsAdapter:
+    """Wraps ``client.documents`` to add ``upload_file`` (cloud-shape) on top of
+    on-prem's ``client.files.upload``.
+
+    All other methods (upload, get, delete, fetch_text_data) pass through to
+    the native on-prem ``documents`` resource unchanged.
+    """
+
     def __init__(self, raw: Any) -> None:
         self._raw = raw
 
-    def upload(self, namespace_name: str, documents: list[dict]) -> Any:
-        return self._raw.upload_namespace_documents(
-            namespace_name, {"documents": documents}
-        )
+    def __getattr__(self, name: str) -> Any:
+        # Delegate any method not defined here (upload, get, delete,
+        # fetch_text_data, upload_job_status) to the real on-prem documents
+        # resource. Only invoked for attrs not found on the instance.
+        return getattr(self._raw.documents, name)
 
-    def get(self, namespace_name: str, ids: list[str]) -> Any:
-        return self._raw.get_namespace_items(namespace_name, {"ids": ids})
+    def upload_file(self, namespace_name: str, file_path: str | Path) -> dict:
+        """Cloud-shape ``documents.upload_file`` for on-prem.
 
-    def delete(self, namespace_name: str, ids: list[str]) -> Any:
-        return self._raw.delete_namespace_items(namespace_name, {"ids": ids})
+        Copies the file into ``~/.moorcheh/uploads``, converts the host path
+        to the container-visible path, and submits via ``client.files.upload``.
 
-    def upload_file(self, *_args: Any, **_kwargs: Any) -> Any:
-        raise OnPremFeatureUnavailable(
-            _FEATURE_DISABLED_MSG.format(feature="upload_file")
-        )
-
-    def fetch_text_data(
-        self,
-        namespace_name: str,
-        limit: int = 100,
-        next_token: str | None = None,
-    ) -> Any:
-        """Emulate cloud's ``fetch_text_data`` via on-prem ``search``.
-
-        Cloud returns ``{"items": [...], "pagination": {...}}`` paginated up
-        to ``limit`` per page; we approximate the same shape with a broad
-        search so callers (memory export, UI, etc.) keep working without
-        branching. On-prem search has no cursor, so we always return a
-        single page (no ``pagination`` key) — callers should terminate
-        their pagination loop when ``has_more`` is missing/false.
+        Returns a dict shaped like the cloud SDK's ``FileUploadResponse``
+        (``success``, ``message``, ``file_name``, ``file_size``,
+        ``namespace``) so route handlers don't need to branch by backend.
+        Note: on-prem upload is asynchronous; ``success=True`` here means the
+        job was accepted, not that indexing has completed.
         """
-        last_exc: Exception | None = None
-        for probe_query in (" ", "*", "."):
-            try:
-                resp = self._raw.search(
-                    {
-                        "query": probe_query,
-                        "namespaces": [namespace_name],
-                        "top_k": limit,
-                    }
-                )
-                if isinstance(resp, dict):
-                    items = resp.get("results", resp.get("items", []))
-                    return {"items": items}
-                return resp
-            except Exception as e:
-                last_exc = e
-                continue
-        raise (
-            last_exc
-            if last_exc is not None
-            else RuntimeError("search failed for fetch_text_data")
+        import shutil
+
+        ensure_upload_dir, host_path_to_container_upload_path = (
+            _import_docker_runtime_helpers()
         )
 
+        src = Path(file_path).resolve()
+        if not src.is_file():
+            raise FileNotFoundError(f"upload_file: not a file: {src}")
 
-class _SimilaritySearchAdapter:
-    """Maps cloud's ``client.similarity_search.query(...)`` onto on-prem ``search``."""
+        upload_root = ensure_upload_dir()
+        host_file = (upload_root / src.name).resolve()
+        if host_file != src:
+            shutil.copy2(src, host_file)
+        container_path = host_path_to_container_upload_path(host_file, upload_root)
 
-    def __init__(self, raw: Any) -> None:
-        self._raw = raw
-
-    def query(
-        self,
-        query: str,
-        namespaces: list[str] | None = None,
-        top_k: int = 10,
-        threshold: float | None = None,
-        kiosk_mode: bool = False,
-        **kwargs: Any,
-    ) -> Any:
-        payload: dict[str, Any] = {
-            "query": query,
-            "namespaces": namespaces or [],
-            "top_k": top_k,
-            "kiosk_mode": kiosk_mode,
+        resp = self._raw.files.upload(
+            namespace_name,
+            files=[{"path": container_path, "force_reindex": False}],
+        )
+        if not isinstance(resp, dict):
+            resp = {}
+        return {
+            "success": True,
+            "message": resp.get("message", "Upload job submitted."),
+            "namespace": namespace_name,
+            "file_name": src.name,
+            "file_size": host_file.stat().st_size if host_file.exists() else None,
+            "job_id": resp.get("job_id"),
         }
-        if threshold is not None:
-            payload["threshold"] = threshold
-        # Pass-through for any future kwargs (e.g. metadata filter).
-        payload.update(kwargs)
-        return self._raw.search(payload)
-
-
-class _AnswerAdapter:
-    def generate(self, *_args: Any, **_kwargs: Any) -> Any:
-        raise OnPremFeatureUnavailable(_ANSWER_DISABLED_MSG)
 
 
 class OnPremClient:
-    """Cloud-shaped facade over ``MoorchehApiClient``."""
+    """Cloud-shaped facade over ``moorcheh.MoorchehClient``."""
 
-    def __init__(self, base_url: str | None = None) -> None:
+    def __init__(self, base_url: str | None = None, timeout: int | None = None) -> None:
         client_cls = _import_raw_client()
-        self._raw = client_cls(base_url or _DEFAULT_URL)
-        self.namespaces = _NamespacesAdapter(self._raw)
+        # ``moorcheh.MoorchehClient`` defaults timeout=30 which is too short
+        # for first-call LLM cold-starts (Ollama can take 1-2 minutes to load
+        # qwen2.5). Honor the caller's timeout when provided; otherwise let
+        # the raw client use its own default.
+        if timeout is not None:
+            self._raw = client_cls(base_url or _DEFAULT_URL, timeout=timeout)
+        else:
+            self._raw = client_cls(base_url or _DEFAULT_URL)
+        # Native resources expose the same shape as the cloud SDK — pass through.
+        self.namespaces = self._raw.namespaces
+        self.similarity_search = self._raw.similarity_search
+        self.answer = self._raw.answer
+        self.vectors = self._raw.vectors
+        self.files = self._raw.files
+        # Only ``documents`` needs an adapter (cloud's ``upload_file`` shim).
         self.documents = _DocumentsAdapter(self._raw)
-        self.similarity_search = _SimilaritySearchAdapter(self._raw)
-        self.answer = _AnswerAdapter()
+
+    def health(self) -> Any:
+        return self._raw.health()
 
 
-class AsyncOnPremClient:
+class AsyncOnPremClient(OnPremClient):
     """Async facade. Memanto only awaits a handful of methods via
     ``asyncio.to_thread`` today, so we expose the same sync ``OnPremClient``
-    shape - existing ``await asyncio.to_thread(client.documents.upload, ...)``
+    shape — existing ``await asyncio.to_thread(client.documents.upload, ...)``
     calls keep working unchanged.
     """
-
-    def __init__(self, base_url: str | None = None) -> None:
-        client_cls = _import_raw_client()
-        self._raw = client_cls(base_url or _DEFAULT_URL)
-        self.namespaces = _NamespacesAdapter(self._raw)
-        self.documents = _DocumentsAdapter(self._raw)
-        self.similarity_search = _SimilaritySearchAdapter(self._raw)
-        self.answer = _AnswerAdapter()

--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -57,11 +57,21 @@ if _config_file.exists():
             _backend = _memanto.get("backend")
             if _backend:
                 os.environ["MEMANTO_BACKEND"] = str(_backend)
-            _on_prem = _memanto.get("on_prem", {})
-            _op_url = _on_prem.get("url")
+    except Exception:
+        pass
+
+    # On-prem URL lives in ~/.memanto/on-prem/state.json so on-prem onboarding
+    # never has to touch the shared cloud yaml.
+    try:
+        import json as _json
+
+        _state_path = Path.home() / ".memanto" / "on-prem" / "state.json"
+        if _state_path.exists():
+            _state = _json.loads(_state_path.read_text())
+            _op_url = _state.get("url")
             if _op_url:
                 os.environ["MOORCHEH_ONPREM_URL"] = str(_op_url)
-            _op_embed = _on_prem.get("embedding_provider")
+            _op_embed = _state.get("embedding_provider")
             if _op_embed:
                 os.environ["MOORCHEH_ONPREM_EMBEDDING_PROVIDER"] = str(_op_embed)
     except Exception:
@@ -107,6 +117,9 @@ class Settings(BaseSettings):
     MEMANTO_BACKEND: str = "cloud"
     MOORCHEH_ONPREM_URL: str = "http://localhost:8080"
     MOORCHEH_ONPREM_EMBEDDING_PROVIDER: str = ""
+    # HTTP read timeout (seconds) for the on-prem MoorchehClient. Default 300
+    # so first-call LLM cold-starts on Ollama don't hit the SDK's 30s default.
+    MOORCHEH_ONPREM_TIMEOUT: int = 300
 
     # Server Configuration
     HOST: str = "0.0.0.0"

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field, field_validator
 
+from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import settings
 from memanto.app.core import MemoryRecord
@@ -326,23 +327,6 @@ async def upload_file(
             )
         )
 
-    # upload_file relies on Moorcheh's server-side file chunking, which the
-    # on-prem image does not expose; refuse early instead of bubbling up the
-    # adapter's OnPremFeatureUnavailable as an opaque 500. The client is
-    # acquired after this guard so a half-configured on-prem env (backend set
-    # but moorcheh-client not installed) still returns 501, not 500.
-    from memanto.app.clients.backend import Backend, parse_backend
-
-    if parse_backend(settings.MEMANTO_BACKEND) == Backend.ON_PREM:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                "upload-file is not available on the on-prem backend "
-                "(no server-side file chunking). "
-                "Switch with: memanto config backend cloud"
-            ),
-        )
-
     client = get_moorcheh_client()
 
     # Validate file extension before reading
@@ -490,20 +474,6 @@ async def answer(
             )
         )
 
-    # answer.generate is a cloud-only feature; refuse early on on-prem. The
-    # client is acquired after this guard so a half-configured on-prem env
-    # (backend set but moorcheh-client not installed) still returns 501, not 500.
-    from memanto.app.clients.backend import Backend, parse_backend
-
-    if parse_backend(settings.MEMANTO_BACKEND) == Backend.ON_PREM:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                "answer is not available on the on-prem backend. "
-                "Switch with: memanto config backend cloud"
-            ),
-        )
-
     client = get_moorcheh_client()
 
     # Resolve defaults from settings
@@ -515,7 +485,9 @@ async def answer(
         else settings.ANSWER_TEMPERATURE
     )
     ai_model = (
-        request.ai_model if request.ai_model is not None else settings.ANSWER_MODEL
+        request.ai_model
+        if request.ai_model is not None
+        else get_active_llm_model(settings.ANSWER_MODEL)
     )
 
     try:
@@ -609,18 +581,6 @@ async def generate_daily_summary(
             )
         )
 
-    from memanto.app.clients.backend import Backend, parse_backend
-
-    if parse_backend(settings.MEMANTO_BACKEND) == Backend.ON_PREM:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                "daily-summary uses the LLM Answer endpoint, which is not "
-                "available on the on-prem backend. "
-                "Switch with: memanto config backend cloud"
-            ),
-        )
-
     resolved_date = request.date or datetime.now().strftime("%Y-%m-%d")
     try:
         result = await asyncio.to_thread(
@@ -655,18 +615,6 @@ async def generate_conflict_report(
             Exception(
                 f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
             )
-        )
-
-    from memanto.app.clients.backend import Backend, parse_backend
-
-    if parse_backend(settings.MEMANTO_BACKEND) == Backend.ON_PREM:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                "conflict detection uses the LLM Answer endpoint, which is not "
-                "available on the on-prem backend. "
-                "Switch with: memanto config backend cloud"
-            ),
         )
 
     resolved_date = request.date or datetime.now().strftime("%Y-%m-%d")

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -9,9 +9,8 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
-from moorcheh_sdk import MoorchehClient
-
-from memanto.app.clients.backend import Backend, parse_backend
+from memanto.app.clients.backend import get_active_llm_model
+from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import get_data_dir, settings
 from memanto.app.core import create_memory_scope
 from memanto.app.services.session_service import get_session_service
@@ -29,7 +28,6 @@ class DailyAnalysisService:
 
     def __init__(
         self,
-        api_key: str,
         sessions_dir: Path | None = None,
         summaries_dir: Path | None = None,
     ):
@@ -37,11 +35,9 @@ class DailyAnalysisService:
         Initialize the daily analysis service.
 
         Args:
-            api_key: Moorcheh API key (passed from DirectClient config)
             sessions_dir: Directory where session MD files are stored
             summaries_dir: Directory where generated summaries will be saved
         """
-        self.api_key = api_key
         self.session_service = get_session_service()
         self.sessions_dir = sessions_dir or self.session_service.sessions_dir
         self.summaries_dir = summaries_dir or get_data_dir() / "summaries"
@@ -53,13 +49,6 @@ class DailyAnalysisService:
         """
         Generate a daily natural language summary for an agent and date.
         """
-        if parse_backend(settings.MEMANTO_BACKEND) == Backend.ON_PREM:
-            print(
-                "[INFO] daily_summary skipped: answer is cloud-only "
-                "(memanto config backend cloud to enable)."
-            )
-            return {"status": "skipped_on_prem"}
-
         # Find all relevant session MD files
         pattern = f"{agent_id}_{date}_*_summary.md"
         session_files = list(self.sessions_dir.glob(pattern))
@@ -80,7 +69,7 @@ class DailyAnalysisService:
 
         full_text = "\n\n---\n\n".join(combined_content)
 
-        client = MoorchehClient(api_key=self.api_key)
+        client = get_moorcheh_client()
         scope = create_memory_scope("agent", agent_id)
         namespace = scope.to_namespace()
 
@@ -104,7 +93,7 @@ Format the output as a Markdown report:
             result = client.answer.generate(
                 namespace=namespace,
                 query=summary_prompt,
-                ai_model=settings.SUMMARY_MODEL,
+                ai_model=get_active_llm_model(settings.SUMMARY_MODEL),
                 top_k=50,
             )
             summary_text = result.get("answer", "Failed to generate summary.")
@@ -149,13 +138,6 @@ Format the output as a Markdown report:
         """
         Generate a structured conflict report (Contradictions, Conflicts, Updates, Duplicates).
         """
-        if parse_backend(settings.MEMANTO_BACKEND) == Backend.ON_PREM:
-            print(
-                "[INFO] conflict_report skipped: answer is cloud-only "
-                "(memanto config backend cloud to enable)."
-            )
-            return {"status": "skipped_on_prem"}
-
         conflicts_dir = Path.home() / ".memanto" / "conflicts"
         conflicts_dir.mkdir(parents=True, exist_ok=True)
 
@@ -172,7 +154,7 @@ Format the output as a Markdown report:
 
         full_text = "\n\n---\n\n".join(combined_content)
 
-        client = MoorchehClient(api_key=self.api_key)
+        client = get_moorcheh_client()
         scope = create_memory_scope("agent", agent_id)
         namespace = scope.to_namespace()
 
@@ -214,7 +196,7 @@ Example response format:
             result = client.answer.generate(
                 namespace=namespace,
                 query=conflict_prompt,
-                ai_model=settings.SUMMARY_MODEL,
+                ai_model=get_active_llm_model(settings.SUMMARY_MODEL),
                 top_k=50,
             )
             conflict_text = result.get("answer", "[]")

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from moorcheh_sdk import MoorchehClient
 
+from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.config import settings
 from memanto.app.core import create_memory_scope
 from memanto.app.utils.errors import MemoryError
@@ -657,10 +658,14 @@ class MemoryReadService:
                     raise MemoryError("No namespaces found")
                 namespace = namespaces[0]
 
-            # Generate answer
-            answer_result = self.client.answer.generate(
-                namespace=namespace, query=query, ai_model=settings.ANSWER_MODEL
-            )
+            # Generate answer. Omit ai_model when on-prem state has no LLM
+            # configured so the on-prem server uses its own default; the
+            # cloud SDK requires a string so don't pass None there.
+            gen_kwargs: dict = {"namespace": namespace, "query": query}
+            _model = get_active_llm_model(settings.ANSWER_MODEL)
+            if _model is not None:
+                gen_kwargs["ai_model"] = _model
+            answer_result = self.client.answer.generate(**gen_kwargs)
 
             return {
                 "answer": answer_result["answer"],

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
+from memanto.app.clients.backend import Backend
 from memanto.app.config import settings
 from memanto.cli.client.direct_client import DirectClient
 from memanto.cli.config.manager import ConfigManager
@@ -57,6 +58,9 @@ async def get_ui_config():
         "on_prem": {
             "url": onprem_cfg.get("url", "http://localhost:8080"),
             "embedding_provider": onprem_cfg.get("embedding_provider", ""),
+            "embedding_model": onprem_cfg.get("embedding_model", ""),
+            "llm_provider": onprem_cfg.get("llm_provider", ""),
+            "llm_model": onprem_cfg.get("llm_model", ""),
         },
         "data_dir": str(_config_manager.get_data_dir()),
         "server": {
@@ -118,13 +122,24 @@ async def update_ui_config(updates: dict):
 
     if "answer" in updates and isinstance(updates["answer"], dict):
         ans = updates["answer"]
-        _config_manager.set_answer_config(
-            model=ans.get("model"),
-            temperature=float(ans["temperature"]) if "temperature" in ans else None,
-            answer_limit=int(ans["answer_limit"]) if "answer_limit" in ans else None,
-            threshold=float(ans["threshold"]) if "threshold" in ans else None,
-            kiosk_mode=bool(ans["kiosk_mode"]) if "kiosk_mode" in ans else None,
-        )
+        # On-prem: the Answer panel is provider/model/api_key only — temperature
+        # etc. are cloud-only knobs. Persist into state.json (provider/model)
+        # and ~/.moorcheh/config.json (full block) without touching the shared
+        # cloud yaml's ``answer.*`` namespace.
+        if _config_manager.get_backend() == Backend.ON_PREM:
+            _update_onprem_answer(ans)
+        else:
+            _config_manager.set_answer_config(
+                model=ans.get("model"),
+                temperature=float(ans["temperature"])
+                if "temperature" in ans
+                else None,
+                answer_limit=int(ans["answer_limit"])
+                if "answer_limit" in ans
+                else None,
+                threshold=float(ans["threshold"]) if "threshold" in ans else None,
+                kiosk_mode=bool(ans["kiosk_mode"]) if "kiosk_mode" in ans else None,
+            )
 
     if "recall" in updates and isinstance(updates["recall"], dict):
         rec = updates["recall"]
@@ -136,6 +151,181 @@ async def update_ui_config(updates: dict):
         )
 
     return {"status": "updated", "updated_keys": list(updates.keys())}
+
+
+_ONPREM_LLM_PROVIDERS = {"ollama", "openai", "cohere"}
+
+
+def _update_onprem_answer(ans: dict) -> None:
+    """Persist on-prem LLM config: state.json (provider/model) + ``~/.moorcheh/config.json``.
+
+    Does NOT restart the server — the ``/api/ui/onprem/restart`` endpoint owns
+    that. Provider/model are required; ``api_key`` is optional for paid
+    providers (falls back to whatever is currently in
+    ``~/.moorcheh/config.json``) and ignored for ollama.
+    """
+    from memanto.cli.commands.core import _recover_moorcheh_api_key
+
+    state = _config_manager.get_onprem_state()
+    embedding_provider = state.get("embedding_provider")
+    embedding_model = state.get("embedding_model")
+    if not embedding_provider or not embedding_model:
+        raise HTTPException(
+            status_code=400,
+            detail="On-prem not onboarded — run `memanto config backend on-prem` first.",
+        )
+
+    # Provider may be omitted (model-only change); reuse the currently
+    # configured provider in that case.
+    provider = (ans.get("provider") or state.get("llm_provider") or "").strip().lower()
+    model = (ans.get("model") or "").strip()
+    api_key = (ans.get("api_key") or "").strip()
+
+    if not provider or not model:
+        raise HTTPException(
+            status_code=400, detail="Provider and model are required."
+        )
+    if provider not in _ONPREM_LLM_PROVIDERS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported on-prem LLM provider: {provider}. "
+            f"Allowed: {', '.join(sorted(_ONPREM_LLM_PROVIDERS))}.",
+        )
+
+    if provider == "ollama":
+        api_key = ""
+    elif not api_key:
+        # User left the field blank: keep whatever key is already in
+        # ~/.moorcheh/config.json (typical case: changing model only).
+        api_key = _recover_moorcheh_api_key("llm", provider)
+        if not api_key:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{provider} requires an API key — none provided and "
+                "none found in ~/.moorcheh/config.json. Enter one and save again.",
+            )
+
+    embedding_key = _recover_moorcheh_api_key("embedding", embedding_provider)
+    try:
+        from moorcheh.user_config import (  # type: ignore[import-not-found]
+            EmbeddingConfig,
+            LlmConfig,
+            default_base_url,
+            save_runtime_config,
+        )
+
+        save_runtime_config(
+            EmbeddingConfig(
+                provider=embedding_provider,
+                model=embedding_model,
+                api_key=embedding_key or None,
+                base_url=default_base_url(embedding_provider),
+            ),
+            LlmConfig(
+                provider=provider,
+                model=model,
+                api_key=api_key or None,
+                base_url=default_base_url(provider),
+            ),
+        )
+    except ImportError as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"moorcheh-client not installed: {e}",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to persist LLM config: {e}"
+        )
+
+    _config_manager.set_onprem_state(llm_provider=provider, llm_model=model)
+
+
+@router.post("/api/ui/onprem/restart")
+async def restart_onprem_backend():
+    """Bounce the on-prem moorcheh stack so it re-reads ``~/.moorcheh/config.json``.
+
+    ``moorcheh down`` + ``moorcheh up`` (with embedding flags recovered from
+    state.json / config.json). Blocks for up to ~6 minutes total (5min for
+    ``up``, 60s for ``/health``).
+    """
+    import subprocess
+
+    import httpx as _httpx
+
+    if _config_manager.get_backend() != Backend.ON_PREM:
+        raise HTTPException(
+            status_code=400, detail="Active backend is not on-prem."
+        )
+
+    from memanto.cli.commands.core import _recover_moorcheh_api_key
+
+    state = _config_manager.get_onprem_state()
+    embedding_provider = state.get("embedding_provider")
+    embedding_model = state.get("embedding_model")
+    if not embedding_provider or not embedding_model:
+        raise HTTPException(
+            status_code=400,
+            detail="On-prem not onboarded — run `memanto config backend on-prem` first.",
+        )
+    embedding_key = _recover_moorcheh_api_key("embedding", embedding_provider)
+
+    # `moorcheh down` is best-effort: if the stack isn't running, that's fine —
+    # we still want to try `up` after.
+    try:
+        subprocess.run(
+            ["moorcheh", "down"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=60,
+            check=False,
+        )
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=500, detail="`moorcheh` CLI not found on PATH."
+        )
+    except subprocess.TimeoutExpired:
+        raise HTTPException(
+            status_code=500, detail="`moorcheh down` timed out after 60s."
+        )
+
+    up_args = [
+        "moorcheh",
+        "up",
+        "--embedding-provider",
+        embedding_provider,
+        "--embedding-model",
+        embedding_model,
+    ]
+    if embedding_key:
+        up_args.extend(["--embedding-api-key", embedding_key])
+    try:
+        subprocess.run(up_args, check=True, timeout=300)
+    except subprocess.CalledProcessError as e:
+        raise HTTPException(
+            status_code=500, detail=f"`moorcheh up` failed: {e}"
+        )
+    except subprocess.TimeoutExpired:
+        raise HTTPException(
+            status_code=500, detail="`moorcheh up` timed out after 5 minutes."
+        )
+
+    health_url = (
+        state.get("url") or "http://localhost:8080"
+    ).rstrip("/") + "/health"
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        try:
+            resp = _httpx.get(health_url, timeout=2.0)
+            if resp.status_code == 200:
+                return {"status": "ok", "message": "Server restarted"}
+        except Exception:
+            pass
+        time.sleep(1.0)
+    raise HTTPException(
+        status_code=500,
+        detail=f"Server did not become healthy at {health_url} within 60s.",
+    )
 
 
 @router.put("/api/ui/api-key")

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -131,9 +131,7 @@ async def update_ui_config(updates: dict):
         else:
             _config_manager.set_answer_config(
                 model=ans.get("model"),
-                temperature=float(ans["temperature"])
-                if "temperature" in ans
-                else None,
+                temperature=float(ans["temperature"]) if "temperature" in ans else None,
                 answer_limit=int(ans["answer_limit"])
                 if "answer_limit" in ans
                 else None,
@@ -182,9 +180,7 @@ def _update_onprem_answer(ans: dict) -> None:
     api_key = (ans.get("api_key") or "").strip()
 
     if not provider or not model:
-        raise HTTPException(
-            status_code=400, detail="Provider and model are required."
-        )
+        raise HTTPException(status_code=400, detail="Provider and model are required.")
     if provider not in _ONPREM_LLM_PROVIDERS:
         raise HTTPException(
             status_code=400,
@@ -254,9 +250,7 @@ async def restart_onprem_backend():
     import httpx as _httpx
 
     if _config_manager.get_backend() != Backend.ON_PREM:
-        raise HTTPException(
-            status_code=400, detail="Active backend is not on-prem."
-        )
+        raise HTTPException(status_code=400, detail="Active backend is not on-prem.")
 
     from memanto.cli.commands.core import _recover_moorcheh_api_key
 
@@ -281,9 +275,7 @@ async def restart_onprem_backend():
             check=False,
         )
     except FileNotFoundError:
-        raise HTTPException(
-            status_code=500, detail="`moorcheh` CLI not found on PATH."
-        )
+        raise HTTPException(status_code=500, detail="`moorcheh` CLI not found on PATH.")
     except subprocess.TimeoutExpired:
         raise HTTPException(
             status_code=500, detail="`moorcheh down` timed out after 60s."
@@ -302,17 +294,13 @@ async def restart_onprem_backend():
     try:
         subprocess.run(up_args, check=True, timeout=300)
     except subprocess.CalledProcessError as e:
-        raise HTTPException(
-            status_code=500, detail=f"`moorcheh up` failed: {e}"
-        )
+        raise HTTPException(status_code=500, detail=f"`moorcheh up` failed: {e}")
     except subprocess.TimeoutExpired:
         raise HTTPException(
             status_code=500, detail="`moorcheh up` timed out after 5 minutes."
         )
 
-    health_url = (
-        state.get("url") or "http://localhost:8080"
-    ).rstrip("/") + "/health"
+    health_url = (state.get("url") or "http://localhost:8080").rstrip("/") + "/health"
     deadline = time.time() + 60
     while time.time() < deadline:
         try:

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -3333,7 +3333,8 @@
                 <table class="config-table" style="width:100%"><tbody>
                 <tr><td>Mode</td><td><span class="badge badge-success">On-Prem</span></td></tr>
                 <tr><td>Server URL</td><td><code style="font-family:var(--font-mono)">${escHtml(onPremCfg.url || 'http://localhost:8080')}</code></td></tr>
-                <tr><td>Embedding Provider</td><td>${onPremCfg.embedding_provider ? `<code style="font-family:var(--font-mono)">${escHtml(onPremCfg.embedding_provider)}</code>` : '—'}</td></tr>
+                <tr><td>Embedding</td><td>${onPremCfg.embedding_provider ? `<code style="font-family:var(--font-mono)">${escHtml(onPremCfg.embedding_provider)}${onPremCfg.embedding_model ? ' / ' + escHtml(onPremCfg.embedding_model) : ''}</code>` : '—'}</td></tr>
+                <tr><td>LLM</td><td>${onPremCfg.llm_provider ? `<code style="font-family:var(--font-mono)">${escHtml(onPremCfg.llm_provider)}${onPremCfg.llm_model ? ' / ' + escHtml(onPremCfg.llm_model) : ''}</code>` : '—'}</td></tr>
                 </tbody></table>
                 <p style="color:var(--text-dim);font-size:12px;margin-top:8px">Switch backends via CLI: <code style="color:var(--accent);font-family:var(--font-mono)">memanto config backend cloud</code></p>
             </div>
@@ -3390,6 +3391,35 @@
                 </div>
             </div>
             <!-- ANSWER CONFIG -->
+            ${onPrem ? `
+            <div class="panel">
+                <div class="panel-title">🤖 LLM Config (On-Prem)</div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label>Provider</label>
+                        <select id="cfgOnpremLlmProvider" onchange="onpremProviderChanged()">
+                            <option value="ollama" ${onPremCfg.llm_provider === 'ollama' ? 'selected' : ''}>Ollama (local)</option>
+                            <option value="openai" ${onPremCfg.llm_provider === 'openai' ? 'selected' : ''}>OpenAI</option>
+                            <option value="cohere" ${onPremCfg.llm_provider === 'cohere' ? 'selected' : ''}>Cohere</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>Model</label>
+                        <input id="cfgOnpremLlmModel" value="${escHtml(onPremCfg.llm_model || '')}" placeholder="e.g. qwen2.5, gpt-4o-mini, command-r-plus-08-2024">
+                    </div>
+                </div>
+                <div class="form-group" id="cfgOnpremApiKeyRow" style="${(onPremCfg.llm_provider || 'ollama') === 'ollama' ? 'display:none' : ''}">
+                    <label>API Key</label>
+                    <input id="cfgOnpremApiKey" type="password" placeholder="Leave blank to keep existing key">
+                </div>
+                <div style="display:flex;gap:12px;margin-top:8px">
+                    <button class="btn btn-secondary" id="btnRestartOnprem" onclick="restartOnpremBackend()">↻ Restart On-Prem Backend</button>
+                </div>
+                <p style="color:var(--text-dim);font-size:12px;margin-top:8px">
+                    Saving writes to <code style="font-family:var(--font-mono)">~/.memanto/on-prem/state.json</code> and <code style="font-family:var(--font-mono)">~/.moorcheh/config.json</code>. Click <strong>Restart</strong> to apply on the running server.
+                </p>
+            </div>
+            ` : `
             <div class="panel">
                 <div class="panel-title">🤖 Answer Config</div>
                 <div class="form-group"><label>Model</label><input id="cfgAiModel" value="${ans.model || 'anthropic.claude-sonnet-4-20250514-v1:0'}" placeholder="e.g. anthropic.claude-sonnet-4-20250514-v1:0"></div>
@@ -3405,6 +3435,7 @@
                     ${cfgToggle('cfgAiKioskMode', 'Kiosk mode (apply threshold to filter low-relevance results)', ans.kiosk_mode ?? false)}
                 </div>
             </div>
+            `}
             <!-- TOP N LIMIT -->
             <div class="panel">
                 <div class="panel-title">🎯 Search & Retrieval</div>
@@ -3492,13 +3523,23 @@
                         auto_renew_enabled: document.getElementById('cfgSessAutoRenew').checked,
                         auto_renew_interval_hours: parseInt(document.getElementById('cfgSessRenewInterval').value) || 6,
                     },
-                    answer: {
-                        model: document.getElementById('cfgAiModel').value.trim(),
-                        temperature: parseFloat(document.getElementById('cfgAiTemp').value) || 0.7,
-                        answer_limit: parseInt(document.getElementById('cfgAiAnswerLimit').value) || 5,
-                        threshold: parseFloat(document.getElementById('cfgAiThreshold').value) || 0.25,
-                        kiosk_mode: document.getElementById('cfgAiKioskMode').checked,
-                    },
+                    answer: isOnPrem()
+                        ? (() => {
+                            const providerEl = document.getElementById('cfgOnpremLlmProvider');
+                            const modelEl = document.getElementById('cfgOnpremLlmModel');
+                            const keyEl = document.getElementById('cfgOnpremApiKey');
+                            const p = { provider: providerEl ? providerEl.value : '', model: modelEl ? modelEl.value.trim() : '' };
+                            const k = keyEl ? keyEl.value : '';
+                            if (k) p.api_key = k;
+                            return p;
+                        })()
+                        : {
+                            model: document.getElementById('cfgAiModel').value.trim(),
+                            temperature: parseFloat(document.getElementById('cfgAiTemp').value) || 0.7,
+                            answer_limit: parseInt(document.getElementById('cfgAiAnswerLimit').value) || 5,
+                            threshold: parseFloat(document.getElementById('cfgAiThreshold').value) || 0.25,
+                            kiosk_mode: document.getElementById('cfgAiKioskMode').checked,
+                        },
                     recall: {
                         limit: parseInt(document.getElementById('cfgRecallLimit').value) || 10,
                         min_similarity: document.getElementById('cfgRecallMinSimilarity').value ? parseFloat(document.getElementById('cfgRecallMinSimilarity').value) : 0
@@ -3516,6 +3557,30 @@
 
         // Legacy alias
         async function saveConfig() { await saveAllConfig(); }
+
+        // Toggle the API-key row when the on-prem LLM provider changes.
+        function onpremProviderChanged() {
+            const sel = document.getElementById('cfgOnpremLlmProvider');
+            const row = document.getElementById('cfgOnpremApiKeyRow');
+            if (!sel || !row) return;
+            row.style.display = sel.value === 'ollama' ? 'none' : '';
+        }
+
+        // Restart the on-prem stack so the moorcheh server re-reads its config.
+        async function restartOnpremBackend() {
+            if (!confirm('Restart the on-prem stack? `moorcheh down` + `moorcheh up` typically takes 20-60s.')) return;
+            const btn = document.getElementById('btnRestartOnprem');
+            if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner"></span> Restarting...'; }
+            try {
+                const res = await api('POST', '/api/ui/onprem/restart', {});
+                toast('Backend restarted: ' + (res.message || 'ok'));
+                S.config = await api('GET', '/api/ui/config');
+            } catch (e) {
+                toast('Restart failed: ' + e.message, 'error');
+            } finally {
+                if (btn) { btn.disabled = false; btn.innerHTML = '↻ Restart On-Prem Backend'; }
+            }
+        }
 
         // ================================================================
         // CONFLICTS

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2366,8 +2366,6 @@
             loadConflictBadge();
         }
 
-        // On-prem disables features the Moorcheh on-prem server doesn't expose
-        // (LLM answer, file upload). Hide those affordances; cloud is unchanged.
         function isOnPrem() {
             return !!(S.config && S.config.backend === 'on-prem');
         }
@@ -2377,21 +2375,8 @@
         }
 
         function applyBackendVisibility() {
-            const onPrem = isOnPrem();
-            const answerTab = document.querySelector('#pgTabs .tab[data-tab="ask"]');
-            const uploadTab = document.querySelector('#pgTabs .tab[data-tab="upload"]');
-            const answerPanel = document.getElementById('tab-ask');
-            const uploadPanel = document.getElementById('tab-upload');
-            [answerTab, uploadTab, answerPanel, uploadPanel].forEach(el => {
-                if (el) el.style.display = onPrem ? 'none' : '';
-            });
-            // If the previously-active tab is now hidden, fall back to Remember.
-            if (onPrem) {
-                const activeTab = document.querySelector('#pgTabs .tab.active');
-                if (activeTab && (activeTab.dataset.tab === 'ask' || activeTab.dataset.tab === 'upload')) {
-                    document.querySelector('#pgTabs .tab[data-tab="remember"]').click();
-                }
-            }
+            // Both backends expose the same Playground features (answer, upload,
+            // recall, remember). Reserved for future backend-specific affordances.
         }
 
         function updateSidebarStatus() {
@@ -3404,8 +3389,7 @@
                     ${cfgToggle('cfgSessAutoRenew', 'Auto-renew sessions before expiry', sess.auto_renew_enabled ?? true)}
                 </div>
             </div>
-            <!-- ANSWER CONFIG (cloud only — on-prem server does not expose RAG) -->
-            ${onPrem ? '' : `
+            <!-- ANSWER CONFIG -->
             <div class="panel">
                 <div class="panel-title">🤖 Answer Config</div>
                 <div class="form-group"><label>Model</label><input id="cfgAiModel" value="${ans.model || 'anthropic.claude-sonnet-4-20250514-v1:0'}" placeholder="e.g. anthropic.claude-sonnet-4-20250514-v1:0"></div>
@@ -3421,7 +3405,6 @@
                     ${cfgToggle('cfgAiKioskMode', 'Kiosk mode (apply threshold to filter low-relevance results)', ans.kiosk_mode ?? false)}
                 </div>
             </div>
-            `}
             <!-- TOP N LIMIT -->
             <div class="panel">
                 <div class="panel-title">🎯 Search & Retrieval</div>
@@ -3509,17 +3492,13 @@
                         auto_renew_enabled: document.getElementById('cfgSessAutoRenew').checked,
                         auto_renew_interval_hours: parseInt(document.getElementById('cfgSessRenewInterval').value) || 6,
                     },
-                    // Answer Config panel is hidden on on-prem (no RAG support),
-                    // so its inputs may not be in the DOM — skip the block.
-                    ...(document.getElementById('cfgAiModel') ? {
-                        answer: {
-                            model: document.getElementById('cfgAiModel').value.trim(),
-                            temperature: parseFloat(document.getElementById('cfgAiTemp').value) || 0.7,
-                            answer_limit: parseInt(document.getElementById('cfgAiAnswerLimit').value) || 5,
-                            threshold: parseFloat(document.getElementById('cfgAiThreshold').value) || 0.25,
-                            kiosk_mode: document.getElementById('cfgAiKioskMode').checked,
-                        },
-                    } : {}),
+                    answer: {
+                        model: document.getElementById('cfgAiModel').value.trim(),
+                        temperature: parseFloat(document.getElementById('cfgAiTemp').value) || 0.7,
+                        answer_limit: parseInt(document.getElementById('cfgAiAnswerLimit').value) || 5,
+                        threshold: parseFloat(document.getElementById('cfgAiThreshold').value) || 0.25,
+                        kiosk_mode: document.getElementById('cfgAiKioskMode').checked,
+                    },
                     recall: {
                         limit: parseInt(document.getElementById('cfgRecallLimit').value) || 10,
                         min_similarity: document.getElementById('cfgRecallMinSimilarity').value ? parseFloat(document.getElementById('cfgRecallMinSimilarity').value) : 0

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -309,7 +309,7 @@ class DirectClient:
                 DailyAnalysisService,
             )
 
-            self._daily_analysis_service = DailyAnalysisService(api_key=self.api_key)
+            self._daily_analysis_service = DailyAnalysisService()
         return self._daily_analysis_service
 
     def _get_export_service(self):

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -150,7 +150,7 @@ class SdkClient:
                 DailyAnalysisService,
             )
 
-            self._daily_analysis_service = DailyAnalysisService(api_key=self.api_key)
+            self._daily_analysis_service = DailyAnalysisService()
         return self._daily_analysis_service
 
     def _get_export_service(self):

--- a/memanto/cli/commands/config_cmd.py
+++ b/memanto/cli/commands/config_cmd.py
@@ -49,14 +49,13 @@ def config_show():
     table.add_row("Interactive Mode", str(cli_cfg.get("interactive_mode", True)))
     table.add_row("Smart Parse", str(cli_cfg.get("smart_parse", True)))
 
-    # Answer Config (cloud only — on-prem server does not expose RAG)
-    if backend == Backend.CLOUD:
-        table.add_section()
-        table.add_row("[bold]Answer Config[/bold]", "")
-        table.add_row("  Model", ans_cfg.get("model", "—"))
-        table.add_row("  Temperature", str(ans_cfg.get("temperature", 0.7)))
-        table.add_row("  Limit", str(ans_cfg.get("answer_limit", 5)))
-        table.add_row("  Threshold", str(ans_cfg.get("threshold", 0.25)))
+    # Answer Config
+    table.add_section()
+    table.add_row("[bold]Answer Config[/bold]", "")
+    table.add_row("  Model", ans_cfg.get("model", "—"))
+    table.add_row("  Temperature", str(ans_cfg.get("temperature", 0.7)))
+    table.add_row("  Limit", str(ans_cfg.get("answer_limit", 5)))
+    table.add_row("  Threshold", str(ans_cfg.get("threshold", 0.25)))
 
     # Recall Config
     table.add_section()

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import time
 from datetime import datetime
+from pathlib import Path
 
 import httpx
 import typer
@@ -151,7 +152,25 @@ def _onprem_setup() -> None:
 
     _ensure_docker_available()
     _ensure_moorcheh_client_installed()
-    embedding_provider, embedding_model, embedding_key = _prompt_embedding_provider()
+
+    # Embedding model is a one-time choice (set on first on-prem onboarding).
+    # On subsequent runs — e.g., switching cloud→on-prem after having previously
+    # onboarded on-prem — reuse what state.json already has and recover the
+    # api_key from ~/.moorcheh/config.json. Skipping this would force the user
+    # to re-pick the same provider/model on every backend swap.
+    existing_state = config_manager.get_onprem_state()
+    if existing_state.get("embedding_provider") and existing_state.get(
+        "embedding_model"
+    ):
+        embedding_provider = existing_state["embedding_provider"]
+        embedding_model = existing_state["embedding_model"]
+        embedding_key = _recover_moorcheh_api_key("embedding", embedding_provider)
+        console.print(
+            f"[dim]  Reusing embedding from previous on-prem setup: "
+            f"{embedding_provider} / {embedding_model}[/dim]"
+        )
+    else:
+        embedding_provider, embedding_model, embedding_key = _prompt_embedding_provider()
     llm_provider, llm_model, llm_key = _prompt_llm_provider(
         embedding_provider, embedding_key
     )
@@ -343,6 +362,30 @@ def _prompt_llm_provider(
         f"[dim]  Ollama LLM model {model} will be pulled into the container.[/dim]"
     )
     return "ollama", model, ""
+
+
+def _recover_moorcheh_api_key(section: str, provider: str) -> str:
+    """Read an api_key out of ``~/.moorcheh/config.json`` for re-onboarding.
+
+    ``section`` is ``"embedding"`` or ``"llm"``. Returns ``""`` for providers
+    that don't need a key (ollama) or when the file/key is missing — callers
+    must handle that (typically by failing fast at ``moorcheh up`` if a paid
+    provider needs a key we couldn't recover).
+    """
+    if provider == "ollama":
+        return ""
+    import json as _json
+
+    cfg = Path.home() / ".moorcheh" / "config.json"
+    if not cfg.exists():
+        return ""
+    try:
+        data = _json.loads(cfg.read_text())
+    except Exception:
+        return ""
+    block = data.get(section) or {}
+    key = block.get("api_key") or ""
+    return key if isinstance(key, str) else ""
 
 
 def _persist_moorcheh_llm_config(

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -170,7 +170,9 @@ def _onprem_setup() -> None:
             f"{embedding_provider} / {embedding_model}[/dim]"
         )
     else:
-        embedding_provider, embedding_model, embedding_key = _prompt_embedding_provider()
+        embedding_provider, embedding_model, embedding_key = (
+            _prompt_embedding_provider()
+        )
     llm_provider, llm_model, llm_key = _prompt_llm_provider(
         embedding_provider, embedding_key
     )

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -2,7 +2,6 @@
 MEMANTO CLI - Core commands (status, serve, ui, main_callback).
 """
 
-import json
 import os
 import platform
 import shutil
@@ -96,8 +95,7 @@ def _prompt_backend_choice() -> Backend:
     )
     console.print(
         f"  [{BRIGHT}]2[/{BRIGHT}]  Moorcheh On-Prem  "
-        "[dim](~5-10 min install, Docker required, no API key, "
-        "no `answer` command)[/dim]"
+        "[dim](~5-10 min install, Docker required, no API key)[/dim]"
     )
     choice = typer.prompt("  Enter 1 or 2", default="1")
     console.print()
@@ -154,25 +152,44 @@ def _onprem_setup() -> None:
     _ensure_docker_available()
     _ensure_moorcheh_client_installed()
     embedding_provider, embedding_model, embedding_key = _prompt_embedding_provider()
+    llm_provider, llm_model, llm_key = _prompt_llm_provider(
+        embedding_provider, embedding_key
+    )
+    # Write the FULL config (embedding + LLM) to ~/.moorcheh/config.json BEFORE
+    # `moorcheh up`, so the server reads the complete config on first boot and
+    # we don't have to bounce the stack. `moorcheh up` itself only knows
+    # `--embedding-*` flags, so without this pre-write the LLM section would
+    # be missing until we restart.
+    _persist_moorcheh_llm_config(
+        embedding_provider,
+        embedding_model,
+        embedding_key,
+        llm_provider,
+        llm_model,
+        llm_key,
+    )
     _moorcheh_up_and_wait(embedding_provider, embedding_model, embedding_key)
 
-    # Ollama runs in a container started by `moorcheh up`; pull the embedding
-    # model inside that container now that the stack is healthy.
+    # Pull any Ollama models needed (embedding and/or LLM) inside the
+    # container started by `moorcheh up`.
     if embedding_provider == "ollama":
         _pull_ollama_model_in_container(embedding_model)
+    if llm_provider == "ollama" and llm_model != embedding_model:
+        _pull_ollama_model_in_container(llm_model)
 
-    # Persist on-prem config + write state.json under ~/.memanto/on-prem/.
-    onprem_dir = config_manager.config_dir / "on-prem"
-    onprem_dir.mkdir(parents=True, exist_ok=True)
-    state = {
-        "installed_at": datetime.utcnow().isoformat() + "Z",
-        "embedding_provider": embedding_provider,
-        "embedding_model": embedding_model,
-        "url": "http://localhost:8080",
-    }
-    (onprem_dir / "state.json").write_text(json.dumps(state, indent=2))
-    config_manager.set_onprem_config(
-        embedding_provider=embedding_provider, url="http://localhost:8080"
+    # Persist everything on-prem in ~/.memanto/on-prem/state.json — the
+    # shared ~/.memanto/config.yaml belongs to the cloud backend; on-prem
+    # never writes into it. ``ConfigManager.get_answer_config()`` reads
+    # ``llm_model`` from this file when the active backend is on-prem, so
+    # ``memanto answer`` automatically picks the right LLM without any
+    # cross-backend pollution.
+    config_manager.set_onprem_state(
+        installed_at=datetime.utcnow().isoformat() + "Z",
+        embedding_provider=embedding_provider,
+        embedding_model=embedding_model,
+        llm_provider=llm_provider,
+        llm_model=llm_model,
+        url="http://localhost:8080",
     )
 
 
@@ -210,8 +227,10 @@ def _ensure_moorcheh_client_installed() -> None:
 
     console.print("[dim]  Installing moorcheh-client...[/dim]")
     try:
+        # >=0.1.3 exposes namespaces/documents/files/answer resources matching
+        # the cloud SDK shape; on-prem Answer requires this version.
         subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "moorcheh-client"]
+            [sys.executable, "-m", "pip", "install", "moorcheh-client>=0.1.3"]
         )
     except subprocess.CalledProcessError as e:
         _error(f"Failed to install moorcheh-client: {e}")
@@ -255,6 +274,119 @@ def _prompt_embedding_provider() -> tuple[str, str, str]:
         "The embedding model will be pulled into that container.[/dim]"
     )
     return "ollama", "nomic-embed-text", ""
+
+
+# Valid on-prem LLM identifiers, sourced from moorcheh.user_config. Listed
+# explicitly so the prompt is stable even if moorcheh-client adds/removes
+# models. Keep in sync with ``moorcheh.user_config.LLM_PROVIDER_MODELS``.
+_LLM_RECOMMENDED = {
+    "ollama": "qwen2.5",
+    "openai": "gpt-4o-mini",
+    "cohere": "command-r-plus-08-2024",
+}
+
+
+def _prompt_llm_provider(
+    embedding_provider: str, embedding_key: str
+) -> tuple[str, str, str]:
+    """Ask user for LLM provider for ``answer.generate``.
+
+    Returns ``(provider, model, api_key_or_empty)``. Mirrors the embedding
+    flow: pick a provider, the recommended model is used automatically
+    (``qwen2.5`` / ``gpt-4o-mini`` / ``command-r-plus-08-2024``). Users who
+    want a different model can edit ``answer.model`` in
+    ``~/.memanto/on-prem/config.yaml`` later.
+    """
+    console.print()
+    console.print(f"[{BOLD_BRIGHT}]Answer LLM provider[/{BOLD_BRIGHT}]")
+    console.print(
+        f"  [{BRIGHT}]1[/{BRIGHT}]  Ollama (local, zero API keys)  "
+        f"[dim]- model: {_LLM_RECOMMENDED['ollama']}[/dim]"
+    )
+    console.print(
+        f"  [{BRIGHT}]2[/{BRIGHT}]  OpenAI  "
+        f"[dim]- model: {_LLM_RECOMMENDED['openai']}, requires an API key[/dim]"
+    )
+    console.print(
+        f"  [{BRIGHT}]3[/{BRIGHT}]  Cohere  "
+        f"[dim]- model: {_LLM_RECOMMENDED['cohere']}, requires an API key[/dim]"
+    )
+    # Default to whichever provider was chosen for embeddings (likely already
+    # has its key set), else Ollama.
+    default_choice = {"ollama": "1", "openai": "2", "cohere": "3"}.get(
+        embedding_provider, "1"
+    )
+    choice = typer.prompt("  Enter 1, 2, or 3", default=default_choice)
+    provider = {"1": "ollama", "2": "openai", "3": "cohere"}.get(
+        str(choice).strip(), "ollama"
+    )
+    model = _LLM_RECOMMENDED[provider]
+    console.print()
+
+    if provider in ("openai", "cohere"):
+        # Reuse the embedding API key when the same provider was chosen so we
+        # don't double-prompt; otherwise ask.
+        if provider == embedding_provider and embedding_key:
+            console.print(
+                f"[dim]  Reusing {provider.title()} API key from embedding setup.[/dim]"
+            )
+            key = embedding_key
+        else:
+            key = typer.prompt(
+                f"  Enter your {provider.title()} API key", hide_input=True
+            ).strip()
+            if not key:
+                _error(f"{provider.title()} API key cannot be empty.")
+        return provider, model, key
+
+    console.print(
+        f"[dim]  Ollama LLM model {model} will be pulled into the container.[/dim]"
+    )
+    return "ollama", model, ""
+
+
+def _persist_moorcheh_llm_config(
+    embedding_provider: str,
+    embedding_model: str,
+    embedding_key: str,
+    llm_provider: str,
+    llm_model: str,
+    llm_key: str,
+) -> None:
+    """Write the LLM section into ``~/.moorcheh/config.json``.
+
+    ``moorcheh up`` writes only the embedding section; the on-prem server
+    needs both to serve ``answer.generate``. Uses moorcheh-client's own
+    ``save_runtime_config`` helper so the schema stays in sync.
+    """
+    try:
+        from moorcheh.user_config import (  # type: ignore[import-not-found]
+            EmbeddingConfig,
+            LlmConfig,
+            default_base_url,
+            save_runtime_config,
+        )
+    except ImportError as e:
+        _error(f"moorcheh.user_config unavailable: {e}")
+        return
+
+    embedding_cfg = EmbeddingConfig(
+        provider=embedding_provider,
+        model=embedding_model,
+        api_key=embedding_key or None,
+        base_url=default_base_url(embedding_provider),
+    )
+    llm_cfg = LlmConfig(
+        provider=llm_provider,
+        model=llm_model,
+        api_key=llm_key or None,
+        base_url=default_base_url(llm_provider),
+    )
+    try:
+        save_runtime_config(embedding_cfg, llm_cfg)
+        console.print("[green]  ✓ LLM config saved to ~/.moorcheh/config.json[/green]")
+    except Exception as e:
+        _error(f"Failed to persist LLM config: {e}")
 
 
 def _pull_ollama_model_in_container(model: str) -> None:

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -186,15 +186,6 @@ def upload(
     """
     from pathlib import Path
 
-    from memanto.app.clients.backend import Backend
-
-    if config_manager.get_backend() == Backend.ON_PREM:
-        _error(
-            "upload is not available on the on-prem backend "
-            "(no server-side file chunking).",
-            hint="Switch with: memanto config backend cloud",
-        )
-
     start = time.perf_counter()
     active_agent_id, active_session_token = config_manager.get_active_session()
 
@@ -477,14 +468,6 @@ def answer(
     ),
 ):
     """Answer a question using RAG (Retrieval-Augmented Generation)."""
-    from memanto.app.clients.backend import Backend
-
-    if config_manager.get_backend() == Backend.ON_PREM:
-        _error(
-            "answer is not available on the on-prem backend.",
-            hint="Switch with: memanto config backend cloud",
-        )
-
     start = time.perf_counter()
     active_agent_id, active_session_token = config_manager.get_active_session()
 
@@ -541,15 +524,6 @@ def daily_summary(
     ),
 ):
     """Generate a daily AI summary from session memories."""
-    from memanto.app.clients.backend import Backend
-
-    if config_manager.get_backend() == Backend.ON_PREM:
-        _error(
-            "daily-summary uses the LLM Answer endpoint, which is not "
-            "available on the on-prem backend.",
-            hint="Switch with: memanto config backend cloud",
-        )
-
     start = time.perf_counter()
     active_agent_id, _ = config_manager.get_active_session()
 
@@ -629,15 +603,6 @@ def detect_conflicts(
 
     This is the command the schedule runs — see ``memanto schedule``.
     """
-    from memanto.app.clients.backend import Backend
-
-    if config_manager.get_backend() == Backend.ON_PREM:
-        _error(
-            "detect-conflicts uses the LLM Answer endpoint, which is not "
-            "available on the on-prem backend.",
-            hint="Switch with: memanto config backend cloud",
-        )
-
     start = time.perf_counter()
     active_agent_id, _ = config_manager.get_active_session()
 

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -149,30 +149,64 @@ class ConfigManager:
         """Persist the active backend choice."""
         self.set("backend", backend.value)
 
-    # On-prem config
+    # On-prem config — strictly isolated under ~/.memanto/on-prem/state.json.
+    # On-prem onboarding/runtime must NOT write into the shared yaml; that file
+    # is the cloud's namespace.
+
+    def _onprem_state_path(self) -> Path:
+        return self.config_dir / "on-prem" / "state.json"
+
+    def get_onprem_state(self) -> dict:
+        """Read the on-prem state.json. Returns ``{}`` if missing/unreadable."""
+        p = self._onprem_state_path()
+        if not p.exists():
+            return {}
+        try:
+            data = json.loads(p.read_text())
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def set_onprem_state(self, **updates) -> None:
+        """Merge ``updates`` into the on-prem state.json (creates dir if needed)."""
+        p = self._onprem_state_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        data = self.get_onprem_state()
+        data.update({k: v for k, v in updates.items() if v is not None})
+        p.write_text(json.dumps(data, indent=2))
 
     def get_onprem_config(self) -> dict:
-        """Get on-prem config dict with defaults."""
+        """Get on-prem config dict (url, embedding_provider, llm_model, ...).
+
+        Sourced exclusively from ``~/.memanto/on-prem/state.json``; defaults
+        apply only when keys are missing from state.
+        """
         defaults = {
             "url": "http://localhost:8080",
             "embedding_provider": "",
+            "embedding_model": "",
+            "llm_provider": "",
+            "llm_model": "",
         }
-        defaults.update(self.load_yaml().get("on_prem", {}))
+        defaults.update(self.get_onprem_state())
         return defaults
 
     def set_onprem_config(
         self,
         embedding_provider: str | None = None,
         url: str | None = None,
+        embedding_model: str | None = None,
+        llm_provider: str | None = None,
+        llm_model: str | None = None,
     ) -> None:
-        """Persist on-prem config values."""
-        data = self.load_yaml()
-        on_prem = data.setdefault("on_prem", {})
-        if embedding_provider is not None:
-            on_prem["embedding_provider"] = embedding_provider
-        if url is not None:
-            on_prem["url"] = url
-        self.save_yaml(data)
+        """Persist on-prem config values into ``~/.memanto/on-prem/state.json``."""
+        self.set_onprem_state(
+            embedding_provider=embedding_provider,
+            url=url,
+            embedding_model=embedding_model,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+        )
 
     # Per-backend data directory
 
@@ -269,7 +303,14 @@ class ConfigManager:
         return defaults
 
     def get_answer_config(self) -> dict:
-        """Get Answer config dict with defaults."""
+        """Get Answer config dict with defaults.
+
+        The ``model`` field is backend-specific: cloud uses the shared yaml
+        (default Bedrock Claude); on-prem uses ``llm_model`` from
+        ``~/.memanto/on-prem/state.json`` (set during onboarding). All other
+        knobs (temperature/threshold/answer_limit/kiosk_mode) are shared
+        because they describe how to query, not which provider to hit.
+        """
         data = self.load_yaml()
         answer = data.get("answer", {})
 
@@ -281,6 +322,12 @@ class ConfigManager:
             "kiosk_mode": False,
         }
         defaults.update(answer)
+        if self.get_backend() == Backend.ON_PREM:
+            # On-prem: override model with the onboarding-selected LLM. Do NOT
+            # fall back to the cloud default — pass through None so callers
+            # can omit ``ai_model`` and let the on-prem server use its
+            # ``~/.moorcheh/config.json`` LLM.
+            defaults["model"] = self.get_onprem_state().get("llm_model") or None
         return defaults
 
     def set_answer_config(

--- a/memanto/cli/ui/display.py
+++ b/memanto/cli/ui/display.py
@@ -169,19 +169,13 @@ def show_welcome_banner(config_manager: ConfigManager) -> None:
         ("memanto agent create <agent_name_or_id>", "Create a new memanto agent"),
         ('memanto remember "..."', "Store a memory"),
         ('memanto recall "..."', "Search memories"),
+        ('memanto answer "..."', "Ask a question (RAG)"),
+        ("memanto connect list", "See agent integrations"),
+        ("memanto connect <agent>", "Connect to an AI agent"),
+        ("memanto ui", "Open the web dashboard UI"),
+        ("memanto status", "Full dashboard"),
+        ("memanto serve", "Start local REST API server"),
     ]
-    # `answer` is a cloud-only feature (RAG via Moorcheh's LLM endpoint).
-    if backend == Backend.CLOUD:
-        commands.append(('memanto answer "..."', "Ask a question (RAG)"))
-    commands.extend(
-        [
-            ("memanto connect list", "See agent integrations"),
-            ("memanto connect <agent>", "Connect to an AI agent"),
-            ("memanto ui", "Open the web dashboard UI"),
-            ("memanto status", "Full dashboard"),
-            ("memanto serve", "Start local REST API server"),
-        ]
-    )
 
     cmd_table = Table(show_header=False, box=None, padding=(0, 1), show_edge=False)
     cmd_table.add_column("Cmd", style=BOLD_BRIGHT, min_width=28)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4,11 +4,9 @@ Tests for the backend abstraction (cloud vs on-prem dispatcher).
 
 from unittest.mock import patch
 
-import pytest
-
 from memanto.app.clients.backend import (
     Backend,
-    OnPremFeatureUnavailable,
+    get_active_llm_model,
     parse_backend,
 )
 
@@ -30,22 +28,85 @@ class TestBackendParse:
         assert parse_backend("hybrid") == Backend.CLOUD
 
 
+class TestActiveLlmModel:
+    """``get_active_llm_model`` is the single source of truth for which model
+    ID gets sent to ``answer.generate``. Cloud returns the configured cloud
+    default; on-prem reads ``llm_model`` from the on-prem state.json without
+    any fallback to cloud values.
+    """
+
+    def test_cloud_returns_cloud_default(self, monkeypatch):
+        from memanto.app.config import settings
+
+        monkeypatch.setattr(settings, "MEMANTO_BACKEND", "cloud")
+        assert get_active_llm_model("anthropic.claude-sonnet-4-6") == (
+            "anthropic.claude-sonnet-4-6"
+        )
+
+    def test_on_prem_reads_state_llm_model(self, tmp_path, monkeypatch):
+        import json
+
+        from memanto.app.config import settings
+
+        monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+        # Redirect Path.home() so we don't depend on developer's real state.
+        monkeypatch.setattr(
+            "memanto.app.clients.backend.Path",
+            type(
+                "P",
+                (),
+                {"home": classmethod(lambda cls: tmp_path)},
+            ),
+        )
+        state_dir = tmp_path / ".memanto" / "on-prem"
+        state_dir.mkdir(parents=True)
+        (state_dir / "state.json").write_text(json.dumps({"llm_model": "qwen2.5"}))
+        # On-prem must NOT fall back to the cloud default.
+        assert get_active_llm_model("anthropic.claude-sonnet-4-6") == "qwen2.5"
+
+    def test_on_prem_missing_state_returns_none(self, tmp_path, monkeypatch):
+        from memanto.app.config import settings
+
+        monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+        monkeypatch.setattr(
+            "memanto.app.clients.backend.Path",
+            type("P", (), {"home": classmethod(lambda cls: tmp_path)}),
+        )
+        # No state.json → return None so callers omit ai_model and let the
+        # server use its own configured LLM (no silent cloud fallback).
+        assert get_active_llm_model("anthropic.claude-sonnet-4-6") is None
+
+
 class TestOnPremClient:
-    def test_answer_generate_always_raises(self):
-        """OnPremClient.answer.generate must reject calls with a clear message."""
-        # Import is lazy so test runs even without ``moorcheh-client`` installed.
+    def test_answer_generate_delegates_to_raw_client(self):
+        """OnPremClient.answer.generate must pass through to the on-prem
+        ``moorcheh.MoorchehClient`` — answer is supported on-prem since
+        moorcheh-client v0.1.3."""
         from memanto.app.clients import onprem
 
-        # Stub _import_raw_client so we don't need the real package.
+        class _FakeAnswer:
+            def __init__(self):
+                self.called_with = None
+
+            def generate(self, **kwargs):
+                self.called_with = kwargs
+                return {"answer": "ok", "namespace": kwargs.get("namespace")}
+
         class _FakeRaw:
-            def __init__(self, base_url):
+            def __init__(self, base_url, timeout=None):
                 self.base_url = base_url
+                self.timeout = timeout
+                self.namespaces = object()
+                self.documents = object()
+                self.similarity_search = object()
+                self.answer = _FakeAnswer()
+                self.vectors = object()
+                self.files = object()
 
         with patch.object(onprem, "_import_raw_client", return_value=_FakeRaw):
             client = onprem.OnPremClient(base_url="http://localhost:8080")
-            with pytest.raises(OnPremFeatureUnavailable) as exc:
-                client.answer.generate(namespace="x", query="y")
-            assert "memanto config backend cloud" in str(exc.value)
+            result = client.answer.generate(namespace="x", query="y")
+            assert result == {"answer": "ok", "namespace": "x"}
 
 
 class TestSingletonDispatch:
@@ -75,8 +136,17 @@ class TestSingletonDispatch:
         mclients.moorcheh_client.reset_client()
 
         class _FakeRaw:
-            def __init__(self, base_url):
+            def __init__(self, base_url, timeout=None):
                 self.base_url = base_url
+                self.timeout = timeout
+                # OnPremClient binds these from the raw client; stub them so
+                # construction succeeds without a real on-prem server.
+                self.namespaces = object()
+                self.documents = object()
+                self.similarity_search = object()
+                self.answer = object()
+                self.vectors = object()
+                self.files = object()
 
         try:
             with patch.object(onprem, "_import_raw_client", return_value=_FakeRaw):


### PR DESCRIPTION
- Add answer functionality to on prem
- update ui for on prem
- update ooon boarding to only allow to set embedding model once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-prem deployments can now run answer generation and daily summaries.
  * Add on-prem LLM provider/model configuration and a UI button to restart the on-prem backend.
  * File uploads to on-prem are accepted as jobs (reported as queued).

* **Improvements**
  * Configuration UI shows embedding and LLM provider/model details for on-prem.
  * CLI onboarding preserves and reuses on-prem embedding/LLM settings.
  * Increased/adjustable on-prem client timeout for more reliable connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->