### PR TITLE
Clean up Claude Code hooks on disconnect

### DIFF
--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -393,10 +393,13 @@ def _remove_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str |
     if not isinstance(session_start, list):
         return None
 
+    expected_payload = agent.hook_config.hook_payload
+    expected_matcher = expected_payload.get("matcher")
+    expected_hooks = [
+        hook for hook in expected_payload.get("hooks", []) if isinstance(hook, dict)
+    ]
     expected_commands = {
-        hook.get("command")
-        for hook in agent.hook_config.hook_payload.get("hooks", [])
-        if isinstance(hook, dict) and hook.get("command")
+        hook.get("command") for hook in expected_hooks if hook.get("command")
     }
     if not expected_commands:
         return None
@@ -410,8 +413,12 @@ def _remove_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str |
 
         remaining_hooks = []
         for hook in group["hooks"]:
-            command = hook.get("command") if isinstance(hook, dict) else None
-            if command in expected_commands:
+            if (
+                group.get("matcher") == expected_matcher
+                and isinstance(hook, dict)
+                and hook.get("command") in expected_commands
+                and any(hook == expected_hook for expected_hook in expected_hooks)
+            ):
                 changed = True
                 continue
             remaining_hooks.append(hook)

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -121,6 +121,24 @@ def remove_agent(
     except Exception as e:
         errors.append(f"Skill removal: {e}")
 
+    # Remove hook configuration (only Claude Code currently)
+    if agent.supports_hooks and agent.hook_config:
+        try:
+            hook_result = _remove_hooks(agent, project_path, is_global)
+            if hook_result:
+                steps.append(hook_result)
+        except Exception as e:
+            errors.append(f"Hook removal: {e}")
+
+    # Remove permissions added by MEMANTO
+    if agent.permissions_file and agent.permissions_payload:
+        try:
+            perm_result = _remove_permissions(agent, project_path, is_global)
+            if perm_result:
+                steps.append(perm_result)
+        except Exception as e:
+            errors.append(f"Permission removal: {e}")
+
     try:
         ConfigManager().remove_connection(
             agent_name, str(project_path) if not is_global else None, is_global
@@ -349,6 +367,76 @@ def _install_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str 
     return None  # Already configured
 
 
+def _remove_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str | None:
+    """Remove MEMANTO hook configuration for agents that support hooks."""
+    if not agent.hook_config:
+        return None
+
+    if is_global:
+        if agent.config_global_dir:
+            config_dir = Path.home() / agent.config_global_dir.lstrip("~/")
+        else:
+            return None
+    else:
+        if agent.config_local_dir:
+            config_dir = project_path / agent.config_local_dir
+        else:
+            return None
+
+    settings_path = config_dir / agent.hook_config.settings_file
+    if not settings_path.exists():
+        return None
+
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    hooks = settings.get("hooks")
+    session_start = hooks.get("SessionStart") if isinstance(hooks, dict) else None
+    if not isinstance(session_start, list):
+        return None
+
+    expected_commands = {
+        hook.get("command")
+        for hook in agent.hook_config.hook_payload.get("hooks", [])
+        if isinstance(hook, dict) and hook.get("command")
+    }
+    if not expected_commands:
+        return None
+
+    changed = False
+    next_session_start = []
+    for group in session_start:
+        if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+            next_session_start.append(group)
+            continue
+
+        remaining_hooks = []
+        for hook in group["hooks"]:
+            command = hook.get("command") if isinstance(hook, dict) else None
+            if command in expected_commands:
+                changed = True
+                continue
+            remaining_hooks.append(hook)
+
+        if remaining_hooks:
+            updated_group = dict(group)
+            updated_group["hooks"] = remaining_hooks
+            next_session_start.append(updated_group)
+        else:
+            changed = True
+
+    if not changed:
+        return None
+
+    if next_session_start:
+        hooks["SessionStart"] = next_session_start
+    else:
+        hooks.pop("SessionStart", None)
+    if not hooks:
+        settings.pop("hooks", None)
+
+    _write_or_remove_json(settings_path, settings)
+    return "Removed SessionStart hook"
+
+
 # Internal: Permission configuration
 
 
@@ -397,6 +485,56 @@ def _install_permissions(
     return None  # Already configured
 
 
+def _remove_permissions(
+    agent: AgentDef, project_path: Path, is_global: bool
+) -> str | None:
+    """Remove permissions added by MEMANTO without disturbing user entries."""
+    if not agent.permissions_file or not agent.permissions_payload:
+        return None
+
+    if is_global:
+        if agent.config_global_dir:
+            config_dir = Path.home() / agent.config_global_dir.lstrip("~/")
+        else:
+            return None
+        perm_path = config_dir / agent.permissions_file
+    else:
+        if agent.config_local_dir:
+            config_dir = project_path / agent.config_local_dir
+        else:
+            return None
+        perm_path = config_dir / agent.permissions_file
+
+    if not perm_path.exists():
+        return None
+
+    existing = json.loads(perm_path.read_text(encoding="utf-8"))
+    permissions = existing.get("permissions")
+    allow_list = permissions.get("allow") if isinstance(permissions, dict) else None
+    if not isinstance(allow_list, list):
+        return None
+
+    expected_permissions = set(
+        agent.permissions_payload.get("permissions", {}).get("allow", [])
+    )
+    if not expected_permissions:
+        return None
+
+    next_allow = [perm for perm in allow_list if perm not in expected_permissions]
+    if len(next_allow) == len(allow_list):
+        return None
+
+    if next_allow:
+        permissions["allow"] = next_allow
+    else:
+        permissions.pop("allow", None)
+    if isinstance(permissions, dict) and not permissions:
+        existing.pop("permissions", None)
+
+    _write_or_remove_json(perm_path, existing)
+    return "Removed permissions"
+
+
 # Utilities
 
 
@@ -408,3 +546,18 @@ def _display_path(path: Path, is_global: bool) -> str:
         return str(path)
     except ValueError:
         return str(path)
+
+
+def _write_or_remove_json(path: Path, data: dict[str, Any]) -> None:
+    """Persist JSON data, or remove the file when the managed data was all it had."""
+    if data:
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        return
+
+    path.unlink()
+    parent = path.parent
+    try:
+        if parent.exists() and not any(parent.iterdir()):
+            parent.rmdir()
+    except Exception:
+        pass

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -1,0 +1,102 @@
+import json
+
+from memanto.cli.connect import engine
+
+
+class DummyConfigManager:
+    def add_connection(self, *args, **kwargs):
+        return None
+
+    def remove_connection(self, *args, **kwargs):
+        return None
+
+
+def stub_config_manager(monkeypatch):
+    monkeypatch.setattr(engine, "ConfigManager", lambda: DummyConfigManager())
+
+
+def read_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_remove_claude_code_removes_installed_hook_and_permissions(
+    tmp_path, monkeypatch
+):
+    stub_config_manager(monkeypatch)
+
+    install_result = engine.install_agent("claude-code", str(tmp_path))
+
+    assert install_result["errors"] == []
+    assert (tmp_path / ".claude" / "settings.json").exists()
+    assert (tmp_path / ".claude" / "settings.local.json").exists()
+
+    remove_result = engine.remove_agent("claude-code", str(tmp_path))
+
+    assert remove_result["errors"] == []
+    assert any("SessionStart hook" in step for step in remove_result["steps"])
+    assert any("permissions" in step for step in remove_result["steps"])
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+    assert not (tmp_path / ".claude" / "settings.local.json").exists()
+
+
+def test_remove_claude_code_preserves_unrelated_hooks_and_permissions(
+    tmp_path, monkeypatch
+):
+    stub_config_manager(monkeypatch)
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    settings_path = claude_dir / "settings.json"
+    permissions_path = claude_dir / "settings.local.json"
+
+    settings_path.write_text(
+        json.dumps(
+            {
+                "theme": "dark",
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "startup",
+                            "hooks": [
+                                {"type": "command", "command": "echo keep"},
+                                {
+                                    "type": "command",
+                                    "command": "memanto memory sync --project-dir .",
+                                    "timeout": 30,
+                                },
+                            ],
+                        },
+                        {"matcher": "other", "hooks": [{"command": "echo other"}]},
+                    ]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    permissions_path.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": ["Bash(git status)", "Bash(memanto:*)"],
+                },
+                "env": {"KEEP": "1"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    remove_result = engine.remove_agent("claude-code", str(tmp_path))
+
+    assert remove_result["errors"] == []
+    settings = read_json(settings_path)
+    permissions = read_json(permissions_path)
+    assert settings["theme"] == "dark"
+    assert settings["hooks"]["SessionStart"] == [
+        {"matcher": "startup", "hooks": [{"type": "command", "command": "echo keep"}]},
+        {"matcher": "other", "hooks": [{"command": "echo other"}]},
+    ]
+    assert permissions == {
+        "permissions": {"allow": ["Bash(git status)"]},
+        "env": {"KEEP": "1"},
+    }

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -61,8 +61,22 @@ def test_remove_claude_code_preserves_unrelated_hooks_and_permissions(
                                 {
                                     "type": "command",
                                     "command": "memanto memory sync --project-dir .",
+                                },
+                                {
+                                    "type": "command",
+                                    "command": "memanto memory sync --project-dir .",
                                     "timeout": 30,
                                 },
+                            ],
+                        },
+                        {
+                            "matcher": "manual",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "memanto memory sync --project-dir .",
+                                    "timeout": 30,
+                                }
                             ],
                         },
                         {"matcher": "other", "hooks": [{"command": "echo other"}]},
@@ -93,7 +107,26 @@ def test_remove_claude_code_preserves_unrelated_hooks_and_permissions(
     permissions = read_json(permissions_path)
     assert settings["theme"] == "dark"
     assert settings["hooks"]["SessionStart"] == [
-        {"matcher": "startup", "hooks": [{"type": "command", "command": "echo keep"}]},
+        {
+            "matcher": "startup",
+            "hooks": [
+                {"type": "command", "command": "echo keep"},
+                {
+                    "type": "command",
+                    "command": "memanto memory sync --project-dir .",
+                },
+            ],
+        },
+        {
+            "matcher": "manual",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "memanto memory sync --project-dir .",
+                    "timeout": 30,
+                }
+            ],
+        },
         {"matcher": "other", "hooks": [{"command": "echo other"}]},
     ]
     assert permissions == {


### PR DESCRIPTION
Related to #770

## Flaw summary

`memanto connect claude-code` installs a Memanto-managed Claude Code `SessionStart` hook and the `Bash(memanto:*)` permission, but `memanto disconnect` / `memanto remove` only deleted Memanto metadata. The Claude configuration remained modified after disconnect, so future Claude Code sessions could still invoke Memanto hooks or keep stale Memanto permissions even after the user explicitly removed the integration.

This is a setup and UX roadblock for adoption because disconnecting an agent should leave the Claude Code config in the same state except for unrelated user-managed hooks and permissions.

## Reproduction

1. Use a temporary home directory with a Claude Code settings file.
2. Run the connect flow for `claude-code` so Memanto adds its `SessionStart` hook and `Bash(memanto:*)` permission.
3. Run `memanto disconnect <agent-id>` or the remove flow.
4. Inspect `.claude/settings.json`.

Before this change, the Memanto hook and permission are still present even though the agent has been removed from Memanto metadata.

## Fix

- Remove only Memanto-managed `SessionStart` hook entries when removing a Claude Code agent.
- Remove only the Memanto-managed `Bash(memanto:*)` permission.
- Preserve unrelated user hooks, permissions, and other Claude settings.
- Delete an empty Claude settings file after cleanup so a pure Memanto install leaves no stale JSON behind.

## Validation

```bash
.venv/bin/python -m pytest tests/test_connect_engine.py -q
.venv/bin/python -m ruff check memanto/cli/connect/engine.py tests/test_connect_engine.py
.venv/bin/python -m mypy memanto/cli/connect/engine.py --ignore-missing-imports
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removing an agent now also cleans up related Claude Code hook settings and permissions.
  * Unrelated hooks and permissions are preserved; settings files are removed when they become empty.
* **Tests**
  * Added coverage to verify hook and permission cleanup for Claude Code, including preservation of unrelated entries in both global and local settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->