### PR TITLE
Fix multi-scope search import path

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -175,7 +175,7 @@ class MemoryReadService:
             namespaces = []
             from typing import cast
 
-            from memanto.memanto.app.constants import ScopeType
+            from memanto.app.constants import ScopeType
 
             for scope_def in scopes:
                 scope = create_memory_scope(

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -197,8 +197,8 @@ class MemoryReadService:
                 metadata_filters=metadata_filters,
             )
 
-            # Build query parameters
-            top_k = limit
+            # Over-fetch because TTL enforcement happens after search results return.
+            top_k = min(max(limit * 2, limit), 100)
 
             # Perform cross-namespace search. Same kiosk_mode caveat as
             # search_memories: min_similarity=0.0 means "no filter".
@@ -218,7 +218,7 @@ class MemoryReadService:
                 self._format_memory_item(item)
                 for item in search_result.get("results", [])
             ]
-            formatted_results = self._filter_expired_memories(formatted_results)
+            formatted_results = self._filter_expired_memories(formatted_results)[:limit]
 
             return {
                 "results": formatted_results,

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -218,6 +218,7 @@ class MemoryReadService:
                 self._format_memory_item(item)
                 for item in search_result.get("results", [])
             ]
+            formatted_results = self._filter_expired_memories(formatted_results)
 
             return {
                 "results": formatted_results,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -293,6 +293,35 @@ class TestMemoryReadService:
         ]
         client.similarity_search.query.assert_called_once()
 
+    def test_search_multi_scope_filters_expired_memories(self):
+        """Multi-scope search should enforce the same TTL rules as single-scope search."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [
+                {
+                    "id": "expired",
+                    "text": "expired memory",
+                    "metadata": {"expires_at": "2000-01-01T00:00:00Z"},
+                },
+                {
+                    "id": "active",
+                    "text": "active memory",
+                    "metadata": {"expires_at": "2999-01-01T00:00:00Z"},
+                },
+            ],
+            "execution_time": 0,
+        }
+
+        result = MemoryReadService(client).search_multi_scope(
+            query="deployment preference",
+            scopes=[{"scope_type": "agent", "scope_id": "alpha"}],
+        )
+
+        assert [item["id"] for item in result["results"]] == ["active"]
+        assert result["total_found"] == 1
+
 
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -293,8 +293,8 @@ class TestMemoryReadService:
         ]
         client.similarity_search.query.assert_called_once()
 
-    def test_search_multi_scope_filters_expired_memories(self):
-        """Multi-scope search should enforce the same TTL rules as single-scope search."""
+    def test_search_multi_scope_over_fetches_before_filtering_expired_memories(self):
+        """Multi-scope search should over-fetch before TTL filtering."""
         from memanto.app.services.memory_read_service import MemoryReadService
 
         client = MagicMock()
@@ -310,6 +310,16 @@ class TestMemoryReadService:
                     "text": "active memory",
                     "metadata": {"expires_at": "2999-01-01T00:00:00Z"},
                 },
+                {
+                    "id": "second-active",
+                    "text": "second active memory",
+                    "metadata": {"expires_at": "2999-01-01T00:00:00Z"},
+                },
+                {
+                    "id": "third-active",
+                    "text": "third active memory",
+                    "metadata": {"expires_at": "2999-01-01T00:00:00Z"},
+                },
             ],
             "execution_time": 0,
         }
@@ -317,10 +327,16 @@ class TestMemoryReadService:
         result = MemoryReadService(client).search_multi_scope(
             query="deployment preference",
             scopes=[{"scope_type": "agent", "scope_id": "alpha"}],
+            limit=2,
         )
 
-        assert [item["id"] for item in result["results"]] == ["active"]
-        assert result["total_found"] == 1
+        assert [item["id"] for item in result["results"]] == [
+            "active",
+            "second-active",
+        ]
+        assert result["total_found"] == 2
+        client.similarity_search.query.assert_called_once()
+        assert client.similarity_search.query.call_args.kwargs["top_k"] == 4
 
 
 class TestForgetEndToEnd:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,32 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadService:
+    def test_search_multi_scope_uses_package_import_path(self):
+        """Multi-scope search should build namespaces without import errors."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [],
+            "execution_time": 0,
+        }
+
+        result = MemoryReadService(client).search_multi_scope(
+            query="deployment preference",
+            scopes=[
+                {"scope_type": "agent", "scope_id": "alpha"},
+                {"scope_type": "workspace", "scope_id": "beta"},
+            ],
+        )
+
+        assert result["searched_namespaces"] == [
+            "memanto_agent_alpha",
+            "memanto_workspace_beta",
+        ]
+        client.similarity_search.query.assert_called_once()
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- fix multi-scope search to import `ScopeType` from the package path used elsewhere
- enforce the same TTL expiration filtering for multi-scope search results as single-scope search
- add regression coverage for namespace building and expired-result filtering

## Tests
- `python -m pytest tests/test_unit.py::TestMemoryReadService -q`
- `python -m pytest tests/test_unit.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the configuration source used for multi-scope memory searches.
  * Improved multi-scope search to properly exclude expired memories from returned results and respect the requested limit.
* **Tests**
  * Added unit tests covering multi-scope namespace construction and ensuring the similarity query is executed once per search.
  * Added tests to verify TTL filtering, correct total counts, and that the search fetches enough candidates to account for post-filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->