### PR TITLE
feat(recall): add cross-agent / multi-namespace recall (#542)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ This means Memanto doesn't need a separate vector DB, embedding pipeline, or rer
 | Agent lifecycle management | `memanto agent ...` | Create/list/delete agents, activate/deactivate sessions, and run `agent bootstrap` for an intelligence snapshot. |
 | Memory capture at scale | `memanto remember` | Store single memories with metadata or batch-ingest up to 100 records from JSON. |
 | File upload to memory | `memanto upload` | Upload documents (.pdf, .docx, .xlsx, .json, .txt, .csv, .md) directly into an agent's memory namespace — content becomes instantly searchable via `recall`. |
-| Advanced retrieval modes | `memanto recall` | Run standard search plus temporal queries (`--as-of`, `--changed-since`) with filters. |
+| Advanced retrieval modes | `memanto recall` | Run standard search plus temporal (`--as-of`, `--changed-since`) and cross-agent (`--agents`) queries with filters. |
 | Grounded QA over memory | `memanto answer` | Generate RAG answers using retrieved memory context. |
 | Daily intelligence workflows | `memanto daily-summary`, `memanto conflicts` | Generate summaries, detect contradictions, and resolve conflicts interactively. |
 | Session and automation controls | `memanto session ...`, `memanto schedule ...` | Inspect sessions and enable scheduled daily summary runs. |

--- a/docs/CLI_USER_GUIDE.md
+++ b/docs/CLI_USER_GUIDE.md
@@ -351,6 +351,11 @@ memanto recall QUERY [OPTIONS]
 - `--type, -t TEXT` - Filter by memory type
 - `--min-confidence FLOAT` - Minimum confidence score
 - `--tags TEXT` - Filter by tags (comma-separated)
+- `--agents TEXT` - Cross-agent recall: comma-separated agent IDs to search across in a single query
+
+> **Note:** `--agents` is semantic search only (not combinable with `--as-of`,
+> `--changed-since`, or `--recent`), and each listed agent must be activated first
+> (`memanto agent activate <agent-id>`).
 
 **Examples:**
 ```bash
@@ -367,6 +372,10 @@ python -m cli.main recall "security" \
 python -m cli.main recall "architecture" \
   --tags "database,backend" \
   --limit 20
+
+# Cross-agent search
+python -m cli.main recall "billing edge cases" \
+  --agents support-acme,proj-orion,proj-helios
 ```
 
 **Output:**

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -96,3 +96,53 @@ def get_current_session(x_session_token: str | None = Header(None)) -> Session:
 
     except (SessionExpiredError, SessionNotFoundError, InvalidSessionTokenError) as e:
         raise map_error_to_http_exception(e)
+
+
+def get_authorized_agent_ids(
+    x_session_token: str | None = Header(None),
+    x_session_tokens: str | None = Header(None),
+) -> dict[str, str]:
+    """
+    Authorize a multi-agent (cross-namespace) request.
+
+    The caller proves authorization for each agent by supplying that agent's
+    session token, via ``X-Session-Tokens`` (comma-separated) and/or
+    ``X-Session-Token``. Each token is validated (signature + expiry); the
+    return value maps ``agent_id -> token`` for every token that validates.
+    The route rejects any requested agent absent from this mapping.
+
+    Raises:
+        HTTPException: 401 if no tokens are supplied or none validate.
+    """
+    raw_tokens: list[str] = []
+    if x_session_tokens:
+        raw_tokens.extend(t.strip() for t in x_session_tokens.split(",") if t.strip())
+    if x_session_token and x_session_token.strip():
+        raw_tokens.append(x_session_token.strip())
+
+    if not raw_tokens:
+        raise HTTPException(
+            status_code=401,
+            detail=(
+                "Missing session token(s). Provide X-Session-Tokens "
+                "(comma-separated) and/or X-Session-Token."
+            ),
+        )
+
+    session_service = get_session_service()
+    authorized: dict[str, str] = {}
+    for token in raw_tokens:
+        try:
+            payload = session_service.validate_session(token)
+        except (SessionExpiredError, InvalidSessionTokenError):
+            # Skip invalid/expired tokens — the route rejects any requested
+            # agent that ends up without a valid token.
+            continue
+        authorized[payload.agent_id] = token
+
+    if not authorized:
+        raise map_error_to_http_exception(
+            InvalidSessionTokenError("No valid session tokens provided.")
+        )
+
+    return authorized

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -138,6 +138,12 @@ def get_authorized_agent_ids(
             # Skip invalid/expired tokens — the route rejects any requested
             # agent that ends up without a valid token.
             continue
+        # Match the token to a live session (existence + active status), like
+        # get_current_session, so a valid JWT for a deleted/deactivated agent
+        # is not accepted.
+        session = session_service.get_session(payload.agent_id)
+        if not session or not session.is_active():
+            continue
         authorized[payload.agent_id] = token
 
     if not authorized:

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -25,15 +25,24 @@ from memanto.app.models import (
     RememberRequest,
 )
 from memanto.app.models.session import Session
-from memanto.app.routes.auth_deps import get_current_session, get_session_service
+from memanto.app.routes.auth_deps import (
+    get_authorized_agent_ids,
+    get_current_session,
+    get_session_service,
+)
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.services.memory_write_service import MemoryWriteService
-from memanto.app.utils.errors import map_error_to_http_exception
+from memanto.app.utils.errors import AuthorizationError, map_error_to_http_exception
 from memanto.app.utils.validation import CostGuard
 from memanto.cli.client.direct_client import DirectClient
 from memanto.cli.config.manager import ConfigManager
 
 router = APIRouter()
+
+# Multi-agent recall lives at the /api/v2 root (POST /api/v2/recall/multi),
+# not under the /agents/{agent_id} prefix the single-agent routes use, so it
+# gets its own prefix-less router that sessions.py mounts at the v2 root.
+multi_router = APIRouter()
 
 _config_manager = ConfigManager()
 
@@ -443,6 +452,113 @@ async def recall(
             "query": request.query,
             "memories": memories,
             "count": len(memories),
+        }
+
+    except Exception as e:
+        raise map_error_to_http_exception(e)
+
+
+class RecallMultiRequest(BaseModel):
+    agent_ids: list[str] = Field(
+        ..., min_length=1, description="Agents to search across (cross-namespace)"
+    )
+    query: str = Field(..., min_length=1, description="Search query")
+    limit: int | None = Field(default=None, ge=1, description="Max merged results")
+    min_similarity: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Minimum similarity score (0-1)"
+    )
+    min_confidence: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Minimum confidence score (0-1)"
+    )
+    type: list[str] | None = Field(default=None, description="Memory type filters")
+
+    @field_validator("agent_ids")
+    @classmethod
+    def clean_agent_ids(cls, v: list[str]) -> list[str]:
+        seen: set[str] = set()
+        cleaned: list[str] = []
+        for agent_id in v:
+            agent_id = (agent_id or "").strip()
+            if agent_id and agent_id not in seen:
+                seen.add(agent_id)
+                cleaned.append(agent_id)
+        if not cleaned:
+            raise ValueError("agent_ids must contain at least one non-empty agent id")
+        return cleaned
+
+
+@multi_router.post("/recall/multi")
+async def recall_multi(
+    request: RecallMultiRequest = Body(...),
+    authorized_agents: dict[str, str] = Depends(get_authorized_agent_ids),
+    client=Depends(get_moorcheh_client),
+):
+    """
+    Cross-agent / multi-namespace recall (Session-based).
+
+    Searches several agents' namespaces in a single query and returns merged,
+    score-sorted results, each annotated with the ``agent_id`` it came from.
+
+    Auth: supply one session token per agent via X-Session-Tokens
+    (comma-separated) and/or X-Session-Token. A requested agent without a valid
+    token is rejected with 403.
+    """
+    CostGuard.validate_query_length(request.query)
+
+    # Authorization: every requested agent must have a valid supplied token.
+    unauthorized = [a for a in request.agent_ids if a not in authorized_agents]
+    if unauthorized:
+        raise map_error_to_http_exception(
+            AuthorizationError(
+                "Not authorized for agent(s): "
+                f"{', '.join(unauthorized)}. Provide a valid session token for "
+                "each agent via X-Session-Tokens."
+            )
+        )
+
+    recall_cfg = _config_manager.get_recall_config()
+    raw_limit = (
+        request.limit
+        if request.limit is not None
+        else recall_cfg.get("limit", settings.RECALL_LIMIT)
+    )
+    raw_min_similarity = (
+        request.min_similarity
+        if request.min_similarity is not None
+        else recall_cfg.get("min_similarity")
+    )
+    try:
+        limit = int(raw_limit)
+        min_similarity = (
+            None if raw_min_similarity is None else float(raw_min_similarity)
+        )
+    except (TypeError, ValueError) as e:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid recall configuration: {e}"
+        )
+    CostGuard.validate_k_limit(limit)
+
+    try:
+        read_service = MemoryReadService(client)
+
+        result = await asyncio.to_thread(
+            read_service.search_multi_agent,
+            query=request.query,
+            agent_ids=request.agent_ids,
+            type=request.type,
+            min_confidence=request.min_confidence,
+            min_similarity_score=min_similarity,
+            limit=limit,
+        )
+
+        memories = result.get("results", [])
+
+        return {
+            "agents": request.agent_ids,
+            "query": request.query,
+            "memories": memories,
+            "count": len(memories),
+            "per_agent_counts": result.get("per_agent_counts", {}),
         }
 
     except Exception as e:

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -41,6 +41,8 @@ from memanto.app.routes.auth_deps import (  # noqa: E402
 )
 
 router.include_router(memory.router, prefix="/agents", tags=["Memory Operations"])
+# Cross-agent recall lives at the v2 root: POST /api/v2/recall/multi
+router.include_router(memory.multi_router, tags=["Memory Operations"])
 
 # Service instances
 agent_service = AgentService()

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -223,6 +223,109 @@ class MemoryReadService:
         except Exception as e:
             raise MemoryError(f"Failed to search across multiple scopes: {e}")
 
+    def search_multi_agent(
+        self,
+        query: str,
+        agent_ids: list[str],
+        type: list[str] | None = None,
+        min_confidence: float | None = None,
+        min_similarity_score: float | None = None,
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        """
+        Cross-agent / multi-namespace recall.
+
+        Searches several agents' memory namespaces in a single query and
+        returns merged, score-sorted results. Each result is annotated with the
+        ``agent_id`` it came from, taken from the stored ``scope_id`` metadata.
+
+        Leverages Moorcheh's native multi-namespace similarity search, so the
+        merge happens server-side; the local re-sort is a safety net after the
+        post-processing TTL filter.
+
+        Note: Moorcheh's merged search response does not echo the source
+        namespace per hit, so attribution relies on the ``scope_id`` metadata
+        written with every remembered memory. Documents created without it
+        (e.g. file uploads chunked server-side by Moorcheh) cannot be
+        attributed and come back with ``agent_id`` set to ``None``.
+
+        Args:
+            query: Natural-language search query.
+            agent_ids: Agents whose namespaces to search.
+            type: Optional memory type filters.
+            min_confidence: Optional minimum confidence filter.
+            min_similarity_score: Optional similarity threshold (enables
+                Moorcheh kiosk_mode when set).
+            limit: Max merged results to return.
+        """
+        try:
+            from typing import cast
+
+            from memanto.app.constants import ScopeType
+
+            # Build the namespace list, de-duplicating agent ids while
+            # preserving order.
+            namespaces: list[str] = []
+            seen_agents: set[str] = set()
+            for agent_id in agent_ids:
+                if agent_id in seen_agents:
+                    continue
+                seen_agents.add(agent_id)
+                scope = create_memory_scope(cast(ScopeType, "agent"), agent_id)
+                namespaces.append(cast(str, scope.to_namespace()))
+
+            if not namespaces:
+                return {
+                    "results": [],
+                    "total_found": 0,
+                    "per_agent_counts": {},
+                }
+
+            enhanced_query = self._build_filtered_query(
+                query=query, type=type, min_confidence=min_confidence
+            )
+
+            top_k = min(limit, 100)  # Moorcheh max is 100
+            search_result = self.client.similarity_search.query(
+                query=enhanced_query,
+                namespaces=namespaces,
+                top_k=top_k,
+                threshold=min_similarity_score,
+                kiosk_mode=min_similarity_score is not None,
+            )
+
+            formatted_results: list[dict[str, Any]] = []
+            for item in search_result.get("results", []):
+                formatted = self._format_memory_item(item)
+                # Attribute each result to its source agent via the stored
+                # scope_id metadata. Moorcheh's merged response carries no
+                # per-hit namespace, so documents without scope_id (e.g. file
+                # uploads) are left unattributed (agent_id = None).
+                formatted["agent_id"] = formatted.get("scope_id")
+                formatted_results.append(formatted)
+
+            # Apply TTL enforcement, then re-sort by score after the merge.
+            formatted_results = self._filter_expired_memories(formatted_results)
+            formatted_results.sort(key=lambda m: m.get("score") or 0.0, reverse=True)
+            formatted_results = formatted_results[:limit]
+
+            per_agent_counts: dict[str, int] = {}
+            for memory in formatted_results:
+                aid = memory.get("agent_id") or "unknown"
+                per_agent_counts[aid] = per_agent_counts.get(aid, 0) + 1
+
+            return {
+                "results": formatted_results,
+                "total_found": len(formatted_results),
+                "per_agent_counts": per_agent_counts,
+                "query": query,
+                "enhanced_query": enhanced_query,
+                "execution_time": search_result.get("execution_time", 0),
+            }
+
+        except Exception as e:
+            raise MemoryError(f"Failed to search across agents: {e}")
+
     def search_as_of(
         self,
         as_of_date: str,

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -2,6 +2,7 @@
 Memory Read Service
 """
 
+import logging
 import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
@@ -13,6 +14,8 @@ from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.config import settings
 from memanto.app.core import create_memory_scope
 from memanto.app.utils.errors import MemoryError
+
+logger = logging.getLogger(__name__)
 
 
 class MemoryReadService:
@@ -245,9 +248,10 @@ class MemoryReadService:
 
         Note: Moorcheh's merged search response does not echo the source
         namespace per hit, so attribution relies on the ``scope_id`` metadata
-        written with every remembered memory. Documents created without it
-        (e.g. file uploads chunked server-side by Moorcheh) cannot be
-        attributed and come back with ``agent_id`` set to ``None``.
+        written with every remembered memory. A hit without it (e.g. a file
+        upload chunked server-side by Moorcheh) cannot be attributed and is
+        dropped with a warning, so the response never contains an ``agent_id``
+        of ``None``.
 
         Args:
             query: Natural-language search query.
@@ -297,11 +301,19 @@ class MemoryReadService:
             formatted_results: list[dict[str, Any]] = []
             for item in search_result.get("results", []):
                 formatted = self._format_memory_item(item)
-                # Attribute each result to its source agent via the stored
-                # scope_id metadata. Moorcheh's merged response carries no
-                # per-hit namespace, so documents without scope_id (e.g. file
-                # uploads) are left unattributed (agent_id = None).
-                formatted["agent_id"] = formatted.get("scope_id")
+                # Attribute via the stored scope_id metadata. Moorcheh's merged
+                # response carries no per-hit namespace, so a hit without
+                # scope_id (e.g. a server-side file-upload chunk) is dropped
+                # rather than returned unattributed.
+                attributed_agent = formatted.get("scope_id")
+                if not attributed_agent:
+                    logger.warning(
+                        "Dropping cross-agent recall hit without scope_id "
+                        "metadata (id=%s): cannot attribute to an agent",
+                        formatted.get("id"),
+                    )
+                    continue
+                formatted["agent_id"] = attributed_agent
                 formatted_results.append(formatted)
 
             # Apply TTL enforcement, then re-sort by score after the merge.
@@ -311,7 +323,7 @@ class MemoryReadService:
 
             per_agent_counts: dict[str, int] = {}
             for memory in formatted_results:
-                aid = memory.get("agent_id") or "unknown"
+                aid = memory["agent_id"]
                 per_agent_counts[aid] = per_agent_counts.get(aid, 0) + 1
 
             return {

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -793,6 +793,97 @@ class DirectClient:
             "count": result.get("total_found", 0),
         }
 
+    def recall_multi(
+        self,
+        agent_ids: list[str],
+        query: str,
+        limit: int | None = None,
+        type: list[str] | None = None,
+        min_confidence: float | None = None,
+        min_similarity: float | None = None,
+    ) -> dict[str, Any]:
+        """
+        Cross-agent recall: search several agents' memories in one query.
+
+        Returns merged, score-sorted results, each annotated with the
+        ``agent_id`` it came from.
+
+        Authorization (direct/CLI model): the caller must hold a valid, active
+        local session for every requested agent (created via
+        ``activate_agent``). Any agent without a live session is rejected.
+
+        Args:
+            agent_ids: Agents whose namespaces to search.
+            query: Natural-language search query.
+            limit: Max merged results (defaults to config).
+            type: Filter by types.
+            min_confidence: Minimum confidence threshold.
+            min_similarity: Minimum similarity threshold.
+
+        Returns:
+            Dict with ``agents``, ``query``, ``memories``, ``count``,
+            ``per_agent_counts``.
+
+        Raises:
+            ValueError: If no agent ids are provided.
+            SessionError: If the caller is not authorized for an agent.
+        """
+        recall_cfg = ConfigManager().get_recall_config()
+        if limit is None:
+            limit = recall_cfg["limit"]
+        if min_similarity is None:
+            min_similarity = recall_cfg.get("min_similarity")
+
+        # Normalize + dedupe agent ids, preserving order
+        cleaned_agent_ids: list[str] = []
+        seen: set[str] = set()
+        for agent_id in agent_ids:
+            agent_id = (agent_id or "").strip()
+            if agent_id and agent_id not in seen:
+                seen.add(agent_id)
+                cleaned_agent_ids.append(agent_id)
+        if not cleaned_agent_ids:
+            raise ValueError("At least one agent_id is required")
+
+        self._validate_query(query, limit)
+
+        # Authorization: require a valid, active session for each agent.
+        session_service = self._get_session_service()
+        unauthorized: list[str] = []
+        for agent_id in cleaned_agent_ids:
+            session = session_service.get_session(agent_id)
+            if not session or not session.is_active():
+                unauthorized.append(agent_id)
+        if unauthorized:
+            raise SessionError(
+                "Not authorized for agent(s): "
+                f"{', '.join(unauthorized)}. Activate each with "
+                "'memanto agent activate <agent-id>'."
+            )
+
+        logger.debug(
+            "Multi-agent recall across %s: query='%s', limit=%d",
+            cleaned_agent_ids,
+            query,
+            limit,
+        )
+        result = self._get_read_service().search_multi_agent(
+            query=query,
+            agent_ids=cleaned_agent_ids,
+            type=type,
+            min_confidence=min_confidence,
+            min_similarity_score=min_similarity,
+            limit=limit,
+        )
+
+        return {
+            "agents": cleaned_agent_ids,
+            "query": query,
+            "memories": result.get("results", []),
+            "count": result.get("total_found", 0),
+            "per_agent_counts": result.get("per_agent_counts", {}),
+        }
+
     def recall_as_of(
         self,
         agent_id: str,

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -847,12 +847,19 @@ class DirectClient:
 
         self._validate_query(query, limit)
 
-        # Authorization: require a valid, active session for each agent.
+        # Authorization: require a live session for each agent, validating its
+        # JWT (signature + expiry) like the single-agent path — not just an
+        # is_active() status check.
         session_service = self._get_session_service()
         unauthorized: list[str] = []
         for agent_id in cleaned_agent_ids:
             session = session_service.get_session(agent_id)
             if not session or not session.is_active():
+                unauthorized.append(agent_id)
+                continue
+            try:
+                session_service.validate_session(session.session_token)
+            except (SessionExpiredError, InvalidSessionTokenError):
                 unauthorized.append(agent_id)
         if unauthorized:
             raise SessionError(

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -858,7 +858,9 @@ class DirectClient:
                 unauthorized.append(agent_id)
                 continue
             try:
-                session_service.validate_session(session.session_token)
+                token_payload = session_service.validate_session(session.session_token)
+                if token_payload.agent_id != agent_id:
+                    unauthorized.append(agent_id)
             except (SessionExpiredError, InvalidSessionTokenError):
                 unauthorized.append(agent_id)
         if unauthorized:

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -677,6 +677,97 @@ class SdkClient:
             "count": result.get("total_found", 0),
         }
 
+    def recall_multi(
+        self,
+        agent_ids: list[str],
+        query: str,
+        limit: int | None = None,
+        type: list[str] | None = None,
+        min_confidence: float | None = None,
+        min_similarity: float | None = None,
+    ) -> dict[str, Any]:
+        """
+        Cross-agent recall: search several agents' memories in one query.
+
+        Returns merged, score-sorted results, each annotated with the
+        ``agent_id`` it came from.
+
+        Authorization (direct/CLI model): the caller must hold a valid, active
+        local session for every requested agent (created via
+        ``activate_agent``). Any agent without a live session is rejected.
+
+        Args:
+            agent_ids: Agents whose namespaces to search.
+            query: Natural-language search query.
+            limit: Max merged results (defaults to config).
+            type: Filter by types.
+            min_confidence: Minimum confidence threshold.
+            min_similarity: Minimum similarity threshold.
+
+        Returns:
+            Dict with ``agents``, ``query``, ``memories``, ``count``,
+            ``per_agent_counts``.
+
+        Raises:
+            ValueError: If no agent ids are provided.
+            SessionError: If the caller is not authorized for an agent.
+        """
+        recall_cfg = ConfigManager().get_recall_config()
+        if limit is None:
+            limit = recall_cfg["limit"]
+        if min_similarity is None:
+            min_similarity = recall_cfg.get("min_similarity")
+
+        # Normalize + dedupe agent ids, preserving order
+        cleaned_agent_ids: list[str] = []
+        seen: set[str] = set()
+        for agent_id in agent_ids:
+            agent_id = (agent_id or "").strip()
+            if agent_id and agent_id not in seen:
+                seen.add(agent_id)
+                cleaned_agent_ids.append(agent_id)
+        if not cleaned_agent_ids:
+            raise ValueError("At least one agent_id is required")
+
+        self._validate_query(query, limit)
+
+        # Authorization: require a valid, active session for each agent.
+        session_service = self._get_session_service()
+        unauthorized: list[str] = []
+        for agent_id in cleaned_agent_ids:
+            session = session_service.get_session(agent_id)
+            if not session or not session.is_active():
+                unauthorized.append(agent_id)
+        if unauthorized:
+            raise SessionError(
+                "Not authorized for agent(s): "
+                f"{', '.join(unauthorized)}. Activate each with "
+                "'memanto agent activate <agent-id>'."
+            )
+
+        logger.debug(
+            "Multi-agent recall across %s: query='%s', limit=%d",
+            cleaned_agent_ids,
+            query,
+            limit,
+        )
+        result = self._get_read_service().search_multi_agent(
+            query=query,
+            agent_ids=cleaned_agent_ids,
+            type=type,
+            min_confidence=min_confidence,
+            min_similarity_score=min_similarity,
+            limit=limit,
+        )
+
+        return {
+            "agents": cleaned_agent_ids,
+            "query": query,
+            "memories": result.get("results", []),
+            "count": result.get("total_found", 0),
+            "per_agent_counts": result.get("per_agent_counts", {}),
+        }
+
     def recall_as_of(
         self,
         agent_id: str,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -731,12 +731,19 @@ class SdkClient:
 
         self._validate_query(query, limit)
 
-        # Authorization: require a valid, active session for each agent.
+        # Authorization: require a live session for each agent, validating its
+        # JWT (signature + expiry) like the single-agent path — not just an
+        # is_active() status check.
         session_service = self._get_session_service()
         unauthorized: list[str] = []
         for agent_id in cleaned_agent_ids:
             session = session_service.get_session(agent_id)
             if not session or not session.is_active():
+                unauthorized.append(agent_id)
+                continue
+            try:
+                session_service.validate_session(session.session_token)
+            except (SessionExpiredError, InvalidSessionTokenError):
                 unauthorized.append(agent_id)
         if unauthorized:
             raise SessionError(

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -270,14 +270,40 @@ def recall(
         "--recent",
         help="Chronological query: return the most recently stored memories (newest first). No search query needed.",
     ),
+    agents: str | None = typer.Option(
+        None,
+        "--agents",
+        help="Cross-agent recall: comma-separated agent IDs to search across (e.g. agent-a,agent-b,agent-c).",
+    ),
 ):
-    """Search and retrieve memories for the active agent with temporal query support."""
+    """Search and retrieve memories with temporal query and cross-agent (--agents) support."""
     start = time.perf_counter()
     active_agent_id, active_session_token = config_manager.get_active_session()
 
     if not active_agent_id or not active_session_token:
         _error(
             "No active agent.", hint="Run 'memanto agent activate <agent-id>' first."
+        )
+
+    # Cross-agent recall is semantic-only; reject temporal/tags combinations.
+    agent_list = [a.strip() for a in agents.split(",") if a.strip()] if agents else None
+    if agent_list and (as_of or changed_since or recent):
+        _error(
+            "Cannot combine --agents with temporal query modes.",
+            hint="Cross-agent recall supports standard search only. "
+            "Drop --as-of/--changed-since/--recent.",
+        )
+    if agent_list and not query:
+        _error(
+            "Missing argument 'QUERY'.",
+            hint="Cross-agent recall requires a search query.",
+        )
+    # --tags is not forwarded by cross-agent recall; reject rather than
+    # silently ignoring it.
+    if agent_list and tags:
+        _error(
+            "Cannot combine --agents with --tags.",
+            hint="Cross-agent recall does not support tag filtering.",
         )
 
     # Check for mutually exclusive temporal flags
@@ -333,7 +359,16 @@ def recall(
         # Determine which API method to call based on temporal flags
         temporal_mode = "standard"
         with console.status("[cyan]Searching memories...", spinner="dots"):
-            if as_of:
+            if agent_list and query:
+                results = client.recall_multi(
+                    agent_ids=agent_list,
+                    query=query,
+                    limit=limit,
+                    type=type,
+                    min_similarity=min_similarity,
+                )
+                temporal_mode = "multi"
+            elif as_of:
                 results = client.recall_as_of(
                     agent_id=agent_id,
                     as_of=as_of,
@@ -385,6 +420,9 @@ def recall(
             "as_of": f"Point-in-time (as of {as_of})",
             "changed_since": f"Differential (since {changed_since})",
             "recent": "Recent (newest first)",
+            "multi": f"Cross-agent ({len(agent_list)} agents)"
+            if agent_list
+            else "Cross-agent",
             "standard": "Standard search",
         }
         mode_label = mode_labels.get(temporal_mode, "Standard search")
@@ -437,6 +475,11 @@ def recall(
             # Show change type for differential queries
             if change_type:
                 panel_content += f"\n[yellow]Change: {change_type}[/yellow]"
+
+            # Show source agent for cross-agent recall
+            agent_attr = memory.get("agent_id")
+            if agent_attr:
+                panel_content += f"\n[{PRIMARY}]Agent: {agent_attr}[/{PRIMARY}]"
 
             # Determine border style
             border_style = BRIGHT if score > 0.8 else PRIMARY

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -420,6 +420,126 @@ class TestMEMANTOAPI:
         call_kwargs = mock_moorcheh.similarity_search.query.call_args.kwargs
         assert "memory_type:fact" in call_kwargs["query"]
 
+    async def _activate_agent(self, client, auth_headers, agent_id):
+        """Helper: create + activate an agent, returning its session token."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": agent_id},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{agent_id}/activate", headers=auth_headers
+        )
+        return activate_resp.json()["session_token"]
+
+    @pytest.mark.asyncio
+    async def test_recall_multi_merges_and_attributes(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Cross-agent recall merges, score-sorts, and tags each result."""
+        token_a = await self._activate_agent(client, auth_headers, "multi-agent-a")
+        token_b = await self._activate_agent(client, auth_headers, "multi-agent-b")
+
+        # Moorcheh merges namespaces server-side; each item carries its
+        # source agent in the flat scope_id metadata field.
+        mock_moorcheh.similarity_search.query.return_value = {
+            "results": [
+                {
+                    "id": "mem-a",
+                    "text": "[FACT] From A\n\nalpha",
+                    "score": 0.80,
+                    "scope_id": "multi-agent-a",
+                    "scope_type": "agent",
+                },
+                {
+                    "id": "mem-b",
+                    "text": "[FACT] From B\n\nbeta",
+                    "score": 0.95,
+                    "scope_id": "multi-agent-b",
+                    "scope_type": "agent",
+                },
+            ],
+            "total_found": 2,
+        }
+
+        headers = {**auth_headers, "X-Session-Tokens": f"{token_a},{token_b}"}
+        payload = {
+            "agent_ids": ["multi-agent-a", "multi-agent-b"],
+            "query": "test query",
+        }
+        response = await client.post(
+            "/api/v2/recall/multi", headers=headers, json=payload
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Both namespaces searched in a single query
+        call_kwargs = mock_moorcheh.similarity_search.query.call_args.kwargs
+        assert set(call_kwargs["namespaces"]) == {
+            "memanto_agent_multi-agent-a",
+            "memanto_agent_multi-agent-b",
+        }
+
+        memories = data["memories"]
+        assert len(memories) == 2
+        # Score-sorted: highest first
+        assert [m["score"] for m in memories] == [0.95, 0.80]
+        # Each result indicates which agent it came from
+        assert memories[0]["agent_id"] == "multi-agent-b"
+        assert memories[1]["agent_id"] == "multi-agent-a"
+        assert data["per_agent_counts"] == {"multi-agent-a": 1, "multi-agent-b": 1}
+
+    @pytest.mark.asyncio
+    async def test_recall_multi_rejects_unauthorized_agent(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Requesting an agent without a supplied token is rejected with 403."""
+        token_a = await self._activate_agent(client, auth_headers, "multi-auth-a")
+
+        # Only agent A's token is supplied, but B is requested.
+        headers = {**auth_headers, "X-Session-Token": token_a}
+        payload = {
+            "agent_ids": ["multi-auth-a", "multi-auth-b"],
+            "query": "test query",
+        }
+        response = await client.post(
+            "/api/v2/recall/multi", headers=headers, json=payload
+        )
+
+        assert response.status_code == 403
+        assert "multi-auth-b" in response.json()["detail"]["message"]
+        # No search is attempted when authorization fails.
+        mock_moorcheh.similarity_search.query.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_recall_multi_requires_session_token(self, client, auth_headers):
+        """Multi-recall without any session token is rejected with 401."""
+        payload = {"agent_ids": ["multi-noauth"], "query": "test query"}
+        response = await client.post(
+            "/api/v2/recall/multi", headers=auth_headers, json=payload
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_recall_multi_forwards_min_confidence(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Multi-recall forwards min_confidence into the Moorcheh query filter."""
+        token = await self._activate_agent(client, auth_headers, "multi-conf-a")
+        headers = {**auth_headers, "X-Session-Token": token}
+        payload = {
+            "agent_ids": ["multi-conf-a"],
+            "query": "test query",
+            "min_confidence": 0.9,
+        }
+        response = await client.post(
+            "/api/v2/recall/multi", headers=headers, json=payload
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_moorcheh.similarity_search.query.call_args.kwargs
+        assert "confidence:high" in call_kwargs["query"]
+
     @pytest.mark.asyncio
     async def test_get_agent(self, client, auth_headers):
         """Test getting agent details"""

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,6 +12,7 @@ session token produced by test_05 is used by all memory tests).
 
 import shutil
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -412,6 +413,93 @@ class TestE2E:
         )
         assert resp.status_code == 200, resp.text
         assert resp.json()["temporal_mode"] == "recent"
+
+    # ------------------------------------------------------------------
+    # Cross-agent recall
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_15c_recall_multi_cross_agent(self, http):
+        """POST /recall/multi — merged, score-sorted results across two agents."""
+        # Stand up a second agent with its own session + a distinctive memory.
+        agent2 = f"{TEST_AGENT_ID}-2"
+        await http.post(
+            "/api/v2/agents",
+            headers=AUTH,
+            json={
+                "agent_id": agent2,
+                "pattern": "support",
+                "description": "Automated E2E cross-agent test agent — safe to delete",
+            },
+        )
+        activate = await http.post(f"/api/v2/agents/{agent2}/activate", headers=AUTH)
+        assert activate.status_code == 200, activate.text
+        token2 = activate.json()["session_token"]
+        state["agent2_id"] = agent2
+        state["agent2_token"] = token2
+
+        await http.post(
+            f"/api/v2/agents/{agent2}/remember",
+            headers={**AUTH, "X-Session-Token": token2},
+            json={
+                "content": "Project Borealis runs on MongoDB and async Python.",
+                "type": "fact",
+            },
+        )
+        # Give Moorcheh a moment to index the new document before searching.
+        time.sleep(8)
+
+        headers = {**AUTH, "X-Session-Tokens": f"{state['session_token']},{token2}"}
+        resp = await http.post(
+            "/api/v2/recall/multi",
+            headers=headers,
+            json={
+                "agent_ids": [TEST_AGENT_ID, agent2],
+                "query": "technology stack and databases",
+                "limit": 10,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["agents"] == [TEST_AGENT_ID, agent2]
+        assert isinstance(data["memories"], list)
+        assert "per_agent_counts" in data
+        # Every result is attributed to one of the searched agents and the
+        # merged list is score-sorted (descending).
+        scores = [m.get("score") or 0.0 for m in data["memories"]]
+        assert scores == sorted(scores, reverse=True)
+        for memory in data["memories"]:
+            assert memory.get("agent_id") in {TEST_AGENT_ID, agent2}
+
+    @pytest.mark.asyncio
+    async def test_15d_recall_multi_rejects_unauthorized(self, http):
+        """POST /recall/multi — a requested agent without a token is rejected (403)."""
+        agent2 = state["agent2_id"]
+        # Only agent-1's token is supplied, but agent-2 is also requested.
+        headers = {**AUTH, "X-Session-Token": state["session_token"]}
+        try:
+            resp = await http.post(
+                "/api/v2/recall/multi",
+                headers=headers,
+                json={
+                    "agent_ids": [TEST_AGENT_ID, agent2],
+                    "query": "anything",
+                },
+            )
+            assert resp.status_code == 403, resp.text
+            assert agent2 in resp.json()["detail"]["message"]
+        finally:
+            # Best-effort cleanup: deactivate the second agent (clears the
+            # active-session marker so later "after deactivate" checks still
+            # see no active session), then drop the agent and its namespace so
+            # repeated CI runs don't accumulate test namespaces in Moorcheh.
+            await http.post(
+                f"/api/v2/agents/{agent2}/deactivate",
+                headers={**AUTH, "X-Session-Token": state["agent2_token"]},
+            )
+            await http.delete(
+                f"/api/v2/agents/{agent2}?delete-backup-too=true", headers=AUTH
+            )
 
     # ------------------------------------------------------------------
     # Conflicts


### PR DESCRIPTION
What problem does this solve?

Every recall is scoped to a single active agent. Users who run multiple agents (one per project, or per customer) can't search across them in one query. This adds cross-agent recall: one query, merged and score-sorted results across the listed agents, each tagged with the agent it came from.

What changed
- Route — POST /api/v2/recall/multi accepting agent_ids plus the usual recall params (query, limit, type, min_confidence, min_similarity), reading through MemoryReadService.search_multi_agent, which uses Moorcheh's native multi-namespace similarity search.
- Client + CLI — recall_multi(...) on both clients and memanto recall "<query>" --agents agent-a,agent-b,agent-c.
- Auth (documented per the issue) — a bundle of existing per-agent session tokens is the multi-agent credential; no new token type is introduced. Over HTTP, supply one token per agent via X-Session-Tokens (comma-separated) and/or X-Session-Token; a requested agent without a valid token is rejected with 403 (no token → 401). In the CLI, each listed agent must have a live local session.

Acceptance criteria from the issue, all met:
- A single query returns merged, score-sorted results across the listed agents.
- Each result indicates which agent it came from (agent_id; response also includes per_agent_counts).
- Requesting an agent the caller isn't authorized for is rejected cleanly.
- Existing single-agent recall behavior is unchanged.

How did you test it?

- Mocked API tests (tests/test_api.py): merge/score-sort/attribution, 403 (unauthorized), 401 (no token), 422 (empty agent_ids), and min_confidence forwarding.
- Gated live E2E (tests/test_e2e.py, runs when MOORCHEH_API_KEY is set, self-cleaning): cross-agent recall + unauthorized rejection against production Moorcheh.
- Manually verified the full HTTP API and the real CLI against live Moorcheh.
- ruff check ., ruff format --check ., mypy ., and pytest all pass.

PR Checklist

- [x] Code follows the project style (ruff, mypy pass)
- [x] Tests added or updated for changed behavior
- [x] All existing tests pass
- [x] Documentation updated (README.md REST API list + docs/CLI_USER_GUIDE.md)
- [x] No secrets or credentials in the diff

Closes #542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-agent semantic recall: POST /api/v2/recall/multi and CLI --agents return merged, score-sorted memories attributed by source agent with per-agent counts; CLI displays source agent on memory panels.

* **Documentation**
  * API and CLI guides updated with endpoint/option usage, constraints, and a cross-agent example.

* **Authorization**
  * Per-agent session tokens required; missing or unauthorized tokens are rejected.

* **Tests**
  * New contract and E2E tests for merge/sort, attribution, authorization, and confidence filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->