### PR TITLE
fix: apply numeric confidence filtering in memory search

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -514,7 +514,7 @@ class MemoryReadService:
             try:
                 confidence = float(raw_confidence)
             except (TypeError, ValueError):
-                if min_confidence == 0.0:
+                if min_confidence <= 0:
                     filtered.append(result)
                 continue
             if confidence >= min_confidence:

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -132,6 +132,11 @@ class MemoryReadService:
             # Apply TTL enforcement - filter out expired memories
             all_results = self._filter_expired_memories(all_results)
 
+            if min_confidence is not None:
+                all_results = self._filter_by_min_confidence(
+                    all_results, min_confidence
+                )
+
             # Apply pagination (offset + limit)
             paginated_results = all_results[offset : offset + limit]
             has_more = len(all_results) > offset + limit
@@ -415,7 +420,7 @@ class MemoryReadService:
         """
         Build enhanced query with Moorcheh's #key:value metadata filters
 
-        Example: "user authentication #memory_type:fact #status:active #confidence:high"
+        Example: "user authentication #memory_type:fact #status:active"
 
         Note: Temporal filters (created_after/created_before) are applied as post-processing
         since Moorcheh's metadata filters use string comparison
@@ -437,12 +442,10 @@ class MemoryReadService:
             for status in status_filter:
                 filter_parts.append(f"#status:{status}")
 
-        # Add confidence filter (convert to category if needed)
-        if min_confidence is not None:
-            if min_confidence >= 0.8:
-                filter_parts.append("#confidence:high")
-            elif min_confidence >= 0.5:
-                filter_parts.append("#confidence:medium")
+        # Numeric confidence is stored as a number in memory documents. Applying
+        # it via Moorcheh keyword syntax would require exact categorical values
+        # that are never written, so callers filter it after formatting results.
+        _ = min_confidence
 
         # Add custom metadata filters
         if metadata_filters:
@@ -499,6 +502,23 @@ class MemoryReadService:
             except (ValueError, AttributeError):
                 pass  # Skip invalid timestamps
 
+        return filtered
+
+    def _filter_by_min_confidence(
+        self, results: list[dict[str, Any]], min_confidence: float
+    ) -> list[dict[str, Any]]:
+        """Keep only results whose numeric confidence meets the threshold."""
+        filtered: list[dict[str, Any]] = []
+        for result in results:
+            raw_confidence = result.get("confidence")
+            try:
+                confidence = float(raw_confidence)
+            except (TypeError, ValueError):
+                if min_confidence == 0.0:
+                    filtered.append(result)
+                continue
+            if confidence >= min_confidence:
+                filtered.append(result)
         return filtered
 
     def _filter_expired_memories(

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -101,6 +101,8 @@ class MemoryReadService:
             # Build query parameters
             # Request extra results to handle offset (Moorcheh doesn't have native offset support)
             requested_limit = limit + offset
+            if min_confidence is not None:
+                requested_limit = 100
             top_k = min(requested_limit, 100)  # Moorcheh max is 100
 
             # Perform search with server-side filtering.

--- a/tests/test_memory_read_confidence.py
+++ b/tests/test_memory_read_confidence.py
@@ -2,47 +2,48 @@ from memanto.app.services.memory_read_service import MemoryReadService
 
 
 class _FakeSimilaritySearch:
-    def __init__(self):
+    def __init__(self, results=None):
         self.last_query = None
+        self.results = results or [
+            {
+                "id": "high",
+                "text": "[FACT] High confidence\n\nRelevant memory",
+                "memory_type": "fact",
+                "scope_type": "agent",
+                "scope_id": "agent-1",
+                "actor_id": "agent-1",
+                "source": "user",
+                "confidence": 0.91,
+                "status": "active",
+                "created_at": "2026-06-25T00:00:00Z",
+                "updated_at": "2026-06-25T00:00:00Z",
+            },
+            {
+                "id": "low",
+                "text": "[FACT] Low confidence\n\nRelevant but weak memory",
+                "memory_type": "fact",
+                "scope_type": "agent",
+                "scope_id": "agent-1",
+                "actor_id": "agent-1",
+                "source": "user",
+                "confidence": 0.41,
+                "status": "active",
+                "created_at": "2026-06-25T00:00:00Z",
+                "updated_at": "2026-06-25T00:00:00Z",
+            },
+        ]
 
     def query(self, **kwargs):
         self.last_query = kwargs["query"]
         return {
-            "results": [
-                {
-                    "id": "high",
-                    "text": "[FACT] High confidence\n\nRelevant memory",
-                    "memory_type": "fact",
-                    "scope_type": "agent",
-                    "scope_id": "agent-1",
-                    "actor_id": "agent-1",
-                    "source": "user",
-                    "confidence": 0.91,
-                    "status": "active",
-                    "created_at": "2026-06-25T00:00:00Z",
-                    "updated_at": "2026-06-25T00:00:00Z",
-                },
-                {
-                    "id": "low",
-                    "text": "[FACT] Low confidence\n\nRelevant but weak memory",
-                    "memory_type": "fact",
-                    "scope_type": "agent",
-                    "scope_id": "agent-1",
-                    "actor_id": "agent-1",
-                    "source": "user",
-                    "confidence": 0.41,
-                    "status": "active",
-                    "created_at": "2026-06-25T00:00:00Z",
-                    "updated_at": "2026-06-25T00:00:00Z",
-                },
-            ],
+            "results": self.results,
             "execution_time": 0,
         }
 
 
 class _FakeClient:
-    def __init__(self):
-        self.similarity_search = _FakeSimilaritySearch()
+    def __init__(self, results=None):
+        self.similarity_search = _FakeSimilaritySearch(results)
 
 
 def test_search_memories_applies_numeric_min_confidence_after_retrieval():
@@ -60,3 +61,31 @@ def test_search_memories_applies_numeric_min_confidence_after_retrieval():
     assert "#confidence:high" not in client.similarity_search.last_query
     assert "#confidence:medium" not in client.similarity_search.last_query
 
+
+def test_zero_min_confidence_preserves_results_without_confidence_field():
+    client = _FakeClient(
+        [
+            {
+                "id": "legacy",
+                "text": "[FACT] Legacy memory\n\nImported before confidence existed",
+                "memory_type": "fact",
+                "scope_type": "agent",
+                "scope_id": "agent-1",
+                "actor_id": "agent-1",
+                "source": "user",
+                "status": "active",
+                "created_at": "2026-06-25T00:00:00Z",
+                "updated_at": "2026-06-25T00:00:00Z",
+            }
+        ]
+    )
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="legacy",
+        agent_id="agent-1",
+        min_confidence=0.0,
+        limit=10,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["legacy"]

--- a/tests/test_memory_read_confidence.py
+++ b/tests/test_memory_read_confidence.py
@@ -1,0 +1,62 @@
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+class _FakeSimilaritySearch:
+    def __init__(self):
+        self.last_query = None
+
+    def query(self, **kwargs):
+        self.last_query = kwargs["query"]
+        return {
+            "results": [
+                {
+                    "id": "high",
+                    "text": "[FACT] High confidence\n\nRelevant memory",
+                    "memory_type": "fact",
+                    "scope_type": "agent",
+                    "scope_id": "agent-1",
+                    "actor_id": "agent-1",
+                    "source": "user",
+                    "confidence": 0.91,
+                    "status": "active",
+                    "created_at": "2026-06-25T00:00:00Z",
+                    "updated_at": "2026-06-25T00:00:00Z",
+                },
+                {
+                    "id": "low",
+                    "text": "[FACT] Low confidence\n\nRelevant but weak memory",
+                    "memory_type": "fact",
+                    "scope_type": "agent",
+                    "scope_id": "agent-1",
+                    "actor_id": "agent-1",
+                    "source": "user",
+                    "confidence": 0.41,
+                    "status": "active",
+                    "created_at": "2026-06-25T00:00:00Z",
+                    "updated_at": "2026-06-25T00:00:00Z",
+                },
+            ],
+            "execution_time": 0,
+        }
+
+
+class _FakeClient:
+    def __init__(self):
+        self.similarity_search = _FakeSimilaritySearch()
+
+
+def test_search_memories_applies_numeric_min_confidence_after_retrieval():
+    client = _FakeClient()
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="relevant",
+        agent_id="agent-1",
+        min_confidence=0.8,
+        limit=10,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["high"]
+    assert "#confidence:high" not in client.similarity_search.last_query
+    assert "#confidence:medium" not in client.similarity_search.last_query
+

--- a/tests/test_memory_read_confidence.py
+++ b/tests/test_memory_read_confidence.py
@@ -35,6 +35,7 @@ class _FakeSimilaritySearch:
 
     def query(self, **kwargs):
         self.last_query = kwargs["query"]
+        self.last_top_k = kwargs["top_k"]
         return {
             "results": self.results,
             "execution_time": 0,
@@ -60,6 +61,52 @@ def test_search_memories_applies_numeric_min_confidence_after_retrieval():
     assert [memory["id"] for memory in result["results"]] == ["high"]
     assert "#confidence:high" not in client.similarity_search.last_query
     assert "#confidence:medium" not in client.similarity_search.last_query
+    assert client.similarity_search.last_top_k == 100
+
+
+def test_min_confidence_fetches_beyond_initial_page_before_filtering():
+    client = _FakeClient(
+        [
+            {
+                "id": "low",
+                "text": "[FACT] Low confidence\n\nRelevant but weak memory",
+                "memory_type": "fact",
+                "scope_type": "agent",
+                "scope_id": "agent-1",
+                "actor_id": "agent-1",
+                "source": "user",
+                "confidence": 0.41,
+                "status": "active",
+                "created_at": "2026-06-25T00:00:00Z",
+                "updated_at": "2026-06-25T00:00:00Z",
+            },
+            {
+                "id": "high",
+                "text": "[FACT] High confidence\n\nRelevant memory",
+                "memory_type": "fact",
+                "scope_type": "agent",
+                "scope_id": "agent-1",
+                "actor_id": "agent-1",
+                "source": "user",
+                "confidence": 0.91,
+                "status": "active",
+                "created_at": "2026-06-25T00:00:00Z",
+                "updated_at": "2026-06-25T00:00:00Z",
+            },
+        ]
+    )
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="relevant",
+        agent_id="agent-1",
+        min_confidence=0.8,
+        limit=1,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["high"]
+    assert result["total_available"] == 1
+    assert result["has_more"] is False
 
 
 def test_zero_min_confidence_preserves_results_without_confidence_field():


### PR DESCRIPTION
Refs #770.

## Summary

`min_confidence` accepted a numeric threshold (`0.0`-`1.0`) but the read service converted it into categorical Moorcheh query keywords such as `#confidence:high` and `#confidence:medium`. Memanto writes `confidence` as a numeric document field (for example `0.91`), not as those categorical strings, so the filter could silently fail to enforce the caller's requested trust threshold.

This PR makes confidence filtering deterministic and backend-independent by:

- removing the unwritten categorical confidence keywords from the enhanced query
- filtering formatted results numerically after retrieval
- applying the same numeric filtering path to normal memory search and the existing multi-scope search service path
- adding a regression test that proves low-confidence memories are excluded and the stale categorical keywords are not sent to the backend query

## Impact

Agents and integrations that rely on `min_confidence` for trusted recall can currently receive low-confidence memories even when they requested only high-confidence data. That undermines memory integrity and can pollute downstream RAG answers or automation decisions with weak/untrusted facts.

## Reproduction

Before this fix, calling `MemoryReadService.search_memories(..., min_confidence=0.8)` builds an enhanced query containing `#confidence:high`, even though stored documents contain numeric metadata like `confidence: 0.91` and `confidence: 0.41`. There is no local numeric post-filter, so low-confidence results returned by the backend are allowed through.

The new test covers that scenario with a fake backend returning one high-confidence and one low-confidence memory.

## Validation

- `python -m pytest tests/test_memory_read_confidence.py -q`
- `python -m pytest tests/test_memory_parsing.py -q`
- `python -m py_compile memanto\app\services\memory_read_service.py tests\test_memory_read_confidence.py`
- `python -m ruff check memanto\app\services\memory_read_service.py tests\test_memory_read_confidence.py`

Payment details can be provided privately if this is accepted for the bounty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now enforce the minimum confidence threshold after retrieval (post–TTL filtering), consistently filtering out lower-confidence items.
  * Confidence is evaluated numerically, including when stored as text, with non-numeric confidence handled per threshold rules.
  * When a minimum confidence is provided, the requested result limit is capped at 100.
  * Search requests no longer include confidence-specific query tokens.

* **Tests**
  * Added coverage for high-confidence filtering, small limits with post-filtering, and `min_confidence=0.0` behavior, including query payload assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->