### PR TITLE
Add Claude Code Skills + Memanto SkillChain bridge

### DIFF
--- a/examples/claudecode-skills-memanto/.gitignore
+++ b/examples/claudecode-skills-memanto/.gitignore
@@ -1,0 +1,3 @@
+.skillchain/
+__pycache__/
+*.pyc

--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,74 @@
+# Claude Code Skills + Memanto SkillChain
+
+This example adds a lightweight memory bridge for Claude Code / mattpocock-style developer skills such as `/grill-with-docs`, `/tdd`, and `/handoff`.
+
+The goal is to reduce context fragmentation between separate skill runs. A completed skill run emits durable engineering decisions, the bridge stores them as memory cards, and later skill runs receive relevant recalled context before they start.
+
+## Modes
+
+- **Reviewer-safe local mode** stores memory in `.skillchain/memory.jsonl` and requires no private credentials.
+- **Live Memanto mode** uses the `memanto` CLI when `MEMANTO_LIVE=1` and `MOORCHEH_API_KEY` are configured.
+
+Reviewer-safe local mode is the canonical review path so maintainers can verify behavior without API keys, network calls, or hidden local state.
+
+## Quick proof
+
+```bash
+cd examples/claudecode-skills-memanto
+python3 validate.py
+```
+
+Expected result:
+
+```text
+PASS: local SkillChain proof completed
+```
+
+## Example lifecycle
+
+### Before a skill
+
+```bash
+python3 skill_memory.py before \
+  --skill /grill-with-docs \
+  --task "Review materialization architecture" \
+  --query "materialization architecture ADR context"
+```
+
+### After a skill
+
+```bash
+python3 skill_memory.py after \
+  --skill /grill-with-docs \
+  --task "Review materialization architecture" \
+  --transcript demo/demo-transcript.md
+```
+
+### Recall before the next skill
+
+```bash
+python3 skill_memory.py before \
+  --skill /tdd \
+  --task "Implement tests from the architecture review" \
+  --query "materialization ADR tests"
+```
+
+## Live Memanto mode
+
+```bash
+export MOORCHEH_API_KEY='...'
+export MEMANTO_LIVE=1
+python3 skill_memory.py before --skill /tdd --task "Implement tests" --query "architecture decisions"
+```
+
+The key is read from the environment only. It is never printed by this example.
+
+## Reviewer-safe demo repo
+
+Public showcase and deterministic proof:
+
+https://github.com/cwwjacobs/mdemo
+
+## Social showcase
+
+X: https://x.com/TerminusProto/status/2064451356392661020?s=20

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Reviewer-safe Memanto SkillChain bridge for Claude Code skills.
+
+Local mode is deterministic and credential-free. Live mode shells out to the
+public Memanto CLI only when MEMANTO_LIVE=1 and MOORCHEH_API_KEY is set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+STATE_DIR = Path(".skillchain")
+LOCAL_MEMORY = STATE_DIR / "memory.jsonl"
+INJECTED_CONTEXT = STATE_DIR / "injected-context.md"
+
+
+@dataclass(frozen=True)
+class MemoryCard:
+    content: str
+    memory_type: str
+    source_skill: str
+    task: str
+    created_at: str
+
+    def to_text(self) -> str:
+        return f"[{self.memory_type}] {self.content} (from {self.source_skill}; task={self.task!r})"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def live_enabled() -> bool:
+    return os.environ.get("MEMANTO_LIVE") == "1" and bool(os.environ.get("MOORCHEH_API_KEY"))
+
+
+def classify(line: str) -> str:
+    lowered = line.lower()
+    if "decision" in lowered or "decided" in lowered:
+        return "decision"
+    if "prefer" in lowered or "style" in lowered or "convention" in lowered:
+        return "preference"
+    if "must" in lowered or "never" in lowered or "always" in lowered:
+        return "instruction"
+    if "artifact" in lowered or "created" in lowered or "wrote" in lowered:
+        return "artifact"
+    return "context"
+
+
+def durable_lines(text: str) -> list[str]:
+    marker = re.compile(
+        r"\b(decision|decided|prefer|preference|must|never|always|required|constraint|artifact|created|wrote|context|adr|test)\b",
+        re.IGNORECASE,
+    )
+    lines: list[str] = []
+    seen: set[str] = set()
+    for raw in text.splitlines():
+        line = " ".join(raw.strip(" -\t").split())
+        if len(line) < 20 or not marker.search(line):
+            continue
+        if looks_secretish(line):
+            continue
+        key = line.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(line[:500])
+    return lines[:12]
+
+
+def looks_secretish(text: str) -> bool:
+    patterns = [
+        r"(?i)(api[_-]?key|secret|password|token)\s*[:=]\s*\S{8,}",
+        r"sk-[A-Za-z0-9_-]{20,}",
+        r"ghp_[A-Za-z0-9_]{20,}",
+        r"github_pat_[A-Za-z0-9_]{20,}",
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
+    ]
+    return any(re.search(pattern, text) for pattern in patterns)
+
+
+def read_local() -> list[MemoryCard]:
+    if not LOCAL_MEMORY.exists():
+        return []
+    cards: list[MemoryCard] = []
+    for line in LOCAL_MEMORY.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        cards.append(MemoryCard(**json.loads(line)))
+    return cards
+
+
+def write_local(cards: list[MemoryCard]) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    LOCAL_MEMORY.write_text("\n".join(json.dumps(asdict(card)) for card in cards) + "\n", encoding="utf-8")
+
+
+def store_local(new_cards: list[MemoryCard]) -> None:
+    cards = read_local()
+    existing = {(card.content, card.source_skill, card.task) for card in cards}
+    for card in new_cards:
+        key = (card.content, card.source_skill, card.task)
+        if key not in existing:
+            cards.append(card)
+            existing.add(key)
+    write_local(cards)
+
+
+def recall_local(query: str, limit: int) -> list[MemoryCard]:
+    words = {word.lower() for word in re.findall(r"[a-zA-Z0-9_/-]{3,}", query)}
+    scored: list[tuple[int, MemoryCard]] = []
+    for card in read_local():
+        haystack = f"{card.content} {card.memory_type} {card.source_skill} {card.task}".lower()
+        score = sum(1 for word in words if word in haystack)
+        if score:
+            scored.append((score, card))
+    scored.sort(key=lambda item: (-item[0], item[1].created_at))
+    return [card for _, card in scored[:limit]]
+
+
+def run_memanto(args: list[str]) -> str:
+    result = subprocess.run(["memanto", *args], text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return result.stdout.strip()
+
+
+def before(args: argparse.Namespace) -> int:
+    if live_enabled():
+        context = run_memanto(["recall", args.query, "--limit", str(args.limit)])
+        mode = "live"
+    else:
+        recalled = recall_local(args.query, args.limit)
+        context = "\n".join(f"- {card.to_text()}" for card in recalled) or "No relevant prior memories found."
+        mode = "local"
+
+    body = (
+        "MEMANTO SKILLCHAIN MEMORY STACK\n"
+        f"mode: {mode}\n"
+        f"current_skill: {args.skill}\n"
+        f"task: {args.task}\n\n"
+        f"{context}\n"
+    )
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    INJECTED_CONTEXT.write_text(body, encoding="utf-8")
+    print(body)
+    return 0
+
+
+def after(args: argparse.Namespace) -> int:
+    transcript = Path(args.transcript).read_text(encoding="utf-8")
+    cards = [
+        MemoryCard(
+            content=line,
+            memory_type=classify(line),
+            source_skill=args.skill,
+            task=args.task,
+            created_at=now_iso(),
+        )
+        for line in durable_lines(transcript)
+    ]
+    if live_enabled():
+        for card in cards:
+            run_memanto(["remember", card.to_text(), "--type", card.memory_type])
+        print(f"Stored {len(cards)} cards in live Memanto mode")
+    else:
+        store_local(cards)
+        print(f"Stored {len(cards)} cards in local mode")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Memanto SkillChain bridge for Claude Code skills")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_before = sub.add_parser("before")
+    p_before.add_argument("--skill", required=True)
+    p_before.add_argument("--task", required=True)
+    p_before.add_argument("--query", required=True)
+    p_before.add_argument("--limit", type=int, default=5)
+    p_before.set_defaults(func=before)
+
+    p_after = sub.add_parser("after")
+    p_after.add_argument("--skill", required=True)
+    p_after.add_argument("--task", required=True)
+    p_after.add_argument("--transcript", required=True)
+    p_after.set_defaults(func=after)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -94,7 +94,11 @@ def read_local() -> list[MemoryCard]:
     for line in LOCAL_MEMORY.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
-        cards.append(MemoryCard(**json.loads(line)))
+        try:
+            cards.append(MemoryCard(**json.loads(line)))
+        except (json.JSONDecodeError, TypeError) as exc:
+            print(f"Warning: skipping malformed memory line: {exc}", file=sys.stderr)
+            continue
     return cards
 
 
@@ -156,7 +160,12 @@ def before(args: argparse.Namespace) -> int:
 
 
 def after(args: argparse.Namespace) -> int:
-    transcript = Path(args.transcript).read_text(encoding="utf-8")
+    transcript_path = Path(args.transcript)
+    try:
+        transcript = transcript_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"Error: transcript file not found: {transcript_path}", file=sys.stderr)
+        return 1
     cards = [
         MemoryCard(
             content=line,

--- a/examples/claudecode-skills-memanto/validate.py
+++ b/examples/claudecode-skills-memanto/validate.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Credential-free validation for the Claude Code Skills + Memanto example."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+
+def run(args: list[str], *, stdin: str | None = None) -> str:
+    result = subprocess.run(args, cwd=ROOT, text=True, input=stdin, capture_output=True, check=False)
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout
+
+
+def main() -> int:
+    shutil.rmtree(ROOT / ".skillchain", ignore_errors=True)
+
+    transcript = ROOT / "demo" / "demo-transcript.md"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(
+        """# Demo transcript
+
+Decision: use materialization as the canonical domain term for turning a lesson plan into generated course files.
+Preference: keep ADR-style context in CONTEXT.md so later skills do not need repeated instructions.
+Context: /grill-with-docs identified the boundary between planning and implementation.
+Artifact: wrote the initial architecture review notes for the tdd handoff.
+""",
+        encoding="utf-8",
+    )
+
+    run(
+        [
+            sys.executable,
+            "skill_memory.py",
+            "after",
+            "--skill",
+            "/grill-with-docs",
+            "--task",
+            "Review materialization architecture",
+            "--transcript",
+            str(transcript),
+        ]
+    )
+
+    recalled = run(
+        [
+            sys.executable,
+            "skill_memory.py",
+            "before",
+            "--skill",
+            "/tdd",
+            "--task",
+            "Implement tests from architecture review",
+            "--query",
+            "materialization ADR CONTEXT.md tests",
+        ]
+    )
+
+    required = ["materialization", "CONTEXT.md", "/grill-with-docs", "MEMANTO SKILLCHAIN MEMORY STACK"]
+    missing = [item for item in required if item not in recalled]
+    if missing:
+        raise SystemExit(f"Missing expected recalled proof tokens: {missing}")
+
+    print("PASS: local SkillChain proof completed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a reviewer-safe `examples/claudecode-skills-memanto` integration for the Moorcheh / Memanto developer skills challenge.

This implements a lightweight SkillChain memory bridge for Claude Code / mattpocock-style skills such as `/grill-with-docs`, `/tdd`, and `/handoff`.

The goal is to reduce context fragmentation between separate skill runs by capturing durable engineering decisions after one skill run and recalling relevant context before later runs.

Related bounty issue: #508

## Social showcase

X: https://x.com/TerminusProto/status/2064451356392661020?s=20

## Reviewer-safe demo repo

https://github.com/cwwjacobs/mdemo

The demo repo includes a reproducible proof path that does not require private API keys or network access.

Demo commit:

```text
3f58edf Add Memanto SkillChain demo proof

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code Skills + Memanto SkillChain example with a local CLI to capture, store, and recall durable memory between skill runs, plus an optional live mode that integrates with the Memanto CLI.
  * Included a credential-free validation script to verify the example end-to-end.

* **Documentation**
  * Added README explaining setup, operating modes, validation steps, and usage notes.

* **Chores**
  * Updated ignore rules to exclude common Python artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->