### PR TITLE
[BOUNTY ] fix(api): add confidence + rate limiting to /{agent_id}/answer endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ temp/
 
 # npm pack output
 *.tgz
+.aider*

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -479,3 +479,4 @@ class AnswerResponse(BaseModel):
     answer: str
     sources: list[Any] = Field(default_factory=list)
     namespace: str
+    confidence: float = 0.0

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -39,6 +39,7 @@ from memanto.app.services.conversation_memory_extraction_service import (
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.services.memory_write_service import MemoryWriteService
 from memanto.app.utils.errors import AuthorizationError, map_error_to_http_exception
+from memanto.app.utils.rate_limiting import enforce_answer_rate_limit
 from memanto.app.utils.validation import CostGuard
 from memanto.cli.client.direct_client import DirectClient
 from memanto.cli.config.manager import ConfigManager
@@ -638,6 +639,9 @@ async def answer(
             detail=f"Session is for agent '{session.agent_id}', cannot access '{agent_id}'",
         )
 
+    # Rate limiting
+    enforce_answer_rate_limit(agent_id)
+
     client = get_moorcheh_client()
 
     # Resolve defaults from settings
@@ -695,6 +699,16 @@ async def answer(
         answer = response.get("answer", "No answer generated.")
         sources = response.get("sources", [])
 
+        # Derive confidence from source scores (same logic as PR #791)
+        if not sources:
+            confidence = 0.0
+        else:
+            scores = [s.get("score") for s in sources if s.get("score") is not None]
+            if scores:
+                confidence = sum(scores) / len(scores)
+            else:
+                confidence = 1.0
+
         return {
             "agent_id": agent_id,
             "session_id": session.session_id,
@@ -702,6 +716,7 @@ async def answer(
             "answer": answer,
             "sources": sources,
             "namespace": namespace,
+            "confidence": confidence,
         }
 
     except Exception as e:


### PR DESCRIPTION
## Bounty Submission: Memanto Bug & Exploit Challenge (#770)

**Severity:** Medium-High — confidence hallucination + missing rate limiting in the main session-based `/answer` endpoint.

**Bounty:** $100 USD via BountyHub

---

### 🐛 The Bug

The session-based `POST /{agent_id}/answer` endpoint (`memanto/app/routes/memory.py`) had two issues:

1. **Missing confidence field**: The endpoint extracted `sources` from the SDK response but silently dropped the `confidence` signal. Meanwhile, the legacy `POST /answer` endpoint was being fixed (PR #791) to surface both sources AND confidence — creating an inconsistency where the modern endpoint had *less* fidelity than the legacy one.

2. **No rate limiting**: Unlike the legacy endpoints (which use `enforce_answer_rate_limit()` via `universal_endpoints.py`), the session-based answer endpoint had no rate limiting protection, making it vulnerable to abuse.

3. **AnswerResponse model** was missing the `confidence` field entirely.

### 🔬 Reproduction

```python
# POST /{agent_id}/answer returns no confidence field
response = await client.post(f"/{agent_id}/answer", json={"question": "..."})
# response has: agent_id, session_id, question, answer, sources, namespace
# response DOES NOT have: confidence  ← BUG
```

### 🛠️ Fix

**`memanto/app/models/__init__.py` — `AnswerResponse`:**
- Added `confidence: float = 0.0` field

**`memanto/app/routes/memory.py` — `answer()`:**
- Added `enforce_answer_rate_limit(agent_id)` call for rate limiting
- Derives `confidence` from source relevance scores (same logic as PR #791): 0.0 when no sources, average of scores when available, 1.0 when sources present but unscored
- Includes `confidence` in the response dict

### ✅ Verification

```python
# Both Python files parse cleanly
python3 -c "import ast; ast.parse(open(...).read())"  # OK for both files
```

### 💰 Bounty

This PR addresses issue #770 (Memanto Bug & Exploit Challenge, $100).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confidence value to answer responses, so results can now include an estimate of how reliable an answer is.
  * Added session-based limits on answer requests to help keep usage more consistent.
* **Bug Fixes**
  * Confidence is now always returned safely, even when no source scores are available.
* **Chores**
  * Updated repository ignore rules to exclude local `.aider*` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->