### PR TITLE
fix(security): prevent CORS reflected-origin credential exposure (#770)

### DIFF
--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -128,6 +128,11 @@ class Settings(BaseSettings):
 
     # CORS Configuration
     ALLOWED_ORIGINS: list[str] = ["*"]
+    # Setting allow_credentials=True with a wildcard origin causes Starlette to
+    # reflect any request Origin back, allowing any site to make credentialed
+    # cross-origin requests.  Default to False; set to True only when ALLOWED_ORIGINS
+    # lists explicit trusted domains (never with "*").
+    CORS_ALLOW_CREDENTIALS: bool = False
 
     # Session Configuration
     MEMANTO_SECRET_KEY: str = "memanto-default-secret-change-in-production"

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -73,10 +73,19 @@ app = FastAPI(
 )
 
 # Add CORS middleware
+# Guard: wildcard origins + allow_credentials=True causes Starlette to reflect
+# any request Origin back with Access-Control-Allow-Credentials: true, letting
+# any site make credentialed cross-origin requests (CORS misconfiguration).
+_wildcard_origins = "*" in settings.ALLOWED_ORIGINS
+if _wildcard_origins and settings.CORS_ALLOW_CREDENTIALS:
+    raise ValueError(
+        "CORS misconfiguration: CORS_ALLOW_CREDENTIALS=true is incompatible with "
+        "ALLOWED_ORIGINS=['*']. Specify explicit trusted origins when enabling credentials."
+    )
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.ALLOWED_ORIGINS,
-    allow_credentials=True,
+    allow_credentials=settings.CORS_ALLOW_CREDENTIALS,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -72,16 +72,22 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+def _validate_cors_settings(allowed_origins: list[str], allow_credentials: bool) -> None:
+    """Raise ValueError when wildcard origins and allow_credentials are combined.
+
+    Starlette reflects the request Origin (instead of returning '*') when both
+    allow_all_origins=True and allow_credentials=True, which lets any website make
+    credentialed cross-origin requests — a CORS misconfiguration.
+    """
+    if "*" in allowed_origins and allow_credentials:
+        raise ValueError(
+            "CORS misconfiguration: CORS_ALLOW_CREDENTIALS=true is incompatible with "
+            "ALLOWED_ORIGINS=['*']. Specify explicit trusted origins when enabling credentials."
+        )
+
+
 # Add CORS middleware
-# Guard: wildcard origins + allow_credentials=True causes Starlette to reflect
-# any request Origin back with Access-Control-Allow-Credentials: true, letting
-# any site make credentialed cross-origin requests (CORS misconfiguration).
-_wildcard_origins = "*" in settings.ALLOWED_ORIGINS
-if _wildcard_origins and settings.CORS_ALLOW_CREDENTIALS:
-    raise ValueError(
-        "CORS misconfiguration: CORS_ALLOW_CREDENTIALS=true is incompatible with "
-        "ALLOWED_ORIGINS=['*']. Specify explicit trusted origins when enabling credentials."
-    )
+_validate_cors_settings(settings.ALLOWED_ORIGINS, settings.CORS_ALLOW_CREDENTIALS)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.ALLOWED_ORIGINS,

--- a/tests/test_cors_fix.py
+++ b/tests/test_cors_fix.py
@@ -1,0 +1,100 @@
+"""
+Tests for CORS misconfiguration fix (#770).
+
+Verifies that:
+1.  allow_credentials=False is the default (CORS_ALLOW_CREDENTIALS unset).
+2.  Wildcard origins + CORS_ALLOW_CREDENTIALS=True raises ValueError at startup.
+3.  Wildcard origins + CORS_ALLOW_CREDENTIALS=False does NOT send
+    Access-Control-Allow-Credentials: true in responses.
+4.  Explicit origins + CORS_ALLOW_CREDENTIALS=True is allowed.
+"""
+
+import os
+import pytest
+import pytest_asyncio
+
+os.environ.setdefault("MOORCHEH_API_KEY", "test-api-key")
+
+
+class TestCorsCredentialsDefault:
+    """CORS_ALLOW_CREDENTIALS defaults to False."""
+
+    def test_default_is_false(self):
+        from memanto.app.config import Settings
+        s = Settings()
+        assert s.CORS_ALLOW_CREDENTIALS is False
+
+    def test_explicit_true_accepted(self):
+        from memanto.app.config import Settings
+        s = Settings(CORS_ALLOW_CREDENTIALS=True)
+        assert s.CORS_ALLOW_CREDENTIALS is True
+
+
+class TestCorsStartupGuard:
+    """Startup guard raises ValueError for wildcard+credentials combo."""
+
+    def _apply_guard(self, allowed_origins, allow_credentials):
+        """Replicate the guard logic from main.py."""
+        _wildcard_origins = "*" in allowed_origins
+        if _wildcard_origins and allow_credentials:
+            raise ValueError(
+                "CORS misconfiguration: CORS_ALLOW_CREDENTIALS=true is incompatible with "
+                "ALLOWED_ORIGINS=['*']. Specify explicit trusted origins when enabling credentials."
+            )
+
+    def test_wildcard_with_credentials_raises(self):
+        with pytest.raises(ValueError, match="CORS misconfiguration"):
+            self._apply_guard(["*"], True)
+
+    def test_wildcard_without_credentials_ok(self):
+        self._apply_guard(["*"], False)  # must not raise
+
+    def test_explicit_origin_with_credentials_ok(self):
+        self._apply_guard(["https://app.example.com"], True)  # must not raise
+
+    def test_empty_origins_with_credentials_ok(self):
+        self._apply_guard([], True)  # must not raise
+
+
+@pytest.mark.asyncio
+class TestCorsHeaderBehavior:
+    """CORS response headers with default config (wildcard, no credentials)."""
+
+    async def test_no_credentials_header_with_wildcard(self):
+        """With wildcard origins + credentials=False, Access-Control-Allow-Credentials
+        must not be 'true' — browsers would reject credentialed cross-origin requests."""
+        import httpx
+        from unittest.mock import patch
+
+        with patch("memanto.app.main._validate_startup_dependencies", return_value=None):
+            from memanto.app.main import app
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            resp = await ac.get("/health", headers={"Origin": "https://evil.com"})
+
+        cred_header = resp.headers.get("access-control-allow-credentials", "").lower()
+        assert cred_header != "true", (
+            "Access-Control-Allow-Credentials must not be 'true' when using wildcard origins"
+        )
+
+    async def test_wildcard_returns_star_not_reflected_origin(self):
+        """With wildcard + credentials=False, Starlette returns '*' (not the request origin).
+        If it reflected the caller's origin here, that would indicate credentials mode is on."""
+        import httpx
+        from unittest.mock import patch
+
+        with patch("memanto.app.main._validate_startup_dependencies", return_value=None):
+            from memanto.app.main import app
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            resp = await ac.get("/health", headers={"Origin": "https://evil.com"})
+
+        origin_header = resp.headers.get("access-control-allow-origin", "")
+        # Starlette returns "*" when allow_all_origins=True and credentials=False.
+        # If it returned "https://evil.com" the credentials flag would have been active.
+        assert origin_header in ("", "*"), (
+            f"Expected '*' or absent, got '{origin_header}' — "
+            "reflected origin indicates credentials mode is still active"
+        )

--- a/tests/test_cors_fix.py
+++ b/tests/test_cors_fix.py
@@ -2,18 +2,19 @@
 Tests for CORS misconfiguration fix (#770).
 
 Verifies that:
-1.  allow_credentials=False is the default (CORS_ALLOW_CREDENTIALS unset).
-2.  Wildcard origins + CORS_ALLOW_CREDENTIALS=True raises ValueError at startup.
-3.  Wildcard origins + CORS_ALLOW_CREDENTIALS=False does NOT send
+1.  CORS_ALLOW_CREDENTIALS defaults to False.
+2.  _validate_cors_settings() (the production guard in main.py) raises ValueError
+    when wildcard origins and allow_credentials are combined.
+3.  Wildcard origins + credentials=False does NOT send
     Access-Control-Allow-Credentials: true in responses.
-4.  Explicit origins + CORS_ALLOW_CREDENTIALS=True is allowed.
 """
 
-import os
 import pytest
-import pytest_asyncio
 
-os.environ.setdefault("MOORCHEH_API_KEY", "test-api-key")
+# Use monkeypatch / fixtures so the env override doesn't bleed into other tests.
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch):
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-api-key")
 
 
 class TestCorsCredentialsDefault:
@@ -30,30 +31,25 @@ class TestCorsCredentialsDefault:
         assert s.CORS_ALLOW_CREDENTIALS is True
 
 
-class TestCorsStartupGuard:
-    """Startup guard raises ValueError for wildcard+credentials combo."""
+class TestValidateCorsSettings:
+    """Tests against the production guard function in main.py."""
 
-    def _apply_guard(self, allowed_origins, allow_credentials):
-        """Replicate the guard logic from main.py."""
-        _wildcard_origins = "*" in allowed_origins
-        if _wildcard_origins and allow_credentials:
-            raise ValueError(
-                "CORS misconfiguration: CORS_ALLOW_CREDENTIALS=true is incompatible with "
-                "ALLOWED_ORIGINS=['*']. Specify explicit trusted origins when enabling credentials."
-            )
+    def _guard(self, allowed_origins, allow_credentials):
+        from memanto.app.main import _validate_cors_settings
+        _validate_cors_settings(allowed_origins, allow_credentials)
 
     def test_wildcard_with_credentials_raises(self):
         with pytest.raises(ValueError, match="CORS misconfiguration"):
-            self._apply_guard(["*"], True)
+            self._guard(["*"], True)
 
     def test_wildcard_without_credentials_ok(self):
-        self._apply_guard(["*"], False)  # must not raise
+        self._guard(["*"], False)  # must not raise
 
     def test_explicit_origin_with_credentials_ok(self):
-        self._apply_guard(["https://app.example.com"], True)  # must not raise
+        self._guard(["https://app.example.com"], True)  # must not raise
 
     def test_empty_origins_with_credentials_ok(self):
-        self._apply_guard([], True)  # must not raise
+        self._guard([], True)  # must not raise
 
 
 @pytest.mark.asyncio
@@ -62,7 +58,7 @@ class TestCorsHeaderBehavior:
 
     async def test_no_credentials_header_with_wildcard(self):
         """With wildcard origins + credentials=False, Access-Control-Allow-Credentials
-        must not be 'true' — browsers would reject credentialed cross-origin requests."""
+        must not be 'true' — otherwise browsers allow credentialed cross-origin requests."""
         import httpx
         from unittest.mock import patch
 
@@ -79,8 +75,8 @@ class TestCorsHeaderBehavior:
         )
 
     async def test_wildcard_returns_star_not_reflected_origin(self):
-        """With wildcard + credentials=False, Starlette returns '*' (not the request origin).
-        If it reflected the caller's origin here, that would indicate credentials mode is on."""
+        """With wildcard + credentials=False, Starlette returns '*', not the request Origin.
+        A reflected Origin here would prove credentials mode is still active."""
         import httpx
         from unittest.mock import patch
 
@@ -92,9 +88,7 @@ class TestCorsHeaderBehavior:
             resp = await ac.get("/health", headers={"Origin": "https://evil.com"})
 
         origin_header = resp.headers.get("access-control-allow-origin", "")
-        # Starlette returns "*" when allow_all_origins=True and credentials=False.
-        # If it returned "https://evil.com" the credentials flag would have been active.
         assert origin_header in ("", "*"), (
             f"Expected '*' or absent, got '{origin_header}' — "
-            "reflected origin indicates credentials mode is still active"
+            "reflected origin means credentials mode is still on"
         )


### PR DESCRIPTION
## Security Finding

**Category:** CORS Misconfiguration (OWASP A05: Security Misconfiguration)
**Severity:** Medium — exploitable in any networked deployment

---

### Root Cause

`main.py` hardcoded `allow_credentials=True` while `config.py` defaults `ALLOWED_ORIGINS` to `["*"]`.

Starlette's `CORSMiddleware` has a documented edge case: when **both** `allow_all_origins=True` AND `allow_credentials=True`, it **reflects the caller's `Origin` header** back in `Access-Control-Allow-Origin` instead of returning `*`, and also sets `Access-Control-Allow-Credentials: true`.

Relevant Starlette source (`starlette/middleware/cors.py`):
```python
# Line 152-153 (starlette 1.3.1)
if self.allow_all_origins and self.allow_credentials:
    self.allow_explicit_origin(headers, origin)   # mirrors request Origin
```

### Attack Scenario

1. Memanto is deployed on a network-accessible host (e.g. `https://api.user.com:8000`)
2. A malicious site (`https://evil.com`) embeds: `fetch("https://api.user.com:8000/api/v2/status", {credentials: "include"})`
3. Memanto responds:
   ```
   Access-Control-Allow-Origin: https://evil.com   ← reflected, not *
   Access-Control-Allow-Credentials: true
   ```
4. Browser allows `evil.com` to read the response — including `session_id`, `agent_id`, `namespace`, session expiry
5. Any future cookie-based auth would be silently included in these cross-origin requests

### Reproduction

```python
import httpx

transport = httpx.ASGITransport(app=app)
async with httpx.AsyncClient(transport=transport, base_url="http://localhost:8000") as ac:
    resp = await ac.get("/api/v2/status", headers={"Origin": "https://evil.com"})
    # Before fix:
    assert resp.headers["access-control-allow-origin"] == "https://evil.com"  # ← leaked
    assert resp.headers["access-control-allow-credentials"] == "true"
```

---

## Fix

Three changes:

**1. `memanto/app/config.py`** — Add `CORS_ALLOW_CREDENTIALS: bool = False`
```python
CORS_ALLOW_CREDENTIALS: bool = False  # default safe; True only with explicit origins
```

**2. `memanto/app/main.py`** — Use setting instead of hardcoded `True`; add startup guard
```python
_wildcard_origins = "*" in settings.ALLOWED_ORIGINS
if _wildcard_origins and settings.CORS_ALLOW_CREDENTIALS:
    raise ValueError(
        "CORS misconfiguration: CORS_ALLOW_CREDENTIALS=true is incompatible with "
        "ALLOWED_ORIGINS=['*']. Specify explicit trusted origins when enabling credentials."
    )
app.add_middleware(
    CORSMiddleware,
    allow_origins=settings.ALLOWED_ORIGINS,
    allow_credentials=settings.CORS_ALLOW_CREDENTIALS,  # was hardcoded True
    ...
)
```

**3. `tests/test_cors_fix.py`** — 8 tests covering:
- `CORS_ALLOW_CREDENTIALS` defaults to `False`
- Startup guard fires on wildcard+credentials combo
- Live HTTP: `Access-Control-Allow-Credentials` is not `true` with default config
- Live HTTP: response returns `*` not reflected origin

**Backward compatibility:** The only observable change is that `Access-Control-Allow-Credentials: true` is no longer sent by default. The current API uses header tokens (`X-Session-Token`, `X-API-Key`), not cookies — so no existing client is affected.

Closes #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CORS handling to reject insecure configurations where wildcard allowed origins are combined with credentialed requests.
  * CORS credentials are now controlled by configuration and are disabled by default.
  * Prevents unexpected credential reflection behavior when `*` is used.
* **Tests**
  * Added CORS test coverage for default settings, startup validation errors, and response headers under key wildcard/no-credentials scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->