### PR TITLE
Fix TTL memory update expiry parsing

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -303,8 +303,17 @@ class MemoryWriteService:
                 updated_memory.set_ttl(updates["ttl_seconds"])
             elif metadata.get("ttl_seconds"):
                 updated_memory.ttl_seconds = metadata["ttl_seconds"]
-                if metadata.get("expires_at"):
-                    updated_memory.expires_at = metadata["expires_at"]
+                raw_expires_at = metadata.get("expires_at")
+                if raw_expires_at:
+                    if isinstance(raw_expires_at, str):
+                        try:
+                            updated_memory.expires_at = datetime.fromisoformat(
+                                raw_expires_at.replace("Z", "+00:00")
+                            )
+                        except (ValueError, AttributeError):
+                            pass  # Keep the default if the stored timestamp is invalid
+                    else:
+                        updated_memory.expires_at = raw_expires_at
 
             # Step 3: Delete old version
             delete_result = self.client.documents.delete(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,45 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryWriteServiceUpdate:
+    def test_update_memory_preserves_string_expires_at(self):
+        """Updating a TTL-backed memory should not fail when the stored
+        ``expires_at`` field comes back as an ISO string from the backend."""
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.get.return_value = {
+            "items": [
+                {
+                    "id": "mem-ttl",
+                    "text": "[FACT] Old title\n\nOld content",
+                    "memory_type": "fact",
+                    "scope_type": "agent",
+                    "scope_id": "alpha",
+                    "actor_id": "user",
+                    "source": "user",
+                    "confidence": 0.8,
+                    "status": "active",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:00Z",
+                    "expires_at": "2099-01-02T00:00:00Z",
+                    "ttl_seconds": 3600,
+                }
+            ]
+        }
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.return_value = {"status": "success"}
+
+        result = MemoryWriteService(client).update_memory(
+            "mem-ttl", "memanto_agent_alpha", {"content": "New content"}
+        )
+
+        assert result["status"] == "success"
+        uploaded_doc = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_doc["expires_at"] == "2099-01-02T00:00:00+00:00"
+        assert uploaded_doc["ttl_seconds"] == 3600
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
Summary

Fix TTL-backed memory updates when the backend returns `expires_at` as an ISO string.

Bug / Impact

`MemoryWriteService.update_memory()` reconstructs a `MemoryRecord` from the existing memory before deleting and re-uploading it. For memories with TTL metadata, `get_memory()` returns `expires_at` as a string. The update path assigned that string directly to `updated_memory.expires_at`, then `to_moorcheh_document()` called `.isoformat()` on it and failed.

Reproduction

```python
from unittest.mock import MagicMock
from memanto.app.services.memory_write_service import MemoryWriteService

client = MagicMock()
client.documents.get.return_value = {
    "items": [{
        "id": "mem-ttl",
        "text": "[FACT] Old title\n\nOld content",
        "memory_type": "fact",
        "scope_type": "agent",
        "scope_id": "alpha",
        "actor_id": "user",
        "source": "user",
        "confidence": 0.8,
        "status": "active",
        "created_at": "2026-01-01T00:00:00Z",
        "updated_at": "2026-01-01T00:00:00Z",
        "expires_at": "2099-01-02T00:00:00Z",
        "ttl_seconds": 3600,
    }]
}
client.documents.delete.return_value = {"actual_deletions": 1}
client.documents.upload.return_value = {"status": "success"}

MemoryWriteService(client).update_memory(
    "mem-ttl", "memanto_agent_alpha", {"content": "New content"}
)
```

Before this change, the call raises:

```text
MemoryError: Failed to update memory: 'str' object has no attribute 'isoformat'
```

Fix

Parse stored ISO-string `expires_at` values back to `datetime` before re-uploading the updated memory. Non-string datetime values are still preserved as before.

Tests

```text
python -m pytest tests/test_unit.py::TestMemoryWriteServiceUpdate::test_update_memory_preserves_string_expires_at -q
python -m pytest tests/test_unit.py -q
```

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of memory expiration values so TTL-backed updates work correctly when the expiration time is returned as a string.
  * Preserves the existing expiration time when an invalid value is encountered instead of overwriting it.
* **Tests**
  * Added coverage for updating memories with string-based expiration timestamps, including timezone normalization and successful update status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->