### PR TITLE
Fix multi-scope memory search import

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -175,7 +175,7 @@ class MemoryReadService:
             namespaces = []
             from typing import cast
 
-            from memanto.memanto.app.constants import ScopeType
+            from memanto.app.constants import ScopeType
 
             for scope_def in scopes:
                 scope = create_memory_scope(

--- a/tests/test_memory_read_service.py
+++ b/tests/test_memory_read_service.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def test_search_multi_scope_builds_namespaces_and_queries_backend():
+    client = MagicMock()
+    client.similarity_search.query.return_value = {
+        "results": [
+            {
+                "id": "mem-1",
+                "text": "[FACT] Favorite language\n\nThe user prefers Python.",
+                "memory_type": "fact",
+                "scope_type": "agent",
+                "scope_id": "alpha",
+                "status": "active",
+            }
+        ],
+        "execution_time": 0.01,
+    }
+
+    result = MemoryReadService(client).search_multi_scope(
+        query="favorite language",
+        scopes=[
+            {"scope_type": "agent", "scope_id": "alpha"},
+            {"scope_type": "project", "scope_id": "roadmap"},
+        ],
+        limit=5,
+    )
+
+    client.similarity_search.query.assert_called_once_with(
+        query="favorite language",
+        namespaces=["memanto_agent_alpha", "memanto_project_roadmap"],
+        top_k=5,
+        threshold=None,
+        kiosk_mode=False,
+    )
+    assert result["total_found"] == 1
+    assert result["searched_namespaces"] == [
+        "memanto_agent_alpha",
+        "memanto_project_roadmap",
+    ]
+    assert result["results"][0]["id"] == "mem-1"


### PR DESCRIPTION
Summary
- Fix the `search_multi_scope` import so it loads `ScopeType` from the package's actual constants module.
- Add a regression test that verifies multi-scope searches build the expected namespaces and call the similarity backend.

Tests
- `pytest tests/test_memory_read_service.py`

Related: #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a path issue in memory search so scoped searches resolve correctly again.
* **Tests**
  * Added coverage for multi-scope memory search, verifying the search request uses the expected namespaces and returns results as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->