### PR TITLE
test: add forget failure-path + cross-agent DELETE rejection tests (Refs PR #632, BountyHub #508)

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -299,6 +299,52 @@ async def batch_remember(
         raise map_error_to_http_exception(e)
 
 
+@router.delete("/{agent_id}/memories/{memory_id}")
+async def delete_memory(
+    agent_id: str,
+    memory_id: str,
+    session: Session = Depends(get_current_session),
+    client=Depends(get_moorcheh_client),
+):
+    """
+    Delete one memory from the active agent's namespace (Session-based).
+
+    Requires:
+    - X-Session-Token: {session_token}
+
+    The session must be for the specified agent_id.
+    """
+    if session.agent_id != agent_id:
+        raise map_error_to_http_exception(
+            Exception(
+                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
+            )
+        )
+
+    try:
+        write_service = MemoryWriteService(client)
+        deleted = await asyncio.to_thread(
+            write_service.delete_memory, memory_id, session.namespace
+        )
+        if not deleted:
+            raise HTTPException(
+                status_code=404, detail=f"Memory '{memory_id}' was not found."
+            )
+
+        return {
+            "agent_id": agent_id,
+            "session_id": session.session_id,
+            "namespace": session.namespace,
+            "memory_id": memory_id,
+            "status": "deleted",
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise map_error_to_http_exception(e)
+
+
 @router.post("/{agent_id}/upload-file")
 async def upload_file(
     agent_id: str,

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -729,6 +729,34 @@ class DirectClient:
 
         return result
 
+    def delete_memory(self, agent_id: str, memory_id: str) -> dict[str, Any]:
+        """
+        Delete a single memory from the active agent namespace.
+
+        Args:
+            agent_id: Target agent.
+            memory_id: Memory document ID to delete.
+
+        Returns:
+            Dict with deletion status metadata.
+
+        Raises:
+            ValueError: If the memory does not exist or was not deleted.
+        """
+        session = self._get_validated_session_for_agent(agent_id)
+        deleted = self._get_write_service().delete_memory(
+            memory_id, session.namespace
+        )
+        if not deleted:
+            raise ValueError(f"Memory '{memory_id}' was not found")
+
+        return {
+            "agent_id": agent_id,
+            "namespace": session.namespace,
+            "memory_id": memory_id,
+            "status": "deleted",
+        }
+
     def recall(
         self,
         agent_id: str,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -566,6 +566,34 @@ class SdkClient:
 
         return result
 
+    def delete_memory(self, agent_id: str, memory_id: str) -> dict[str, Any]:
+        """
+        Delete a single memory from the active agent namespace.
+
+        Args:
+            agent_id: Target agent.
+            memory_id: Memory document ID to delete.
+
+        Returns:
+            Dict with deletion status metadata.
+
+        Raises:
+            ValueError: If the memory does not exist or was not deleted.
+        """
+        session = self._get_validated_session_for_agent(agent_id)
+        deleted = self._get_write_service().delete_memory(
+            memory_id, session.namespace
+        )
+        if not deleted:
+            raise ValueError(f"Memory '{memory_id}' was not found")
+
+        return {
+            "agent_id": agent_id,
+            "namespace": session.namespace,
+            "memory_id": memory_id,
+            "status": "deleted",
+        }
+
     def upload_file(self, agent_id: str, file_path: str) -> dict[str, Any]:
         """
         Upload a file directly to the agent's memory namespace.

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -173,6 +173,47 @@ def remember(
 
 
 @app.command()
+def forget(
+    memory_id: str = typer.Argument(..., help="Memory ID to delete"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Delete without asking for confirmation"
+    ),
+):
+    """Delete one memory from the active agent."""
+    start = time.perf_counter()
+    active_agent_id, active_session_token = config_manager.get_active_session()
+
+    if not active_agent_id or not active_session_token:
+        _error(
+            "No active agent.", hint="Run 'memanto agent activate <agent-id>' first."
+        )
+
+    if not force:
+        confirmed = typer.confirm(
+            f"Delete memory '{memory_id}' from agent '{active_agent_id}'?"
+        )
+        if not confirmed:
+            console.print("[yellow]Deletion cancelled.[/yellow]")
+            raise typer.Exit(0)
+
+    client = get_client()
+
+    try:
+        with console.status("[cyan]Deleting memory...", spinner="dots"):
+            result = client.delete_memory(
+                agent_id=active_agent_id, memory_id=memory_id
+            )
+        elapsed = time.perf_counter() - start
+
+        console.print("[green]Memory deleted successfully![/green]")
+        console.print(f"[dim]Memory ID: {result.get('memory_id', memory_id)}[/dim]")
+        console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")
+
+    except Exception as e:
+        _error(f"Failed to delete memory: {e}")
+
+
+@app.command()
 def upload(
     file_path: str = typer.Argument(..., help="Path to the file to upload"),
 ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -310,6 +310,33 @@ class TestMEMANTOAPI:
         assert "missing-memory" in response.json()["detail"]
 
     @pytest.mark.asyncio
+    async def test_delete_memory_rejected_for_cross_agent(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Test DELETE is rejected when session.agent_id != URL agent_id."""
+        other_agent = "different-agent"
+
+        app.dependency_overrides[get_current_session] = lambda: Session(
+            session_id="sess-test",
+            session_token="token-test",
+            agent_id=other_agent,
+            namespace=f"memanto_agent_{other_agent}",
+            started_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+        app.dependency_overrides[get_moorcheh_client] = lambda: mock_moorcheh
+        try:
+            response = await client.delete(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/memories/mem-123",
+                headers=auth_headers,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 403
+        mock_moorcheh.documents.delete.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_answer_with_session(self, client, auth_headers, mock_moorcheh):
         """Test RAG answer with session token"""
         # Setup session

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,18 @@
 import os
 import shutil
 import tempfile
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import settings
 from memanto.app.main import app
+from memanto.app.models.session import Session
+from memanto.app.routes.auth_deps import get_current_session
 
 # Set test environment
 os.environ["MOORCHEH_API_KEY"] = "test-api-key"
@@ -245,6 +249,65 @@ class TestMEMANTOAPI:
 
         assert response.status_code == 200
         assert response.json()["status"] == "queued"
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_with_session(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Test deleting one memory with session token."""
+        mock_moorcheh.documents.delete.return_value = {"actual_deletions": 1}
+
+        app.dependency_overrides[get_current_session] = lambda: Session(
+            session_id="sess-test",
+            session_token="token-test",
+            agent_id=self.TEST_AGENT_ID,
+            namespace=f"memanto_agent_{self.TEST_AGENT_ID}",
+            started_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+        app.dependency_overrides[get_moorcheh_client] = lambda: mock_moorcheh
+        try:
+            response = await client.delete(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/memories/mem-123",
+                headers=auth_headers,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "deleted"
+        assert data["memory_id"] == "mem-123"
+        mock_moorcheh.documents.delete.assert_called_once_with(
+            namespace_name=f"memanto_agent_{self.TEST_AGENT_ID}", ids=["mem-123"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_returns_404_when_missing(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Test deleting a missing memory returns a clear 404."""
+        mock_moorcheh.documents.delete.return_value = {"actual_deletions": 0}
+
+        app.dependency_overrides[get_current_session] = lambda: Session(
+            session_id="sess-test",
+            session_token="token-test",
+            agent_id=self.TEST_AGENT_ID,
+            namespace=f"memanto_agent_{self.TEST_AGENT_ID}",
+            started_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+        app.dependency_overrides[get_moorcheh_client] = lambda: mock_moorcheh
+        try:
+            response = await client.delete(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/memories/missing-memory",
+                headers=auth_headers,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 404
+        assert "missing-memory" in response.json()["detail"]
 
     @pytest.mark.asyncio
     async def test_answer_with_session(self, client, auth_headers, mock_moorcheh):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,6 +209,30 @@ class TestMEMANTOCLI:
         assert "stored successfully" in result.stdout.lower()
         assert "mem-123" in result.stdout
 
+    def test_forget_force(self, mock_all_clients):
+        """Test 'memanto forget --force' deletes one memory."""
+        mock_all_clients.delete_memory.return_value = {
+            "memory_id": "mem-123",
+            "status": "deleted",
+        }
+
+        result = runner.invoke(app, ["forget", "mem-123", "--force"])
+
+        assert result.exit_code == 0
+        assert "deleted successfully" in result.stdout.lower()
+        assert "mem-123" in result.stdout
+        mock_all_clients.delete_memory.assert_called_once_with(
+            agent_id="test-agent", memory_id="mem-123"
+        )
+
+    def test_forget_confirmation_declined(self, mock_all_clients):
+        """Test 'memanto forget' can be cancelled before deletion."""
+        result = runner.invoke(app, ["forget", "mem-123"], input="n\n")
+
+        assert result.exit_code == 0
+        assert "cancelled" in result.stdout.lower()
+        mock_all_clients.delete_memory.assert_not_called()
+
     def test_recall(self, mock_all_clients):
         """Test 'memanto recall'"""
         mock_all_clients.recall.return_value = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -233,6 +233,18 @@ class TestMEMANTOCLI:
         assert "cancelled" in result.stdout.lower()
         mock_all_clients.delete_memory.assert_not_called()
 
+    def test_forget_nonexistent_memory(self, mock_all_clients):
+        """Test 'memanto forget' surfaces a clear error when memory is missing."""
+        mock_all_clients.delete_memory.side_effect = Exception("memory not found")
+
+        result = runner.invoke(app, ["forget", "mem-404", "--force"])
+
+        assert result.exit_code != 0
+        assert "memory not found" in result.stdout.lower() or "memory not found" in (result.stderr or "").lower()
+        mock_all_clients.delete_memory.assert_called_once_with(
+            agent_id="test-agent", memory_id="mem-404"
+        )
+
     def test_recall(self, mock_all_clients):
         """Test 'memanto recall'"""
         mock_all_clients.recall.return_value = {


### PR DESCRIPTION
## Summary

This follow-up PR addresses the 2 CodeRabbit review items on PR #632 (`feat: add memory forget command`):

1. **`test_forget_nonexistent_memory`** — verifies that `memanto forget --force` surfaces a clear non-zero exit + error message when the underlying `delete_memory` raises (e.g. memory not found).
2. **`test_delete_memory_rejected_for_cross_agent`** — verifies that `DELETE /api/v2/agents/<id>/memories/<id>` returns 403 and does not call `moorcheh.documents.delete` when `session.agent_id != URL agent_id` (the cross-agent guard at `memanto/app/routes/memory.py:316`).

Refs PR #632 · Issue #539 · BountyHub #508 $100

## Validation
- `py_compile` OK
- `ruff check` clean
- `git diff --check` clean
- 2 new tests added (2 files +39/-0)

## Note
PR #632 (`codex/forget-single-memory`) remains the source PR. This PR (`fix/pr632-tests`) is a non-overlapping follow-up that adds the missing test coverage. Both can be merged independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API support to delete a single memory from an active agent session (returns `status: "deleted"`; returns 404 when the memory is missing; rejects cross-agent access).
  * Added matching delete-memory methods to the Direct and SDK clients.
  * Introduced the `memanto forget` CLI command with a confirmation prompt and `--force` to skip it.

* **Tests**
  * Added API contract tests and CLI integration tests covering successful deletion, missing-memory behavior, confirmation-cancel flow, and cross-agent rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->