### PR TITLE
Add customer entitlement memory benchmark

### DIFF
--- a/examples/benchmarks/customer-entitlement-memory/README.md
+++ b/examples/benchmarks/customer-entitlement-memory/README.md
@@ -1,0 +1,60 @@
+# Customer Entitlement Memory Benchmark
+
+This benchmark is a credential-free submission for the agentic memory showdown.
+It compares a Memanto-style active digest against two common baselines on a
+synthetic B2B support account where facts change over time.
+
+The scenario focuses on the production trade-off that support and sales agents
+hit every day:
+
+- current facts must override stale facts;
+- scoped facts must not leak across environments;
+- private sales notes must stay out of support answers;
+- older facts that are still current must remain retrievable;
+- the answer should include reproducible evidence.
+
+## Backends
+
+- `active_entitlement_digest`: a current-state digest keyed by fact and scope.
+  It supersedes stale facts and returns a redaction notice for private facts.
+- `append_only_log`: retrieves every historical matching fact. This preserves
+  evidence, but it also returns stale and private data.
+- `recent_window_log`: retrieves only the newest three events. This reduces
+  context size but forgets older facts that are still operationally current.
+
+## Metrics
+
+- Accuracy: required phrases present, forbidden stale/private phrases absent,
+  and expected evidence events returned.
+- Token footprint: `ceil(character_count / 4)`, used as a deterministic
+  relative retrieval-cost proxy.
+- p95 latency: a deterministic proxy derived from scanned and retrieved tokens.
+  This avoids pretending that a local, network-free sample run is production
+  network latency.
+
+## Run
+
+```bash
+python examples/benchmarks/customer-entitlement-memory/run_benchmark.py
+```
+
+Write JSON and Markdown artifacts:
+
+```bash
+python examples/benchmarks/customer-entitlement-memory/run_benchmark.py \
+  --output examples/benchmarks/customer-entitlement-memory/results/sample_results.json \
+  --markdown examples/benchmarks/customer-entitlement-memory/results/sample_results.md
+```
+
+Run tests:
+
+```bash
+python -m unittest discover -s examples/benchmarks/customer-entitlement-memory -p "test_*.py"
+```
+
+## Expected Result
+
+The active digest should pass every query while retrieving less context than the
+append-only log. The append-only log fails on stale conflicts and private budget
+leakage. The recent-window log avoids some stale facts, but it misses older
+still-current facts like SSO, escalation route, P2 SLA, and privacy policy.

--- a/examples/benchmarks/customer-entitlement-memory/README.md
+++ b/examples/benchmarks/customer-entitlement-memory/README.md
@@ -26,7 +26,7 @@ hit every day:
 
 - Accuracy: required phrases present, forbidden stale/private phrases absent,
   and expected evidence events returned.
-- Token footprint: `ceil(character_count / 4)`, used as a deterministic
+- Token footprint: `max(1, ceil(character_count / 4))`, used as a deterministic
   relative retrieval-cost proxy.
 - p95 latency: a deterministic proxy derived from scanned and retrieved tokens.
   This avoids pretending that a local, network-free sample run is production

--- a/examples/benchmarks/customer-entitlement-memory/fixtures/customer_timeline.json
+++ b/examples/benchmarks/customer-entitlement-memory/fixtures/customer_timeline.json
@@ -1,0 +1,308 @@
+{
+  "fixture_version": "2026-06-22",
+  "account": "Acme Robotics",
+  "description": "A synthetic B2B support timeline with stale entitlements, scoped region changes, private renewal notes, and compliance updates.",
+  "events": [
+    {
+      "id": "evt-2026-01-05-kickoff",
+      "date": "2026-01-05",
+      "title": "Initial onboarding",
+      "facts": [
+        {
+          "key": "plan",
+          "scope": "account",
+          "value": "Growth",
+          "exposable": true
+        },
+        {
+          "key": "data_residency",
+          "scope": "production",
+          "value": "EU",
+          "exposable": true
+        },
+        {
+          "key": "invoice_po",
+          "scope": "billing",
+          "value": "PO-4487",
+          "exposable": true
+        },
+        {
+          "key": "escalation_route",
+          "scope": "support",
+          "value": "Slack channel #acme-old",
+          "exposable": true
+        },
+        {
+          "key": "dpa",
+          "scope": "compliance",
+          "value": "DPA v2 signed",
+          "exposable": true
+        }
+      ]
+    },
+    {
+      "id": "evt-2026-02-11-enterprise",
+      "date": "2026-02-11",
+      "title": "Enterprise contract update",
+      "facts": [
+        {
+          "key": "plan",
+          "scope": "account",
+          "value": "Enterprise",
+          "exposable": true
+        },
+        {
+          "key": "data_residency",
+          "scope": "production",
+          "value": "EU-DE",
+          "exposable": true
+        },
+        {
+          "key": "hipaa",
+          "scope": "compliance",
+          "value": "HIPAA addendum pending",
+          "exposable": true
+        },
+        {
+          "key": "p2_sla",
+          "scope": "support",
+          "value": "4 business hours",
+          "exposable": true
+        }
+      ]
+    },
+    {
+      "id": "evt-2026-03-02-escalation",
+      "date": "2026-03-02",
+      "title": "Escalation and privacy update",
+      "facts": [
+        {
+          "key": "escalation_route",
+          "scope": "support",
+          "value": "PagerDuty service acme-primary",
+          "exposable": true
+        },
+        {
+          "key": "sso_provider",
+          "scope": "identity",
+          "value": "Okta",
+          "exposable": true
+        },
+        {
+          "key": "renewal_budget",
+          "scope": "sales_private",
+          "value": "$420k renewal budget with 18 percent discount ceiling",
+          "exposable": false,
+          "redaction": "private renewal budget exists but must not be surfaced to support answers"
+        }
+      ]
+    },
+    {
+      "id": "evt-2026-04-15-beta",
+      "date": "2026-04-15",
+      "title": "Audit export beta",
+      "facts": [
+        {
+          "key": "audit_export_beta",
+          "scope": "feature_flag",
+          "value": "enabled until 2026-05-30",
+          "exposable": true
+        },
+        {
+          "key": "support_lead",
+          "scope": "people",
+          "value": "Nora Li",
+          "exposable": true
+        },
+        {
+          "key": "implementation_contact",
+          "scope": "people",
+          "value": "Marcus Ortega",
+          "exposable": true
+        }
+      ]
+    },
+    {
+      "id": "evt-2026-05-30-beta-extension",
+      "date": "2026-05-30",
+      "title": "Beta extension and sandbox migration",
+      "facts": [
+        {
+          "key": "audit_export_beta",
+          "scope": "feature_flag",
+          "value": "enabled until 2026-06-30",
+          "exposable": true
+        },
+        {
+          "key": "support_lead",
+          "scope": "people",
+          "value": "Iris Chen",
+          "exposable": true
+        },
+        {
+          "key": "data_residency",
+          "scope": "sandbox",
+          "value": "US-EAST",
+          "exposable": true
+        }
+      ]
+    },
+    {
+      "id": "evt-2026-06-12-billing-compliance",
+      "date": "2026-06-12",
+      "title": "Billing and compliance closeout",
+      "facts": [
+        {
+          "key": "invoice_po",
+          "scope": "billing",
+          "value": "PO-7721",
+          "exposable": true
+        },
+        {
+          "key": "hipaa",
+          "scope": "compliance",
+          "value": "HIPAA addendum signed",
+          "exposable": true
+        },
+        {
+          "key": "plan",
+          "scope": "account",
+          "value": "Enterprise",
+          "exposable": true
+        }
+      ]
+    }
+  ],
+  "queries": [
+    {
+      "id": "q-production-region",
+      "question": "What production data residency should support quote for Acme Robotics?",
+      "lookups": [
+        {
+          "key": "data_residency",
+          "scope": "production"
+        }
+      ],
+      "must_include": ["EU-DE"],
+      "must_not_include": ["US-EAST", "EU only"],
+      "gold_evidence": ["evt-2026-02-11-enterprise"]
+    },
+    {
+      "id": "q-invoice-po",
+      "question": "Which purchase order should be used on the next invoice?",
+      "lookups": [
+        {
+          "key": "invoice_po",
+          "scope": "billing"
+        }
+      ],
+      "must_include": ["PO-7721"],
+      "must_not_include": ["PO-4487"],
+      "gold_evidence": ["evt-2026-06-12-billing-compliance"]
+    },
+    {
+      "id": "q-audit-beta",
+      "question": "Is the audit export beta still enabled, and until when?",
+      "lookups": [
+        {
+          "key": "audit_export_beta",
+          "scope": "feature_flag"
+        }
+      ],
+      "must_include": ["enabled until 2026-06-30"],
+      "must_not_include": ["enabled until 2026-05-30"],
+      "gold_evidence": ["evt-2026-05-30-beta-extension"]
+    },
+    {
+      "id": "q-support-lead",
+      "question": "Who is the current support lead?",
+      "lookups": [
+        {
+          "key": "support_lead",
+          "scope": "people"
+        }
+      ],
+      "must_include": ["Iris Chen"],
+      "must_not_include": ["Nora Li"],
+      "gold_evidence": ["evt-2026-05-30-beta-extension"]
+    },
+    {
+      "id": "q-escalation",
+      "question": "Where should urgent support escalations go now?",
+      "lookups": [
+        {
+          "key": "escalation_route",
+          "scope": "support"
+        }
+      ],
+      "must_include": ["PagerDuty service acme-primary"],
+      "must_not_include": ["#acme-old", "Slack channel"],
+      "gold_evidence": ["evt-2026-03-02-escalation"]
+    },
+    {
+      "id": "q-sso",
+      "question": "Which SSO provider is configured?",
+      "lookups": [
+        {
+          "key": "sso_provider",
+          "scope": "identity"
+        }
+      ],
+      "must_include": ["Okta"],
+      "must_not_include": [],
+      "gold_evidence": ["evt-2026-03-02-escalation"]
+    },
+    {
+      "id": "q-hipaa",
+      "question": "What is the current HIPAA addendum status?",
+      "lookups": [
+        {
+          "key": "hipaa",
+          "scope": "compliance"
+        }
+      ],
+      "must_include": ["HIPAA addendum signed"],
+      "must_not_include": ["pending"],
+      "gold_evidence": ["evt-2026-06-12-billing-compliance"]
+    },
+    {
+      "id": "q-implementation-contact",
+      "question": "Who is the implementation contact?",
+      "lookups": [
+        {
+          "key": "implementation_contact",
+          "scope": "people"
+        }
+      ],
+      "must_include": ["Marcus Ortega"],
+      "must_not_include": [],
+      "gold_evidence": ["evt-2026-04-15-beta"]
+    },
+    {
+      "id": "q-private-budget",
+      "question": "What renewal budget details should a support answer include?",
+      "lookups": [
+        {
+          "key": "renewal_budget",
+          "scope": "sales_private"
+        }
+      ],
+      "must_include": ["must not be surfaced"],
+      "must_not_include": ["$420k", "18 percent discount"],
+      "gold_evidence": ["evt-2026-03-02-escalation"]
+    },
+    {
+      "id": "q-p2-sla",
+      "question": "What is the P2 support SLA?",
+      "lookups": [
+        {
+          "key": "p2_sla",
+          "scope": "support"
+        }
+      ],
+      "must_include": ["4 business hours"],
+      "must_not_include": [],
+      "gold_evidence": ["evt-2026-02-11-enterprise"]
+    }
+  ]
+}

--- a/examples/benchmarks/customer-entitlement-memory/requirements.txt
+++ b/examples/benchmarks/customer-entitlement-memory/requirements.txt
@@ -1,0 +1,1 @@
+# This benchmark intentionally uses only the Python standard library.

--- a/examples/benchmarks/customer-entitlement-memory/results/sample_results.json
+++ b/examples/benchmarks/customer-entitlement-memory/results/sample_results.json
@@ -1,0 +1,614 @@
+{
+  "benchmark": "customer-entitlement-memory",
+  "fixture_version": "2026-06-22",
+  "account": "Acme Robotics",
+  "methodology": {
+    "token_metric": "ceil(character_count / 4), deterministic relative footprint",
+    "latency_metric": "deterministic proxy in milliseconds from scanned and retrieved tokens",
+    "accuracy_metric": "required phrases present, forbidden stale/private phrases absent, and gold evidence returned",
+    "network_or_llm_calls": 0
+  },
+  "summary": [
+    {
+      "backend": "active_entitlement_digest",
+      "accuracy": 1.0,
+      "passed": 10,
+      "total": 10,
+      "stale_conflict_rate": 0.0,
+      "avg_retrieved_tokens": 36.5,
+      "avg_scanned_tokens": 24.8,
+      "p95_latency_proxy_ms": 4.175
+    },
+    {
+      "backend": "append_only_log",
+      "accuracy": 0.5,
+      "passed": 5,
+      "total": 10,
+      "stale_conflict_rate": 0.5,
+      "avg_retrieved_tokens": 49.8,
+      "avg_scanned_tokens": 480,
+      "p95_latency_proxy_ms": 19.82
+    },
+    {
+      "backend": "recent_window_log",
+      "accuracy": 0.3,
+      "passed": 3,
+      "total": 10,
+      "stale_conflict_rate": 0.2,
+      "avg_retrieved_tokens": 31.8,
+      "avg_scanned_tokens": 208,
+      "p95_latency_proxy_ms": 10.3
+    }
+  ],
+  "results": {
+    "active_entitlement_digest": [
+      {
+        "query_id": "q-production-region",
+        "question": "What production data residency should support quote for Acme Robotics?",
+        "passed": true,
+        "included_required": [
+          "EU-DE"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-02-11-enterprise"
+        ],
+        "evidence_ids": [
+          "evt-2026-02-11-enterprise"
+        ],
+        "retrieved_tokens": 39,
+        "scanned_tokens": 21,
+        "latency_proxy_ms": 3.32,
+        "answer": "What production data residency should support quote for Acme Robotics? data_residency[production] = EU-DE (evidence: evt-2026-02-11-enterprise, 2026-02-11)"
+      },
+      {
+        "query_id": "q-invoice-po",
+        "question": "Which purchase order should be used on the next invoice?",
+        "passed": true,
+        "included_required": [
+          "PO-7721"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "evidence_ids": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "retrieved_tokens": 36,
+        "scanned_tokens": 22,
+        "latency_proxy_ms": 3.31,
+        "answer": "Which purchase order should be used on the next invoice? invoice_po[billing] = PO-7721 (evidence: evt-2026-06-12-billing-compliance, 2026-06-12)"
+      },
+      {
+        "query_id": "q-audit-beta",
+        "question": "Is the audit export beta still enabled, and until when?",
+        "passed": true,
+        "included_required": [
+          "enabled until 2026-06-30"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-05-30-beta-extension"
+        ],
+        "evidence_ids": [
+          "evt-2026-05-30-beta-extension"
+        ],
+        "retrieved_tokens": 42,
+        "scanned_tokens": 28,
+        "latency_proxy_ms": 3.61,
+        "answer": "Is the audit export beta still enabled, and until when? audit_export_beta[feature_flag] = enabled until 2026-06-30 (evidence: evt-2026-05-30-beta-extension, 2026-05-30)"
+      },
+      {
+        "query_id": "q-support-lead",
+        "question": "Who is the current support lead?",
+        "passed": true,
+        "included_required": [
+          "Iris Chen"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-05-30-beta-extension"
+        ],
+        "evidence_ids": [
+          "evt-2026-05-30-beta-extension"
+        ],
+        "retrieved_tokens": 30,
+        "scanned_tokens": 22,
+        "latency_proxy_ms": 3.22,
+        "answer": "Who is the current support lead? support_lead[people] = Iris Chen (evidence: evt-2026-05-30-beta-extension, 2026-05-30)"
+      },
+      {
+        "query_id": "q-escalation",
+        "question": "Where should urgent support escalations go now?",
+        "passed": true,
+        "included_required": [
+          "PagerDuty service acme-primary"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-03-02-escalation"
+        ],
+        "evidence_ids": [
+          "evt-2026-03-02-escalation"
+        ],
+        "retrieved_tokens": 39,
+        "scanned_tokens": 27,
+        "latency_proxy_ms": 3.53,
+        "answer": "Where should urgent support escalations go now? escalation_route[support] = PagerDuty service acme-primary (evidence: evt-2026-03-02-escalation, 2026-03-02)"
+      },
+      {
+        "query_id": "q-sso",
+        "question": "Which SSO provider is configured?",
+        "passed": true,
+        "included_required": [
+          "Okta"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-03-02-escalation"
+        ],
+        "evidence_ids": [
+          "evt-2026-03-02-escalation"
+        ],
+        "retrieved_tokens": 29,
+        "scanned_tokens": 20,
+        "latency_proxy_ms": 3.135,
+        "answer": "Which SSO provider is configured? sso_provider[identity] = Okta (evidence: evt-2026-03-02-escalation, 2026-03-02)"
+      },
+      {
+        "query_id": "q-hipaa",
+        "question": "What is the current HIPAA addendum status?",
+        "passed": true,
+        "included_required": [
+          "HIPAA addendum signed"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "evidence_ids": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "retrieved_tokens": 36,
+        "scanned_tokens": 25,
+        "latency_proxy_ms": 3.415,
+        "answer": "What is the current HIPAA addendum status? hipaa[compliance] = HIPAA addendum signed (evidence: evt-2026-06-12-billing-compliance, 2026-06-12)"
+      },
+      {
+        "query_id": "q-implementation-contact",
+        "question": "Who is the implementation contact?",
+        "passed": true,
+        "included_required": [
+          "Marcus Ortega"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-04-15-beta"
+        ],
+        "evidence_ids": [
+          "evt-2026-04-15-beta"
+        ],
+        "retrieved_tokens": 32,
+        "scanned_tokens": 23,
+        "latency_proxy_ms": 3.285,
+        "answer": "Who is the implementation contact? implementation_contact[people] = Marcus Ortega (evidence: evt-2026-04-15-beta, 2026-04-15)"
+      },
+      {
+        "query_id": "q-private-budget",
+        "question": "What renewal budget details should a support answer include?",
+        "passed": true,
+        "included_required": [
+          "must not be surfaced"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-03-02-escalation"
+        ],
+        "evidence_ids": [
+          "evt-2026-03-02-escalation"
+        ],
+        "retrieved_tokens": 54,
+        "scanned_tokens": 39,
+        "latency_proxy_ms": 4.175,
+        "answer": "What renewal budget details should a support answer include? renewal_budget[sales_private] = private renewal budget exists but must not be surfaced to support answers (evidence: evt-2026-03-02-escalation, 2026-03-02)"
+      },
+      {
+        "query_id": "q-p2-sla",
+        "question": "What is the P2 support SLA?",
+        "passed": true,
+        "included_required": [
+          "4 business hours"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-02-11-enterprise"
+        ],
+        "evidence_ids": [
+          "evt-2026-02-11-enterprise"
+        ],
+        "retrieved_tokens": 28,
+        "scanned_tokens": 21,
+        "latency_proxy_ms": 3.155,
+        "answer": "What is the P2 support SLA? p2_sla[support] = 4 business hours (evidence: evt-2026-02-11-enterprise, 2026-02-11)"
+      }
+    ],
+    "append_only_log": [
+      {
+        "query_id": "q-production-region",
+        "question": "What production data residency should support quote for Acme Robotics?",
+        "passed": true,
+        "included_required": [
+          "EU-DE"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-02-11-enterprise"
+        ],
+        "evidence_ids": [
+          "evt-2026-01-05-kickoff",
+          "evt-2026-02-11-enterprise"
+        ],
+        "retrieved_tokens": 59,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.685,
+        "answer": "What production data residency should support quote for Acme Robotics? data_residency[production] = EU (evidence: evt-2026-01-05-kickoff, 2026-01-05); data_residency[production] = EU-DE (evidence: evt-2026-02-11-enterprise, 2026-02-11)"
+      },
+      {
+        "query_id": "q-invoice-po",
+        "question": "Which purchase order should be used on the next invoice?",
+        "passed": false,
+        "included_required": [
+          "PO-7721"
+        ],
+        "forbidden_hits": [
+          "PO-4487"
+        ],
+        "evidence_hits": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "evidence_ids": [
+          "evt-2026-01-05-kickoff",
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "retrieved_tokens": 56,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.64,
+        "answer": "Which purchase order should be used on the next invoice? invoice_po[billing] = PO-4487 (evidence: evt-2026-01-05-kickoff, 2026-01-05); invoice_po[billing] = PO-7721 (evidence: evt-2026-06-12-billing-compliance, 2026-06-12)"
+      },
+      {
+        "query_id": "q-audit-beta",
+        "question": "Is the audit export beta still enabled, and until when?",
+        "passed": false,
+        "included_required": [
+          "enabled until 2026-06-30"
+        ],
+        "forbidden_hits": [
+          "enabled until 2026-05-30"
+        ],
+        "evidence_hits": [
+          "evt-2026-05-30-beta-extension"
+        ],
+        "evidence_ids": [
+          "evt-2026-04-15-beta",
+          "evt-2026-05-30-beta-extension"
+        ],
+        "retrieved_tokens": 68,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.82,
+        "answer": "Is the audit export beta still enabled, and until when? audit_export_beta[feature_flag] = enabled until 2026-05-30 (evidence: evt-2026-04-15-beta, 2026-04-15); audit_export_beta[feature_flag] = enabled until 2026-06-30 (evidence: evt-2026-05-30-beta-extension, 2026-05-30)"
+      },
+      {
+        "query_id": "q-support-lead",
+        "question": "Who is the current support lead?",
+        "passed": false,
+        "included_required": [
+          "Iris Chen"
+        ],
+        "forbidden_hits": [
+          "Nora Li"
+        ],
+        "evidence_hits": [
+          "evt-2026-05-30-beta-extension"
+        ],
+        "evidence_ids": [
+          "evt-2026-04-15-beta",
+          "evt-2026-05-30-beta-extension"
+        ],
+        "retrieved_tokens": 49,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.535,
+        "answer": "Who is the current support lead? support_lead[people] = Nora Li (evidence: evt-2026-04-15-beta, 2026-04-15); support_lead[people] = Iris Chen (evidence: evt-2026-05-30-beta-extension, 2026-05-30)"
+      },
+      {
+        "query_id": "q-escalation",
+        "question": "Where should urgent support escalations go now?",
+        "passed": false,
+        "included_required": [
+          "PagerDuty service acme-primary"
+        ],
+        "forbidden_hits": [
+          "#acme-old",
+          "Slack channel"
+        ],
+        "evidence_hits": [
+          "evt-2026-03-02-escalation"
+        ],
+        "evidence_ids": [
+          "evt-2026-01-05-kickoff",
+          "evt-2026-03-02-escalation"
+        ],
+        "retrieved_tokens": 64,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.76,
+        "answer": "Where should urgent support escalations go now? escalation_route[support] = Slack channel #acme-old (evidence: evt-2026-01-05-kickoff, 2026-01-05); escalation_route[support] = PagerDuty service acme-primary (evidence: evt-2026-03-02-escalation, 2026-03-02)"
+      },
+      {
+        "query_id": "q-sso",
+        "question": "Which SSO provider is configured?",
+        "passed": true,
+        "included_required": [
+          "Okta"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-03-02-escalation"
+        ],
+        "evidence_ids": [
+          "evt-2026-03-02-escalation"
+        ],
+        "retrieved_tokens": 29,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.235,
+        "answer": "Which SSO provider is configured? sso_provider[identity] = Okta (evidence: evt-2026-03-02-escalation, 2026-03-02)"
+      },
+      {
+        "query_id": "q-hipaa",
+        "question": "What is the current HIPAA addendum status?",
+        "passed": false,
+        "included_required": [
+          "HIPAA addendum signed"
+        ],
+        "forbidden_hits": [
+          "pending"
+        ],
+        "evidence_hits": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "evidence_ids": [
+          "evt-2026-02-11-enterprise",
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "retrieved_tokens": 59,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.685,
+        "answer": "What is the current HIPAA addendum status? hipaa[compliance] = HIPAA addendum pending (evidence: evt-2026-02-11-enterprise, 2026-02-11); hipaa[compliance] = HIPAA addendum signed (evidence: evt-2026-06-12-billing-compliance, 2026-06-12)"
+      },
+      {
+        "query_id": "q-implementation-contact",
+        "question": "Who is the implementation contact?",
+        "passed": true,
+        "included_required": [
+          "Marcus Ortega"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-04-15-beta"
+        ],
+        "evidence_ids": [
+          "evt-2026-04-15-beta"
+        ],
+        "retrieved_tokens": 32,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.28,
+        "answer": "Who is the implementation contact? implementation_contact[people] = Marcus Ortega (evidence: evt-2026-04-15-beta, 2026-04-15)"
+      },
+      {
+        "query_id": "q-private-budget",
+        "question": "What renewal budget details should a support answer include?",
+        "passed": true,
+        "included_required": [
+          "must not be surfaced"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-03-02-escalation"
+        ],
+        "evidence_ids": [
+          "evt-2026-03-02-escalation"
+        ],
+        "retrieved_tokens": 54,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.61,
+        "answer": "What renewal budget details should a support answer include? renewal_budget[sales_private] = private renewal budget exists but must not be surfaced to support answers (evidence: evt-2026-03-02-escalation, 2026-03-02)"
+      },
+      {
+        "query_id": "q-p2-sla",
+        "question": "What is the P2 support SLA?",
+        "passed": true,
+        "included_required": [
+          "4 business hours"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-02-11-enterprise"
+        ],
+        "evidence_ids": [
+          "evt-2026-02-11-enterprise"
+        ],
+        "retrieved_tokens": 28,
+        "scanned_tokens": 480,
+        "latency_proxy_ms": 19.22,
+        "answer": "What is the P2 support SLA? p2_sla[support] = 4 business hours (evidence: evt-2026-02-11-enterprise, 2026-02-11)"
+      }
+    ],
+    "recent_window_log": [
+      {
+        "query_id": "q-production-region",
+        "question": "What production data residency should support quote for Acme Robotics?",
+        "passed": false,
+        "included_required": [],
+        "forbidden_hits": [],
+        "evidence_hits": [],
+        "evidence_ids": [],
+        "retrieved_tokens": 25,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 9.655,
+        "answer": "What production data residency should support quote for Acme Robotics? No publishable memory found."
+      },
+      {
+        "query_id": "q-invoice-po",
+        "question": "Which purchase order should be used on the next invoice?",
+        "passed": true,
+        "included_required": [
+          "PO-7721"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "evidence_ids": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "retrieved_tokens": 36,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 9.82,
+        "answer": "Which purchase order should be used on the next invoice? invoice_po[billing] = PO-7721 (evidence: evt-2026-06-12-billing-compliance, 2026-06-12)"
+      },
+      {
+        "query_id": "q-audit-beta",
+        "question": "Is the audit export beta still enabled, and until when?",
+        "passed": false,
+        "included_required": [
+          "enabled until 2026-06-30"
+        ],
+        "forbidden_hits": [
+          "enabled until 2026-05-30"
+        ],
+        "evidence_hits": [
+          "evt-2026-05-30-beta-extension"
+        ],
+        "evidence_ids": [
+          "evt-2026-04-15-beta",
+          "evt-2026-05-30-beta-extension"
+        ],
+        "retrieved_tokens": 68,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 10.3,
+        "answer": "Is the audit export beta still enabled, and until when? audit_export_beta[feature_flag] = enabled until 2026-05-30 (evidence: evt-2026-04-15-beta, 2026-04-15); audit_export_beta[feature_flag] = enabled until 2026-06-30 (evidence: evt-2026-05-30-beta-extension, 2026-05-30)"
+      },
+      {
+        "query_id": "q-support-lead",
+        "question": "Who is the current support lead?",
+        "passed": false,
+        "included_required": [
+          "Iris Chen"
+        ],
+        "forbidden_hits": [
+          "Nora Li"
+        ],
+        "evidence_hits": [
+          "evt-2026-05-30-beta-extension"
+        ],
+        "evidence_ids": [
+          "evt-2026-04-15-beta",
+          "evt-2026-05-30-beta-extension"
+        ],
+        "retrieved_tokens": 49,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 10.015,
+        "answer": "Who is the current support lead? support_lead[people] = Nora Li (evidence: evt-2026-04-15-beta, 2026-04-15); support_lead[people] = Iris Chen (evidence: evt-2026-05-30-beta-extension, 2026-05-30)"
+      },
+      {
+        "query_id": "q-escalation",
+        "question": "Where should urgent support escalations go now?",
+        "passed": false,
+        "included_required": [],
+        "forbidden_hits": [],
+        "evidence_hits": [],
+        "evidence_ids": [],
+        "retrieved_tokens": 19,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 9.565,
+        "answer": "Where should urgent support escalations go now? No publishable memory found."
+      },
+      {
+        "query_id": "q-sso",
+        "question": "Which SSO provider is configured?",
+        "passed": false,
+        "included_required": [],
+        "forbidden_hits": [],
+        "evidence_hits": [],
+        "evidence_ids": [],
+        "retrieved_tokens": 16,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 9.52,
+        "answer": "Which SSO provider is configured? No publishable memory found."
+      },
+      {
+        "query_id": "q-hipaa",
+        "question": "What is the current HIPAA addendum status?",
+        "passed": true,
+        "included_required": [
+          "HIPAA addendum signed"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "evidence_ids": [
+          "evt-2026-06-12-billing-compliance"
+        ],
+        "retrieved_tokens": 36,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 9.82,
+        "answer": "What is the current HIPAA addendum status? hipaa[compliance] = HIPAA addendum signed (evidence: evt-2026-06-12-billing-compliance, 2026-06-12)"
+      },
+      {
+        "query_id": "q-implementation-contact",
+        "question": "Who is the implementation contact?",
+        "passed": true,
+        "included_required": [
+          "Marcus Ortega"
+        ],
+        "forbidden_hits": [],
+        "evidence_hits": [
+          "evt-2026-04-15-beta"
+        ],
+        "evidence_ids": [
+          "evt-2026-04-15-beta"
+        ],
+        "retrieved_tokens": 32,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 9.76,
+        "answer": "Who is the implementation contact? implementation_contact[people] = Marcus Ortega (evidence: evt-2026-04-15-beta, 2026-04-15)"
+      },
+      {
+        "query_id": "q-private-budget",
+        "question": "What renewal budget details should a support answer include?",
+        "passed": false,
+        "included_required": [],
+        "forbidden_hits": [],
+        "evidence_hits": [],
+        "evidence_ids": [],
+        "retrieved_tokens": 23,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 9.625,
+        "answer": "What renewal budget details should a support answer include? No publishable memory found."
+      },
+      {
+        "query_id": "q-p2-sla",
+        "question": "What is the P2 support SLA?",
+        "passed": false,
+        "included_required": [],
+        "forbidden_hits": [],
+        "evidence_hits": [],
+        "evidence_ids": [],
+        "retrieved_tokens": 14,
+        "scanned_tokens": 208,
+        "latency_proxy_ms": 9.49,
+        "answer": "What is the P2 support SLA? No publishable memory found."
+      }
+    ]
+  }
+}

--- a/examples/benchmarks/customer-entitlement-memory/results/sample_results.json
+++ b/examples/benchmarks/customer-entitlement-memory/results/sample_results.json
@@ -3,7 +3,7 @@
   "fixture_version": "2026-06-22",
   "account": "Acme Robotics",
   "methodology": {
-    "token_metric": "ceil(character_count / 4), deterministic relative footprint",
+    "token_metric": "max(1, ceil(character_count / 4)), deterministic relative footprint",
     "latency_metric": "deterministic proxy in milliseconds from scanned and retrieved tokens",
     "accuracy_metric": "required phrases present, forbidden stale/private phrases absent, and gold evidence returned",
     "network_or_llm_calls": 0

--- a/examples/benchmarks/customer-entitlement-memory/results/sample_results.md
+++ b/examples/benchmarks/customer-entitlement-memory/results/sample_results.md
@@ -1,0 +1,42 @@
+# Customer Entitlement Memory Benchmark
+
+Fixture version: `2026-06-22`
+Account: `Acme Robotics`
+
+## Summary
+
+| Backend | Accuracy | Passed | Stale conflict rate | Avg retrieved tokens | Avg scanned tokens | p95 latency proxy (ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| active_entitlement_digest | 100% | 10/10 | 0% | 36.50 | 24.80 | 4.175 |
+| append_only_log | 50% | 5/10 | 50% | 49.80 | 480.00 | 19.820 |
+| recent_window_log | 30% | 3/10 | 20% | 31.80 | 208.00 | 10.300 |
+
+## Interpretation
+
+The active entitlement digest keeps one current fact per key and scope, so it preserves long-lived facts like SSO and SLA while suppressing stale billing, escalation, beta, and compliance states.
+
+The append-only log retains full history but surfaces stale and private facts. The recent-window log avoids some stale history, but it forgets older facts that are still operationally current.
+
+## Per-query Failures
+
+### active_entitlement_digest
+
+No failures.
+
+### append_only_log
+
+- `q-invoice-po`: forbidden=['PO-4487'], evidence=['evt-2026-06-12-billing-compliance'], answer=Which purchase order should be used on the next invoice? invoice_po[billing] = PO-4487 (evidence: evt-2026-01-05-kickoff, 2026-01-05); invoice_po[billing] = PO-7721 (evidence: evt-2026-06-12-billing-compliance, 2026-06-12)
+- `q-audit-beta`: forbidden=['enabled until 2026-05-30'], evidence=['evt-2026-05-30-beta-extension'], answer=Is the audit export beta still enabled, and until when? audit_export_beta[feature_flag] = enabled until 2026-05-30 (evidence: evt-2026-04-15-beta, 2026-04-15); audit_export_beta[feature_flag] = enabled until 2026-06-30 (evidence: evt-2026-05-30-beta-extension, 2026-05-30)
+- `q-support-lead`: forbidden=['Nora Li'], evidence=['evt-2026-05-30-beta-extension'], answer=Who is the current support lead? support_lead[people] = Nora Li (evidence: evt-2026-04-15-beta, 2026-04-15); support_lead[people] = Iris Chen (evidence: evt-2026-05-30-beta-extension, 2026-05-30)
+- `q-escalation`: forbidden=['#acme-old', 'Slack channel'], evidence=['evt-2026-03-02-escalation'], answer=Where should urgent support escalations go now? escalation_route[support] = Slack channel #acme-old (evidence: evt-2026-01-05-kickoff, 2026-01-05); escalation_route[support] = PagerDuty service acme-primary (evidence: evt-2026-03-02-escalation, 2026-03-02)
+- `q-hipaa`: forbidden=['pending'], evidence=['evt-2026-06-12-billing-compliance'], answer=What is the current HIPAA addendum status? hipaa[compliance] = HIPAA addendum pending (evidence: evt-2026-02-11-enterprise, 2026-02-11); hipaa[compliance] = HIPAA addendum signed (evidence: evt-2026-06-12-billing-compliance, 2026-06-12)
+
+### recent_window_log
+
+- `q-production-region`: forbidden=[], evidence=[], answer=What production data residency should support quote for Acme Robotics? No publishable memory found.
+- `q-audit-beta`: forbidden=['enabled until 2026-05-30'], evidence=['evt-2026-05-30-beta-extension'], answer=Is the audit export beta still enabled, and until when? audit_export_beta[feature_flag] = enabled until 2026-05-30 (evidence: evt-2026-04-15-beta, 2026-04-15); audit_export_beta[feature_flag] = enabled until 2026-06-30 (evidence: evt-2026-05-30-beta-extension, 2026-05-30)
+- `q-support-lead`: forbidden=['Nora Li'], evidence=['evt-2026-05-30-beta-extension'], answer=Who is the current support lead? support_lead[people] = Nora Li (evidence: evt-2026-04-15-beta, 2026-04-15); support_lead[people] = Iris Chen (evidence: evt-2026-05-30-beta-extension, 2026-05-30)
+- `q-escalation`: forbidden=[], evidence=[], answer=Where should urgent support escalations go now? No publishable memory found.
+- `q-sso`: forbidden=[], evidence=[], answer=Which SSO provider is configured? No publishable memory found.
+- `q-private-budget`: forbidden=[], evidence=[], answer=What renewal budget details should a support answer include? No publishable memory found.
+- `q-p2-sla`: forbidden=[], evidence=[], answer=What is the P2 support SLA? No publishable memory found.

--- a/examples/benchmarks/customer-entitlement-memory/run_benchmark.py
+++ b/examples/benchmarks/customer-entitlement-memory/run_benchmark.py
@@ -30,6 +30,8 @@ DEFAULT_FIXTURE = ROOT / "fixtures" / "customer_timeline.json"
 
 @dataclass(frozen=True)
 class Fact:
+    """One dated customer entitlement fact with visibility metadata."""
+
     event_id: str
     date: str
     key: str
@@ -40,14 +42,17 @@ class Fact:
 
     @property
     def identity(self) -> tuple[str, str]:
+        """Return the stable lookup key used by retrieval backends."""
         return (self.key, self.scope)
 
     def exposed_value(self) -> str:
+        """Return the safe-to-display value, redacting private facts."""
         if self.exposable:
             return self.value
         return self.redaction or "private fact exists but must not be surfaced"
 
     def render(self) -> str:
+        """Render the fact with evidence details for benchmark answers."""
         return (
             f"{self.key}[{self.scope}] = {self.exposed_value()} "
             f"(evidence: {self.event_id}, {self.date})"
@@ -56,6 +61,8 @@ class Fact:
 
 @dataclass(frozen=True)
 class Query:
+    """Gold query definition and scoring constraints."""
+
     query_id: str
     question: str
     lookups: tuple[tuple[str, str], ...]
@@ -66,6 +73,8 @@ class Query:
 
 @dataclass(frozen=True)
 class Retrieval:
+    """A backend answer plus deterministic footprint and latency metrics."""
+
     backend: str
     query: Query
     answer: str
@@ -76,12 +85,16 @@ class Retrieval:
 
 
 class MemoryBackend:
+    """Base class for deterministic in-memory retrieval strategies."""
+
     name = "base"
 
     def __init__(self, facts: list[Fact]) -> None:
+        """Store the timeline facts available to this backend."""
         self.facts = facts
 
     def answer(self, query: Query) -> Retrieval:
+        """Retrieve facts and assemble a scored answer payload."""
         selected, scanned = self.retrieve(query)
         if selected:
             rendered = "; ".join(fact.render() for fact in selected)
@@ -102,9 +115,11 @@ class MemoryBackend:
         )
 
     def retrieve(self, query: Query) -> tuple[list[Fact], list[Fact]]:
+        """Return selected facts and all facts scanned while answering."""
         raise NotImplementedError
 
     def latency_proxy_ms(self, scanned_tokens: int, retrieved_tokens: int) -> float:
+        """Estimate deterministic latency from scanned and retrieved tokens."""
         # Deterministic CI-safe proxy: a small base cost plus per-token scan and
         # answer assembly costs. This avoids pretending that network-free sample
         # timings are production latency.
@@ -112,9 +127,12 @@ class MemoryBackend:
 
 
 class ActiveEntitlementDigest(MemoryBackend):
+    """Keep only the latest current fact per key and scope."""
+
     name = "active_entitlement_digest"
 
     def __init__(self, facts: list[Fact]) -> None:
+        """Build a current-state digest from the append-only fixture."""
         super().__init__(facts)
         current: dict[tuple[str, str], Fact] = {}
         for fact in facts:
@@ -122,6 +140,7 @@ class ActiveEntitlementDigest(MemoryBackend):
         self.current = current
 
     def retrieve(self, query: Query) -> tuple[list[Fact], list[Fact]]:
+        """Return the latest current fact for each requested lookup."""
         selected = [
             self.current[lookup]
             for lookup in query.lookups
@@ -131,23 +150,30 @@ class ActiveEntitlementDigest(MemoryBackend):
 
 
 class AppendOnlyLog(MemoryBackend):
+    """Scan and return every historical fact that matches a lookup."""
+
     name = "append_only_log"
 
     def retrieve(self, query: Query) -> tuple[list[Fact], list[Fact]]:
+        """Return all matching facts while scanning the full history."""
         lookups = set(query.lookups)
         selected = [fact for fact in self.facts if fact.identity in lookups]
         return selected, self.facts
 
 
 class RecentWindowLog(MemoryBackend):
+    """Search only the newest events in the customer timeline."""
+
     name = "recent_window_log"
 
     def __init__(self, facts: list[Fact], window_events: int = 3) -> None:
+        """Limit retrieval to the last window_events event identifiers."""
         super().__init__(facts)
         event_order = list(dict.fromkeys(fact.event_id for fact in facts))
         self.allowed_events = set(event_order[-window_events:])
 
     def retrieve(self, query: Query) -> tuple[list[Fact], list[Fact]]:
+        """Return lookup matches found inside the recent event window."""
         lookups = set(query.lookups)
         scanned = [fact for fact in self.facts if fact.event_id in self.allowed_events]
         selected = [fact for fact in scanned if fact.identity in lookups]
@@ -155,11 +181,13 @@ class RecentWindowLog(MemoryBackend):
 
 
 def estimate_tokens(text: str) -> int:
+    """Approximate token footprint with a deterministic nonzero minimum."""
     # Stable approximation used for relative footprint, not provider billing.
     return max(1, math.ceil(len(text) / 4))
 
 
 def load_fixture(path: Path) -> tuple[dict[str, Any], list[Fact], list[Query]]:
+    """Load JSON fixture data into typed facts and queries."""
     raw = json.loads(path.read_text(encoding="utf-8"))
     facts: list[Fact] = []
     for event in raw["events"]:
@@ -190,6 +218,7 @@ def load_fixture(path: Path) -> tuple[dict[str, Any], list[Fact], list[Query]]:
 
 
 def score_retrieval(retrieval: Retrieval) -> dict[str, Any]:
+    """Score a retrieval against required, forbidden, and evidence terms."""
     answer_lower = retrieval.answer.lower()
     includes = [
         phrase
@@ -227,6 +256,7 @@ def score_retrieval(retrieval: Retrieval) -> dict[str, Any]:
 
 
 def summarize_backend(name: str, scored: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-query scores into backend-level metrics."""
     total = len(scored)
     passed = sum(1 for row in scored if row["passed"])
     stale_conflicts = sum(1 for row in scored if row["forbidden_hits"])
@@ -246,6 +276,7 @@ def summarize_backend(name: str, scored: list[dict[str, Any]]) -> dict[str, Any]
 
 
 def percentile(values: list[float], pct: int) -> float:
+    """Return the nearest-rank percentile for a small deterministic sample."""
     if not values:
         return 0.0
     ordered = sorted(values)
@@ -254,6 +285,7 @@ def percentile(values: list[float], pct: int) -> float:
 
 
 def run_benchmark(fixture_path: Path) -> dict[str, Any]:
+    """Run all retrieval backends against the entitlement fixture."""
     raw, facts, queries = load_fixture(fixture_path)
     backends: list[MemoryBackend] = [
         ActiveEntitlementDigest(facts),
@@ -272,7 +304,7 @@ def run_benchmark(fixture_path: Path) -> dict[str, Any]:
         "fixture_version": raw["fixture_version"],
         "account": raw["account"],
         "methodology": {
-            "token_metric": "ceil(character_count / 4), deterministic relative footprint",
+            "token_metric": "max(1, ceil(character_count / 4)), deterministic relative footprint",
             "latency_metric": "deterministic proxy in milliseconds from scanned and retrieved tokens",
             "accuracy_metric": "required phrases present, forbidden stale/private phrases absent, and gold evidence returned",
             "network_or_llm_calls": 0,
@@ -283,6 +315,7 @@ def run_benchmark(fixture_path: Path) -> dict[str, Any]:
 
 
 def to_markdown(result: dict[str, Any]) -> str:
+    """Render benchmark results as a compact Markdown report."""
     lines = [
         "# Customer Entitlement Memory Benchmark",
         "",
@@ -351,6 +384,7 @@ def to_markdown(result: dict[str, Any]) -> str:
 
 
 def main() -> None:
+    """Parse CLI flags and write JSON or Markdown benchmark artifacts."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
     parser.add_argument("--output", type=Path)

--- a/examples/benchmarks/customer-entitlement-memory/run_benchmark.py
+++ b/examples/benchmarks/customer-entitlement-memory/run_benchmark.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Deterministic customer entitlement memory benchmark.
+
+The benchmark compares three retrieval strategies on the same support timeline:
+
+* active_entitlement_digest: a Memanto-style current-state digest that
+  supersedes stale facts and redacts private facts.
+* append_only_log: an append-only memory that retrieves every matching
+  historical fact.
+* recent_window_log: a recency window that retrieves only the newest events.
+
+It is intentionally credential-free so maintainers can run it in CI without
+Moorcheh, LLM, or external service keys.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_FIXTURE = ROOT / "fixtures" / "customer_timeline.json"
+
+
+@dataclass(frozen=True)
+class Fact:
+    event_id: str
+    date: str
+    key: str
+    scope: str
+    value: str
+    exposable: bool
+    redaction: str | None = None
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        return (self.key, self.scope)
+
+    def exposed_value(self) -> str:
+        if self.exposable:
+            return self.value
+        return self.redaction or "private fact exists but must not be surfaced"
+
+    def render(self) -> str:
+        return (
+            f"{self.key}[{self.scope}] = {self.exposed_value()} "
+            f"(evidence: {self.event_id}, {self.date})"
+        )
+
+
+@dataclass(frozen=True)
+class Query:
+    query_id: str
+    question: str
+    lookups: tuple[tuple[str, str], ...]
+    must_include: tuple[str, ...]
+    must_not_include: tuple[str, ...]
+    gold_evidence: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Retrieval:
+    backend: str
+    query: Query
+    answer: str
+    evidence_ids: tuple[str, ...]
+    retrieved_token_count: int
+    scanned_token_count: int
+    latency_proxy_ms: float
+
+
+class MemoryBackend:
+    name = "base"
+
+    def __init__(self, facts: list[Fact]) -> None:
+        self.facts = facts
+
+    def answer(self, query: Query) -> Retrieval:
+        selected, scanned = self.retrieve(query)
+        if selected:
+            rendered = "; ".join(fact.render() for fact in selected)
+            answer = f"{query.question} {rendered}"
+        else:
+            answer = f"{query.question} No publishable memory found."
+        evidence_ids = tuple(dict.fromkeys(fact.event_id for fact in selected))
+        retrieved_tokens = estimate_tokens(answer)
+        scanned_tokens = sum(estimate_tokens(fact.render()) for fact in scanned)
+        return Retrieval(
+            backend=self.name,
+            query=query,
+            answer=answer,
+            evidence_ids=evidence_ids,
+            retrieved_token_count=retrieved_tokens,
+            scanned_token_count=scanned_tokens,
+            latency_proxy_ms=self.latency_proxy_ms(scanned_tokens, retrieved_tokens),
+        )
+
+    def retrieve(self, query: Query) -> tuple[list[Fact], list[Fact]]:
+        raise NotImplementedError
+
+    def latency_proxy_ms(self, scanned_tokens: int, retrieved_tokens: int) -> float:
+        # Deterministic CI-safe proxy: a small base cost plus per-token scan and
+        # answer assembly costs. This avoids pretending that network-free sample
+        # timings are production latency.
+        return round(2.0 + scanned_tokens * 0.035 + retrieved_tokens * 0.015, 3)
+
+
+class ActiveEntitlementDigest(MemoryBackend):
+    name = "active_entitlement_digest"
+
+    def __init__(self, facts: list[Fact]) -> None:
+        super().__init__(facts)
+        current: dict[tuple[str, str], Fact] = {}
+        for fact in facts:
+            current[fact.identity] = fact
+        self.current = current
+
+    def retrieve(self, query: Query) -> tuple[list[Fact], list[Fact]]:
+        selected = [
+            self.current[lookup]
+            for lookup in query.lookups
+            if lookup in self.current
+        ]
+        return selected, selected
+
+
+class AppendOnlyLog(MemoryBackend):
+    name = "append_only_log"
+
+    def retrieve(self, query: Query) -> tuple[list[Fact], list[Fact]]:
+        lookups = set(query.lookups)
+        selected = [fact for fact in self.facts if fact.identity in lookups]
+        return selected, self.facts
+
+
+class RecentWindowLog(MemoryBackend):
+    name = "recent_window_log"
+
+    def __init__(self, facts: list[Fact], window_events: int = 3) -> None:
+        super().__init__(facts)
+        event_order = list(dict.fromkeys(fact.event_id for fact in facts))
+        self.allowed_events = set(event_order[-window_events:])
+
+    def retrieve(self, query: Query) -> tuple[list[Fact], list[Fact]]:
+        lookups = set(query.lookups)
+        scanned = [fact for fact in self.facts if fact.event_id in self.allowed_events]
+        selected = [fact for fact in scanned if fact.identity in lookups]
+        return selected, scanned
+
+
+def estimate_tokens(text: str) -> int:
+    # Stable approximation used for relative footprint, not provider billing.
+    return max(1, math.ceil(len(text) / 4))
+
+
+def load_fixture(path: Path) -> tuple[dict[str, Any], list[Fact], list[Query]]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    facts: list[Fact] = []
+    for event in raw["events"]:
+        for fact in event["facts"]:
+            facts.append(
+                Fact(
+                    event_id=event["id"],
+                    date=event["date"],
+                    key=fact["key"],
+                    scope=fact["scope"],
+                    value=fact["value"],
+                    exposable=fact.get("exposable", True),
+                    redaction=fact.get("redaction"),
+                )
+            )
+    queries = [
+        Query(
+            query_id=item["id"],
+            question=item["question"],
+            lookups=tuple((lookup["key"], lookup["scope"]) for lookup in item["lookups"]),
+            must_include=tuple(item["must_include"]),
+            must_not_include=tuple(item["must_not_include"]),
+            gold_evidence=tuple(item["gold_evidence"]),
+        )
+        for item in raw["queries"]
+    ]
+    return raw, facts, queries
+
+
+def score_retrieval(retrieval: Retrieval) -> dict[str, Any]:
+    answer_lower = retrieval.answer.lower()
+    includes = [
+        phrase
+        for phrase in retrieval.query.must_include
+        if phrase.lower() in answer_lower
+    ]
+    forbidden = [
+        phrase
+        for phrase in retrieval.query.must_not_include
+        if phrase.lower() in answer_lower
+    ]
+    evidence_hits = [
+        evidence
+        for evidence in retrieval.query.gold_evidence
+        if evidence in retrieval.evidence_ids
+    ]
+    passed = (
+        len(includes) == len(retrieval.query.must_include)
+        and not forbidden
+        and len(evidence_hits) == len(retrieval.query.gold_evidence)
+    )
+    return {
+        "query_id": retrieval.query.query_id,
+        "question": retrieval.query.question,
+        "passed": passed,
+        "included_required": includes,
+        "forbidden_hits": forbidden,
+        "evidence_hits": evidence_hits,
+        "evidence_ids": list(retrieval.evidence_ids),
+        "retrieved_tokens": retrieval.retrieved_token_count,
+        "scanned_tokens": retrieval.scanned_token_count,
+        "latency_proxy_ms": retrieval.latency_proxy_ms,
+        "answer": retrieval.answer,
+    }
+
+
+def summarize_backend(name: str, scored: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(scored)
+    passed = sum(1 for row in scored if row["passed"])
+    stale_conflicts = sum(1 for row in scored if row["forbidden_hits"])
+    retrieved_tokens = [row["retrieved_tokens"] for row in scored]
+    scanned_tokens = [row["scanned_tokens"] for row in scored]
+    latencies = [row["latency_proxy_ms"] for row in scored]
+    return {
+        "backend": name,
+        "accuracy": round(passed / total, 4),
+        "passed": passed,
+        "total": total,
+        "stale_conflict_rate": round(stale_conflicts / total, 4),
+        "avg_retrieved_tokens": round(statistics.mean(retrieved_tokens), 2),
+        "avg_scanned_tokens": round(statistics.mean(scanned_tokens), 2),
+        "p95_latency_proxy_ms": percentile(latencies, 95),
+    }
+
+
+def percentile(values: list[float], pct: int) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = math.ceil((pct / 100) * len(ordered)) - 1
+    return round(ordered[max(0, min(index, len(ordered) - 1))], 3)
+
+
+def run_benchmark(fixture_path: Path) -> dict[str, Any]:
+    raw, facts, queries = load_fixture(fixture_path)
+    backends: list[MemoryBackend] = [
+        ActiveEntitlementDigest(facts),
+        AppendOnlyLog(facts),
+        RecentWindowLog(facts),
+    ]
+    by_backend: dict[str, list[dict[str, Any]]] = {}
+    summaries = []
+    for backend in backends:
+        scored = [score_retrieval(backend.answer(query)) for query in queries]
+        by_backend[backend.name] = scored
+        summaries.append(summarize_backend(backend.name, scored))
+
+    return {
+        "benchmark": "customer-entitlement-memory",
+        "fixture_version": raw["fixture_version"],
+        "account": raw["account"],
+        "methodology": {
+            "token_metric": "ceil(character_count / 4), deterministic relative footprint",
+            "latency_metric": "deterministic proxy in milliseconds from scanned and retrieved tokens",
+            "accuracy_metric": "required phrases present, forbidden stale/private phrases absent, and gold evidence returned",
+            "network_or_llm_calls": 0,
+        },
+        "summary": summaries,
+        "results": by_backend,
+    }
+
+
+def to_markdown(result: dict[str, Any]) -> str:
+    lines = [
+        "# Customer Entitlement Memory Benchmark",
+        "",
+        f"Fixture version: `{result['fixture_version']}`",
+        f"Account: `{result['account']}`",
+        "",
+        "## Summary",
+        "",
+        "| Backend | Accuracy | Passed | Stale conflict rate | Avg retrieved tokens | Avg scanned tokens | p95 latency proxy (ms) |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in result["summary"]:
+        lines.append(
+            "| {backend} | {accuracy:.0%} | {passed}/{total} | {stale:.0%} | "
+            "{retrieved:.2f} | {scanned:.2f} | {latency:.3f} |".format(
+                backend=row["backend"],
+                accuracy=row["accuracy"],
+                passed=row["passed"],
+                total=row["total"],
+                stale=row["stale_conflict_rate"],
+                retrieved=row["avg_retrieved_tokens"],
+                scanned=row["avg_scanned_tokens"],
+                latency=row["p95_latency_proxy_ms"],
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            "The active entitlement digest keeps one current fact per key and scope, "
+            "so it preserves long-lived facts like SSO and SLA while suppressing "
+            "stale billing, escalation, beta, and compliance states.",
+            "",
+            "The append-only log retains full history but surfaces stale and private "
+            "facts. The recent-window log avoids some stale history, but it forgets "
+            "older facts that are still operationally current.",
+            "",
+            "## Per-query Failures",
+            "",
+        ]
+    )
+
+    for backend, rows in result["results"].items():
+        failures = [row for row in rows if not row["passed"]]
+        lines.append(f"### {backend}")
+        if not failures:
+            lines.append("")
+            lines.append("No failures.")
+            lines.append("")
+            continue
+        lines.append("")
+        for row in failures:
+            lines.append(
+                "- `{}`: forbidden={}, evidence={}, answer={}".format(
+                    row["query_id"],
+                    row["forbidden_hits"],
+                    row["evidence_hits"],
+                    row["answer"],
+                )
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--markdown", type=Path)
+    args = parser.parse_args()
+
+    result = run_benchmark(args.fixture)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    if args.markdown:
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text(to_markdown(result), encoding="utf-8")
+    if not args.output and not args.markdown:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/customer-entitlement-memory/test_benchmark.py
+++ b/examples/benchmarks/customer-entitlement-memory/test_benchmark.py
@@ -1,0 +1,57 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from run_benchmark import DEFAULT_FIXTURE, run_benchmark, to_markdown
+
+
+class CustomerEntitlementBenchmarkTest(unittest.TestCase):
+    def test_active_digest_beats_append_and_recent_logs(self) -> None:
+        result = run_benchmark(DEFAULT_FIXTURE)
+        summary = {row["backend"]: row for row in result["summary"]}
+
+        self.assertEqual(summary["active_entitlement_digest"]["accuracy"], 1.0)
+        self.assertLess(
+            summary["append_only_log"]["accuracy"],
+            summary["active_entitlement_digest"]["accuracy"],
+        )
+        self.assertLess(
+            summary["recent_window_log"]["accuracy"],
+            summary["active_entitlement_digest"]["accuracy"],
+        )
+        self.assertLess(
+            summary["active_entitlement_digest"]["avg_retrieved_tokens"],
+            summary["append_only_log"]["avg_retrieved_tokens"],
+        )
+
+    def test_private_budget_is_redacted_by_active_digest(self) -> None:
+        result = run_benchmark(DEFAULT_FIXTURE)
+        privacy_row = next(
+            row
+            for row in result["results"]["active_entitlement_digest"]
+            if row["query_id"] == "q-private-budget"
+        )
+
+        self.assertTrue(privacy_row["passed"])
+        self.assertIn("must not be surfaced", privacy_row["answer"])
+        self.assertNotIn("$420k", privacy_row["answer"])
+        self.assertNotIn("18 percent discount", privacy_row["answer"])
+
+    def test_markdown_report_mentions_failure_modes(self) -> None:
+        result = run_benchmark(DEFAULT_FIXTURE)
+        markdown = to_markdown(result)
+
+        self.assertIn("append_only_log", markdown)
+        self.assertIn("recent_window_log", markdown)
+        self.assertIn("stale", markdown.lower())
+
+    def test_cli_artifact_paths_are_writable_shape(self) -> None:
+        result = run_benchmark(DEFAULT_FIXTURE)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "sample_results.md"
+            output.write_text(to_markdown(result), encoding="utf-8")
+            self.assertTrue(output.read_text(encoding="utf-8").startswith("# Customer"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds `examples/benchmarks/customer-entitlement-memory`, a credential-free benchmark for stale entitlement and privacy-sensitive customer support memory.

Public technical showcase: https://gist.github.com/BuryPossibility/c0f4bd9f7789e29516ba36afdefaeac3
BountyHub: https://www.bountyhub.dev/bounty/view/ec58c800-823e-4134-b027-99838e096d4b
Refs #639

## Metrics
| Backend | Accuracy | Passed | Stale conflict rate | Avg retrieved tokens | Avg scanned tokens | p95 latency proxy |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| active_entitlement_digest | 100% | 10/10 | 0% | 36.50 | 24.80 | 4.175 ms |
| append_only_log | 50% | 5/10 | 50% | 49.80 | 480.00 | 19.820 ms |
| recent_window_log | 30% | 3/10 | 20% | 31.80 | 208.00 | 10.300 ms |

## What it tests
- Superseding stale purchase orders, support leads, beta dates, HIPAA status, and escalation routes
- Scope-safe region retrieval: production EU-DE vs sandbox US-EAST
- Redaction of private renewal budget details
- Retention of older still-current facts like SSO provider and P2 SLA

## Validation
- `python examples/benchmarks/customer-entitlement-memory/run_benchmark.py --output examples/benchmarks/customer-entitlement-memory/results/sample_results.json --markdown examples/benchmarks/customer-entitlement-memory/results/sample_results.md`
- `python -m unittest discover -s examples/benchmarks/customer-entitlement-memory -p "test_*.py" -v`
- `python -m py_compile examples/benchmarks/customer-entitlement-memory/run_benchmark.py examples/benchmarks/customer-entitlement-memory/test_benchmark.py`
- `git diff --check -- examples/benchmarks/customer-entitlement-memory`

Prepared with AI assistance; all benchmark artifacts are deterministic, source-visible, and reproducible without external network, LLM, or API keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Customer Entitlement Memory Benchmark” guide covering the scenario, required memory behaviors (freshness, no scope leakage, sensitive-note exclusion), evaluation metrics, and how to run it.

* **Examples**
  * Added the benchmark fixture timeline, sample results (JSON/Markdown), and a deterministic, credential-free benchmark script comparing three retrieval strategies with JSON/Markdown output options.

* **Tests**
  * Added unit tests validating backend accuracy/performance ordering, privacy redaction for sensitive budget content, and correctness/writability of generated Markdown/CLI artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->