### PR TITLE
Fix/forget on prem

### DIFF
--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -83,7 +83,7 @@ class AgentService:
             # than the cloud SDK's typed ConflictError when the namespace
             # already exists. Match on message so both backends behave the same.
             msg = str(e).lower()
-            if "already exists" in msg or "conflict" in msg or "409" in msg:
+            if ("namespace" in msg and "already exists" in msg) or "conflict" in msg:
                 print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
             else:
                 raise Exception(

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -202,7 +202,9 @@ class MemoryReadService:
 
             # Perform cross-namespace search. Same kiosk_mode caveat as
             # search_memories: min_similarity=0.0 means "no filter".
-            use_kiosk = min_similarity_score is not None and 0 < min_similarity_score <= 1
+            use_kiosk = (
+                min_similarity_score is not None and 0 < min_similarity_score <= 1
+            )
             search_result = self.client.similarity_search.query(
                 query=enhanced_query,
                 namespaces=namespaces,

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -108,9 +108,7 @@ class MemoryReadService:
             # Only enable kiosk_mode when the caller actually set a positive
             # threshold; min_similarity=0.0 means "no filter", but on-prem
             # kiosk_mode + threshold=0.0 still filters everything out.
-            use_kiosk = (
-                min_similarity_score is not None and min_similarity_score > 0
-            )
+            use_kiosk = min_similarity_score is not None and min_similarity_score > 0
             search_result = self.client.similarity_search.query(
                 query=enhanced_query,
                 namespaces=namespaces,
@@ -204,9 +202,7 @@ class MemoryReadService:
 
             # Perform cross-namespace search. Same kiosk_mode caveat as
             # search_memories: min_similarity=0.0 means "no filter".
-            use_kiosk = (
-                min_similarity_score is not None and min_similarity_score > 0
-            )
+            use_kiosk = min_similarity_score is not None and min_similarity_score > 0
             search_result = self.client.similarity_search.query(
                 query=enhanced_query,
                 namespaces=namespaces,

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -349,10 +349,18 @@ class MemoryWriteService:
                 self.client.documents.delete(namespace_name=namespace, ids=[memory_id]),
             )
 
-            actual_deletions = result.get("actual_deletions", 0)
-            if not isinstance(actual_deletions, int):
-                actual_deletions = 0
-            return actual_deletions > 0
+            # Cloud returns ``actual_deletions``; on-prem's /items/delete only
+            # returns ``deleted_ids`` (and ``status``). Mirror the cloud SDK's
+            # ``_deletion_processed_count`` so both backends report success.
+            raw = result.get("actual_deletions")
+            if isinstance(raw, int):
+                return raw > 0
+            for key in ("deleted_ids", "requested_ids"):
+                ids = result.get(key)
+                if isinstance(ids, list):
+                    return len(ids) > 0
+            # Some on-prem builds only return ``{"status": "success"}``.
+            return str(result.get("status", "")).lower() in {"success", "ok"}
 
         except Exception as e:
             raise MemoryError(f"Failed to delete memory: {e}")

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2275,6 +2275,54 @@
             setTimeout(() => el.remove(), 4000);
         }
 
+        // Confirm dialog — themed replacement for browser ``confirm()``. Returns
+        // a Promise<boolean>. Callers should ``await confirmDialog({...})``.
+        // ``danger: true`` styles the primary action with ``btn-danger``.
+        function confirmDialog({ title = 'Confirm', message = '', confirmLabel = 'Confirm', cancelLabel = 'Cancel', danger = false } = {}) {
+            return new Promise(resolve => {
+                const backdrop = document.createElement('div');
+                backdrop.className = 'modal-backdrop';
+                const primaryCls = danger ? 'btn btn-danger' : 'btn btn-primary';
+                backdrop.innerHTML = `<div class="modal" style="width:min(440px,90vw)">
+                    <div class="modal-header">
+                        <h3>${escHtml(title)}</h3>
+                        <button class="modal-close" data-act="cancel">×</button>
+                    </div>
+                    <p style="color:var(--text-secondary);line-height:1.6;margin-bottom:20px">${escHtml(message)}</p>
+                    <div style="display:flex;justify-content:flex-end;gap:8px">
+                        <button class="btn btn-secondary" data-act="cancel">${escHtml(cancelLabel)}</button>
+                        <button class="${primaryCls}" data-act="confirm">${escHtml(confirmLabel)}</button>
+                    </div>
+                </div>`;
+                const close = (result) => {
+                    document.removeEventListener('keydown', onKey);
+                    backdrop.remove();
+                    resolve(result);
+                };
+                const onKey = (e) => {
+                    if (e.key === 'Escape') close(false);
+                    else if (e.key === 'Enter') close(true);
+                };
+                backdrop.addEventListener('click', (e) => {
+                    // Click on the backdrop itself (outside the .modal) cancels.
+                    if (e.target === backdrop) { close(false); return; }
+                    // Button delegation: walk up to nearest [data-act] in case
+                    // the click landed on inner text/icon rather than the
+                    // <button> element.
+                    const actEl = e.target.closest && e.target.closest('[data-act]');
+                    if (!actEl) return;
+                    const act = actEl.getAttribute('data-act');
+                    if (act === 'cancel') close(false);
+                    else if (act === 'confirm') close(true);
+                });
+                document.addEventListener('keydown', onKey);
+                document.body.appendChild(backdrop);
+                // Focus the primary action so Enter just works
+                const btn = backdrop.querySelector('[data-act="confirm"]');
+                if (btn) btn.focus();
+            });
+        }
+
         // Confidence class
         function confClass(c) { const v = parseFloat(c) || 0; return v >= 0.8 ? 'conf-high' : v >= 0.5 ? 'conf-med' : 'conf-low'; }
         function confBadge(c) { const v = parseFloat(c) || 0; return `<span class="${confClass(c)}" style="font-weight:600">${v.toFixed(2)}</span>`; }
@@ -2730,7 +2778,7 @@
                 const res = await api('POST', `/api/v2/agents/${S.agentId}/recall`, body);
                 const mems = res.memories || [];
                 if (!mems.length) { box.innerHTML = '<p style="color:var(--text-dim);padding:20px">No memories found</p>'; return; }
-                box.innerHTML = buildMemoryTable(mems);
+                box.innerHTML = buildMemoryTable(mems, true);
             } catch (e) { box.innerHTML = `<p style="color:var(--error);padding:20px">Error: ${e.message}</p>`; }
         }
 
@@ -2878,13 +2926,52 @@
             <td style="font-size:11px">${escHtml(trunc(tags, 40))}</td>
         </tr>`;
                 if (expandable) {
-                    html += `<tr class="expand-row" id="exp-${i}"><td colspan="8"><div class="expand-content">${escHtml(m.content || m.text || 'No content')}\n\nID: ${m.id || '—'}\nScore: ${m.score ?? '—'}\nSource: ${m.source || '—'}\nUpdated: ${fmtDate(m.updated_at)}</div></td></tr>`;
+                    const memId = m.id ? String(m.id) : '';
+                    const forgetBtn = memId
+                        ? `<button class="btn btn-danger btn-sm" onclick="forgetMemory('${escHtml(memId)}', this, event)">Forget</button>`
+                        : '<span style="font-size:11px;color:var(--text-dim)">No ID — cannot forget</span>';
+                    html += `<tr class="expand-row" id="exp-${i}"><td colspan="8"><div class="expand-content">${escHtml(m.content || m.text || 'No content')}\n\nID: ${memId || '—'}\nScore: ${m.score ?? '—'}\nSource: ${m.source || '—'}\nUpdated: ${fmtDate(m.updated_at)}</div><div style="padding:8px 16px;display:flex;justify-content:flex-end">${forgetBtn}</div></td></tr>`;
                 }
             });
             html += '</tbody></table>';
             return html;
         }
         function toggleRow(id) { const r = document.getElementById(id); if (r) r.classList.toggle('open'); }
+
+        // Delete a single memory from the active agent. Mirrors the CLI
+        // ``memanto forget`` command and the ``DELETE /api/v2/agents/{id}/
+        // memories/{mid}`` REST route. Removes both rows (data + expand) from
+        // the DOM on success; also drops the entry from ``S.memories`` /
+        // ``S.history`` so explorer/history views stay consistent without a
+        // full refetch.
+        async function forgetMemory(memoryId, btn, ev) {
+            if (ev) { ev.stopPropagation(); ev.preventDefault(); }
+            if (!S.agentId || !S.token) { toast('No active agent/session', 'error'); return; }
+            if (!memoryId) { toast('Memory ID missing', 'error'); return; }
+            const ok = await confirmDialog({
+                title: 'Forget memory?',
+                message: `Memory '${memoryId}' will be permanently deleted from agent '${S.agentId}'. This cannot be undone.`,
+                confirmLabel: 'Forget',
+                cancelLabel: 'Cancel',
+                danger: true,
+            });
+            if (!ok) return;
+            const orig = btn ? btn.innerHTML : null;
+            if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner"></span> Forgetting...'; }
+            try {
+                await api('DELETE', `/api/v2/agents/${S.agentId}/memories/${encodeURIComponent(memoryId)}`);
+                toast(`Forgot memory ${memoryId}`);
+                const expandRow = btn ? btn.closest('tr.expand-row') : null;
+                const dataRow = expandRow ? expandRow.previousElementSibling : null;
+                if (dataRow) dataRow.remove();
+                if (expandRow) expandRow.remove();
+                if (Array.isArray(S.memories)) S.memories = S.memories.filter(m => String(m.id) !== String(memoryId));
+                if (Array.isArray(S.history)) S.history = S.history.filter(m => String(m.id) !== String(memoryId));
+            } catch (e) {
+                toast('Failed to forget memory: ' + e.message, 'error');
+                if (btn) { btn.disabled = false; btn.innerHTML = orig || 'Forget'; }
+            }
+        }
 
         // ================================================================
         // HISTORY (GitHub-style contribution graph + timeline)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -243,6 +243,109 @@ class TestAgentService:
         print("✅ Agent deleted successfully")
 
 
+class TestMemoryWriteServiceDelete:
+    """``delete_memory`` must report success for both cloud and on-prem
+    response shapes. Cloud returns ``actual_deletions``; on-prem's
+    ``/items/delete`` only returns ``deleted_ids``/``status``."""
+
+    @pytest.mark.parametrize(
+        "response,expected",
+        [
+            ({"actual_deletions": 1, "deleted_ids": ["m1"]}, True),
+            ({"actual_deletions": 0, "deleted_ids": []}, False),
+            ({"status": "success", "deleted_ids": ["m1"]}, True),
+            ({"status": "success", "deleted_ids": []}, False),
+            ({"status": "success"}, True),
+            ({"requested_ids": ["m1"]}, True),
+            ({}, False),
+        ],
+    )
+    def test_delete_memory_handles_backend_shapes(self, response, expected):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = response
+        assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
+
+
+class TestForgetEndToEnd:
+    """End-to-end ``forget`` flow through ``DirectClient``: create agent →
+    activate → delete_memory. Asserts on-prem's response shape
+    (``deleted_ids`` only, no ``actual_deletions``) is reported as success
+    and that a genuine miss still surfaces as ``ValueError``."""
+
+    @pytest.fixture
+    def direct_client(self, tmp_path, monkeypatch, mock_moorcheh_for_tests):
+        """A wired ``DirectClient`` with the agent + session dirs redirected
+        into ``tmp_path`` so we don't touch ``~/.memanto``. The conftest's
+        ``mock_moorcheh_for_tests`` covers ``app.clients.moorcheh`` and
+        ``agent_service.get_moorcheh_client``; ``DirectClient`` has its own
+        inline ``MoorchehClient`` class, so we also patch that and force the
+        lazy ``_moorcheh`` slot to the shared mock."""
+        from memanto.cli.client import direct_client as direct_mod
+        from memanto.cli.client.direct_client import DirectClient
+
+        monkeypatch.setattr(
+            "memanto.app.services.agent_service.get_data_dir",
+            lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            "memanto.app.services.session_service.get_data_dir",
+            lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            direct_mod, "MoorchehClient", lambda **_: mock_moorcheh_for_tests
+        )
+
+        client = DirectClient(api_key="test-key")
+        client._moorcheh = mock_moorcheh_for_tests  # write/read share this
+        client.create_agent("test-agent", "tool", "e2e")
+        client.activate_agent("test-agent", duration_hours=1)
+        return client, mock_moorcheh_for_tests
+
+    def test_forget_succeeds_on_onprem_response_shape(self, direct_client):
+        """On-prem returns ``deleted_ids`` without ``actual_deletions`` —
+        forget must report success."""
+        client, moorcheh = direct_client
+        moorcheh.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": ["mem-abc"],
+        }
+
+        result = client.delete_memory(agent_id="test-agent", memory_id="mem-abc")
+
+        assert result["status"] == "deleted"
+        assert result["memory_id"] == "mem-abc"
+        assert result["namespace"] == "memanto_agent_test-agent"
+        moorcheh.documents.delete.assert_called_once_with(
+            namespace_name="memanto_agent_test-agent", ids=["mem-abc"]
+        )
+
+    def test_forget_reports_not_found_when_truly_missing(self, direct_client):
+        """Empty ``deleted_ids`` (genuine miss) still surfaces as ValueError."""
+        client, moorcheh = direct_client
+        moorcheh.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": [],
+        }
+
+        with pytest.raises(ValueError, match="was not found"):
+            client.delete_memory(agent_id="test-agent", memory_id="ghost")
+
+    def test_forget_succeeds_on_cloud_response_shape(self, direct_client):
+        """Cloud's ``actual_deletions`` path stays green (regression guard)."""
+        client, moorcheh = direct_client
+        moorcheh.documents.delete.return_value = {
+            "actual_deletions": 1,
+            "deleted_ids": ["mem-xyz"],
+            "status": "success",
+        }
+
+        result = client.delete_memory(agent_id="test-agent", memory_id="mem-xyz")
+        assert result["status"] == "deleted"
+        assert result["memory_id"] == "mem-xyz"
+
+
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""
 


### PR DESCRIPTION
- Add forget memory to onprem and UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a custom confirmation dialog for destructive actions.
  * Added "Forget" button in Memory Explorer to delete individual memories with automatic view updates.

* **Bug Fixes**
  * Improved memory deletion detection to correctly handle multiple backend response formats.

* **Tests**
  * Added comprehensive tests for memory deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->