### PR TITLE
fix(memory): return HTTP 403 for cross-agent scope mismatch

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -147,10 +147,9 @@ async def remember(
 
     # Enforce session scope: token must match agent_id
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     try:
@@ -235,10 +234,9 @@ async def batch_remember(
     """
     # Enforce session scope: token must match agent_id
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     try:
@@ -321,10 +319,9 @@ async def upload_file(
     - Content-Type: multipart/form-data
     """
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     client = get_moorcheh_client()
@@ -392,10 +389,9 @@ async def recall(
 
     # Enforce session scope
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     recall_cfg = _config_manager.get_recall_config()
@@ -468,10 +464,9 @@ async def answer(
 
     # Enforce session scope
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     client = get_moorcheh_client()
@@ -575,10 +570,9 @@ async def generate_daily_summary(
     POST ``/{agent_id}/conflicts/generate`` or the scheduled job.
     """
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     resolved_date = request.date or datetime.now().strftime("%Y-%m-%d")
@@ -611,10 +605,9 @@ async def generate_conflict_report(
     This is the same work the scheduled task performs.
     """
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     resolved_date = request.date or datetime.now().strftime("%Y-%m-%d")
@@ -650,10 +643,9 @@ async def list_conflicts(
     """
     # Enforce session scope
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     try:
@@ -685,10 +677,9 @@ async def resolve_conflict(
     Uses the same underlying conflict resolution service used by CLI.
     """
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     resolved_date = request.date or datetime.now().strftime("%Y-%m-%d")
@@ -732,10 +723,9 @@ async def recall_as_of(
     - X-Session-Token: {session_token}
     """
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     # request.limit is None → fetch all (no cap). Cost guard only applies when capped.
@@ -785,10 +775,9 @@ async def recall_changed_since(
     - X-Session-Token: {session_token}
     """
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     # request.limit is None → fetch all (no cap). Cost guard only applies when capped.
@@ -839,10 +828,9 @@ async def recall_recent(
     The session must be for the specified agent_id.
     """
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
     # request.limit is None → fetch all (no cap). Cost guard only applies when capped.


### PR DESCRIPTION
## Summary

The session-scope guard in every agent-scoped endpoint mapped cross-agent
access (`session.agent_id != URL agent_id`) to a generic `Exception`,
which the global error mapper then converted to HTTP **500**. That is
semantically wrong: an authorization failure must be **403**, not 500.

Replace all 12 occurrences with a direct `HTTPException(status_code=403, ...)`.

## Why now

- **CodeRabbit** flagged this exact bug on PR #733's `DELETE /memories/{id}`
  test (cross-agent rejection test was asserting 403 but the current
  code returns 500 → test fails against current `main`).
- The same code path is shared by 12 endpoints, so a focused single-PR
  fix is the cleanest place to land the change.

## Endpoints touched

`remember`, `batch_remember`, `upload_file`, `recall`, `answer`,
`generate_daily_summary`, `generate_conflict_report`, `list_conflicts`,
`resolve_conflict`, `recall_as_of`, `recall_changed_since`,
`recall_recent`.

## Diff

```diff
     if session.agent_id != agent_id:
-        raise map_error_to_http_exception(
-            Exception(
-                f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'"
-            )
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
```

- 1 file changed, 36 insertions(+), 48 deletions(-)
- All 12 sites are identical pattern replacements, no behavior change
  beyond the status code.

## Validation

- `python -m ruff check memanto/app/routes/memory.py` → clean
- Existing tests that asserted `status_code == 500` for an unrelated
  code path (`test_create_agent_fails_when_server_key_missing`) are not
  affected (different route, different failure mode).
- No existing test asserts `500` for any cross-agent check (confirmed by
  grep over `tests/`).

## Related

- **Refs PR #733** (test follow-up for #632 `feat: add memory forget command`)
  - test asserts `403` for cross-agent DELETE; currently fails against
    `main` because the underlying route returns 500.
- **Refs PR #736** (test follow-up for #633 `feat: add memory edit command`)
  - parallel test for the PATCH endpoint.
- Once this lands, rebase PR #733 and PR #736 onto `main` and the
  cross-agent tests will pass.

Refs PR #733, PR #736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized session authorization error handling across memory operations to ensure consistent and secure access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->