### PR TITLE
[codex] Add incident runbook memory benchmark

### DIFF
--- a/examples/benchmarks/incident-runbook-memory/README.md
+++ b/examples/benchmarks/incident-runbook-memory/README.md
@@ -1,0 +1,77 @@
+# Incident Runbook Memory Benchmark
+
+This benchmark evaluates the core 2026 agent-memory tradeoff from issue #639:
+current-state accuracy versus retrieved-context footprint.
+
+The scenario is an incident-response assistant that receives dense, shifting
+technical notes over five sessions. Facts mutate over time: owners rotate,
+runbooks are superseded, customer-facing language changes, and one raw note
+contains a synthetic credential. The benchmark asks current-state questions and
+scores each backend against golden answers.
+
+## Backends
+
+| Backend | Role |
+|---|---|
+| `active_incident_digest` | Memanto-style active memory that keeps the latest fact per subject/key and redacts secrets before retrieval. |
+| `append_only_log` | Archive-memory control that returns every raw event for the queried subject. |
+| `recent_window_log` | Short-context control that keeps only the five newest raw events. |
+
+The two controls are deliberately simple and deterministic. They are not
+published vendor scores for Mem0, Letta, Zep/Graphiti, or Hindsight. They are
+included so the experimental harness, dataset, metrics, and expected behavior
+can be reviewed without API keys. The same `MemoryBackend` protocol can be used
+to add hosted provider adapters while preserving the dataset and evaluator.
+
+## Metrics
+
+The runner reports:
+
+- retrieval accuracy against golden current facts
+- total ingested tokens
+- stored tokens
+- average retrieved tokens
+- deterministic p95 latency estimate
+- stale conflict rate
+- secret leak rate
+
+Latency is modeled from scanned records and retrieved tokens so CI runs are
+stable. Hosted adapters should replace that value with measured wall-clock
+latency while keeping the same query set.
+
+## Run
+
+No runtime dependency is required beyond Python 3.10+.
+
+```bash
+python run_benchmark.py --output results/sample_results.json --markdown results/sample_results.md
+```
+
+From the repository root:
+
+```bash
+python examples/benchmarks/incident-runbook-memory/run_benchmark.py \
+  --output examples/benchmarks/incident-runbook-memory/results/sample_results.json \
+  --markdown examples/benchmarks/incident-runbook-memory/results/sample_results.md
+```
+
+Run the tests:
+
+```bash
+python -m unittest discover -s examples/benchmarks/incident-runbook-memory -p test_*.py
+```
+
+## Dataset Design
+
+All backends ingest the same ordered event stream. The golden queries cover:
+
+- a service owner that changed from `payments-oncall` to `checkout-platform-oncall`
+- a checkout runbook that superseded `restart-all-pods`
+- customer language that changed for `payments-ledger`
+- a mitigation that changed for `catalog-worker`
+- a failover region that changed from `us-east-1` to `eu-west-1`
+- an early but still-current `billing-cron` owner
+- a synthetic credential that must not be surfaced
+
+This makes the benchmark stress both sides of the challenge: stale-context
+avoidance and resource footprint.

--- a/examples/benchmarks/incident-runbook-memory/README.md
+++ b/examples/benchmarks/incident-runbook-memory/README.md
@@ -14,8 +14,8 @@ scores each backend against golden answers.
 | Backend | Role |
 |---|---|
 | `active_incident_digest` | Memanto-style active memory that keeps the latest fact per subject/key and redacts secrets before retrieval. |
-| `append_only_log` | Archive-memory control that returns every raw event for the queried subject. |
-| `recent_window_log` | Short-context control that keeps only the five newest raw events. |
+| `append_only_log` | Archive-memory control that returns every raw event for the queried subject/key. |
+| `recent_window_log` | Short-context control that keeps only the five newest raw events and returns subject/key matches. |
 
 The two controls are deliberately simple and deterministic. They are not
 published vendor scores for Mem0, Letta, Zep/Graphiti, or Hindsight. They are

--- a/examples/benchmarks/incident-runbook-memory/requirements.txt
+++ b/examples/benchmarks/incident-runbook-memory/requirements.txt
@@ -1,0 +1,1 @@
+# This benchmark uses only the Python standard library.

--- a/examples/benchmarks/incident-runbook-memory/results/sample_results.json
+++ b/examples/benchmarks/incident-runbook-memory/results/sample_results.json
@@ -33,10 +33,10 @@
       "total_queries": 7,
       "total_ingested_tokens": 124,
       "stored_tokens": 124,
-      "avg_retrieved_tokens": 31.143,
-      "p95_latency_ms": 21.665,
+      "avg_retrieved_tokens": 15.143,
+      "p95_latency_ms": 20.58,
       "stale_conflict_rate": 0.857,
-      "secret_leak_rate": 0.429
+      "secret_leak_rate": 0.143
     },
     {
       "backend": "recent_window_log",
@@ -45,7 +45,7 @@
       "total_queries": 7,
       "total_ingested_tokens": 124,
       "stored_tokens": 45,
-      "avg_retrieved_tokens": 8.429,
+      "avg_retrieved_tokens": 5.286,
       "p95_latency_ms": 7.485,
       "stale_conflict_rate": 0.0,
       "secret_leak_rate": 0.0
@@ -155,17 +155,14 @@
       "question": "Who owns checkout-api right now?",
       "backend": "append_only_log",
       "correct": false,
-      "retrieved_tokens": 51,
-      "latency_ms": 21.665,
+      "retrieved_tokens": 13,
+      "latency_ms": 20.335,
       "scanned_records": 14,
       "stale_conflict": true,
-      "secret_leak": true,
+      "secret_leak": false,
       "retrieved_items": [
         "checkout-api owner is payments-oncall during the first rollout.",
-        "checkout-api runbook says restart-all-pods after clearing the queue.",
-        "checkout-api debug note includes sk_live_checkout_debug_123 for a local replay, and the credential must never be sent to an agent.",
-        "checkout-api owner changed to checkout-platform-oncall.",
-        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
+        "checkout-api owner changed to checkout-platform-oncall."
       ]
     },
     {
@@ -173,16 +170,13 @@
       "question": "Which runbook action should checkout-api use?",
       "backend": "append_only_log",
       "correct": false,
-      "retrieved_tokens": 51,
-      "latency_ms": 21.665,
+      "retrieved_tokens": 19,
+      "latency_ms": 20.545,
       "scanned_records": 14,
       "stale_conflict": true,
-      "secret_leak": true,
+      "secret_leak": false,
       "retrieved_items": [
-        "checkout-api owner is payments-oncall during the first rollout.",
         "checkout-api runbook says restart-all-pods after clearing the queue.",
-        "checkout-api debug note includes sk_live_checkout_debug_123 for a local replay, and the credential must never be sent to an agent.",
-        "checkout-api owner changed to checkout-platform-oncall.",
         "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
       ]
     },
@@ -191,14 +185,13 @@
       "question": "What should support say about payments-ledger retries?",
       "backend": "append_only_log",
       "correct": false,
-      "retrieved_tokens": 30,
-      "latency_ms": 20.93,
+      "retrieved_tokens": 20,
+      "latency_ms": 20.58,
       "scanned_records": 14,
       "stale_conflict": true,
       "secret_leak": false,
       "retrieved_items": [
         "payments-ledger customer message: payments are failing for some customers.",
-        "payments-ledger ops note: ledger lag is caused by settlement batching.",
         "payments-ledger customer message changed: payments post within 30 minutes after retry."
       ]
     },
@@ -251,17 +244,13 @@
       "question": "What debug credential can be shown to the agent?",
       "backend": "append_only_log",
       "correct": false,
-      "retrieved_tokens": 51,
-      "latency_ms": 21.665,
+      "retrieved_tokens": 19,
+      "latency_ms": 20.545,
       "scanned_records": 14,
       "stale_conflict": true,
       "secret_leak": true,
       "retrieved_items": [
-        "checkout-api owner is payments-oncall during the first rollout.",
-        "checkout-api runbook says restart-all-pods after clearing the queue.",
-        "checkout-api debug note includes sk_live_checkout_debug_123 for a local replay, and the credential must never be sent to an agent.",
-        "checkout-api owner changed to checkout-platform-oncall.",
-        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
+        "checkout-api debug note includes sk_live_checkout_debug_123 for a local replay, and the credential must never be sent to an agent."
       ]
     },
     {
@@ -269,14 +258,12 @@
       "question": "Who owns checkout-api right now?",
       "backend": "recent_window_log",
       "correct": false,
-      "retrieved_tokens": 11,
-      "latency_ms": 7.485,
+      "retrieved_tokens": 0,
+      "latency_ms": 7.1,
       "scanned_records": 5,
       "stale_conflict": false,
       "secret_leak": false,
-      "retrieved_items": [
-        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
-      ]
+      "retrieved_items": []
     },
     {
       "query_id": "q2_checkout_runbook",
@@ -351,14 +338,12 @@
       "question": "What debug credential can be shown to the agent?",
       "backend": "recent_window_log",
       "correct": false,
-      "retrieved_tokens": 11,
-      "latency_ms": 7.485,
+      "retrieved_tokens": 0,
+      "latency_ms": 7.1,
       "scanned_records": 5,
       "stale_conflict": false,
       "secret_leak": false,
-      "retrieved_items": [
-        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
-      ]
+      "retrieved_items": []
     }
   ],
   "notes": [

--- a/examples/benchmarks/incident-runbook-memory/results/sample_results.json
+++ b/examples/benchmarks/incident-runbook-memory/results/sample_results.json
@@ -1,0 +1,369 @@
+{
+  "benchmark": "incident-runbook-memory",
+  "version": "1.0.0",
+  "description": "Dense incident-response memory with superseded runbooks, old owner state, retained early facts, and a synthetic leaked credential.",
+  "dataset": {
+    "event_count": 14,
+    "query_count": 7,
+    "sessions": [
+      "session-1",
+      "session-2",
+      "session-3",
+      "session-4",
+      "session-5"
+    ]
+  },
+  "metrics": [
+    {
+      "backend": "active_incident_digest",
+      "retrieval_accuracy": 1.0,
+      "correct_queries": 7,
+      "total_queries": 7,
+      "total_ingested_tokens": 124,
+      "stored_tokens": 54,
+      "avg_retrieved_tokens": 5.429,
+      "p95_latency_ms": 12.095,
+      "stale_conflict_rate": 0.0,
+      "secret_leak_rate": 0.0
+    },
+    {
+      "backend": "append_only_log",
+      "retrieval_accuracy": 0.143,
+      "correct_queries": 1,
+      "total_queries": 7,
+      "total_ingested_tokens": 124,
+      "stored_tokens": 124,
+      "avg_retrieved_tokens": 31.143,
+      "p95_latency_ms": 21.665,
+      "stale_conflict_rate": 0.857,
+      "secret_leak_rate": 0.429
+    },
+    {
+      "backend": "recent_window_log",
+      "retrieval_accuracy": 0.571,
+      "correct_queries": 4,
+      "total_queries": 7,
+      "total_ingested_tokens": 124,
+      "stored_tokens": 45,
+      "avg_retrieved_tokens": 8.429,
+      "p95_latency_ms": 7.485,
+      "stale_conflict_rate": 0.0,
+      "secret_leak_rate": 0.0
+    }
+  ],
+  "records": [
+    {
+      "query_id": "q1_checkout_owner",
+      "question": "Who owns checkout-api right now?",
+      "backend": "active_incident_digest",
+      "correct": true,
+      "retrieved_tokens": 2,
+      "latency_ms": 11.85,
+      "scanned_records": 9,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "checkout-api.owner: checkout-platform-oncall"
+      ]
+    },
+    {
+      "query_id": "q2_checkout_runbook",
+      "question": "Which runbook action should checkout-api use?",
+      "backend": "active_incident_digest",
+      "correct": true,
+      "retrieved_tokens": 9,
+      "latency_ms": 12.095,
+      "scanned_records": 9,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "checkout-api.runbook: rollback checkout-canary and do not restart all pods"
+      ]
+    },
+    {
+      "query_id": "q3_payments_customer_message",
+      "question": "What should support say about payments-ledger retries?",
+      "backend": "active_incident_digest",
+      "correct": true,
+      "retrieved_tokens": 8,
+      "latency_ms": 12.06,
+      "scanned_records": 9,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "payments-ledger.customer_message: payments post within 30 minutes after retry"
+      ]
+    },
+    {
+      "query_id": "q4_catalog_mitigation",
+      "question": "What mitigation is current for catalog-worker?",
+      "backend": "active_incident_digest",
+      "correct": true,
+      "retrieved_tokens": 7,
+      "latency_ms": 12.025,
+      "scanned_records": 9,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "catalog-worker.mitigation: raise redis TTL to 45 seconds"
+      ]
+    },
+    {
+      "query_id": "q5_search_region",
+      "question": "Where should search-indexer fail over now?",
+      "backend": "active_incident_digest",
+      "correct": true,
+      "retrieved_tokens": 2,
+      "latency_ms": 11.85,
+      "scanned_records": 9,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "search-indexer.region: eu-west-1"
+      ]
+    },
+    {
+      "query_id": "q6_billing_owner",
+      "question": "Who still owns billing-cron even though it was mentioned early?",
+      "backend": "active_incident_digest",
+      "correct": true,
+      "retrieved_tokens": 2,
+      "latency_ms": 11.85,
+      "scanned_records": 9,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "billing-cron.owner: analytics-platform-oncall"
+      ]
+    },
+    {
+      "query_id": "q7_checkout_debug_secret",
+      "question": "What debug credential can be shown to the agent?",
+      "backend": "active_incident_digest",
+      "correct": true,
+      "retrieved_tokens": 8,
+      "latency_ms": 12.06,
+      "scanned_records": 9,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "checkout-api.debug_note: debug credential [REDACTED_SECRET] must never be sent"
+      ]
+    },
+    {
+      "query_id": "q1_checkout_owner",
+      "question": "Who owns checkout-api right now?",
+      "backend": "append_only_log",
+      "correct": false,
+      "retrieved_tokens": 51,
+      "latency_ms": 21.665,
+      "scanned_records": 14,
+      "stale_conflict": true,
+      "secret_leak": true,
+      "retrieved_items": [
+        "checkout-api owner is payments-oncall during the first rollout.",
+        "checkout-api runbook says restart-all-pods after clearing the queue.",
+        "checkout-api debug note includes sk_live_checkout_debug_123 for a local replay, and the credential must never be sent to an agent.",
+        "checkout-api owner changed to checkout-platform-oncall.",
+        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
+      ]
+    },
+    {
+      "query_id": "q2_checkout_runbook",
+      "question": "Which runbook action should checkout-api use?",
+      "backend": "append_only_log",
+      "correct": false,
+      "retrieved_tokens": 51,
+      "latency_ms": 21.665,
+      "scanned_records": 14,
+      "stale_conflict": true,
+      "secret_leak": true,
+      "retrieved_items": [
+        "checkout-api owner is payments-oncall during the first rollout.",
+        "checkout-api runbook says restart-all-pods after clearing the queue.",
+        "checkout-api debug note includes sk_live_checkout_debug_123 for a local replay, and the credential must never be sent to an agent.",
+        "checkout-api owner changed to checkout-platform-oncall.",
+        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
+      ]
+    },
+    {
+      "query_id": "q3_payments_customer_message",
+      "question": "What should support say about payments-ledger retries?",
+      "backend": "append_only_log",
+      "correct": false,
+      "retrieved_tokens": 30,
+      "latency_ms": 20.93,
+      "scanned_records": 14,
+      "stale_conflict": true,
+      "secret_leak": false,
+      "retrieved_items": [
+        "payments-ledger customer message: payments are failing for some customers.",
+        "payments-ledger ops note: ledger lag is caused by settlement batching.",
+        "payments-ledger customer message changed: payments post within 30 minutes after retry."
+      ]
+    },
+    {
+      "query_id": "q4_catalog_mitigation",
+      "question": "What mitigation is current for catalog-worker?",
+      "backend": "append_only_log",
+      "correct": false,
+      "retrieved_tokens": 17,
+      "latency_ms": 20.475,
+      "scanned_records": 14,
+      "stale_conflict": true,
+      "secret_leak": false,
+      "retrieved_items": [
+        "catalog-worker mitigation was clear cache cluster before retrying.",
+        "catalog-worker mitigation changed: raise redis TTL to 45 seconds."
+      ]
+    },
+    {
+      "query_id": "q5_search_region",
+      "question": "Where should search-indexer fail over now?",
+      "backend": "append_only_log",
+      "correct": false,
+      "retrieved_tokens": 11,
+      "latency_ms": 20.265,
+      "scanned_records": 14,
+      "stale_conflict": true,
+      "secret_leak": false,
+      "retrieved_items": [
+        "search-indexer failover region is us-east-1.",
+        "search-indexer failover region changed to eu-west-1."
+      ]
+    },
+    {
+      "query_id": "q6_billing_owner",
+      "question": "Who still owns billing-cron even though it was mentioned early?",
+      "backend": "append_only_log",
+      "correct": true,
+      "retrieved_tokens": 7,
+      "latency_ms": 20.125,
+      "scanned_records": 14,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "billing-cron owner is analytics-platform-oncall; escalation is low."
+      ]
+    },
+    {
+      "query_id": "q7_checkout_debug_secret",
+      "question": "What debug credential can be shown to the agent?",
+      "backend": "append_only_log",
+      "correct": false,
+      "retrieved_tokens": 51,
+      "latency_ms": 21.665,
+      "scanned_records": 14,
+      "stale_conflict": true,
+      "secret_leak": true,
+      "retrieved_items": [
+        "checkout-api owner is payments-oncall during the first rollout.",
+        "checkout-api runbook says restart-all-pods after clearing the queue.",
+        "checkout-api debug note includes sk_live_checkout_debug_123 for a local replay, and the credential must never be sent to an agent.",
+        "checkout-api owner changed to checkout-platform-oncall.",
+        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
+      ]
+    },
+    {
+      "query_id": "q1_checkout_owner",
+      "question": "Who owns checkout-api right now?",
+      "backend": "recent_window_log",
+      "correct": false,
+      "retrieved_tokens": 11,
+      "latency_ms": 7.485,
+      "scanned_records": 5,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
+      ]
+    },
+    {
+      "query_id": "q2_checkout_runbook",
+      "question": "Which runbook action should checkout-api use?",
+      "backend": "recent_window_log",
+      "correct": true,
+      "retrieved_tokens": 11,
+      "latency_ms": 7.485,
+      "scanned_records": 5,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
+      ]
+    },
+    {
+      "query_id": "q3_payments_customer_message",
+      "question": "What should support say about payments-ledger retries?",
+      "backend": "recent_window_log",
+      "correct": true,
+      "retrieved_tokens": 11,
+      "latency_ms": 7.485,
+      "scanned_records": 5,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "payments-ledger customer message changed: payments post within 30 minutes after retry."
+      ]
+    },
+    {
+      "query_id": "q4_catalog_mitigation",
+      "question": "What mitigation is current for catalog-worker?",
+      "backend": "recent_window_log",
+      "correct": true,
+      "retrieved_tokens": 9,
+      "latency_ms": 7.415,
+      "scanned_records": 5,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "catalog-worker mitigation changed: raise redis TTL to 45 seconds."
+      ]
+    },
+    {
+      "query_id": "q5_search_region",
+      "question": "Where should search-indexer fail over now?",
+      "backend": "recent_window_log",
+      "correct": true,
+      "retrieved_tokens": 6,
+      "latency_ms": 7.31,
+      "scanned_records": 5,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "search-indexer failover region changed to eu-west-1."
+      ]
+    },
+    {
+      "query_id": "q6_billing_owner",
+      "question": "Who still owns billing-cron even though it was mentioned early?",
+      "backend": "recent_window_log",
+      "correct": false,
+      "retrieved_tokens": 0,
+      "latency_ms": 7.1,
+      "scanned_records": 5,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": []
+    },
+    {
+      "query_id": "q7_checkout_debug_secret",
+      "question": "What debug credential can be shown to the agent?",
+      "backend": "recent_window_log",
+      "correct": false,
+      "retrieved_tokens": 11,
+      "latency_ms": 7.485,
+      "scanned_records": 5,
+      "stale_conflict": false,
+      "secret_leak": false,
+      "retrieved_items": [
+        "checkout-api runbook changed: rollback checkout-canary and do not restart all pods."
+      ]
+    }
+  ],
+  "notes": [
+    "All backends ingest the same ordered event stream.",
+    "Latency is a deterministic local estimate derived from scanned records and retrieved tokens, not a hosted-provider stopwatch.",
+    "The active digest models current-state memory behavior and redacts secrets before retrieval."
+  ]
+}

--- a/examples/benchmarks/incident-runbook-memory/results/sample_results.md
+++ b/examples/benchmarks/incident-runbook-memory/results/sample_results.md
@@ -1,0 +1,23 @@
+# Incident Runbook Memory Benchmark
+
+Dense incident-response memory with superseded runbooks, old owner state, retained early facts, and a synthetic leaked credential.
+
+## Summary
+
+| Backend | Retrieval accuracy | Avg retrieved tokens | p95 latency (ms) | Stale conflict rate | Secret leak rate |
+|---|---:|---:|---:|---:|---:|
+| active_incident_digest | 100.0% | 5.4 | 12.1 | 0.0% | 0.0% |
+| append_only_log | 14.3% | 31.1 | 21.7 | 85.7% | 42.9% |
+| recent_window_log | 57.1% | 8.4 | 7.5 | 0.0% | 0.0% |
+
+## Interpretation
+
+- `active_incident_digest` keeps only current facts per subject/key, so it avoids stale owner/runbook conflicts and redacts the synthetic credential before retrieval.
+- `append_only_log` preserves every raw event, which improves auditability but bloats retrieved context and surfaces superseded facts unless another layer filters them.
+- `recent_window_log` keeps context small, but it drops older facts that are still current, such as the billing-cron owner.
+
+## Reproduce
+
+```bash
+python run_benchmark.py --output results/sample_results.json --markdown results/sample_results.md
+```

--- a/examples/benchmarks/incident-runbook-memory/results/sample_results.md
+++ b/examples/benchmarks/incident-runbook-memory/results/sample_results.md
@@ -7,8 +7,8 @@ Dense incident-response memory with superseded runbooks, old owner state, retain
 | Backend | Retrieval accuracy | Avg retrieved tokens | p95 latency (ms) | Stale conflict rate | Secret leak rate |
 |---|---:|---:|---:|---:|---:|
 | active_incident_digest | 100.0% | 5.4 | 12.1 | 0.0% | 0.0% |
-| append_only_log | 14.3% | 31.1 | 21.7 | 85.7% | 42.9% |
-| recent_window_log | 57.1% | 8.4 | 7.5 | 0.0% | 0.0% |
+| append_only_log | 14.3% | 15.1 | 20.6 | 85.7% | 14.3% |
+| recent_window_log | 57.1% | 5.3 | 7.5 | 0.0% | 0.0% |
 
 ## Interpretation
 

--- a/examples/benchmarks/incident-runbook-memory/run_benchmark.py
+++ b/examples/benchmarks/incident-runbook-memory/run_benchmark.py
@@ -1,0 +1,604 @@
+"""Incident runbook memory benchmark.
+
+This deterministic benchmark compares an active, current-state memory digest
+against append-only and recent-window log baselines on the same evolving
+incident dataset. It is intentionally dependency-free so the benchmark can run
+in CI and on fresh contributor machines without API keys.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+BENCHMARK_NAME = "incident-runbook-memory"
+BENCHMARK_VERSION = "1.0.0"
+SECRET_PATTERN = re.compile(
+    r"\b(?:sk|pk|token|secret)_[A-Za-z0-9_=-]{8,}\b",
+    flags=re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvent:
+    """One fact observed by the incident-response agent."""
+
+    turn: int
+    session: str
+    subject: str
+    key: str
+    value: str
+    text: str
+
+
+@dataclass(frozen=True)
+class GoldenQuery:
+    """A retrieval question with deterministic golden-answer checks."""
+
+    query_id: str
+    question: str
+    subjects: tuple[str, ...]
+    keys: tuple[str, ...]
+    expected_terms: tuple[str, ...]
+    forbidden_terms: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Retrieval:
+    """Backend retrieval payload and resource-footprint counters."""
+
+    backend: str
+    query_id: str
+    retrieved_items: tuple[str, ...]
+    scanned_records: int
+    latency_ms: float
+
+
+class MemoryBackend(Protocol):
+    """Common interface for benchmark backends."""
+
+    name: str
+
+    def ingest(self, events: list[MemoryEvent]) -> None:
+        """Load the event stream into the backend."""
+
+    def retrieve(self, query: GoldenQuery) -> Retrieval:
+        """Retrieve context for one golden query."""
+
+    def stored_text(self) -> str:
+        """Return all stored text for storage-token accounting."""
+
+
+def count_tokens(text: str) -> int:
+    """Count whitespace-delimited tokens for deterministic resource metrics."""
+
+    return len(text.split())
+
+
+def redact_secrets(text: str) -> str:
+    """Remove credentials from active memory state."""
+
+    return SECRET_PATTERN.sub("[REDACTED_SECRET]", text)
+
+
+def estimated_latency_ms(
+    *, base_ms: float, scanned_records: int, retrieved_tokens: int
+) -> float:
+    """Estimate p95-compatible retrieval latency without wall-clock noise."""
+
+    return round(base_ms + (0.42 * scanned_records) + (0.035 * retrieved_tokens), 3)
+
+
+class ActiveIncidentDigest:
+    """Memanto-style active memory: current facts replace superseded facts."""
+
+    name = "active_incident_digest"
+
+    def __init__(self) -> None:
+        self._facts: dict[tuple[str, str], str] = {}
+
+    def ingest(self, events: list[MemoryEvent]) -> None:
+        for event in events:
+            digest_line = f"{event.subject}.{event.key}: {redact_secrets(event.value)}"
+            self._facts[(event.subject, event.key)] = digest_line
+
+    def retrieve(self, query: GoldenQuery) -> Retrieval:
+        items = []
+        for subject in query.subjects:
+            for key in query.keys:
+                item = self._facts.get((subject, key))
+                if item:
+                    items.append(item)
+
+        tokens = count_tokens("\n".join(items))
+        return Retrieval(
+            backend=self.name,
+            query_id=query.query_id,
+            retrieved_items=tuple(items),
+            scanned_records=len(self._facts),
+            latency_ms=estimated_latency_ms(
+                base_ms=8.0,
+                scanned_records=len(self._facts),
+                retrieved_tokens=tokens,
+            ),
+        )
+
+    def stored_text(self) -> str:
+        return "\n".join(self._facts[key] for key in sorted(self._facts))
+
+
+class AppendOnlyLog:
+    """Archive-memory baseline: every matching raw event is returned."""
+
+    name = "append_only_log"
+
+    def __init__(self) -> None:
+        self._events: list[MemoryEvent] = []
+
+    def ingest(self, events: list[MemoryEvent]) -> None:
+        self._events = list(events)
+
+    def retrieve(self, query: GoldenQuery) -> Retrieval:
+        items = [
+            event.text
+            for event in self._events
+            if event.subject in query.subjects
+        ]
+        tokens = count_tokens("\n".join(items))
+        return Retrieval(
+            backend=self.name,
+            query_id=query.query_id,
+            retrieved_items=tuple(items),
+            scanned_records=len(self._events),
+            latency_ms=estimated_latency_ms(
+                base_ms=14.0,
+                scanned_records=len(self._events),
+                retrieved_tokens=tokens,
+            ),
+        )
+
+    def stored_text(self) -> str:
+        return "\n".join(event.text for event in self._events)
+
+
+class RecentWindowLog:
+    """Short-context baseline: only the most recent raw memories are retained."""
+
+    name = "recent_window_log"
+
+    def __init__(self, window_size: int = 5) -> None:
+        self._window_size = window_size
+        self._events: list[MemoryEvent] = []
+
+    def ingest(self, events: list[MemoryEvent]) -> None:
+        self._events = list(events[-self._window_size :])
+
+    def retrieve(self, query: GoldenQuery) -> Retrieval:
+        items = [
+            event.text
+            for event in self._events
+            if event.subject in query.subjects
+        ]
+        tokens = count_tokens("\n".join(items))
+        return Retrieval(
+            backend=self.name,
+            query_id=query.query_id,
+            retrieved_items=tuple(items),
+            scanned_records=len(self._events),
+            latency_ms=estimated_latency_ms(
+                base_ms=5.0,
+                scanned_records=len(self._events),
+                retrieved_tokens=tokens,
+            ),
+        )
+
+    def stored_text(self) -> str:
+        return "\n".join(event.text for event in self._events)
+
+
+def build_dataset() -> list[MemoryEvent]:
+    """Return the dense, shifting incident event stream."""
+
+    return [
+        MemoryEvent(
+            1,
+            "session-1",
+            "checkout-api",
+            "owner",
+            "payments-oncall",
+            "checkout-api owner is payments-oncall during the first rollout.",
+        ),
+        MemoryEvent(
+            2,
+            "session-1",
+            "billing-cron",
+            "owner",
+            "analytics-platform-oncall",
+            "billing-cron owner is analytics-platform-oncall; escalation is low.",
+        ),
+        MemoryEvent(
+            3,
+            "session-1",
+            "checkout-api",
+            "runbook",
+            "restart-all-pods after clearing the queue",
+            "checkout-api runbook says restart-all-pods after clearing the queue.",
+        ),
+        MemoryEvent(
+            4,
+            "session-1",
+            "payments-ledger",
+            "customer_message",
+            "payments are failing for some customers",
+            "payments-ledger customer message: payments are failing for some customers.",
+        ),
+        MemoryEvent(
+            5,
+            "session-2",
+            "catalog-worker",
+            "mitigation",
+            "clear cache cluster before retrying the job",
+            "catalog-worker mitigation was clear cache cluster before retrying.",
+        ),
+        MemoryEvent(
+            6,
+            "session-2",
+            "search-indexer",
+            "region",
+            "us-east-1",
+            "search-indexer failover region is us-east-1.",
+        ),
+        MemoryEvent(
+            7,
+            "session-3",
+            "checkout-api",
+            "debug_note",
+            "debug credential sk_live_checkout_debug_123 must never be sent",
+            "checkout-api debug note includes sk_live_checkout_debug_123 for a "
+            "local replay, and the credential must never be sent to an agent.",
+        ),
+        MemoryEvent(
+            8,
+            "session-3",
+            "checkout-api",
+            "owner",
+            "checkout-platform-oncall",
+            "checkout-api owner changed to checkout-platform-oncall.",
+        ),
+        MemoryEvent(
+            9,
+            "session-3",
+            "payments-ledger",
+            "ops_note",
+            "ledger lag is caused by partner settlement batching",
+            "payments-ledger ops note: ledger lag is caused by settlement batching.",
+        ),
+        MemoryEvent(
+            10,
+            "session-4",
+            "checkout-api",
+            "runbook",
+            "rollback checkout-canary and do not restart all pods",
+            "checkout-api runbook changed: rollback checkout-canary and do not "
+            "restart all pods.",
+        ),
+        MemoryEvent(
+            11,
+            "session-4",
+            "payments-ledger",
+            "customer_message",
+            "payments post within 30 minutes after retry",
+            "payments-ledger customer message changed: payments post within 30 "
+            "minutes after retry.",
+        ),
+        MemoryEvent(
+            12,
+            "session-4",
+            "catalog-worker",
+            "mitigation",
+            "raise redis TTL to 45 seconds",
+            "catalog-worker mitigation changed: raise redis TTL to 45 seconds.",
+        ),
+        MemoryEvent(
+            13,
+            "session-5",
+            "search-indexer",
+            "region",
+            "eu-west-1",
+            "search-indexer failover region changed to eu-west-1.",
+        ),
+        MemoryEvent(
+            14,
+            "session-5",
+            "deployment-window",
+            "freeze",
+            "stop non-emergency releases at 17:00 UTC",
+            "deployment-window freeze: stop non-emergency releases at 17:00 UTC.",
+        ),
+    ]
+
+
+def build_queries() -> list[GoldenQuery]:
+    """Return current-state questions and conflict checks."""
+
+    return [
+        GoldenQuery(
+            "q1_checkout_owner",
+            "Who owns checkout-api right now?",
+            ("checkout-api",),
+            ("owner",),
+            ("checkout-platform-oncall",),
+            ("payments-oncall",),
+        ),
+        GoldenQuery(
+            "q2_checkout_runbook",
+            "Which runbook action should checkout-api use?",
+            ("checkout-api",),
+            ("runbook",),
+            ("rollback checkout-canary",),
+            ("restart-all-pods", "sk_live_checkout_debug_123"),
+        ),
+        GoldenQuery(
+            "q3_payments_customer_message",
+            "What should support say about payments-ledger retries?",
+            ("payments-ledger",),
+            ("customer_message",),
+            ("payments post within 30 minutes",),
+            ("payments are failing",),
+        ),
+        GoldenQuery(
+            "q4_catalog_mitigation",
+            "What mitigation is current for catalog-worker?",
+            ("catalog-worker",),
+            ("mitigation",),
+            ("raise redis TTL to 45 seconds",),
+            ("clear cache cluster",),
+        ),
+        GoldenQuery(
+            "q5_search_region",
+            "Where should search-indexer fail over now?",
+            ("search-indexer",),
+            ("region",),
+            ("eu-west-1",),
+            ("us-east-1",),
+        ),
+        GoldenQuery(
+            "q6_billing_owner",
+            "Who still owns billing-cron even though it was mentioned early?",
+            ("billing-cron",),
+            ("owner",),
+            ("analytics-platform-oncall",),
+            (),
+        ),
+        GoldenQuery(
+            "q7_checkout_debug_secret",
+            "What debug credential can be shown to the agent?",
+            ("checkout-api",),
+            ("debug_note",),
+            ("[REDACTED_SECRET]",),
+            ("sk_live_checkout_debug_123",),
+        ),
+    ]
+
+
+def evaluate_retrieval(query: GoldenQuery, retrieval: Retrieval) -> dict[str, object]:
+    """Score one retrieval against the golden answer."""
+
+    context = "\n".join(retrieval.retrieved_items)
+    context_lower = context.lower()
+    expected_hit = all(term.lower() in context_lower for term in query.expected_terms)
+    conflict_hit = any(term.lower() in context_lower for term in query.forbidden_terms)
+    secret_hit = SECRET_PATTERN.search(context) is not None
+    tokens = count_tokens(context)
+
+    return {
+        "query_id": query.query_id,
+        "question": query.question,
+        "backend": retrieval.backend,
+        "correct": expected_hit and not conflict_hit and not secret_hit,
+        "retrieved_tokens": tokens,
+        "latency_ms": retrieval.latency_ms,
+        "scanned_records": retrieval.scanned_records,
+        "stale_conflict": conflict_hit,
+        "secret_leak": secret_hit,
+        "retrieved_items": list(retrieval.retrieved_items),
+    }
+
+
+def percentile(values: list[float], pct: float) -> float:
+    """Return the nearest-rank percentile for deterministic small samples."""
+
+    if not values:
+        return 0.0
+
+    sorted_values = sorted(values)
+    rank = max(1, math.ceil((pct / 100.0) * len(sorted_values)))
+    return sorted_values[rank - 1]
+
+
+def summarize_backend(
+    backend: MemoryBackend,
+    events: list[MemoryEvent],
+    records: list[dict[str, object]],
+) -> dict[str, object]:
+    """Compute backend-level benchmark metrics."""
+
+    total_queries = len(records)
+    correct_count = sum(1 for record in records if record["correct"])
+    conflict_count = sum(1 for record in records if record["stale_conflict"])
+    secret_count = sum(1 for record in records if record["secret_leak"])
+    retrieved_tokens = [int(record["retrieved_tokens"]) for record in records]
+    latencies = [float(record["latency_ms"]) for record in records]
+    stored_tokens = count_tokens(backend.stored_text())
+    ingested_tokens = count_tokens("\n".join(event.text for event in events))
+
+    return {
+        "backend": backend.name,
+        "retrieval_accuracy": round(correct_count / total_queries, 3),
+        "correct_queries": correct_count,
+        "total_queries": total_queries,
+        "total_ingested_tokens": ingested_tokens,
+        "stored_tokens": stored_tokens,
+        "avg_retrieved_tokens": round(sum(retrieved_tokens) / total_queries, 3),
+        "p95_latency_ms": round(percentile(latencies, 95), 3),
+        "stale_conflict_rate": round(conflict_count / total_queries, 3),
+        "secret_leak_rate": round(secret_count / total_queries, 3),
+    }
+
+
+def run_benchmark() -> dict[str, object]:
+    """Run the benchmark and return a JSON-serializable result."""
+
+    events = build_dataset()
+    queries = build_queries()
+    backends: list[MemoryBackend] = [
+        ActiveIncidentDigest(),
+        AppendOnlyLog(),
+        RecentWindowLog(),
+    ]
+
+    metrics = []
+    records = []
+    for backend in backends:
+        backend.ingest(events)
+        backend_records = [
+            evaluate_retrieval(query, backend.retrieve(query)) for query in queries
+        ]
+        records.extend(backend_records)
+        metrics.append(summarize_backend(backend, events, backend_records))
+
+    return {
+        "benchmark": BENCHMARK_NAME,
+        "version": BENCHMARK_VERSION,
+        "description": (
+            "Dense incident-response memory with superseded runbooks, old owner "
+            "state, retained early facts, and a synthetic leaked credential."
+        ),
+        "dataset": {
+            "event_count": len(events),
+            "query_count": len(queries),
+            "sessions": sorted({event.session for event in events}),
+        },
+        "metrics": metrics,
+        "records": records,
+        "notes": [
+            "All backends ingest the same ordered event stream.",
+            "Latency is a deterministic local estimate derived from scanned "
+            "records and retrieved tokens, not a hosted-provider stopwatch.",
+            "The active digest models current-state memory behavior and redacts "
+            "secrets before retrieval.",
+        ],
+    }
+
+
+def write_json(result: dict[str, object], path: Path) -> None:
+    """Write benchmark results as pretty JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+
+
+def format_percent(value: object) -> str:
+    """Format a decimal metric as a percentage."""
+
+    return f"{float(value) * 100:.1f}%"
+
+
+def write_markdown(result: dict[str, object], path: Path) -> None:
+    """Write a compact Markdown report."""
+
+    metrics = result["metrics"]
+    if not isinstance(metrics, list):
+        raise TypeError("result['metrics'] must be a list")
+
+    lines = [
+        "# Incident Runbook Memory Benchmark",
+        "",
+        str(result["description"]),
+        "",
+        "## Summary",
+        "",
+        "| Backend | Retrieval accuracy | Avg retrieved tokens | "
+        "p95 latency (ms) | Stale conflict rate | Secret leak rate |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+
+    for row in metrics:
+        if not isinstance(row, dict):
+            raise TypeError("metrics rows must be dictionaries")
+        lines.append(
+            "| {backend} | {accuracy} | {tokens:.1f} | {latency:.1f} | "
+            "{conflicts} | {secrets} |".format(
+                backend=row["backend"],
+                accuracy=format_percent(row["retrieval_accuracy"]),
+                tokens=float(row["avg_retrieved_tokens"]),
+                latency=float(row["p95_latency_ms"]),
+                conflicts=format_percent(row["stale_conflict_rate"]),
+                secrets=format_percent(row["secret_leak_rate"]),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            "- `active_incident_digest` keeps only current facts per subject/key, "
+            "so it avoids stale owner/runbook conflicts and redacts the "
+            "synthetic credential before retrieval.",
+            "- `append_only_log` preserves every raw event, which improves "
+            "auditability but bloats retrieved context and surfaces superseded "
+            "facts unless another layer filters them.",
+            "- `recent_window_log` keeps context small, but it drops older facts "
+            "that are still current, such as the billing-cron owner.",
+            "",
+            "## Reproduce",
+            "",
+            "```bash",
+            "python run_benchmark.py --output results/sample_results.json "
+            "--markdown results/sample_results.md",
+            "```",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("results") / "sample_results.json",
+        help="Path for JSON benchmark results.",
+    )
+    parser.add_argument(
+        "--markdown",
+        type=Path,
+        default=Path("results") / "sample_results.md",
+        help="Path for Markdown benchmark report.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI entry point."""
+
+    args = parse_args()
+    result = run_benchmark()
+    write_json(result, args.output)
+    write_markdown(result, args.markdown)
+    print(f"Wrote {args.output}")
+    print(f"Wrote {args.markdown}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/incident-runbook-memory/run_benchmark.py
+++ b/examples/benchmarks/incident-runbook-memory/run_benchmark.py
@@ -100,14 +100,20 @@ class ActiveIncidentDigest:
     name = "active_incident_digest"
 
     def __init__(self) -> None:
+        """Create an empty current-fact map."""
+
         self._facts: dict[tuple[str, str], str] = {}
 
     def ingest(self, events: list[MemoryEvent]) -> None:
+        """Store the latest redacted fact for each subject/key pair."""
+
         for event in events:
             digest_line = f"{event.subject}.{event.key}: {redact_secrets(event.value)}"
             self._facts[(event.subject, event.key)] = digest_line
 
     def retrieve(self, query: GoldenQuery) -> Retrieval:
+        """Return only current facts matching the query subjects and keys."""
+
         items = []
         for subject in query.subjects:
             for key in query.keys:
@@ -129,6 +135,8 @@ class ActiveIncidentDigest:
         )
 
     def stored_text(self) -> str:
+        """Return the active digest contents in stable order."""
+
         return "\n".join(self._facts[key] for key in sorted(self._facts))
 
 
@@ -138,16 +146,22 @@ class AppendOnlyLog:
     name = "append_only_log"
 
     def __init__(self) -> None:
+        """Create an empty raw event log."""
+
         self._events: list[MemoryEvent] = []
 
     def ingest(self, events: list[MemoryEvent]) -> None:
+        """Append the full raw event stream."""
+
         self._events = list(events)
 
     def retrieve(self, query: GoldenQuery) -> Retrieval:
+        """Return raw log entries matching the query subjects and keys."""
+
         items = [
             event.text
             for event in self._events
-            if event.subject in query.subjects
+            if event.subject in query.subjects and event.key in query.keys
         ]
         tokens = count_tokens("\n".join(items))
         return Retrieval(
@@ -163,6 +177,8 @@ class AppendOnlyLog:
         )
 
     def stored_text(self) -> str:
+        """Return all raw log entries for storage-token accounting."""
+
         return "\n".join(event.text for event in self._events)
 
 
@@ -172,17 +188,23 @@ class RecentWindowLog:
     name = "recent_window_log"
 
     def __init__(self, window_size: int = 5) -> None:
+        """Create a fixed-size recent-event window."""
+
         self._window_size = window_size
         self._events: list[MemoryEvent] = []
 
     def ingest(self, events: list[MemoryEvent]) -> None:
+        """Retain only the newest raw events."""
+
         self._events = list(events[-self._window_size :])
 
     def retrieve(self, query: GoldenQuery) -> Retrieval:
+        """Return recent raw entries matching the query subjects and keys."""
+
         items = [
             event.text
             for event in self._events
-            if event.subject in query.subjects
+            if event.subject in query.subjects and event.key in query.keys
         ]
         tokens = count_tokens("\n".join(items))
         return Retrieval(
@@ -198,6 +220,8 @@ class RecentWindowLog:
         )
 
     def stored_text(self) -> str:
+        """Return the retained recent window for storage-token accounting."""
+
         return "\n".join(event.text for event in self._events)
 
 

--- a/examples/benchmarks/incident-runbook-memory/test_benchmark.py
+++ b/examples/benchmarks/incident-runbook-memory/test_benchmark.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 
 def load_benchmark_module():
+    """Load the sibling benchmark runner as an importable module."""
+
     module_path = Path(__file__).with_name("run_benchmark.py")
     if not module_path.exists():
         raise AssertionError("run_benchmark module is missing")
@@ -28,7 +31,11 @@ def load_benchmark_module():
 
 
 class IncidentRunbookBenchmarkTests(unittest.TestCase):
+    """Regression tests for the incident runbook memory benchmark."""
+
     def test_active_digest_outperforms_log_baseline(self) -> None:
+        """The active digest should beat the append-only control."""
+
         benchmark = load_benchmark_module()
 
         result = benchmark.run_benchmark()
@@ -46,6 +53,8 @@ class IncidentRunbookBenchmarkTests(unittest.TestCase):
         self.assertEqual(active["secret_leak_rate"], 0.0)
 
     def test_recent_window_misses_older_still_current_facts(self) -> None:
+        """Recent-only memory should miss an older still-current fact."""
+
         benchmark = load_benchmark_module()
 
         result = benchmark.run_benchmark()
@@ -58,22 +67,21 @@ class IncidentRunbookBenchmarkTests(unittest.TestCase):
         )
 
     def test_report_writers_create_json_and_markdown(self) -> None:
+        """Report writers should create readable JSON and Markdown artifacts."""
+
         benchmark = load_benchmark_module()
         result = benchmark.run_benchmark()
 
-        result_dir = Path(__file__).parent / "results"
-        json_path = result_dir / "test_results.json"
-        md_path = result_dir / "test_results.md"
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result_dir = Path(tmp_dir)
+            json_path = result_dir / "test_results.json"
+            md_path = result_dir / "test_results.md"
 
-        try:
             benchmark.write_json(result, json_path)
             benchmark.write_markdown(result, md_path)
 
             parsed = json.loads(json_path.read_text(encoding="utf-8"))
             markdown = md_path.read_text(encoding="utf-8")
-        finally:
-            json_path.unlink(missing_ok=True)
-            md_path.unlink(missing_ok=True)
 
         self.assertEqual(parsed["benchmark"], "incident-runbook-memory")
         self.assertIn("| Backend | Retrieval accuracy |", markdown)

--- a/examples/benchmarks/incident-runbook-memory/test_benchmark.py
+++ b/examples/benchmarks/incident-runbook-memory/test_benchmark.py
@@ -1,0 +1,84 @@
+"""Tests for the incident runbook memory benchmark."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+def load_benchmark_module():
+    module_path = Path(__file__).with_name("run_benchmark.py")
+    if not module_path.exists():
+        raise AssertionError("run_benchmark module is missing")
+
+    spec = importlib.util.spec_from_file_location("run_benchmark", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("run_benchmark module cannot be loaded")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except ModuleNotFoundError as exc:
+        raise AssertionError("run_benchmark has a missing dependency") from exc
+    return module
+
+
+class IncidentRunbookBenchmarkTests(unittest.TestCase):
+    def test_active_digest_outperforms_log_baseline(self) -> None:
+        benchmark = load_benchmark_module()
+
+        result = benchmark.run_benchmark()
+        backends = {row["backend"]: row for row in result["metrics"]}
+
+        self.assertIn("active_incident_digest", backends)
+        self.assertIn("append_only_log", backends)
+
+        active = backends["active_incident_digest"]
+        append_only = backends["append_only_log"]
+
+        self.assertGreater(active["retrieval_accuracy"], append_only["retrieval_accuracy"])
+        self.assertLess(active["avg_retrieved_tokens"], append_only["avg_retrieved_tokens"])
+        self.assertEqual(active["stale_conflict_rate"], 0.0)
+        self.assertEqual(active["secret_leak_rate"], 0.0)
+
+    def test_recent_window_misses_older_still_current_facts(self) -> None:
+        benchmark = load_benchmark_module()
+
+        result = benchmark.run_benchmark()
+        backends = {row["backend"]: row for row in result["metrics"]}
+
+        self.assertIn("recent_window_log", backends)
+        self.assertLess(
+            backends["recent_window_log"]["retrieval_accuracy"],
+            backends["active_incident_digest"]["retrieval_accuracy"],
+        )
+
+    def test_report_writers_create_json_and_markdown(self) -> None:
+        benchmark = load_benchmark_module()
+        result = benchmark.run_benchmark()
+
+        result_dir = Path(__file__).parent / "results"
+        json_path = result_dir / "test_results.json"
+        md_path = result_dir / "test_results.md"
+
+        try:
+            benchmark.write_json(result, json_path)
+            benchmark.write_markdown(result, md_path)
+
+            parsed = json.loads(json_path.read_text(encoding="utf-8"))
+            markdown = md_path.read_text(encoding="utf-8")
+        finally:
+            json_path.unlink(missing_ok=True)
+            md_path.unlink(missing_ok=True)
+
+        self.assertEqual(parsed["benchmark"], "incident-runbook-memory")
+        self.assertIn("| Backend | Retrieval accuracy |", markdown)
+        self.assertIn("active_incident_digest", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #639

## Summary

Adds a reproducible incident-response memory benchmark under `examples/benchmarks/incident-runbook-memory` for the bounty in #639.

The benchmark uses one dense, shifting incident dataset across three deterministic backends:

- `active_incident_digest`: Memanto-style active current-state memory with secret redaction
- `append_only_log`: archive-memory control that returns every raw matching event for the queried subject/key
- `recent_window_log`: short-context control that keeps only the five newest raw events and returns subject/key matches

## Sample Results

| Backend | Retrieval accuracy | Avg retrieved tokens | p95 latency (ms) | Stale conflict rate | Secret leak rate |
|---|---:|---:|---:|---:|---:|
| `active_incident_digest` | 100.0% | 5.4 | 12.1 | 0.0% | 0.0% |
| `append_only_log` | 14.3% | 15.1 | 20.6 | 85.7% | 14.3% |
| `recent_window_log` | 57.1% | 5.3 | 7.5 | 0.0% | 0.0% |

## Review Follow-up

Addressed CodeRabbit's actionable review comments by:

- applying subject+key filtering consistently across baseline backends
- switching writer tests to `tempfile.TemporaryDirectory()`
- adding missing docstrings for the new benchmark/test functions and methods
- regenerating `results/sample_results.json` and `results/sample_results.md`

## Reproduce

```bash
python examples/benchmarks/incident-runbook-memory/run_benchmark.py --output examples/benchmarks/incident-runbook-memory/results/sample_results.json --markdown examples/benchmarks/incident-runbook-memory/results/sample_results.md

python -m unittest discover -s examples/benchmarks/incident-runbook-memory -p test_*.py
```

## Validation

- `python -m unittest discover -s examples/benchmarks/incident-runbook-memory -p test_*.py`
- `python -m ruff check examples/benchmarks/incident-runbook-memory`
- `python -m py_compile examples/benchmarks/incident-runbook-memory/run_benchmark.py examples/benchmarks/incident-runbook-memory/test_benchmark.py`
- `git diff --check`

## Bounty Notes

This is a deterministic harness with plug-in backend boundaries, not a published hosted-provider benchmark. The README calls that out explicitly and explains how hosted Mem0/Letta/Zep/Hindsight adapters can reuse the same dataset and evaluator.

Social media showcase: pending contributor post.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an incident-response “agent-memory tradeoff” benchmark with three retrieval backends and a CLI to generate deterministic JSON and Markdown reports.
  * Reports accuracy, latency (estimated), token efficiency, stale-conflict rate, and secret-leak rate (including redaction checks).

* **Documentation**
  * Added detailed README describing dataset design, golden query categories (including a non-retrievable credential), and how to run/validate the benchmark.
  * Added sample benchmark report output.

* **Tests**
  * Added automated benchmark tests verifying backend comparisons, zero stale/conflict and secret-leak expectations, and report writer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->