### PR TITLE
Add Claude Code skills memory bridge example

### DIFF
--- a/examples/claudecode-skills-memanto/README.md
+++ b/examples/claudecode-skills-memanto/README.md
@@ -1,0 +1,67 @@
+# Claude Code Skills + Memanto
+
+This example adds a small bridge that lets Claude Code skill workflows recall
+and record engineering context through the `memanto` CLI.
+
+It is designed for the repeated-instructions problem: when one skill captures a
+design decision, later skills can retrieve that decision without asking you to
+paste the same project rules again.
+
+## Setup
+
+```bash
+pip install memanto
+memanto connect claude-code
+```
+
+No extra Python dependencies are required by this example.
+
+## Usage
+
+Inject relevant prior memories before starting a skill:
+
+```bash
+python skill_memory.py inject --event '{
+  "skill": "tdd",
+  "task": "add retry tests",
+  "project_path": "/workspace/billing",
+  "files": ["billing/retry.py"]
+}'
+```
+
+Record what a completed skill learned:
+
+```bash
+python skill_memory.py record --event '{
+  "skill": "tdd",
+  "task": "add retry tests",
+  "project_path": "/workspace/billing",
+  "summary": "Retries stop after the third failed provider attempt.",
+  "decisions": ["Keep retry policy per provider adapter."]
+}'
+```
+
+Both commands also accept the event JSON on stdin, which makes them easy to wrap
+from Claude Code hooks or custom skill runners.
+
+## How It Works
+
+- `inject` builds a query from the current skill, task, project, and touched
+  files, then calls `memanto recall ... --json`.
+- Recalled memories are formatted as concise additional context so the next
+  skill gets only the relevant decisions.
+- `record` writes a completion summary and explicit decisions with
+  `memanto remember --type decision`.
+- Empty summaries are skipped so the memory namespace does not accumulate noise.
+
+## Hook Wrapper Sketch
+
+A skill runner can call `inject` before invoking a skill and prepend the returned
+`additionalContext` to the skill prompt. After the skill finishes, call `record`
+with a short summary and the decisions worth preserving.
+
+```bash
+python skill_memory.py inject < skill-start-event.json
+python skill_memory.py record < skill-complete-event.json
+```
+

--- a/examples/claudecode-skills-memanto/requirements.txt
+++ b/examples/claudecode-skills-memanto/requirements.txt
@@ -1,0 +1,1 @@
+# This example uses only the Python standard library plus the memanto CLI.

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -149,7 +149,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     bridge = SkillMemoryBridge()
-    event = load_event(args.event)
+    try:
+        event = load_event(args.event)
+    except (json.JSONDecodeError, ValueError) as error:
+        print(f"Invalid event input: {error}", file=sys.stderr)
+        return 1
+
     if args.mode == "inject":
         payload = bridge.inject_context(event)
     else:

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Claude Code skills memory bridge backed by the Memanto CLI.
+
+This example keeps skill workflows stateless on disk while letting Memanto
+persist the engineering decisions that matter across sessions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import Any
+
+CommandRunner = Callable[[list[str]], Any]
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, check=False, text=True)
+
+
+class SkillMemoryBridge:
+    def __init__(
+        self,
+        runner: CommandRunner = run_command,
+        recall_limit: int = 5,
+        context_budget: int = 1600,
+    ) -> None:
+        self.runner = runner
+        self.recall_limit = recall_limit
+        self.context_budget = context_budget
+
+    def inject_context(self, event: dict[str, Any]) -> dict[str, str]:
+        query = self._build_recall_query(event)
+        try:
+            result = self.runner(
+                ["memanto", "recall", query, "--limit", str(self.recall_limit), "--json"]
+            )
+        except FileNotFoundError:
+            return {"additionalContext": ""}
+
+        memories = self._parse_memories(getattr(result, "stdout", ""))
+        if not memories:
+            return {"additionalContext": ""}
+
+        lines = ["Relevant engineering memory from prior skill runs:"]
+        for memory in memories:
+            memory_type = memory.get("type", "memory")
+            score = memory.get("score")
+            score_text = f", score {score:.2f}" if isinstance(score, int | float) else ""
+            content = str(memory.get("content", "")).strip()
+            if content:
+                lines.append(f"- [{memory_type}{score_text}] {content}")
+
+        return {"additionalContext": self._clip("\n".join(lines))}
+
+    def record_completion(self, event: dict[str, Any]) -> dict[str, Any]:
+        summary = str(event.get("summary", "")).strip()
+        decisions = [
+            str(decision).strip()
+            for decision in event.get("decisions", [])
+            if str(decision).strip()
+        ]
+        if not summary and not decisions:
+            return {"stored": False, "reason": "empty summary"}
+
+        skill = str(event.get("skill", "unknown-skill")).strip() or "unknown-skill"
+        task = str(event.get("task", "unspecified task")).strip() or "unspecified task"
+        project_path = str(event.get("project_path", "")).strip()
+        memory_body = self._format_memory_body(summary, decisions, project_path)
+        title = f"Skill {skill} completed: {task}"
+
+        try:
+            result = self.runner(
+                [
+                    "memanto",
+                    "remember",
+                    title,
+                    memory_body,
+                    "--type",
+                    "decision",
+                ]
+            )
+        except FileNotFoundError:
+            return {"stored": False, "reason": "memanto CLI unavailable"}
+
+        return {
+            "stored": getattr(result, "returncode", 0) == 0,
+            "title": title,
+        }
+
+    def _build_recall_query(self, event: dict[str, Any]) -> str:
+        skill = str(event.get("skill", "unknown-skill")).strip() or "unknown-skill"
+        task = str(event.get("task", "unspecified task")).strip() or "unspecified task"
+        project_path = str(event.get("project_path", "unknown project")).strip()
+        files = event.get("files", [])
+        file_text = ", ".join(str(path) for path in files) if files else "no files"
+        return f"Skill {skill} for task {task} in {project_path} touching {file_text}"
+
+    def _parse_memories(self, stdout: str) -> list[dict[str, Any]]:
+        try:
+            payload = json.loads(stdout or "{}")
+        except json.JSONDecodeError:
+            return []
+
+        if isinstance(payload, dict):
+            memories = payload.get("memories", [])
+        elif isinstance(payload, list):
+            memories = payload
+        else:
+            memories = []
+
+        return [memory for memory in memories if isinstance(memory, dict)]
+
+    def _format_memory_body(
+        self, summary: str, decisions: list[str], project_path: str
+    ) -> str:
+        parts = []
+        if summary:
+            parts.append(summary)
+        if decisions:
+            parts.append("Decisions:\n" + "\n".join(f"- {item}" for item in decisions))
+        if project_path:
+            parts.append(f"Project path: {project_path}")
+        return "\n\n".join(parts)
+
+    def _clip(self, text: str) -> str:
+        if len(text) <= self.context_budget:
+            return text
+        return text[: self.context_budget - 3].rstrip() + "..."
+
+
+def load_event(raw_event: str | None) -> dict[str, Any]:
+    raw = raw_event if raw_event is not None else sys.stdin.read()
+    if not raw.strip():
+        return {}
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("event JSON must be an object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Memanto bridge for Claude Code skills")
+    parser.add_argument("mode", choices=["inject", "record"])
+    parser.add_argument("--event", help="JSON event payload. Defaults to stdin.")
+    args = parser.parse_args(argv)
+
+    bridge = SkillMemoryBridge()
+    event = load_event(args.event)
+    if args.mode == "inject":
+        payload = bridge.inject_context(event)
+    else:
+        payload = bridge.record_completion(event)
+
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/claudecode-skills-memanto/skill_memory.py
+++ b/examples/claudecode-skills-memanto/skill_memory.py
@@ -18,21 +18,26 @@ CommandRunner = Callable[[list[str]], Any]
 
 
 def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a Memanto CLI command and return the completed process."""
     return subprocess.run(command, capture_output=True, check=False, text=True)
 
 
 class SkillMemoryBridge:
+    """Bridge Claude Code skill lifecycle events to Memanto memory commands."""
+
     def __init__(
         self,
         runner: CommandRunner = run_command,
         recall_limit: int = 5,
         context_budget: int = 1600,
     ) -> None:
+        """Configure the CLI runner and recall output limits."""
         self.runner = runner
         self.recall_limit = recall_limit
         self.context_budget = context_budget
 
     def inject_context(self, event: dict[str, Any]) -> dict[str, str]:
+        """Recall relevant engineering memories for a skill event."""
         query = self._build_recall_query(event)
         try:
             result = self.runner(
@@ -57,6 +62,7 @@ class SkillMemoryBridge:
         return {"additionalContext": self._clip("\n".join(lines))}
 
     def record_completion(self, event: dict[str, Any]) -> dict[str, Any]:
+        """Persist completion notes from a finished skill run."""
         summary = str(event.get("summary", "")).strip()
         decisions = [
             str(decision).strip()
@@ -92,6 +98,7 @@ class SkillMemoryBridge:
         }
 
     def _build_recall_query(self, event: dict[str, Any]) -> str:
+        """Build the Memanto recall query from the skill event metadata."""
         skill = str(event.get("skill", "unknown-skill")).strip() or "unknown-skill"
         task = str(event.get("task", "unspecified task")).strip() or "unspecified task"
         project_path = str(event.get("project_path", "unknown project")).strip()
@@ -100,6 +107,7 @@ class SkillMemoryBridge:
         return f"Skill {skill} for task {task} in {project_path} touching {file_text}"
 
     def _parse_memories(self, stdout: str) -> list[dict[str, Any]]:
+        """Parse Memanto JSON output into memory dictionaries."""
         try:
             payload = json.loads(stdout or "{}")
         except json.JSONDecodeError:
@@ -117,6 +125,7 @@ class SkillMemoryBridge:
     def _format_memory_body(
         self, summary: str, decisions: list[str], project_path: str
     ) -> str:
+        """Format a completion event into a Memanto memory body."""
         parts = []
         if summary:
             parts.append(summary)
@@ -127,12 +136,14 @@ class SkillMemoryBridge:
         return "\n\n".join(parts)
 
     def _clip(self, text: str) -> str:
+        """Constrain recalled context to the configured character budget."""
         if len(text) <= self.context_budget:
             return text
         return text[: self.context_budget - 3].rstrip() + "..."
 
 
 def load_event(raw_event: str | None) -> dict[str, Any]:
+    """Load a JSON skill event from an argument or standard input."""
     raw = raw_event if raw_event is not None else sys.stdin.read()
     if not raw.strip():
         return {}
@@ -143,6 +154,7 @@ def load_event(raw_event: str | None) -> dict[str, Any]:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the skill memory bridge CLI."""
     parser = argparse.ArgumentParser(description="Memanto bridge for Claude Code skills")
     parser.add_argument("mode", choices=["inject", "record"])
     parser.add_argument("--event", help="JSON event payload. Defaults to stdin.")

--- a/tests/test_claudecode_skill_memory.py
+++ b/tests/test_claudecode_skill_memory.py
@@ -11,6 +11,7 @@ MODULE_PATH = (
 
 
 def load_module():
+    """Load the example module from its documentation directory."""
     spec = importlib.util.spec_from_file_location("skill_memory", MODULE_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -19,12 +20,16 @@ def load_module():
 
 
 class FakeRunner:
+    """Capture Memanto CLI commands while returning configured output."""
+
     def __init__(self, stdout="", returncode=0):
+        """Configure fake process output for command calls."""
         self.stdout = stdout
         self.returncode = returncode
         self.commands = []
 
     def __call__(self, command):
+        """Record a command and return a process-like result object."""
         self.commands.append(command)
 
         class Result:
@@ -38,10 +43,12 @@ class FakeRunner:
 
 
 def missing_runner(command):
+    """Simulate the Memanto CLI being absent from PATH."""
     raise FileNotFoundError(command[0])
 
 
 def test_inject_context_formats_recalled_engineering_decisions():
+    """Inject mode formats recalled Memanto memories into context."""
     skill_memory = load_module()
     recall_payload = {
         "memories": [
@@ -85,6 +92,7 @@ def test_inject_context_formats_recalled_engineering_decisions():
 
 
 def test_record_completion_stores_decisions_and_skips_empty_summaries():
+    """Record mode stores non-empty summaries and skips empty events."""
     skill_memory = load_module()
     runner = FakeRunner(stdout='{"memory_id": "mem-1"}')
     bridge = skill_memory.SkillMemoryBridge(runner=runner)
@@ -121,6 +129,7 @@ def test_record_completion_stores_decisions_and_skips_empty_summaries():
 
 
 def test_missing_memanto_cli_fails_open_without_crashing():
+    """Missing Memanto binaries return empty outputs instead of raising."""
     skill_memory = load_module()
     bridge = skill_memory.SkillMemoryBridge(runner=missing_runner)
 
@@ -136,6 +145,7 @@ def test_missing_memanto_cli_fails_open_without_crashing():
 
 
 def test_main_reports_invalid_event_input(capsys):
+    """Invalid event JSON is reported as a CLI error."""
     skill_memory = load_module()
 
     exit_code = skill_memory.main(["inject", "--event", "[]"])

--- a/tests/test_claudecode_skill_memory.py
+++ b/tests/test_claudecode_skill_memory.py
@@ -1,0 +1,135 @@
+import importlib.util
+import json
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "claudecode-skills-memanto"
+    / "skill_memory.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("skill_memory", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeRunner:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.commands = []
+
+    def __call__(self, command):
+        self.commands.append(command)
+
+        class Result:
+            pass
+
+        result = Result()
+        result.stdout = self.stdout
+        result.stderr = ""
+        result.returncode = self.returncode
+        return result
+
+
+def missing_runner(command):
+    raise FileNotFoundError(command[0])
+
+
+def test_inject_context_formats_recalled_engineering_decisions():
+    skill_memory = load_module()
+    recall_payload = {
+        "memories": [
+            {
+                "content": "Use repository-local helpers before introducing new abstractions.",
+                "type": "preference",
+                "score": 0.91,
+            },
+            {
+                "content": "Payment code must keep provider-specific retries isolated.",
+                "type": "decision",
+                "score": 0.84,
+            },
+        ]
+    }
+    runner = FakeRunner(stdout=json.dumps(recall_payload))
+    bridge = skill_memory.SkillMemoryBridge(runner=runner)
+
+    output = bridge.inject_context(
+        {
+            "skill": "tdd",
+            "task": "add retry tests",
+            "project_path": "/workspace/billing",
+            "files": ["billing/retry.py"],
+        }
+    )
+
+    assert "Relevant engineering memory" in output["additionalContext"]
+    assert "repository-local helpers" in output["additionalContext"]
+    assert "provider-specific retries" in output["additionalContext"]
+    assert runner.commands == [
+        [
+            "memanto",
+            "recall",
+            "Skill tdd for task add retry tests in /workspace/billing touching billing/retry.py",
+            "--limit",
+            "5",
+            "--json",
+        ]
+    ]
+
+
+def test_record_completion_stores_decisions_and_skips_empty_summaries():
+    skill_memory = load_module()
+    runner = FakeRunner(stdout='{"memory_id": "mem-1"}')
+    bridge = skill_memory.SkillMemoryBridge(runner=runner)
+
+    stored = bridge.record_completion(
+        {
+            "skill": "tdd",
+            "task": "add retry tests",
+            "project_path": "/workspace/billing",
+            "summary": "Captured that retries stop after the third failed provider attempt.",
+            "decisions": ["Keep retry policy per provider adapter."],
+        }
+    )
+
+    skipped = bridge.record_completion(
+        {
+            "skill": "tdd",
+            "task": "empty",
+            "project_path": "/workspace/billing",
+            "summary": "   ",
+            "decisions": [],
+        }
+    )
+
+    assert stored["stored"] is True
+    assert skipped == {"stored": False, "reason": "empty summary"}
+    assert len(runner.commands) == 1
+    command = runner.commands[0]
+    assert command[:3] == ["memanto", "remember", "Skill tdd completed: add retry tests"]
+    assert "--type" in command
+    assert "decision" in command
+    assert "Captured that retries stop after the third failed provider attempt." in command[3]
+    assert "Keep retry policy per provider adapter." in command[3]
+
+
+def test_missing_memanto_cli_fails_open_without_crashing():
+    skill_memory = load_module()
+    bridge = skill_memory.SkillMemoryBridge(runner=missing_runner)
+
+    assert bridge.inject_context({"skill": "tdd", "task": "demo"}) == {
+        "additionalContext": ""
+    }
+    assert bridge.record_completion(
+        {"skill": "tdd", "task": "demo", "summary": "Useful decision."}
+    ) == {
+        "stored": False,
+        "reason": "memanto CLI unavailable",
+    }

--- a/tests/test_claudecode_skill_memory.py
+++ b/tests/test_claudecode_skill_memory.py
@@ -133,3 +133,15 @@ def test_missing_memanto_cli_fails_open_without_crashing():
         "stored": False,
         "reason": "memanto CLI unavailable",
     }
+
+
+def test_main_reports_invalid_event_input(capsys):
+    skill_memory = load_module()
+
+    exit_code = skill_memory.main(["inject", "--event", "[]"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "Invalid event input" in captured.err
+    assert "event JSON must be an object" in captured.err


### PR DESCRIPTION
## Summary

Contributes to #508 by adding a Claude Code skills memory bridge example under `examples/claudecode-skills-memanto`.

The example demonstrates a lightweight integration layer where skill runners can:

- call `inject` before a skill starts to retrieve relevant engineering decisions via `memanto recall --json`
- call `record` after a skill completes to persist the summary and explicit decisions via `memanto remember --type decision`
- skip empty summaries so the memory namespace does not accumulate noise
- fail open if the `memanto` CLI is unavailable, which keeps skill execution from crashing

## Files Added

- `examples/claudecode-skills-memanto/skill_memory.py`
- `examples/claudecode-skills-memanto/README.md`
- `examples/claudecode-skills-memanto/requirements.txt`
- `tests/test_claudecode_skill_memory.py`

## Verification

- `.venv/bin/python -m pytest tests/test_claudecode_skill_memory.py -q`
- `.venv/bin/ruff check examples/claudecode-skills-memanto/skill_memory.py tests/test_claudecode_skill_memory.py`
- `git diff --check`
- Manual CLI smoke test for the unavailable-CLI path:
  `python examples/claudecode-skills-memanto/skill_memory.py record --event '{"skill":"tdd","task":"demo","summary":"Remember to keep adapters explicit."}'`

## Showcase

Public technical showcase:
https://gist.github.com/lcwLcw123/eb0895a121219bee66978823dc8308c5

The showcase walks through the cross-session memory problem, the `inject`/`record` workflow, review-safe failure behavior, and the local verification commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed README for the Claude Code ↔ memanto CLI example with install, setup, and usage scenarios.

* **New Features**
  * Provided a runnable example that injects recalled memories into workflows and records summaries/decisions via the memanto CLI.

* **Tests**
  * Added tests validating memory injection formatting, recording behavior (including empty summaries), CLI input validation, and graceful handling when the memanto CLI is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->