### PR TITLE
fix: use same on prem moorcheh data if samenamespace already exist on…

### DIFF
--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -79,10 +79,16 @@ class AgentService:
             # Namespace already exists - this is OK, agent might have been created before
             print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
         except Exception as e:
-            # Unexpected error - fail the agent creation
-            raise Exception(
-                f"Failed to create namespace '{namespace}' in Moorcheh: {str(e)}"
-            )
+            # On-prem raises moorcheh.errors.MoorchehApiError (HTTP 409) rather
+            # than the cloud SDK's typed ConflictError when the namespace
+            # already exists. Match on message so both backends behave the same.
+            msg = str(e).lower()
+            if "already exists" in msg or "conflict" in msg or "409" in msg:
+                print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
+            else:
+                raise Exception(
+                    f"Failed to create namespace '{namespace}' in Moorcheh: {str(e)}"
+                )
 
         # Create agent metadata
         agent = AgentInfo(

--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -83,7 +83,7 @@ class AgentService:
             # than the cloud SDK's typed ConflictError when the namespace
             # already exists. Match on message so both backends behave the same.
             msg = str(e).lower()
-            if "already exists" in msg or "conflict" in msg or "409" in msg:
+            if ("namespace" in msg and "already exists" in msg) or "conflict" in msg:
                 print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
             else:
                 raise Exception(

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -108,9 +108,7 @@ class MemoryReadService:
             # Only enable kiosk_mode when the caller actually set a positive
             # threshold; min_similarity=0.0 means "no filter", but on-prem
             # kiosk_mode + threshold=0.0 still filters everything out.
-            use_kiosk = (
-                min_similarity_score is not None and min_similarity_score > 0
-            )
+            use_kiosk = min_similarity_score is not None and min_similarity_score > 0
             search_result = self.client.similarity_search.query(
                 query=enhanced_query,
                 namespaces=namespaces,
@@ -204,9 +202,7 @@ class MemoryReadService:
 
             # Perform cross-namespace search. Same kiosk_mode caveat as
             # search_memories: min_similarity=0.0 means "no filter".
-            use_kiosk = (
-                min_similarity_score is not None and min_similarity_score > 0
-            )
+            use_kiosk = min_similarity_score is not None and min_similarity_score > 0
             search_result = self.client.similarity_search.query(
                 query=enhanced_query,
                 namespaces=namespaces,

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -104,13 +104,19 @@ class MemoryReadService:
             requested_limit = limit + offset
             top_k = min(requested_limit, 100)  # Moorcheh max is 100
 
-            # Perform search with server-side filtering
+            # Perform search with server-side filtering.
+            # Only enable kiosk_mode when the caller actually set a positive
+            # threshold; min_similarity=0.0 means "no filter", but on-prem
+            # kiosk_mode + threshold=0.0 still filters everything out.
+            use_kiosk = (
+                min_similarity_score is not None and min_similarity_score > 0
+            )
             search_result = self.client.similarity_search.query(
                 query=enhanced_query,
                 namespaces=namespaces,
                 top_k=top_k,
-                threshold=min_similarity_score,
-                kiosk_mode=min_similarity_score is not None,
+                threshold=min_similarity_score if use_kiosk else None,
+                kiosk_mode=use_kiosk,
             )
 
             search_items = search_result.get("results", [])
@@ -196,13 +202,17 @@ class MemoryReadService:
             # Build query parameters
             top_k = limit
 
-            # Perform cross-namespace search
+            # Perform cross-namespace search. Same kiosk_mode caveat as
+            # search_memories: min_similarity=0.0 means "no filter".
+            use_kiosk = (
+                min_similarity_score is not None and min_similarity_score > 0
+            )
             search_result = self.client.similarity_search.query(
                 query=enhanced_query,
                 namespaces=namespaces,
                 top_k=top_k,
-                threshold=min_similarity_score,
-                kiosk_mode=min_similarity_score is not None,
+                threshold=min_similarity_score if use_kiosk else None,
+                kiosk_mode=use_kiosk,
             )
 
             # Format results

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -202,7 +202,7 @@ class MemoryReadService:
 
             # Perform cross-namespace search. Same kiosk_mode caveat as
             # search_memories: min_similarity=0.0 means "no filter".
-            use_kiosk = min_similarity_score is not None and min_similarity_score > 0
+            use_kiosk = min_similarity_score is not None and 0 < min_similarity_score <= 1
             search_result = self.client.similarity_search.query(
                 query=enhanced_query,
                 namespaces=namespaces,


### PR DESCRIPTION
- update on-prem to use namespace is exist on agent creation ,instead of error 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent creation error handling by more reliably detecting “namespace already exists” conditions, so setup continues instead of failing unnecessarily.
  * Fixed memory search behavior for `min_similarity_score = 0.0` by preventing kiosk/threshold filtering from being applied when no positive similarity threshold is requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->