### PR TITLE
Fix namespace parsing for underscored scope IDs

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -34,7 +34,7 @@ class MemoryScope(BaseModel):
         """Parse namespace back to scope"""
         from typing import cast
 
-        parts = namespace.split("_")
+        parts = namespace.split("_", 2)
         if len(parts) != 3 or parts[0] != "memanto":
             raise ValueError(f"Invalid MEMANTO namespace format: {namespace}")
         return cls(scope_type=cast(ScopeType, parts[1]), scope_id=parts[2])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -366,6 +366,16 @@ class TestMEMANTOArchitecture:
         print(f"✅ V2 namespace format confirmed: {namespace}")
         print("   ✅ NO tenant_id required!")
 
+    def test_namespace_round_trips_scope_ids_with_underscores(self):
+        """Scope IDs with underscores must round-trip through namespace parsing."""
+        from memanto.app.core import MemoryScope, parse_namespace
+
+        scope = MemoryScope(scope_type="agent", scope_id="claude_dev")
+        namespace = scope.to_namespace()
+
+        assert namespace == "memanto_agent_claude_dev"
+        assert parse_namespace(namespace) == scope
+
     def test_jwt_token_structure(self):
         """Verify JWT token contains correct fields"""
         from memanto.app.services.session_service import SessionService


### PR DESCRIPTION
## Summary

Fix a namespace round-trip bug for valid scope IDs that contain underscores.

## Bug / Impact

Memanto generates namespaces as `memanto_{scope_type}_{scope_id}`. For an agent ID such as `claude_dev`, `MemoryScope.to_namespace()` produces `memanto_agent_claude_dev`.

Before this change, `MemoryScope.from_namespace()` used `namespace.split("_")` and required exactly three parts, so the namespace generated by Memanto itself raised:

`ValueError: Invalid MEMANTO namespace format: memanto_agent_claude_dev`

This can break memory scope parsing for realistic agent, workspace, or session identifiers that use underscores, affecting memory isolation and namespace introspection.

## Reproduction

```bash
python -c "from memanto.app.core import MemoryScope; s=MemoryScope(scope_type='agent', scope_id='claude_dev'); print(s.to_namespace()); print(MemoryScope.from_namespace(s.to_namespace()))"
```

## Fix

Parse only the first two separators with `split("_", 2)`, preserving the full `scope_id` segment.

## Tests

- `python -m pytest tests\test_unit.py::TestMEMANTOArchitecture -q`
- `python -m pytest tests\test_unit.py -q`

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace handling so scope IDs with underscores are preserved correctly when converting to and from the app’s namespace format.
  * Added coverage to confirm namespaces round-trip accurately for IDs containing underscores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->