### PR TITLE
Allow project and task namespaces

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -15,6 +15,7 @@ from memanto.app.constants import (
     ScopeType,
     SourceType,
     StatusType,
+    VALID_SCOPE_TYPES,
 )
 
 
@@ -323,5 +324,6 @@ def parse_namespace(namespace: str) -> MemoryScope:
 
 def validate_namespace_format(namespace: str) -> bool:
     """Validate namespace follows MEMANTO convention"""
-    pattern = r"^memanto_(user|workspace|agent|session)_[a-zA-Z0-9_-]+$"
+    scope_pattern = "|".join(sorted(map(re.escape, VALID_SCOPE_TYPES)))
+    pattern = rf"^memanto_({scope_pattern})_[a-zA-Z0-9_-]+$"
     return bool(re.match(pattern, namespace))

--- a/memanto/app/legacy/context_summarization_service.py
+++ b/memanto/app/legacy/context_summarization_service.py
@@ -11,12 +11,16 @@ from typing import Any, cast
 from moorcheh_sdk import MoorchehClient
 
 from memanto.app.config import settings
-from memanto.app.constants import ScopeType
+from memanto.app.constants import ScopeType, VALID_SCOPE_TYPES
 from memanto.app.core import MemoryRecord
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.services.memory_write_service import MemoryWriteService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
+
+
+def _normalize_scope_type(scope_type: str) -> ScopeType:
+    return cast(ScopeType, scope_type if scope_type in VALID_SCOPE_TYPES else "agent")
 
 
 class ContextSummarizationService:
@@ -124,12 +128,7 @@ Provide a clear, organized summary that an AI agent could use to understand the 
             if link_to_originals:
                 summary_metadata["original_memory_ids"] = memory_ids
 
-            resolved_scope_type = cast(
-                ScopeType,
-                scope_type
-                if scope_type in {"user", "workspace", "agent", "session"}
-                else "agent",
-            )
+            resolved_scope_type = _normalize_scope_type(scope_type)
             summary_memory = MemoryRecord(
                 id=generate_memory_id(),
                 type="context",  # Use 'context' type for summaries
@@ -223,12 +222,7 @@ Create a clear, organized summary preserving key information."""
             if not summary_text:
                 raise MemoryError("Failed to generate summary")
 
-            resolved_scope_type = cast(
-                ScopeType,
-                scope_type
-                if scope_type in {"user", "workspace", "agent", "session"}
-                else "agent",
-            )
+            resolved_scope_type = _normalize_scope_type(scope_type)
             # Create and store summary memory
             summary_memory = MemoryRecord(
                 id=generate_memory_id(),

--- a/memanto/app/legacy/context_summarization_service.py
+++ b/memanto/app/legacy/context_summarization_service.py
@@ -57,10 +57,12 @@ class ContextSummarizationService:
             Dict with summary memory details
         """
         try:
+            resolved_scope_type = _normalize_scope_type(scope_type)
+
             # Step 1: Retrieve memories from the scope
             search_result = self.read_service.search_memories(
                 query="",  # Empty query to get all
-                scope_type=scope_type,
+                scope_type=resolved_scope_type,
                 scope_id=scope_id,
                 type=memory_types,
                 limit=max_memories,
@@ -88,10 +90,9 @@ class ContextSummarizationService:
                 memory_texts.append(formatted)
 
             # Step 3: Generate AI summary using Moorcheh
-            from memanto.app.constants import ScopeType
             from memanto.app.core import create_memory_scope
 
-            scope = create_memory_scope(cast(ScopeType, scope_type), scope_id)
+            scope = create_memory_scope(resolved_scope_type, scope_id)
             namespace = scope.to_namespace()
 
             summary_prompt = f"""Summarize the following {len(memories)} memories into a concise context summary.
@@ -128,7 +129,6 @@ Provide a clear, organized summary that an AI agent could use to understand the 
             if link_to_originals:
                 summary_metadata["original_memory_ids"] = memory_ids
 
-            resolved_scope_type = _normalize_scope_type(scope_type)
             summary_memory = MemoryRecord(
                 id=generate_memory_id(),
                 type="context",  # Use 'context' type for summaries

--- a/memanto/app/legacy/universal_services.py
+++ b/memanto/app/legacy/universal_services.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from memanto.app.clients.moorcheh import get_async_moorcheh_client, get_moorcheh_client
 from memanto.app.constants import (
     VALID_MEMORY_TYPES,
+    VALID_SCOPE_TYPES,
     MemoryType,
     ProvenanceType,
     ScopeType,
@@ -28,6 +29,10 @@ from memanto.app.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+def _normalize_scope_type(scope_type: str) -> ScopeType:
+    return cast(ScopeType, scope_type if scope_type in VALID_SCOPE_TYPES else "agent")
+
+
 class MemoryExplainService:
     """Service for explaining memory retrieval decisions"""
 
@@ -39,11 +44,10 @@ class MemoryExplainService:
 
         # Compute namespace for routing explanation
         scope_type_raw = str(request.scope.get("type", "agent"))
-        if scope_type_raw not in {"user", "workspace", "agent", "session"}:
-            scope_type_raw = "agent"
+        scope_type = _normalize_scope_type(scope_type_raw)
         scope_id = str(request.scope.get("id", tenant_id))
 
-        scope_obj = create_memory_scope(cast(ScopeType, scope_type_raw), scope_id)
+        scope_obj = create_memory_scope(scope_type, scope_id)
         namespace = cast(str, scope_obj.to_namespace())
 
         client = get_async_moorcheh_client()
@@ -220,8 +224,7 @@ class MemorySupersedeService:
             raise ValueError("superseding_memory.content is required")
 
         scope_type_raw = str(new_memory_data.get("scope_type", "agent"))
-        if scope_type_raw not in {"user", "workspace", "agent", "session"}:
-            scope_type_raw = "agent"
+        scope_type = _normalize_scope_type(scope_type_raw)
 
         scope_id = str(new_memory_data.get("scope_id", tenant_id))
         title = str(new_memory_data.get("title") or content[:50])
@@ -246,7 +249,7 @@ class MemorySupersedeService:
                 type=resolved_memory_type,
                 title=title,
                 content=content,
-                scope_type=cast(ScopeType, scope_type_raw),
+                scope_type=scope_type,
                 scope_id=scope_id,
                 actor_id=str(new_memory_data.get("actor_id", tenant_id)),
                 confidence=confidence,
@@ -298,11 +301,10 @@ class MemoryExportService:
         """Export memories for a scope"""
 
         scope_type_raw = str(request.scope.get("type", "agent"))
-        if scope_type_raw not in {"user", "workspace", "agent", "session"}:
-            scope_type_raw = "agent"
+        scope_type = _normalize_scope_type(scope_type_raw)
         scope_id = str(request.scope.get("id", tenant_id))
 
-        scope_obj = create_memory_scope(cast(ScopeType, scope_type_raw), scope_id)
+        scope_obj = create_memory_scope(scope_type, scope_id)
         namespace = cast(str, scope_obj.to_namespace())
 
         client = get_async_moorcheh_client()

--- a/memanto/app/routes/namespaces.py
+++ b/memanto/app/routes/namespaces.py
@@ -61,12 +61,10 @@ async def delete_namespace(
     try:
         from typing import cast
 
-        from memanto.app.constants import ScopeType
+        from memanto.app.constants import ScopeType, VALID_SCOPE_TYPES
 
         scope_type_resolved = (
-            scope_type
-            if scope_type in {"user", "workspace", "agent", "session"}
-            else "agent"
+            scope_type if scope_type in VALID_SCOPE_TYPES else "agent"
         )
         service = NamespaceService(client)
         success = service.delete_namespace(
@@ -92,12 +90,10 @@ async def check_namespace_exists(
     try:
         from typing import cast
 
-        from memanto.app.constants import ScopeType
+        from memanto.app.constants import ScopeType, VALID_SCOPE_TYPES
 
         scope_type_resolved = (
-            scope_type
-            if scope_type in {"user", "workspace", "agent", "session"}
-            else "agent"
+            scope_type if scope_type in VALID_SCOPE_TYPES else "agent"
         )
         service = NamespaceService(client)
         exists = service.namespace_exists(

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -646,18 +646,8 @@ class MemoryReadService:
         try:
             # Determine namespace for answer generation
             if scope_type and scope_id:
-                from typing import cast
-
-                from memanto.app.constants import ScopeType, VALID_SCOPE_TYPES
-
-                scope_type_resolved = (
-                    scope_type
-                    if scope_type in VALID_SCOPE_TYPES
-                    else "agent"
-                )
-                scope = create_memory_scope(
-                    cast(ScopeType, scope_type_resolved), scope_id
-                )
+                scope_type_resolved = self._resolve_scope_type(scope_type)
+                scope = create_memory_scope(scope_type_resolved, scope_id)
                 namespace = scope.to_namespace()
             else:
                 # Use first available namespace
@@ -684,24 +674,24 @@ class MemoryReadService:
         except Exception as e:
             raise MemoryError(f"Failed to generate answer: {e}")
 
+    def _resolve_scope_type(self, scope_type: str) -> "ScopeType":
+        from memanto.app.constants import ScopeType, VALID_SCOPE_TYPES
+
+        return cast(
+            ScopeType,
+            scope_type if scope_type in VALID_SCOPE_TYPES else "agent",
+        )
+
     def _get_search_namespaces(
         self, scope_type: str | None = None, scope_id: str | None = None
     ) -> list[str]:
         """Get namespaces to search based on filters"""
         from typing import cast
 
-        from memanto.app.constants import ScopeType
-
         if scope_type and scope_id:
             # Search specific scope
-            from memanto.app.constants import VALID_SCOPE_TYPES
-
-            scope_type_resolved = (
-                scope_type
-                if scope_type in VALID_SCOPE_TYPES
-                else "agent"
-            )
-            scope = create_memory_scope(cast(ScopeType, scope_type_resolved), scope_id)
+            scope_type_resolved = self._resolve_scope_type(scope_type)
+            scope = create_memory_scope(scope_type_resolved, scope_id)
             return [cast(str, scope.to_namespace())]
         else:
             # Search all namespaces

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -648,11 +648,11 @@ class MemoryReadService:
             if scope_type and scope_id:
                 from typing import cast
 
-                from memanto.app.constants import ScopeType
+                from memanto.app.constants import ScopeType, VALID_SCOPE_TYPES
 
                 scope_type_resolved = (
                     scope_type
-                    if scope_type in {"user", "workspace", "agent", "session"}
+                    if scope_type in VALID_SCOPE_TYPES
                     else "agent"
                 )
                 scope = create_memory_scope(
@@ -694,9 +694,11 @@ class MemoryReadService:
 
         if scope_type and scope_id:
             # Search specific scope
+            from memanto.app.constants import VALID_SCOPE_TYPES
+
             scope_type_resolved = (
                 scope_type
-                if scope_type in {"user", "workspace", "agent", "session"}
+                if scope_type in VALID_SCOPE_TYPES
                 else "agent"
             )
             scope = create_memory_scope(cast(ScopeType, scope_type_resolved), scope_id)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -354,6 +354,12 @@ class TestMEMANTOArchitecture:
         import asyncio
 
         from memanto.app.core import validate_namespace_format
+        from memanto.app.legacy.context_summarization_service import (
+            _normalize_scope_type as normalize_summary_scope_type,
+        )
+        from memanto.app.legacy.universal_services import (
+            _normalize_scope_type as normalize_universal_scope_type,
+        )
         from memanto.app.routes.namespaces import check_namespace_exists, delete_namespace
         from memanto.app.services.memory_read_service import MemoryReadService
         from memanto.app.services.namespace_service import NamespaceService
@@ -395,6 +401,13 @@ class TestMEMANTOArchitecture:
         assert asyncio.run(
             check_namespace_exists("task", "ticket-123", client=exists_client)
         ) == {"exists": True}
+
+        assert normalize_summary_scope_type("project") == "project"
+        assert normalize_summary_scope_type("task") == "task"
+        assert normalize_summary_scope_type("unknown") == "agent"
+        assert normalize_universal_scope_type("project") == "project"
+        assert normalize_universal_scope_type("task") == "task"
+        assert normalize_universal_scope_type("unknown") == "agent"
 
     def test_no_tenant_id_in_namespace(self):
         """Verify namespace format does NOT include tenant_id"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -352,6 +352,7 @@ class TestMEMANTOArchitecture:
     def test_project_and_task_namespaces_are_valid(self):
         """Project/task scopes are valid ScopeType values and must pass validation."""
         from memanto.app.core import validate_namespace_format
+        from memanto.app.services.memory_read_service import MemoryReadService
         from memanto.app.services.namespace_service import NamespaceService
 
         assert validate_namespace_format("memanto_project_roadmap-2026")
@@ -370,6 +371,14 @@ class TestMEMANTOArchitecture:
             "memanto_project_roadmap-2026", type="text"
         )
         client.namespaces.create.assert_any_call("memanto_task_ticket-123", type="text")
+
+        reader = MemoryReadService(client)
+        assert reader._get_search_namespaces("project", "roadmap-2026") == [
+            "memanto_project_roadmap-2026"
+        ]
+        assert reader._get_search_namespaces("task", "ticket-123") == [
+            "memanto_task_ticket-123"
+        ]
 
     def test_no_tenant_id_in_namespace(self):
         """Verify namespace format does NOT include tenant_id"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -351,7 +351,10 @@ class TestMEMANTOArchitecture:
 
     def test_project_and_task_namespaces_are_valid(self):
         """Project/task scopes are valid ScopeType values and must pass validation."""
+        import asyncio
+
         from memanto.app.core import validate_namespace_format
+        from memanto.app.routes.namespaces import check_namespace_exists, delete_namespace
         from memanto.app.services.memory_read_service import MemoryReadService
         from memanto.app.services.namespace_service import NamespaceService
 
@@ -379,6 +382,19 @@ class TestMEMANTOArchitecture:
         assert reader._get_search_namespaces("task", "ticket-123") == [
             "memanto_task_ticket-123"
         ]
+
+        asyncio.run(delete_namespace("project", "roadmap-2026", client=client))
+        client.namespaces.delete.assert_called_once_with(
+            "memanto_project_roadmap-2026"
+        )
+
+        exists_client = MagicMock()
+        exists_client.namespaces.list.return_value = {
+            "namespaces": [{"namespace_name": "memanto_task_ticket-123"}]
+        }
+        assert asyncio.run(
+            check_namespace_exists("task", "ticket-123", client=exists_client)
+        ) == {"exists": True}
 
     def test_no_tenant_id_in_namespace(self):
         """Verify namespace format does NOT include tenant_id"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -349,6 +349,28 @@ class TestForgetEndToEnd:
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""
 
+    def test_project_and_task_namespaces_are_valid(self):
+        """Project/task scopes are valid ScopeType values and must pass validation."""
+        from memanto.app.core import validate_namespace_format
+        from memanto.app.services.namespace_service import NamespaceService
+
+        assert validate_namespace_format("memanto_project_roadmap-2026")
+        assert validate_namespace_format("memanto_task_ticket-123")
+
+        client = MagicMock()
+        service = NamespaceService(client)
+
+        assert service.create_namespace("project", "roadmap-2026") == (
+            "memanto_project_roadmap-2026"
+        )
+        assert service.create_namespace("task", "ticket-123") == (
+            "memanto_task_ticket-123"
+        )
+        client.namespaces.create.assert_any_call(
+            "memanto_project_roadmap-2026", type="text"
+        )
+        client.namespaces.create.assert_any_call("memanto_task_ticket-123", type="text")
+
     def test_no_tenant_id_in_namespace(self):
         """Verify namespace format does NOT include tenant_id"""
         from memanto.app.services.session_service import SessionService


### PR DESCRIPTION
## Summary
- allow the declared `project` and `task` scope types through namespace creation, search, delete, and existence checks
- replace duplicated legacy scope allowlists with the shared `VALID_SCOPE_TYPES` constant
- keep unknown scope values falling back to `agent` for backward-compatible behavior
- add regression coverage for project/task namespaces across service, route, and legacy paths

## Tests
- `python -m pytest tests/test_unit.py::TestMEMANTOArchitecture::test_project_and_task_namespaces_are_valid -q`
- `python -m pytest tests/test_unit.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace validation now derives allowed scope types from a shared list, ensuring consistent `memanto_*` formatting for project/task namespaces.
  * Memory retrieval answer generation and search namespace selection now use consistent scope-type resolution with the existing `"agent"` fallback.
  * Namespace delete and existence checks now use the same shared scope-type resolution and fallback behavior.
  * Legacy explain/supersede/export flows now normalize incoming scope types consistently via the shared allowed list.

* **Tests**
  * Added unit coverage for project/task namespace validation, creation, search namespace selection, delete/existence behavior, and scope normalization fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->