### PR TITLE
fix: repair multi-scope memory search import

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -175,7 +175,7 @@ class MemoryReadService:
             namespaces = []
             from typing import cast
 
-            from memanto.memanto.app.constants import ScopeType
+            from memanto.app.constants import ScopeType
 
             for scope_def in scopes:
                 scope = create_memory_scope(

--- a/tests/test_memory_read_multi_scope.py
+++ b/tests/test_memory_read_multi_scope.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def test_search_multi_scope_builds_namespaces_from_scope_defs():
+    client = MagicMock()
+    client.similarity_search.query.return_value = {
+        "results": [],
+        "execution_time": 0.01,
+    }
+    service = MemoryReadService(client)
+
+    result = service.search_multi_scope(
+        query="deployment preference",
+        scopes=[
+            {"scope_type": "agent", "scope_id": "support-agent"},
+            {"scope_type": "project", "scope_id": "alpha"},
+        ],
+        limit=5,
+    )
+
+    client.similarity_search.query.assert_called_once_with(
+        query="deployment preference",
+        namespaces=["memanto_agent_support-agent", "memanto_project_alpha"],
+        top_k=5,
+        threshold=None,
+        kiosk_mode=False,
+    )
+    assert result["searched_namespaces"] == [
+        "memanto_agent_support-agent",
+        "memanto_project_alpha",
+    ]
+    assert result["total_found"] == 0


### PR DESCRIPTION
Refs #770.

## Summary

`MemoryReadService.search_multi_scope()` currently imports `ScopeType` from `memanto.memanto.app.constants`, which is not a valid package path. Any caller that reaches this code path fails before the multi-scope search can build namespaces or query the backend.

This PR:
- fixes the import to `memanto.app.constants`
- adds focused regression coverage for multi-scope namespace construction and query dispatch

## Reproduction

Before the fix, calling `search_multi_scope()` with valid scope definitions raises a wrapped `MemoryError` caused by `ModuleNotFoundError: No module named 'memanto.memanto'`.

## Validation

- `python -m pytest tests/test_memory_read_multi_scope.py -q`
- `python -m ruff check memanto/app/services/memory_read_service.py tests/test_memory_read_multi_scope.py`
- `python -m py_compile memanto/app/services/memory_read_service.py tests/test_memory_read_multi_scope.py`
- `git diff --check`

Note: I installed `pytest-asyncio` and `pytest-timeout` locally because the repository pytest config references `asyncio_mode` and `timeout`; those plugins are required for pytest to parse the config.

Payment details can be provided privately if this is accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how multi-scope memory searches resolve the scope type at runtime, improving search behavior and preventing lookup issues.
  * Ensured searches continue to return the expected namespace list and result counts across multiple scopes.

* **Tests**
  * Added coverage for multi-scope search behavior, including namespace generation, request parameters, and empty-result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->