### PR TITLE
Preserve falsey memory metadata values

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -746,13 +746,17 @@ class MemoryReadService:
 
         # Check if metadata is in nested format (Moorcheh API spec)
         metadata = item.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
 
         # Helper to get field from either nested metadata or flat structure
         def get_field(field_name, flat_field_name=None):
             """Get field from metadata object or fallback to flat field"""
             flat_name = flat_field_name or field_name
             # Try metadata object first (API spec), then flat field (fallback)
-            return metadata.get(field_name) or item.get(flat_name)
+            if field_name in metadata and metadata[field_name] is not None:
+                return metadata[field_name]
+            return item.get(flat_name)
 
         # Parse tags - can be comma-separated string or array
         tags_value = get_field("tags")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,31 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceFormatting:
+    def test_format_memory_item_preserves_falsey_metadata_values(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        item = {
+            "id": "m-low",
+            "text": "[FACT] Low confidence\n\nThis memory is intentionally weak.",
+            "metadata": {
+                "memory_type": "fact",
+                "confidence": 0.0,
+                "status": "active",
+                "tags": [],
+                "validation_count": 0,
+                "contradiction_detected": False,
+            },
+        }
+
+        formatted = MemoryReadService(MagicMock())._format_memory_item(item)
+
+        assert formatted["confidence"] == 0.0
+        assert formatted["tags"] == []
+        assert formatted["validation_count"] == 0
+        assert formatted["contradiction_detected"] is False
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- Preserve explicit nested metadata values even when they are falsey, such as confidence=0.0.
- Treat non-dict metadata defensively before formatting memory results.
- Add a regression test so low-confidence memory metadata does not get converted to None.

Related to #770.

## Tests
- python -m pytest tests/test_unit.py::TestMemoryReadServiceFormatting::test_format_memory_item_preserves_falsey_metadata_values -q
- python -m pytest tests/test_unit.py -q