### PR TITLE
fix(security): gate sensitive UI endpoints to localhost-only (#770)

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -709,7 +709,7 @@ async def browse_path(
 
 
 @router.post("/api/ui/connections/install")
-async def connections_install(body: dict):
+async def connections_install(body: dict, _: None = Depends(_require_local)):
     """Install MEMANTO integration for one or more agents at a given location.
 
     Body: {"agents": ["claude-code", ...], "project_dir": "/abs/path", "is_global": false}
@@ -744,7 +744,7 @@ async def connections_install(body: dict):
 
 
 @router.post("/api/ui/connections/uninstall")
-async def connections_uninstall(body: dict):
+async def connections_uninstall(body: dict, _: None = Depends(_require_local)):
     """Remove MEMANTO integration for a single agent at a given location.
 
     Body: {"agent": "claude-code", "project_dir": "/abs/path", "is_global": false}
@@ -918,7 +918,7 @@ def _migrate_get_metrics_fn(provider: str):
 
 
 @router.post("/api/ui/migrate/dry-run")
-async def migrate_dry_run(body: dict):
+async def migrate_dry_run(body: dict, _: None = Depends(_require_local)):
     """Preview a migration without writing.
 
     Body: ``{provider, file?, api_key?}``. Returns the mapped row count,
@@ -976,7 +976,7 @@ async def migrate_dry_run(body: dict):
 
 
 @router.post("/api/ui/migrate/import")
-async def migrate_import(body: dict):
+async def migrate_import(body: dict, _: None = Depends(_require_local)):
     """Run an end-to-end migration.
 
     Body: ``{provider, file?, api_key?, agent_id?}``. Loads-or-exports,

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -4,6 +4,7 @@ MEMANTO Web UI Router
 Serves the Web UI static files and provides UI-specific API endpoints.
 """
 
+import ipaddress
 import os
 import signal
 import time
@@ -30,6 +31,21 @@ _config_manager = ConfigManager()
 STATIC_DIR = Path(__file__).parent.parent / "static"
 
 
+def _is_loopback(host: str | None) -> bool:
+    """Return True if *host* is any loopback address (IPv4, IPv6, or IPv4-mapped IPv6)."""
+    if host is None:
+        return False
+    try:
+        addr = ipaddress.ip_address(host)
+        if addr.is_loopback:
+            return True
+        # ::ffff:127.0.0.1 – IPv4-mapped IPv6 – is_loopback returns False
+        ipv4_mapped = getattr(addr, "ipv4_mapped", None)
+        return ipv4_mapped is not None and ipv4_mapped.is_loopback
+    except ValueError:
+        return False
+
+
 async def _require_local(request: Request) -> None:
     """Reject requests that do not originate from the loopback interface.
 
@@ -39,7 +55,7 @@ async def _require_local(request: Request) -> None:
     the filesystem, or replace API credentials without authentication.
     """
     client_host = request.client.host if request.client else None
-    if client_host not in ("127.0.0.1", "::1"):
+    if not _is_loopback(client_host):
         raise HTTPException(
             status_code=403,
             detail=(

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -28,6 +28,26 @@ _config_manager = ConfigManager()
 
 # Path to the static directory
 STATIC_DIR = Path(__file__).parent.parent / "static"
+
+
+async def _require_local(request: Request) -> None:
+    """Reject requests that do not originate from the loopback interface.
+
+    UI management endpoints (shutdown, browse, config update, API key update)
+    are designed for local desktop use only.  Allowing them from arbitrary
+    network addresses would let any reachable host kill the server, enumerate
+    the filesystem, or replace API credentials without authentication.
+    """
+    client_host = request.client.host if request.client else None
+    if client_host not in ("127.0.0.1", "::1"):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "UI management endpoints are only accessible from localhost. "
+                f"Request origin: {client_host}"
+            ),
+        )
+
 
 
 def _build_ui_direct_client() -> DirectClient | None:
@@ -106,7 +126,7 @@ async def get_ui_config():
 
 
 @router.patch("/api/ui/config")
-async def update_ui_config(updates: dict):
+async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
     """
     Update non-sensitive MEMANTO configuration from the Web UI.
 
@@ -263,7 +283,7 @@ def _update_onprem_answer(ans: dict) -> None:
 
 
 @router.post("/api/ui/onprem/restart")
-async def restart_onprem_backend():
+async def restart_onprem_backend(_: None = Depends(_require_local)):
     """Bounce the on-prem moorcheh stack so it re-reads ``~/.moorcheh/config.json``.
 
     ``moorcheh down`` + ``moorcheh up`` (with embedding flags recovered from
@@ -342,7 +362,7 @@ async def restart_onprem_backend():
 
 
 @router.put("/api/ui/api-key")
-async def update_api_key(body: dict):
+async def update_api_key(body: dict, _: None = Depends(_require_local)):
     """
     Update the Moorcheh API key from the Web UI.
     Expects: {"api_key": "new-key-value"}
@@ -628,7 +648,10 @@ async def get_connections():
 
 
 @router.get("/api/ui/browse")
-async def browse_path(path: str | None = None):
+async def browse_path(
+    path: str | None = None,
+    _: None = Depends(_require_local),
+):
     """List subdirectories of a given path (server-side folder picker).
 
     Defaults to the user's home directory when ``path`` is missing or invalid.
@@ -759,7 +782,10 @@ async def connections_uninstall(body: dict):
 
 
 @router.post("/api/ui/shutdown")
-async def shutdown_server(background_tasks: BackgroundTasks):
+async def shutdown_server(
+    background_tasks: BackgroundTasks,
+    _: None = Depends(_require_local),
+):
     """
     Gracefully shutdown the MEMANTO server.
     Called by the UI when the browser tab is closed.

--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -1,7 +1,8 @@
 """Tests for unauthenticated UI endpoint vulnerability fix."""
+import asyncio
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 
 def _make_app():
@@ -31,19 +32,13 @@ class TestUnauthenticatedUIEndpoints:
     stored API key.
     """
 
-    def _remote_client(self, app):
-        """Return a TestClient that simulates a remote (non-loopback) caller."""
-        client = TestClient(app, raise_server_exceptions=False)
-        # Patch the request to appear to come from a remote host
-        return client
-
     def test_shutdown_rejected_from_remote(self):
         """POST /api/ui/shutdown must return 403 for a non-local request."""
         app = _make_app()
         # Starlette TestClient uses "testclient" as the host — not 127.0.0.1
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.post("/api/ui/shutdown")
-        # "testclient" is not in ("127.0.0.1", "::1") → must be 403
+        # "testclient" is not a loopback address → must be 403
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
 
     def test_browse_rejected_from_remote(self):
@@ -54,15 +49,63 @@ class TestUnauthenticatedUIEndpoints:
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
 
     def test_update_config_rejected_from_remote(self):
-        """POST /api/ui/config must return 403 for a non-local request."""
+        """PATCH /api/ui/config must return 403 for a non-local request."""
         app = _make_app()
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.patch("/api/ui/config", json={})
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
 
     def test_update_api_key_rejected_from_remote(self):
-        """POST /api/ui/api-key must return 403 for a non-local request."""
+        """PUT /api/ui/api-key must return 403 for a non-local request."""
         app = _make_app()
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.put("/api/ui/api-key", json={"api_key": "stolen"})
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+
+class TestLoopbackDetection:
+    """Unit tests for the _is_loopback helper used by _require_local.
+
+    Covers all loopback address forms so the guard is not bypassable via
+    address variants not included in the original string-literal check.
+    """
+
+    def test_ipv4_loopback_accepted(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("127.0.0.1") is True
+
+    def test_ipv6_loopback_accepted(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("::1") is True
+
+    def test_ipv4_mapped_ipv6_loopback_accepted(self):
+        """::ffff:127.0.0.1 is the IPv4-mapped form of 127.0.0.1 — must pass."""
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("::ffff:127.0.0.1") is True
+
+    def test_remote_ipv4_rejected(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("192.168.1.100") is False
+
+    def test_none_rejected(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback(None) is False
+
+    def test_testclient_host_rejected(self):
+        """Starlette TestClient sends host="testclient" — must be treated as remote."""
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("testclient") is False
+
+    def test_require_local_allows_loopback(self):
+        """_require_local must not raise for a 127.0.0.1 caller."""
+        from memanto.app.ui.routes.ui_router import _require_local
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        asyncio.run(_require_local(mock_request))  # must not raise
+
+    def test_require_local_allows_ipv4_mapped_loopback(self):
+        """_require_local must not raise for a ::ffff:127.0.0.1 caller."""
+        from memanto.app.ui.routes.ui_router import _require_local
+        mock_request = MagicMock()
+        mock_request.client.host = "::ffff:127.0.0.1"
+        asyncio.run(_require_local(mock_request))  # must not raise

--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -1,0 +1,68 @@
+"""Tests for unauthenticated UI endpoint vulnerability fix."""
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+
+def _make_app():
+    """Create a minimal FastAPI app with just the UI router, bypassing startup deps."""
+    from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
+    from memanto.app.ui.routes.ui_router import router as ui_router
+
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(ui_router)
+    return app
+
+
+class TestUnauthenticatedUIEndpoints:
+    """Unauthenticated requests from non-localhost must be refused with HTTP 403.
+
+    The UI router exposes management endpoints (shutdown, filesystem browse,
+    config update, API-key replacement, on-prem restart) with no token-based
+    authentication.  Without a localhost-origin guard any host that can reach
+    the server process can kill it, read directory listings, or replace the
+    stored API key.
+    """
+
+    def _remote_client(self, app):
+        """Return a TestClient that simulates a remote (non-loopback) caller."""
+        client = TestClient(app, raise_server_exceptions=False)
+        # Patch the request to appear to come from a remote host
+        return client
+
+    def test_shutdown_rejected_from_remote(self):
+        """POST /api/ui/shutdown must return 403 for a non-local request."""
+        app = _make_app()
+        # Starlette TestClient uses "testclient" as the host — not 127.0.0.1
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/api/ui/shutdown")
+        # "testclient" is not in ("127.0.0.1", "::1") → must be 403
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_browse_rejected_from_remote(self):
+        """GET /api/ui/browse?path=/etc must return 403 for a non-local request."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/ui/browse?path=/etc")
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_update_config_rejected_from_remote(self):
+        """POST /api/ui/config must return 403 for a non-local request."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.patch("/api/ui/config", json={})
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_update_api_key_rejected_from_remote(self):
+        """POST /api/ui/api-key must return 403 for a non-local request."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.put("/api/ui/api-key", json={"api_key": "stolen"})
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"


### PR DESCRIPTION
## Security Fix: Unauthenticated UI Endpoints Accessible from Network (#770)

**Severity:** High — multiple management endpoints are reachable from any network host without authentication

**Bounty:** /claim #770

---

### The Vulnerability

Five endpoints in `memanto/app/ui/routes/ui_router.py` were reachable from any host on the network with no authentication whatsoever:

| Endpoint | HTTP | Risk |
|---|---|---|
| `/api/ui/shutdown` | POST | **DoS** — any host can kill the server process |
| `/api/ui/browse?path=/etc` | GET | **Information disclosure** — arbitrary filesystem path enumeration |
| `/api/ui/config` | PATCH | **Config tampering** — overwrite server configuration |
| `/api/ui/api-key` | PUT | **Credential theft** — replace the stored Moorcheh API key |
| `/api/ui/onprem/restart` | POST | **DoS** — bounce the on-prem moorcheh backend |

The application binds to `0.0.0.0:8000` (see `main.py`). CORS middleware blocks cross-origin *browser* fetch, but has no effect on direct HTTP clients (curl, Python requests, etc.).

**Proof of concept** (no auth required):
```bash
# Kill the server
curl -X POST http://target:8000/api/ui/shutdown

# Enumerate filesystem
curl "http://target:8000/api/ui/browse?path=/root"
curl "http://target:8000/api/ui/browse?path=/etc"

# Replace the Moorcheh API key
curl -X PUT http://target:8000/api/ui/api-key \
     -H "Content-Type: application/json" \
     -d '{"api_key": "attacker-key"}'
```

### Root Cause

The UI router endpoints were designed for local desktop use but had no enforcement that requests originated from the loopback interface.

### Fix

Added a `_require_local()` FastAPI dependency that reads `request.client.host` and raises HTTP 403 for any caller that is not `127.0.0.1` or `::1`. The dependency is applied with `Depends(_require_local)` on all five dangerous endpoints.

```python
async def _require_local(request: Request) -> None:
    client_host = request.client.host if request.client else None
    if client_host not in ("127.0.0.1", "::1"):
        raise HTTPException(
            status_code=403,
            detail=(
                "UI management endpoints are only accessible from localhost. "
                f"Request origin: {client_host}"
            ),
        )
```

### Tests

`tests/test_ui_auth.py` — 4 tests verifying that shutdown, browse, config update, and API-key replacement all return HTTP 403 when called from a non-loopback origin (the Starlette `TestClient` uses `"testclient"` as the host, which is not in the allowlist).

```
tests/test_ui_auth.py::TestUnauthenticatedUIEndpoints::test_shutdown_rejected_from_remote PASSED
tests/test_ui_auth.py::TestUnauthenticatedUIEndpoints::test_browse_rejected_from_remote PASSED
tests/test_ui_auth.py::TestUnauthenticatedUIEndpoints::test_update_config_rejected_from_remote PASSED
tests/test_ui_auth.py::TestUnauthenticatedUIEndpoints::test_update_api_key_rejected_from_remote PASSED
```

### Files Changed

- `memanto/app/ui/routes/ui_router.py` — added `_require_local` dependency + applied to 5 endpoints
- `tests/test_ui_auth.py` — 4 new tests (new file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secured UI management endpoints with a localhost-only access rule.
  * Requests from non-loopback clients are now rejected with **403**, including actions like UI config updates, API key changes, restart, browsing, connection install/uninstall, shutdown, and migration operations.
* **Tests**
  * Added automated tests to verify endpoints reject non-local requests.
  * Added unit coverage for loopback detection to ensure IPv4, IPv6, and IPv4-mapped IPv6 behavior is handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->