### PR TITLE
[codex] Add on-prem Ollama regression tests

### DIFF
--- a/tests/test_onprem_ollama.py
+++ b/tests/test_onprem_ollama.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock, call
+
+from moorcheh import ollama_setup
+
+from memanto.cli.commands import core
+
+
+def test_pull_ollama_model_uses_host_http_when_native_ollama_is_reachable(
+    monkeypatch,
+):
+    http_pull = Mock()
+    container_pull = Mock()
+    monkeypatch.setattr(ollama_setup, "ollama_is_reachable", lambda: True)
+    monkeypatch.setattr(ollama_setup, "pull_ollama_model_http", http_pull)
+    monkeypatch.setattr(core, "_pull_ollama_model_in_container", container_pull)
+
+    core._pull_ollama_model("nomic-embed-text")
+
+    http_pull.assert_called_once_with("nomic-embed-text")
+    container_pull.assert_not_called()
+
+
+def test_pull_ollama_model_falls_back_to_container_when_host_is_unreachable(
+    monkeypatch,
+):
+    http_pull = Mock()
+    container_pull = Mock()
+    monkeypatch.setattr(ollama_setup, "ollama_is_reachable", lambda: False)
+    monkeypatch.setattr(ollama_setup, "pull_ollama_model_http", http_pull)
+    monkeypatch.setattr(core, "_pull_ollama_model_in_container", container_pull)
+
+    core._pull_ollama_model("nomic-embed-text")
+
+    http_pull.assert_not_called()
+    container_pull.assert_called_once_with("nomic-embed-text")
+
+
+def test_onprem_setup_routes_ollama_models_through_shared_pull_helper(monkeypatch):
+    state = {
+        "embedding_provider": "ollama",
+        "embedding_model": "nomic-embed-text",
+        "llm_provider": "ollama",
+        "llm_model": "qwen2.5",
+    }
+    pull_model = Mock()
+    container_pull = Mock()
+
+    monkeypatch.setattr(core, "_ensure_docker_available", Mock())
+    monkeypatch.setattr(core, "_ensure_moorcheh_client_installed", Mock())
+    monkeypatch.setattr(core.config_manager, "get_onprem_state", lambda: state)
+    monkeypatch.setattr(core, "_persist_moorcheh_llm_config", Mock())
+    monkeypatch.setattr(core, "_moorcheh_up_and_wait", Mock())
+    monkeypatch.setattr(core, "_pull_ollama_model", pull_model)
+    monkeypatch.setattr(core, "_pull_ollama_model_in_container", container_pull)
+    monkeypatch.setattr(core.config_manager, "set_onprem_state", Mock())
+
+    core._onprem_setup()
+
+    assert pull_model.call_args_list == [
+        call("nomic-embed-text"),
+        call("qwen2.5"),
+    ]
+    container_pull.assert_not_called()


### PR DESCRIPTION
## Summary

- add regression coverage for the native host Ollama path fixed in #758
- verify reachable host Ollama uses the HTTP pull helper without touching Docker
- verify unreachable host Ollama falls back to the bundled container
- verify on-prem setup routes both Quick Setup models through the shared pull helper

## Why

Issue #753 showed that on-prem setup could detect and reuse a healthy native Ollama instance, then still try to pull models through a Docker container that did not exist. The production fix is already present on `main` via #758, but the corrected dispatch behavior had no regression coverage.

## Impact

Tests only. No runtime behavior changes.

## Validation

- `pytest tests/test_onprem_ollama.py -vv` — 3 passed
- `HOME=/tmp/memanto-test-home pytest --ignore=tests/test_e2e.py` — 138 passed
- `ruff check .` — passed
- `git diff --check` — passed

Closes regression coverage gap for #753.
