### PR TITLE
fix(security): extend localhost guard to all remaining UI endpoints + glob injection (#770)

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -709,7 +709,7 @@ async def browse_path(
 
 
 @router.post("/api/ui/connections/install")
-async def connections_install(body: dict):
+async def connections_install(body: dict, _: None = Depends(_require_local)):
     """Install MEMANTO integration for one or more agents at a given location.
 
     Body: {"agents": ["claude-code", ...], "project_dir": "/abs/path", "is_global": false}
@@ -744,7 +744,7 @@ async def connections_install(body: dict):
 
 
 @router.post("/api/ui/connections/uninstall")
-async def connections_uninstall(body: dict):
+async def connections_uninstall(body: dict, _: None = Depends(_require_local)):
     """Remove MEMANTO integration for a single agent at a given location.
 
     Body: {"agent": "claude-code", "project_dir": "/abs/path", "is_global": false}
@@ -918,7 +918,7 @@ def _migrate_get_metrics_fn(provider: str):
 
 
 @router.post("/api/ui/migrate/dry-run")
-async def migrate_dry_run(body: dict):
+async def migrate_dry_run(body: dict, _: None = Depends(_require_local)):
     """Preview a migration without writing.
 
     Body: ``{provider, file?, api_key?}``. Returns the mapped row count,
@@ -976,7 +976,7 @@ async def migrate_dry_run(body: dict):
 
 
 @router.post("/api/ui/migrate/import")
-async def migrate_import(body: dict):
+async def migrate_import(body: dict, _: None = Depends(_require_local)):
     """Run an end-to-end migration.
 
     Body: ``{provider, file?, api_key?, agent_id?}``. Loads-or-exports,

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -4,6 +4,7 @@ MEMANTO Web UI Router
 Serves the Web UI static files and provides UI-specific API endpoints.
 """
 
+import ipaddress
 import os
 import signal
 import time
@@ -30,6 +31,21 @@ _config_manager = ConfigManager()
 STATIC_DIR = Path(__file__).parent.parent / "static"
 
 
+def _is_loopback(host: str | None) -> bool:
+    """Return True if *host* is any loopback address (IPv4, IPv6, or IPv4-mapped IPv6)."""
+    if host is None:
+        return False
+    try:
+        addr = ipaddress.ip_address(host)
+        if addr.is_loopback:
+            return True
+        # ::ffff:127.0.0.1 – IPv4-mapped IPv6 – is_loopback returns False
+        ipv4_mapped = getattr(addr, "ipv4_mapped", None)
+        return ipv4_mapped is not None and ipv4_mapped.is_loopback
+    except ValueError:
+        return False
+
+
 async def _require_local(request: Request) -> None:
     """Reject requests that do not originate from the loopback interface.
 
@@ -39,7 +55,7 @@ async def _require_local(request: Request) -> None:
     the filesystem, or replace API credentials without authentication.
     """
     client_host = request.client.host if request.client else None
-    if client_host not in ("127.0.0.1", "::1"):
+    if not _is_loopback(client_host):
         raise HTTPException(
             status_code=403,
             detail=(

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -28,6 +28,26 @@ _config_manager = ConfigManager()
 
 # Path to the static directory
 STATIC_DIR = Path(__file__).parent.parent / "static"
+
+
+async def _require_local(request: Request) -> None:
+    """Reject requests that do not originate from the loopback interface.
+
+    UI management endpoints (shutdown, browse, config update, API key update)
+    are designed for local desktop use only.  Allowing them from arbitrary
+    network addresses would let any reachable host kill the server, enumerate
+    the filesystem, or replace API credentials without authentication.
+    """
+    client_host = request.client.host if request.client else None
+    if client_host not in ("127.0.0.1", "::1"):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "UI management endpoints are only accessible from localhost. "
+                f"Request origin: {client_host}"
+            ),
+        )
+
 
 
 def _build_ui_direct_client() -> DirectClient | None:
@@ -106,7 +126,7 @@ async def get_ui_config():
 
 
 @router.patch("/api/ui/config")
-async def update_ui_config(updates: dict):
+async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
     """
     Update non-sensitive MEMANTO configuration from the Web UI.
 
@@ -263,7 +283,7 @@ def _update_onprem_answer(ans: dict) -> None:
 
 
 @router.post("/api/ui/onprem/restart")
-async def restart_onprem_backend():
+async def restart_onprem_backend(_: None = Depends(_require_local)):
     """Bounce the on-prem moorcheh stack so it re-reads ``~/.moorcheh/config.json``.
 
     ``moorcheh down`` + ``moorcheh up`` (with embedding flags recovered from
@@ -342,7 +362,7 @@ async def restart_onprem_backend():
 
 
 @router.put("/api/ui/api-key")
-async def update_api_key(body: dict):
+async def update_api_key(body: dict, _: None = Depends(_require_local)):
     """
     Update the Moorcheh API key from the Web UI.
     Expects: {"api_key": "new-key-value"}
@@ -628,7 +648,10 @@ async def get_connections():
 
 
 @router.get("/api/ui/browse")
-async def browse_path(path: str | None = None):
+async def browse_path(
+    path: str | None = None,
+    _: None = Depends(_require_local),
+):
     """List subdirectories of a given path (server-side folder picker).
 
     Defaults to the user's home directory when ``path`` is missing or invalid.
@@ -759,7 +782,10 @@ async def connections_uninstall(body: dict):
 
 
 @router.post("/api/ui/shutdown")
-async def shutdown_server(background_tasks: BackgroundTasks):
+async def shutdown_server(
+    background_tasks: BackgroundTasks,
+    _: None = Depends(_require_local),
+):
     """
     Gracefully shutdown the MEMANTO server.
     Called by the UI when the browser tab is closed.

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -92,7 +92,7 @@ def _build_ui_direct_client() -> DirectClient | None:
 
 
 @router.get("/api/ui/config")
-async def get_ui_config():
+async def get_ui_config(_: None = Depends(_require_local)):
     """
     Get current MEMANTO configuration for the Web UI.
 
@@ -392,7 +392,7 @@ async def update_api_key(body: dict, _: None = Depends(_require_local)):
 
 
 @router.get("/api/ui/conflicts")
-async def list_conflicts(agent_id: str | None = None, date: str | None = None):
+async def list_conflicts(agent_id: str | None = None, date: str | None = None, _: None = Depends(_require_local)):
     """
     List unresolved conflicts for an agent.
     Uses DirectClient.list_conflicts under the hood.
@@ -423,7 +423,7 @@ async def list_conflicts(agent_id: str | None = None, date: str | None = None):
 
 
 @router.get("/api/ui/conflict-scans")
-async def list_conflict_scans(agent_id: str | None = None):
+async def list_conflict_scans(agent_id: str | None = None, _: None = Depends(_require_local)):
     """
     Return, per day, when the conflict scan last ran for an agent.
 
@@ -440,6 +440,10 @@ async def list_conflict_scans(agent_id: str | None = None):
         if not aid:
             return {"scans": {}, "agent_id": None}
         agent_id = aid
+
+    # Guard against glob-special characters that would leak cross-agent conflict data
+    if not re.match(r"^[A-Za-z0-9_-]+$", agent_id):
+        raise HTTPException(status_code=400, detail="Invalid agent_id: must match [A-Za-z0-9_-]+")
 
     conflicts_dir = Path.home() / ".memanto" / "conflicts"
     scans: dict[str, dict] = {}
@@ -473,7 +477,7 @@ async def list_conflict_scans(agent_id: str | None = None):
 
 
 @router.get("/api/ui/daily-summary")
-async def read_daily_summary(agent_id: str | None = None, date: str | None = None):
+async def read_daily_summary(agent_id: str | None = None, date: str | None = None, _: None = Depends(_require_local)):
     """
     Return the existing daily summary for an agent/date if one was already
     generated. Does NOT trigger generation — that's the POST endpoint.
@@ -514,7 +518,7 @@ async def read_daily_summary(agent_id: str | None = None, date: str | None = Non
 
 
 @router.post("/api/ui/daily-summary")
-async def generate_daily_summary(body: dict | None = None):
+async def generate_daily_summary(body: dict | None = None, _: None = Depends(_require_local)):
     """
     Trigger an on-demand daily summary for the active agent.
     Expects (optional): {"agent_id": "...", "date": "YYYY-MM-DD",
@@ -546,7 +550,7 @@ async def generate_daily_summary(body: dict | None = None):
 
 
 @router.post("/api/ui/conflicts/generate")
-async def generate_conflict_report(body: dict | None = None):
+async def generate_conflict_report(body: dict | None = None, _: None = Depends(_require_local)):
     """
     Trigger an on-demand conflict report for the active agent. This is the
     same work the scheduled task performs.
@@ -575,7 +579,7 @@ async def generate_conflict_report(body: dict | None = None):
 
 
 @router.post("/api/ui/conflicts/resolve")
-async def resolve_conflict(body: dict):
+async def resolve_conflict(body: dict, _: None = Depends(_require_local)):
     """
     Resolve a single conflict.
     Expects: {"agent_id": "...", "date": "...", "conflict_index": 0, "action": "keep_old"|"keep_new"|"keep_both"|"remove_both"|"manual", "manual_content": "..."}
@@ -617,7 +621,7 @@ async def resolve_conflict(body: dict):
 
 
 @router.get("/api/ui/connections")
-async def get_connections():
+async def get_connections(_: None = Depends(_require_local)):
     """List all supported agents merged with the local connections registry.
 
     Returns the agent catalog from `agent_registry`, each enriched with what's

--- a/tests/test_remaining_ui_auth.py
+++ b/tests/test_remaining_ui_auth.py
@@ -1,0 +1,129 @@
+"""Tests for the second round of localhost-guarded UI endpoints.
+
+Verifies that all remaining read/write UI endpoints that were previously
+accessible without authentication now return HTTP 403 for non-local callers,
+and that the glob injection guard in /api/ui/conflict-scans rejects
+wildcard-bearing agent IDs.
+"""
+import asyncio
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+
+
+def _make_app():
+    """Minimal FastAPI app with UI router only."""
+    from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
+    from memanto.app.ui.routes.ui_router import router as ui_router
+
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(ui_router)
+    return app
+
+
+class TestRemainingUnauthenticatedEndpoints:
+    """All previously unguarded read/write endpoints must return 403 from remote callers.
+
+    The TestClient sends requests with host="testclient", which is not a loopback
+    address, so every endpoint protected by _require_local must reject it.
+    """
+
+    def test_get_config_rejected_from_remote(self):
+        """GET /api/ui/config must return 403 for non-local callers."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/ui/config")
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_list_conflicts_rejected_from_remote(self):
+        """GET /api/ui/conflicts must return 403 for non-local callers."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/ui/conflicts")
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_list_conflict_scans_rejected_from_remote(self):
+        """GET /api/ui/conflict-scans must return 403 for non-local callers."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/ui/conflict-scans")
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_read_daily_summary_rejected_from_remote(self):
+        """GET /api/ui/daily-summary must return 403 for non-local callers."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/ui/daily-summary")
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_generate_daily_summary_rejected_from_remote(self):
+        """POST /api/ui/daily-summary must return 403 for non-local callers."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/api/ui/daily-summary", json={})
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_generate_conflict_report_rejected_from_remote(self):
+        """POST /api/ui/conflicts/generate must return 403 for non-local callers."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/api/ui/conflicts/generate", json={})
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_resolve_conflict_rejected_from_remote(self):
+        """POST /api/ui/conflicts/resolve must return 403 for non-local callers."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/api/ui/conflicts/resolve", json={"agent_id": "x", "date": "2026-01-01", "conflict_index": 0, "action": "keep_new"})
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_get_connections_rejected_from_remote(self):
+        """GET /api/ui/connections must return 403 for non-local callers."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/ui/connections")
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+
+class TestGlobInjectionGuard:
+    """agent_id=* (or any glob special char) in /api/ui/conflict-scans must be rejected.
+
+    Without this guard, an attacker who bypasses the _require_local check
+    (e.g. via a reverse proxy on localhost) could read conflict metadata from
+    all agents by passing agent_id=* to trigger a glob that matches all files.
+    """
+
+    def test_glob_wildcard_rejected(self):
+        """agent_id=* must return 400 from /api/ui/conflict-scans."""
+        from memanto.app.ui.routes.ui_router import _require_local, _is_loopback
+
+        # Simulate loopback call to bypass _require_local, then verify agent_id check
+        from fastapi import FastAPI, HTTPException, Request
+        from memanto.app.ui.routes.ui_router import router as ui_router
+        import re
+
+        # The glob guard is in list_conflict_scans; test it directly via the regex
+        bad_ids = ["*", "agent*", "?", "[A-Z]", "../traversal", "agent.1"]
+        for bad_id in bad_ids:
+            assert not re.match(r"^[A-Za-z0-9_-]+$", bad_id), f"{bad_id!r} should not match safe pattern"
+
+    def test_safe_agent_id_accepted(self):
+        """Valid agent_id characters must pass the glob guard."""
+        import re
+        good_ids = ["agent1", "my-agent", "agent_01", "ABC123", "a-b_c"]
+        for good_id in good_ids:
+            assert re.match(r"^[A-Za-z0-9_-]+$", good_id), f"{good_id!r} should match safe pattern"
+
+    def test_require_local_allows_loopback_for_conflict_scans(self):
+        """_require_local must not raise for 127.0.0.1, so the guard is accessible from localhost."""
+        from memanto.app.ui.routes.ui_router import _require_local
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        asyncio.run(_require_local(mock_request))  # must not raise

--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -1,7 +1,8 @@
 """Tests for unauthenticated UI endpoint vulnerability fix."""
+import asyncio
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 
 def _make_app():
@@ -31,19 +32,13 @@ class TestUnauthenticatedUIEndpoints:
     stored API key.
     """
 
-    def _remote_client(self, app):
-        """Return a TestClient that simulates a remote (non-loopback) caller."""
-        client = TestClient(app, raise_server_exceptions=False)
-        # Patch the request to appear to come from a remote host
-        return client
-
     def test_shutdown_rejected_from_remote(self):
         """POST /api/ui/shutdown must return 403 for a non-local request."""
         app = _make_app()
         # Starlette TestClient uses "testclient" as the host — not 127.0.0.1
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.post("/api/ui/shutdown")
-        # "testclient" is not in ("127.0.0.1", "::1") → must be 403
+        # "testclient" is not a loopback address → must be 403
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
 
     def test_browse_rejected_from_remote(self):
@@ -54,15 +49,63 @@ class TestUnauthenticatedUIEndpoints:
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
 
     def test_update_config_rejected_from_remote(self):
-        """POST /api/ui/config must return 403 for a non-local request."""
+        """PATCH /api/ui/config must return 403 for a non-local request."""
         app = _make_app()
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.patch("/api/ui/config", json={})
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
 
     def test_update_api_key_rejected_from_remote(self):
-        """POST /api/ui/api-key must return 403 for a non-local request."""
+        """PUT /api/ui/api-key must return 403 for a non-local request."""
         app = _make_app()
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.put("/api/ui/api-key", json={"api_key": "stolen"})
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+
+class TestLoopbackDetection:
+    """Unit tests for the _is_loopback helper used by _require_local.
+
+    Covers all loopback address forms so the guard is not bypassable via
+    address variants not included in the original string-literal check.
+    """
+
+    def test_ipv4_loopback_accepted(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("127.0.0.1") is True
+
+    def test_ipv6_loopback_accepted(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("::1") is True
+
+    def test_ipv4_mapped_ipv6_loopback_accepted(self):
+        """::ffff:127.0.0.1 is the IPv4-mapped form of 127.0.0.1 — must pass."""
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("::ffff:127.0.0.1") is True
+
+    def test_remote_ipv4_rejected(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("192.168.1.100") is False
+
+    def test_none_rejected(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback(None) is False
+
+    def test_testclient_host_rejected(self):
+        """Starlette TestClient sends host="testclient" — must be treated as remote."""
+        from memanto.app.ui.routes.ui_router import _is_loopback
+        assert _is_loopback("testclient") is False
+
+    def test_require_local_allows_loopback(self):
+        """_require_local must not raise for a 127.0.0.1 caller."""
+        from memanto.app.ui.routes.ui_router import _require_local
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        asyncio.run(_require_local(mock_request))  # must not raise
+
+    def test_require_local_allows_ipv4_mapped_loopback(self):
+        """_require_local must not raise for a ::ffff:127.0.0.1 caller."""
+        from memanto.app.ui.routes.ui_router import _require_local
+        mock_request = MagicMock()
+        mock_request.client.host = "::ffff:127.0.0.1"
+        asyncio.run(_require_local(mock_request))  # must not raise

--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -1,0 +1,68 @@
+"""Tests for unauthenticated UI endpoint vulnerability fix."""
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+
+def _make_app():
+    """Create a minimal FastAPI app with just the UI router, bypassing startup deps."""
+    from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
+    from memanto.app.ui.routes.ui_router import router as ui_router
+
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(ui_router)
+    return app
+
+
+class TestUnauthenticatedUIEndpoints:
+    """Unauthenticated requests from non-localhost must be refused with HTTP 403.
+
+    The UI router exposes management endpoints (shutdown, filesystem browse,
+    config update, API-key replacement, on-prem restart) with no token-based
+    authentication.  Without a localhost-origin guard any host that can reach
+    the server process can kill it, read directory listings, or replace the
+    stored API key.
+    """
+
+    def _remote_client(self, app):
+        """Return a TestClient that simulates a remote (non-loopback) caller."""
+        client = TestClient(app, raise_server_exceptions=False)
+        # Patch the request to appear to come from a remote host
+        return client
+
+    def test_shutdown_rejected_from_remote(self):
+        """POST /api/ui/shutdown must return 403 for a non-local request."""
+        app = _make_app()
+        # Starlette TestClient uses "testclient" as the host — not 127.0.0.1
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/api/ui/shutdown")
+        # "testclient" is not in ("127.0.0.1", "::1") → must be 403
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_browse_rejected_from_remote(self):
+        """GET /api/ui/browse?path=/etc must return 403 for a non-local request."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/ui/browse?path=/etc")
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_update_config_rejected_from_remote(self):
+        """POST /api/ui/config must return 403 for a non-local request."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.patch("/api/ui/config", json={})
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_update_api_key_rejected_from_remote(self):
+        """POST /api/ui/api-key must return 403 for a non-local request."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.put("/api/ui/api-key", json={"api_key": "stolen"})
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"


### PR DESCRIPTION
## Summary

This PR extends the localhost-only access guard introduced in #794 to **8 additional UI endpoints** that were previously reachable by any unauthenticated network host, and adds a separate **glob injection fix** in `/api/ui/conflict-scans`.

> **Note:** This branch is based on `fix/unauth-ui-endpoints-770` (#794). Once #794 merges, this PR can be cleanly rebased onto main.

### Newly guarded endpoints

| Endpoint | Risk without guard |
|---|---|
| `GET /api/ui/config` | Config info disclosure |
| `GET /api/ui/conflicts` | Cross-agent memory data leak via IDOR |
| `GET /api/ui/conflict-scans` | Cross-agent metadata leak + glob injection |
| `GET /api/ui/daily-summary` | Arbitrary summary file read, filesystem path disclosure |
| `POST /api/ui/daily-summary` | Triggers AI summary generation with user-supplied paths |
| `POST /api/ui/conflicts/generate` | Triggers conflict scan under attacker-chosen agent_id |
| `POST /api/ui/conflicts/resolve` | Overwrites conflict resolution state unauthenticated |
| `GET /api/ui/connections` | Enumerates installed agent connections |

### Glob injection in `/api/ui/conflict-scans` (CWE-73)

`agent_id` was interpolated directly into a `pathlib.glob()` pattern:

```python
# Before
for path in conflicts_dir.glob(f"{agent_id}_*{suffix}"):
```

With `agent_id=*`, the pattern becomes `*_*_conflicts.json`, matching **all** conflict files from all agents. An attacker could enumerate every agent's conflict counts and scan timestamps without authentication.

**Fix:** reject `agent_id` values that contain glob-special characters (`*`, `?`, `[`, `]`, `/`, `.`) with `HTTP 400` before the glob call.

```python
# After
if not re.match(r"^[A-Za-z0-9_-]+$", agent_id):
    raise HTTPException(status_code=400, detail="Invalid agent_id: must match [A-Za-z0-9_-]+")
for path in conflicts_dir.glob(f"{agent_id}_*{suffix}"):
```

### Tests

11 new tests in `tests/test_remaining_ui_auth.py`:
- 8 rejection tests (one per endpoint, using Starlette TestClient whose host is `"testclient"` ≠ loopback)
- 2 regex unit tests for the glob guard (wildcard-bearing IDs rejected, safe IDs accepted)
- 1 positive loopback test confirming `_require_local` allows `127.0.0.1`

```
11 passed in 0.76s
```

## Test plan

- [ ] All 11 tests in `tests/test_remaining_ui_auth.py` pass
- [ ] All pre-existing tests pass (12 in `test_ui_auth.py`, 31 in `test_unit.py`)
- [ ] Verify `GET /api/ui/conflict-scans?agent_id=*` returns 403 (localhost guard) or 400 (glob guard)
- [ ] Verify `GET /api/ui/connections` from localhost continues to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)