### PR TITLE
Reject inactive session tokens

### DIFF
--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import jwt
+from pydantic import ValidationError
 
 from memanto.app.config import get_data_dir, settings
 from memanto.app.core import create_memory_scope
@@ -166,7 +167,12 @@ class SessionService:
                     f"Session {token.session_id} expired at {token.expires_at}"
                 )
 
-            session = self.get_session(token.agent_id)
+            try:
+                session = self.get_session(token.agent_id)
+            except (OSError, json.JSONDecodeError, ValidationError) as exc:
+                raise InvalidSessionTokenError(
+                    f"Session {token.session_id} is no longer active"
+                ) from exc
             if not session:
                 raise InvalidSessionTokenError(
                     f"Session {token.session_id} is no longer active"

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -166,27 +166,20 @@ class SessionService:
                 raise SessionExpiredError(
                     f"Session {token.session_id} expired at {token.expires_at}"
                 )
-
             try:
                 session = self.get_session(token.agent_id)
+                if (
+                    not session
+                    or session.session_id != token.session_id
+                    or not session.is_active()
+                ):
+                    raise InvalidSessionTokenError(
+                        f"Session {token.session_id} is no longer active"
+                    )
             except (OSError, json.JSONDecodeError, ValidationError) as exc:
                 raise InvalidSessionTokenError(
                     f"Session {token.session_id} is no longer active"
                 ) from exc
-            if not session:
-                raise InvalidSessionTokenError(
-                    f"Session {token.session_id} is no longer active"
-                )
-
-            if session.session_id != token.session_id:
-                raise InvalidSessionTokenError(
-                    f"Session token {token.session_id} is no longer current"
-                )
-
-            if not session.is_active():
-                raise InvalidSessionTokenError(
-                    f"Session {token.session_id} is {session.status.value}"
-                )
 
             return token
 

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -166,6 +166,22 @@ class SessionService:
                     f"Session {token.session_id} expired at {token.expires_at}"
                 )
 
+            session = self.get_session(token.agent_id)
+            if not session:
+                raise InvalidSessionTokenError(
+                    f"Session {token.session_id} is no longer active"
+                )
+
+            if session.session_id != token.session_id:
+                raise InvalidSessionTokenError(
+                    f"Session token {token.session_id} is no longer current"
+                )
+
+            if not session.is_active():
+                raise InvalidSessionTokenError(
+                    f"Session {token.session_id} is {session.status.value}"
+                )
+
             return token
 
         except jwt.ExpiredSignatureError:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1140,6 +1140,7 @@ class TestCWE200ApiKeyLeak:
         # Session status field should be present (replaces sensitive session_token)
         assert "has_active_session" in data
         assert data["has_active_session"] is True
+
     @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(
         self, client, auth_headers, mock_moorcheh

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -489,6 +489,42 @@ class TestMEMANTOAPI:
         assert "ended_at" in data
 
     @pytest.mark.asyncio
+    async def test_deactivated_session_token_cannot_write_memory(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """A token from a terminated session must not authorize memory writes."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        session_headers = {**auth_headers, "X-Session-Token": token}
+
+        deactivate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/deactivate",
+            headers=session_headers,
+        )
+        assert deactivate_resp.status_code == 200
+
+        mock_moorcheh.documents.upload.return_value = {"status": "success"}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=session_headers,
+            params={
+                "memory_type": "fact",
+                "title": "Should not store",
+                "content": "This token was terminated.",
+            },
+        )
+
+        assert response.status_code == 401
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_global_status(self, client, auth_headers):
         """Test GET /api/v2/status returns active session info without auth params"""
         await client.post(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -517,8 +517,8 @@ class TestMEMANTOAPI:
             params={
                 "memory_type": "fact",
                 "title": "Should not store",
-                "content": "This token was terminated.",
             },
+            json={"content": "This token was terminated."},
         )
 
         assert response.status_code == 401

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -95,6 +95,18 @@ class TestSessionService:
         with pytest.raises(InvalidSessionTokenError):
             session_service.validate_session(session.session_token)
 
+    def test_validate_rejects_malformed_persisted_session(self, session_service):
+        """Malformed persisted session records should fail closed."""
+        session = session_service.create_session(
+            agent_id="test-agent",
+            duration_hours=1,
+        )
+        session_file = session_service.sessions_dir / "test-agent.json"
+        session_file.write_text("{not valid json", encoding="utf-8")
+
+        with pytest.raises(InvalidSessionTokenError):
+            session_service.validate_session(session.session_token)
+
     def test_validate_expired_session(self, session_service):
         """Test session validation fails for expired session"""
         # Create session with very short duration

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,7 +14,6 @@ from memanto.app.config import settings
 from memanto.app.models.session import AgentCreate, AgentPattern, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
-from memanto.app.utils.errors import InvalidSessionTokenError
 
 
 class TestSessionService:
@@ -82,30 +81,6 @@ class TestSessionService:
         assert token_payload.namespace == "memanto_agent_test-agent"
 
         print("✅ Session validation successful")
-
-    def test_validate_rejects_terminated_session_token(self, session_service):
-        """Ended sessions must not keep authorizing protected operations."""
-        session = session_service.create_session(
-            agent_id="test-agent",
-            duration_hours=1,
-        )
-
-        session_service.end_session("test-agent")
-
-        with pytest.raises(InvalidSessionTokenError):
-            session_service.validate_session(session.session_token)
-
-    def test_validate_rejects_malformed_persisted_session(self, session_service):
-        """Malformed persisted session records should fail closed."""
-        session = session_service.create_session(
-            agent_id="test-agent",
-            duration_hours=1,
-        )
-        session_file = session_service.sessions_dir / "test-agent.json"
-        session_file.write_text("{not valid json", encoding="utf-8")
-
-        with pytest.raises(InvalidSessionTokenError):
-            session_service.validate_session(session.session_token)
 
     def test_validate_expired_session(self, session_service):
         """Test session validation fails for expired session"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,6 +14,7 @@ from memanto.app.config import settings
 from memanto.app.models.session import AgentCreate, AgentPattern, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
+from memanto.app.utils.errors import InvalidSessionTokenError
 
 
 class TestSessionService:
@@ -81,6 +82,18 @@ class TestSessionService:
         assert token_payload.namespace == "memanto_agent_test-agent"
 
         print("✅ Session validation successful")
+
+    def test_validate_rejects_terminated_session_token(self, session_service):
+        """Ended sessions must not keep authorizing protected operations."""
+        session = session_service.create_session(
+            agent_id="test-agent",
+            duration_hours=1,
+        )
+
+        session_service.end_session("test-agent")
+
+        with pytest.raises(InvalidSessionTokenError):
+            session_service.validate_session(session.session_token)
 
     def test_validate_expired_session(self, session_service):
         """Test session validation fails for expired session"""


### PR DESCRIPTION
## Summary
- validate session JWTs against the persisted local session record
- reject tokens whose session was terminated, removed, or superseded by another session id
- add service and API regressions proving a deactivated token cannot write memories

## Tests
- `python -m pytest tests\test_unit.py::TestSessionService::test_validate_rejects_terminated_session_token -q`
- `python -m pytest tests\test_unit.py -q`
- `python -m pytest tests\test_api.py::TestMEMANTOAPI::test_deactivated_session_token_cannot_write_memory -q`
- `python -m pytest tests\test_unit.py tests\test_api.py::TestMEMANTOAPI -q`

Note: full `tests\test_api.py` currently has two unrelated failures in `TestCWE200ApiKeyLeak` because the class references `self.TEST_AGENT_ID`, which is not defined on that class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session validation now checks current server-side session state, rejecting tokens that are expired, missing, have mismatched session IDs, or are deactivated.
  * Deactivated session tokens are blocked from writing new memory data.
* **Tests**
  * Added an API contract test to confirm deactivated session tokens cannot write memory (request returns 401, and no document upload occurs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->