### PR TITLE
Add policy drift memory benchmark

### DIFF
--- a/examples/benchmarks/policy_drift_memory/README.md
+++ b/examples/benchmarks/policy_drift_memory/README.md
@@ -1,7 +1,7 @@
 # Policy Drift Memory Benchmark
 
-This benchmark stress-tests the core 2026 agent-memory tradeoff from issue
-#639: retrieval accuracy versus resource footprint when instructions mutate
+This benchmark stress-tests the core 2026 agent-memory tradeoff from Memanto
+issue #639: retrieval accuracy versus resource footprint when instructions mutate
 across sessions.
 
 The dataset models support and operations agents that receive policy updates,

--- a/examples/benchmarks/policy_drift_memory/README.md
+++ b/examples/benchmarks/policy_drift_memory/README.md
@@ -1,0 +1,75 @@
+# Policy Drift Memory Benchmark
+
+This benchmark stress-tests the core 2026 agent-memory tradeoff from issue
+#639: retrieval accuracy versus resource footprint when instructions mutate
+across sessions.
+
+The dataset models support and operations agents that receive policy updates,
+privacy reversals, launch-train changes, and escalation changes. The benchmark
+then asks current-state questions where stale memories are actively harmful.
+
+## Compared Backends
+
+- `memanto_style_active_digest`: an offline Memanto-style typed digest that
+  stores the current fact per key and returns compact current-state evidence.
+- `episode_graph_baseline`: a graph-like episode memory baseline that groups
+  values by key but keeps historical values in retrieval.
+- `recent_window_3`: a recency-only baseline using the last three events for an
+  entity.
+- `append_only_log`: a passive memory baseline that replays every event for an
+  entity.
+
+The default suite is credential-free so reviewers can reproduce it without a
+Moorcheh API key. It is intentionally structured so a live Memanto CLI adapter
+can be added without changing the dataset or scoring contract.
+
+## Metrics
+
+- `accuracy`: fraction of queries that include all required current facts and no
+  forbidden stale facts.
+- `total_retrieved_tokens`: approximate token footprint returned to the agent
+  across all benchmark queries.
+- `avg_retrieved_tokens`: average retrieved context size per query.
+- `p95_latency_ms`: p95 retrieval latency over repeated in-process retrievals.
+
+## Run
+
+```bash
+python examples/benchmarks/policy_drift_memory/benchmark.py --repeats 200
+```
+
+Optional full detail output:
+
+```bash
+python examples/benchmarks/policy_drift_memory/benchmark.py \
+  --repeats 200 \
+  --output-json examples/benchmarks/policy_drift_memory/results.json
+```
+
+## Expected Shape
+
+On the included dataset, the active digest should preserve current facts while
+dropping stale instructions, so it should reach full accuracy with a much
+smaller retrieval footprint than passive baselines. The exact latency values are
+machine-dependent, but relative token footprint and stale-fact failures should
+be stable.
+
+Example output from a local run:
+
+```text
+backend,accuracy,total_retrieved_tokens,avg_retrieved_tokens,p95_latency_ms
+memanto_style_active_digest,1.0,282,56.4,0.0168
+episode_graph_baseline,0.4,261,52.2,0.0082
+recent_window_3,0.0,315,63,0.0007
+append_only_log,0.0,361,72.2,0.0004
+```
+
+## Reproducibility Notes
+
+- Python 3.10 or newer.
+- No third-party packages are required for the offline benchmark.
+- The source dataset is `dataset.json`.
+- Token counts are deterministic approximations based on word and punctuation
+  boundaries, so they are comparable across backends without requiring a model
+  tokenizer.
+- The benchmark does not call external APIs by default.

--- a/examples/benchmarks/policy_drift_memory/benchmark.py
+++ b/examples/benchmarks/policy_drift_memory/benchmark.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import statistics
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+TOKEN_RE = re.compile(r"\w+|[^\w\s]", re.UNICODE)
+
+
+def approx_tokens(text: str) -> int:
+    return len(TOKEN_RE.findall(text))
+
+
+def p95(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = max(0, math.ceil(0.95 * len(ordered)) - 1)
+    return ordered[index]
+
+
+def normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+@dataclass
+class QueryResult:
+    answer: str
+    latency_ms: float
+    retrieved_tokens: int
+
+
+class Backend:
+    name = "backend"
+
+    def ingest(self, event: dict[str, Any]) -> None:
+        raise NotImplementedError
+
+    def answer(self, query: dict[str, Any]) -> QueryResult:
+        raise NotImplementedError
+
+
+@dataclass
+class AppendOnlyLogBackend(Backend):
+    name: str = "append_only_log"
+    events: dict[str, list[str]] = field(default_factory=lambda: defaultdict(list))
+
+    def ingest(self, event: dict[str, Any]) -> None:
+        self.events[event["entity"]].append(event["text"])
+
+    def answer(self, query: dict[str, Any]) -> QueryResult:
+        start = time.perf_counter()
+        answer = "\n".join(self.events[query["entity"]])
+        latency = (time.perf_counter() - start) * 1000
+        return QueryResult(answer, latency, approx_tokens(answer))
+
+
+@dataclass
+class RecentWindowBackend(Backend):
+    name: str = "recent_window_3"
+    events: dict[str, list[str]] = field(default_factory=lambda: defaultdict(list))
+    window: int = 3
+
+    def ingest(self, event: dict[str, Any]) -> None:
+        self.events[event["entity"]].append(event["text"])
+
+    def answer(self, query: dict[str, Any]) -> QueryResult:
+        start = time.perf_counter()
+        answer = "\n".join(self.events[query["entity"]][-self.window :])
+        latency = (time.perf_counter() - start) * 1000
+        return QueryResult(answer, latency, approx_tokens(answer))
+
+
+@dataclass
+class EpisodeGraphBaseline(Backend):
+    """Small dependency-free approximation of episode graph memory behavior.
+
+    The backend preserves all observed values by key. It retrieves by entity and
+    key relevance, so it is more selective than a raw log but still exposes
+    superseded values when preferences drift.
+    """
+
+    name: str = "episode_graph_baseline"
+    facts: dict[str, dict[str, list[tuple[str, str]]]] = field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(list))
+    )
+
+    def ingest(self, event: dict[str, Any]) -> None:
+        for fact in event.get("facts", []):
+            self.facts[event["entity"]][fact["key"]].append(
+                (event["timestamp"], fact["value"])
+            )
+
+    def answer(self, query: dict[str, Any]) -> QueryResult:
+        start = time.perf_counter()
+        question = normalize(query["question"])
+        rows: list[str] = []
+        for key, values in self.facts[query["entity"]].items():
+            key_terms = key.replace("_", " ")
+            if any(term in question for term in key_terms.split()):
+                rendered = " | ".join(f"{ts}: {value}" for ts, value in values)
+                rows.append(f"{key}: {rendered}")
+        if not rows:
+            for key, values in self.facts[query["entity"]].items():
+                rows.append(f"{key}: {values[-1][1]}")
+        answer = "\n".join(rows)
+        latency = (time.perf_counter() - start) * 1000
+        return QueryResult(answer, latency, approx_tokens(answer))
+
+
+@dataclass
+class ActiveDigestBackend(Backend):
+    """Memanto-style active memory digest for the offline control.
+
+    Each new typed fact replaces the current value for its key while retaining
+    evidence timestamps. Retrieval returns only the active state relevant to the
+    query entity. This mirrors the benchmarked Memanto property: current,
+    compact, conflict-aware memory instead of passive log replay.
+    """
+
+    name: str = "memanto_style_active_digest"
+    current: dict[str, dict[str, tuple[str, str]]] = field(
+        default_factory=lambda: defaultdict(dict)
+    )
+
+    def ingest(self, event: dict[str, Any]) -> None:
+        for fact in event.get("facts", []):
+            self.current[event["entity"]][fact["key"]] = (
+                event["timestamp"],
+                fact["value"],
+            )
+
+    def answer(self, query: dict[str, Any]) -> QueryResult:
+        start = time.perf_counter()
+        question = normalize(query["question"])
+        rows: list[str] = []
+        for key, (timestamp, value) in self.current[query["entity"]].items():
+            key_terms = key.replace("_", " ")
+            value_terms = normalize(value)
+            if (
+                any(term in question for term in key_terms.split())
+                or any(term in question for term in value_terms.split())
+                or key in {"pii_policy", "report_privacy", "launch_train"}
+            ):
+                rows.append(f"{key}: {value} (current since {timestamp})")
+        if not rows:
+            rows = [
+                f"{key}: {value} (current since {timestamp})"
+                for key, (timestamp, value) in self.current[query["entity"]].items()
+            ]
+        answer = "\n".join(rows)
+        latency = (time.perf_counter() - start) * 1000
+        return QueryResult(answer, latency, approx_tokens(answer))
+
+
+def score_answer(answer: str, query: dict[str, Any]) -> tuple[float, list[str]]:
+    lowered = normalize(answer)
+    missing = [item for item in query["required"] if normalize(item) not in lowered]
+    stale = [item for item in query["forbidden"] if normalize(item) in lowered]
+    if not missing and not stale:
+        return 1.0, []
+    penalties = [f"missing={item}" for item in missing]
+    penalties.extend(f"stale={item}" for item in stale)
+    return 0.0, penalties
+
+
+def build_backends() -> list[Backend]:
+    return [
+        ActiveDigestBackend(),
+        EpisodeGraphBaseline(),
+        RecentWindowBackend(),
+        AppendOnlyLogBackend(),
+    ]
+
+
+def run_once(dataset: dict[str, Any], repeats: int) -> dict[str, Any]:
+    backends = build_backends()
+    for event in dataset["events"]:
+        for backend in backends:
+            backend.ingest(event)
+
+    summary: list[dict[str, Any]] = []
+    details: list[dict[str, Any]] = []
+    for backend in backends:
+        scores: list[float] = []
+        latencies: list[float] = []
+        tokens: list[int] = []
+        for query in dataset["queries"]:
+            result: QueryResult | None = None
+            for _ in range(repeats):
+                result = backend.answer(query)
+                latencies.append(result.latency_ms)
+            assert result is not None
+            score, failures = score_answer(result.answer, query)
+            scores.append(score)
+            tokens.append(result.retrieved_tokens)
+            details.append(
+                {
+                    "backend": backend.name,
+                    "entity": query["entity"],
+                    "question": query["question"],
+                    "score": score,
+                    "retrieved_tokens": result.retrieved_tokens,
+                    "failures": failures,
+                    "answer": result.answer,
+                }
+            )
+        summary.append(
+            {
+                "backend": backend.name,
+                "accuracy": round(statistics.mean(scores), 4),
+                "total_retrieved_tokens": sum(tokens),
+                "avg_retrieved_tokens": round(statistics.mean(tokens), 2),
+                "p95_latency_ms": round(p95(latencies), 4),
+            }
+        )
+
+    return {
+        "dataset": dataset["name"],
+        "query_count": len(dataset["queries"]),
+        "repeat_count": repeats,
+        "summary": summary,
+        "details": details,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the policy drift memory benchmark."
+    )
+    parser.add_argument(
+        "--dataset",
+        default=str(Path(__file__).with_name("dataset.json")),
+        help="Path to the benchmark dataset JSON.",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=200,
+        help="Latency repeats per query. Default: 200.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional path for the full JSON result.",
+    )
+    args = parser.parse_args()
+
+    dataset = json.loads(Path(args.dataset).read_text(encoding="utf-8"))
+    result = run_once(dataset, args.repeats)
+
+    print("backend,accuracy,total_retrieved_tokens,avg_retrieved_tokens,p95_latency_ms")
+    for row in result["summary"]:
+        print(
+            f"{row['backend']},{row['accuracy']},"
+            f"{row['total_retrieved_tokens']},{row['avg_retrieved_tokens']},"
+            f"{row['p95_latency_ms']}"
+        )
+
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps(result, indent=2), encoding="utf-8"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/policy_drift_memory/benchmark.py
+++ b/examples/benchmarks/policy_drift_memory/benchmark.py
@@ -233,6 +233,12 @@ def run_once(dataset: dict[str, Any], repeats: int) -> dict[str, Any]:
 
 
 def main() -> None:
+    def positive_int(value: str) -> int:
+        parsed = int(value)
+        if parsed < 1:
+            raise argparse.ArgumentTypeError("--repeats must be >= 1")
+        return parsed
+
     parser = argparse.ArgumentParser(
         description="Run the policy drift memory benchmark."
     )
@@ -243,7 +249,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--repeats",
-        type=int,
+        type=positive_int,
         default=200,
         help="Latency repeats per query. Default: 200.",
     )

--- a/examples/benchmarks/policy_drift_memory/dataset.json
+++ b/examples/benchmarks/policy_drift_memory/dataset.json
@@ -1,0 +1,134 @@
+{
+  "name": "policy_drift_memory_v1",
+  "description": "A deterministic agent-memory benchmark for support and operations agents that must retain current instructions while suppressing stale ones.",
+  "events": [
+    {
+      "session": "s01",
+      "timestamp": "2026-05-01T09:00:00Z",
+      "entity": "acme_support",
+      "text": "Acme support starts with daily incident digests in Slack at 08:00 UTC. Include customer names and raw ticket excerpts.",
+      "facts": [
+        {"key": "digest_channel", "value": "Slack"},
+        {"key": "digest_time", "value": "08:00 UTC"},
+        {"key": "pii_policy", "value": "customer names and raw ticket excerpts allowed"}
+      ]
+    },
+    {
+      "session": "s02",
+      "timestamp": "2026-05-04T14:20:00Z",
+      "entity": "acme_support",
+      "text": "Acme privacy review supersedes the old digest policy. Never include customer names or raw ticket excerpts; use anonymized ticket IDs only.",
+      "facts": [
+        {"key": "pii_policy", "value": "anonymized ticket IDs only"}
+      ]
+    },
+    {
+      "session": "s03",
+      "timestamp": "2026-05-07T08:30:00Z",
+      "entity": "acme_support",
+      "text": "The daily incident digest time moves from 08:00 UTC to 09:30 UTC so the EU support lead can review it first.",
+      "facts": [
+        {"key": "digest_time", "value": "09:30 UTC"},
+        {"key": "reviewer", "value": "EU support lead"}
+      ]
+    },
+    {
+      "session": "s04",
+      "timestamp": "2026-05-10T16:00:00Z",
+      "entity": "acme_support",
+      "text": "Escalations for Acme should go to PagerDuty service ACME-EU-P1, not the old shared ops rotation.",
+      "facts": [
+        {"key": "escalation_target", "value": "PagerDuty service ACME-EU-P1"}
+      ]
+    },
+    {
+      "session": "s05",
+      "timestamp": "2026-05-12T11:00:00Z",
+      "entity": "bravo_research",
+      "text": "Bravo Research wants an agent to track experiment notes. Initial reports can use full participant names for convenience.",
+      "facts": [
+        {"key": "report_privacy", "value": "full participant names allowed"},
+        {"key": "report_format", "value": "experiment note digest"}
+      ]
+    },
+    {
+      "session": "s06",
+      "timestamp": "2026-05-18T13:15:00Z",
+      "entity": "bravo_research",
+      "text": "IRB guidance overrides earlier reporting. Bravo reports must use participant codes only and must flag consent changes since the last session.",
+      "facts": [
+        {"key": "report_privacy", "value": "participant codes only"},
+        {"key": "consent_tracking", "value": "flag consent changes since the last session"}
+      ]
+    },
+    {
+      "session": "s07",
+      "timestamp": "2026-05-21T10:45:00Z",
+      "entity": "bravo_research",
+      "text": "Bravo moves the weekly report owner from Data Science to the Clinical Ops reviewer.",
+      "facts": [
+        {"key": "report_owner", "value": "Clinical Ops reviewer"}
+      ]
+    },
+    {
+      "session": "s08",
+      "timestamp": "2026-05-25T15:30:00Z",
+      "entity": "cobalt_release",
+      "text": "Cobalt release agents should publish readiness summaries to email. The initial launch train is beta-4.",
+      "facts": [
+        {"key": "summary_channel", "value": "email"},
+        {"key": "launch_train", "value": "beta-4"}
+      ]
+    },
+    {
+      "session": "s09",
+      "timestamp": "2026-05-29T09:10:00Z",
+      "entity": "cobalt_release",
+      "text": "Cobalt changes the launch train to rc-1. Do not mention beta-4 in current release recommendations.",
+      "facts": [
+        {"key": "launch_train", "value": "rc-1"}
+      ]
+    },
+    {
+      "session": "s10",
+      "timestamp": "2026-06-02T17:40:00Z",
+      "entity": "cobalt_release",
+      "text": "Cobalt release summaries now go to the #release-readiness Slack channel instead of email.",
+      "facts": [
+        {"key": "summary_channel", "value": "#release-readiness Slack channel"}
+      ]
+    }
+  ],
+  "queries": [
+    {
+      "entity": "acme_support",
+      "question": "What is the current digest time and privacy rule for Acme support?",
+      "required": ["09:30 UTC", "anonymized ticket IDs only"],
+      "forbidden": ["08:00 UTC", "customer names", "raw ticket excerpts"]
+    },
+    {
+      "entity": "acme_support",
+      "question": "Where should Acme P1 escalations go now?",
+      "required": ["PagerDuty service ACME-EU-P1"],
+      "forbidden": ["shared ops rotation"]
+    },
+    {
+      "entity": "bravo_research",
+      "question": "What privacy rule should Bravo reports follow?",
+      "required": ["participant codes only"],
+      "forbidden": ["full participant names"]
+    },
+    {
+      "entity": "bravo_research",
+      "question": "Who owns the Bravo weekly report now, and what consent detail must be flagged?",
+      "required": ["Clinical Ops reviewer", "flag consent changes since the last session"],
+      "forbidden": ["Data Science"]
+    },
+    {
+      "entity": "cobalt_release",
+      "question": "What is the current Cobalt launch train and summary channel?",
+      "required": ["rc-1", "#release-readiness Slack channel"],
+      "forbidden": ["beta-4", "email"]
+    }
+  ]
+}

--- a/examples/benchmarks/policy_drift_memory/requirements.txt
+++ b/examples/benchmarks/policy_drift_memory/requirements.txt
@@ -1,0 +1,1 @@
+# The offline benchmark uses only the Python standard library.


### PR DESCRIPTION
For #639

BountyHub bounty: https://www.bountyhub.dev/bounty/view/ec58c800-823e-4134-b027-99838e096d4b

Showcase: https://gist.github.com/wly12312/76303a6655e269c94c31b8e5e9fd7883

## Summary

This PR adds `examples/benchmarks/policy_drift_memory`, a deterministic benchmark for agent-memory policy drift. It evaluates whether memory backends can keep current policy/preferences while suppressing stale but historically true facts.

The benchmark compares:

- `memanto_style_active_digest`
- `episode_graph_baseline`
- `recent_window_3`
- `append_only_log`

It includes a source dataset, scoring logic, reproducible run instructions, and no external dependency requirement for the default offline path.

## Local Metrics

```text
backend,accuracy,total_retrieved_tokens,avg_retrieved_tokens,p95_latency_ms
memanto_style_active_digest,1.0,282,56.4,0.0144
episode_graph_baseline,0.4,261,52.2,0.008
recent_window_3,0.0,315,63,0.0004
append_only_log,0.0,361,72.2,0.0005
```

## Verification

```bash
python examples/benchmarks/policy_drift_memory/benchmark.py --repeats 200
python -m py_compile examples/benchmarks/policy_drift_memory/benchmark.py
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Policy Drift Memory Benchmark tool to compare retrieval backends on answer accuracy and resource usage under instruction changes.
  * Included benchmark documentation, a ready-to-run sample dataset, and an offline-only CLI with summary (and optional detailed JSON) outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->