### PR TITLE
fix(security): remove hardcoded credentials and insecure JWT secret fallbacks

### DIFF
--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -130,7 +130,10 @@ class Settings(BaseSettings):
     ALLOWED_ORIGINS: list[str] = ["*"]
 
     # Session Configuration
-    MEMANTO_SECRET_KEY: str = "memanto-default-secret-change-in-production"
+    # MEMANTO_SECRET_KEY must be set via environment variable.
+    # No default is provided: a missing secret causes an explicit startup error
+    # rather than silently using a publicly known fallback value (CWE-521).
+    MEMANTO_SECRET_KEY: str = ""
     SESSION_DEFAULT_DURATION_HOURS: int = 6
     SESSION_AUTO_EXTEND: bool = True
     SESSION_EXTEND_THRESHOLD_MINUTES: int = 30

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -57,7 +57,7 @@ class SessionService:
             secret_key: Secret key for JWT signing (defaults to env var or generated)
             sessions_dir: Directory for session storage (defaults to ~/.memanto/sessions/)
         """
-        resolved_secret_key = secret_key or os.getenv("MEMANTO_SECRET_KEY") or ""
+        resolved_secret_key = (secret_key or os.getenv("MEMANTO_SECRET_KEY") or "").strip()
         if not resolved_secret_key:
             raise RuntimeError(
                 "MEMANTO_SECRET_KEY is not configured. "

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -57,11 +57,12 @@ class SessionService:
             secret_key: Secret key for JWT signing (defaults to env var or generated)
             sessions_dir: Directory for session storage (defaults to ~/.memanto/sessions/)
         """
-        resolved_secret_key = (
-            secret_key
-            or os.getenv("MEMANTO_SECRET_KEY")
-            or "memanto-default-secret-change-in-production"
-        )
+        resolved_secret_key = secret_key or os.getenv("MEMANTO_SECRET_KEY") or ""
+        if not resolved_secret_key:
+            raise RuntimeError(
+                "MEMANTO_SECRET_KEY is not configured. "
+                "Set this environment variable to a strong random secret before starting the server."
+            )
         self.secret_key: str = resolved_secret_key
         self.sessions_dir = sessions_dir or get_data_dir() / "sessions"
         self.sessions_dir.mkdir(parents=True, exist_ok=True)

--- a/memanto/app/utils/auth.py
+++ b/memanto/app/utils/auth.py
@@ -49,6 +49,11 @@ def _load_tenant_api_keys() -> dict:
                 raise ValueError(
                     f"entry for key '{api_key}' must be a JSON object"
                 )
+            if not api_key.startswith("tk_"):
+                raise ValueError(
+                    f"API key '{api_key[:8]}…' does not start with 'tk_' — "
+                    "all keys in MEMANTO_TENANT_API_KEYS must use the 'tk_' prefix"
+                )
             missing = _REQUIRED_ENTRY_FIELDS - entry.keys()
             if missing:
                 raise ValueError(

--- a/memanto/app/utils/auth.py
+++ b/memanto/app/utils/auth.py
@@ -2,12 +2,67 @@
 Authentication and Authorization for MEMANTO
 """
 
+import json
+import logging
+import os
+
 import jwt
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
 from memanto.app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _load_tenant_api_keys() -> dict:
+    """Load tenant API keys from the MEMANTO_TENANT_API_KEYS environment variable.
+
+    Expected format (JSON):
+      {
+        "<api_key>": {
+          "tenant_id": "<id>",
+          "roles": ["admin", "user"],
+          "scopes_allowed": ["user", "workspace", "agent", "session"]
+        }
+      }
+
+    Returns an empty dict when the variable is unset so that the server starts
+    in a restricted state rather than with demo credentials.
+    """
+    raw = os.getenv("MEMANTO_TENANT_API_KEYS", "")
+    if not raw:
+        logger.warning(
+            "MEMANTO_TENANT_API_KEYS is not set — API-key authentication is disabled. "
+            "Set this environment variable to enable tenant API keys."
+        )
+        return {}
+    try:
+        keys = json.loads(raw)
+        if not isinstance(keys, dict):
+            raise ValueError("must be a JSON object")
+        return keys
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise RuntimeError(
+            "MEMANTO_TENANT_API_KEYS is set but could not be parsed as JSON: "
+            f"{exc}"
+        ) from exc
+
+
+def _load_jwt_secret() -> str:
+    """Return the JWT signing secret from the environment.
+
+    Raises RuntimeError on startup when no secret is configured so that the
+    server never silently falls back to a publicly known default value.
+    """
+    secret = os.getenv("JWT_SECRET") or getattr(settings, "JWT_SECRET", None)
+    if not secret:
+        raise RuntimeError(
+            "JWT_SECRET is not configured. "
+            "Set the JWT_SECRET environment variable to a strong random value."
+        )
+    return secret
 
 
 class AuthenticatedUser(BaseModel):
@@ -23,23 +78,10 @@ class AuthService:
     """Authentication and authorization service"""
 
     def __init__(self):
-        # In production, load from secure storage
-        self.tenant_api_keys = {
-            # Format: api_key -> tenant_info
-            "tk_acme_prod_abc123": {
-                "tenant_id": "acme",
-                "roles": ["admin", "user"],
-                "scopes_allowed": ["user", "workspace", "agent", "session"],
-            },
-            "tk_demo_test_xyz789": {
-                "tenant_id": "demo",
-                "roles": ["user"],
-                "scopes_allowed": ["user", "agent"],
-            },
-        }
+        self.tenant_api_keys = _load_tenant_api_keys()
 
-        # JWT configuration
-        self.jwt_secret = getattr(settings, "JWT_SECRET", "dev-secret-change-in-prod")
+        # JWT configuration — secret is mandatory; raises on missing config
+        self.jwt_secret = _load_jwt_secret()
         self.jwt_algorithm = "HS256"
         self.jwt_issuer = getattr(settings, "JWT_ISSUER", "memanto")
 

--- a/memanto/app/utils/auth.py
+++ b/memanto/app/utils/auth.py
@@ -15,6 +15,8 @@ from memanto.app.config import settings
 
 logger = logging.getLogger(__name__)
 
+_REQUIRED_ENTRY_FIELDS = {"tenant_id", "roles", "scopes_allowed"}
+
 
 def _load_tenant_api_keys() -> dict:
     """Load tenant API keys from the MEMANTO_TENANT_API_KEYS environment variable.
@@ -42,6 +44,16 @@ def _load_tenant_api_keys() -> dict:
         keys = json.loads(raw)
         if not isinstance(keys, dict):
             raise ValueError("must be a JSON object")
+        for api_key, entry in keys.items():
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"entry for key '{api_key}' must be a JSON object"
+                )
+            missing = _REQUIRED_ENTRY_FIELDS - entry.keys()
+            if missing:
+                raise ValueError(
+                    f"entry for key '{api_key}' is missing required fields: {sorted(missing)}"
+                )
         return keys
     except (json.JSONDecodeError, ValueError) as exc:
         raise RuntimeError(
@@ -57,12 +69,12 @@ def _load_jwt_secret() -> str:
     server never silently falls back to a publicly known default value.
     """
     secret = os.getenv("JWT_SECRET") or getattr(settings, "JWT_SECRET", None)
-    if not secret:
+    if not secret or not secret.strip():
         raise RuntimeError(
             "JWT_SECRET is not configured. "
             "Set the JWT_SECRET environment variable to a strong random value."
         )
-    return secret
+    return secret.strip()
 
 
 class AuthenticatedUser(BaseModel):


### PR DESCRIPTION
## Summary

Fixes two critical credential exposure vulnerabilities identified in the memanto security audit (#770):

### 🔴 CWE-798: Hardcoded tenant API keys in source code

`memanto/app/utils/auth.py` contained two hardcoded tenant API keys in the `AuthService.__init__` dict:
- `tk_acme_prod_abc123` → tenant `acme` with admin+user roles and full scope access
- `tk_demo_test_xyz789` → tenant `demo` with user role

Any user with read access to this public repository (1160+ stars) could authenticate as either tenant with full permissions.

**Fix:** Keys are now loaded from the `MEMANTO_TENANT_API_KEYS` environment variable as JSON. When unset, the server starts with API-key auth disabled and logs a warning rather than silently using known credentials.

### 🔴 CWE-321: Hardcoded JWT secret fallbacks

Two hardcoded fallback secrets were used when environment variables were absent:
- `utils/auth.py`: `"dev-secret-change-in-prod"` fallback in `_load_jwt_secret`
- `config.py:133`: `MEMANTO_SECRET_KEY = "memanto-default-secret-change-in-production"`
- `session_service.py:63`: same `"memanto-default-secret-change-in-production"` fallback

Anyone knowing the published fallback string can forge valid JWT tokens and impersonate any session.

**Fix:** All three call sites now raise `RuntimeError` at startup when no secret is configured, so the server fails loudly instead of running with a publicly known signing key.

## Changes

| File | Change |
|------|--------|
| `memanto/app/utils/auth.py` | Remove hardcoded keys; add `_load_tenant_api_keys()` and `_load_jwt_secret()` helpers |
| `memanto/app/config.py` | Change `MEMANTO_SECRET_KEY` default from known string to `""` |
| `memanto/app/services/session_service.py` | Raise `RuntimeError` instead of falling back to known secret |

## Migration

Set these environment variables before starting the server:

```bash
# Required — strong random secret (e.g. openssl rand -hex 32)
export MEMANTO_SECRET_KEY="<random>"
export JWT_SECRET="<random>"

# Optional — tenant API keys as JSON (omit to disable API-key auth)
export MEMANTO_TENANT_API_KEYS='{"<your_key>": {"tenant_id": "acme", "roles": ["admin"], "scopes_allowed": ["user","workspace","agent","session"]}}'
```

Closes #770 (partial — addresses CWE-798 and CWE-321 findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Security Hardening**
  * Fail fast on startup when required authentication secrets are missing, blank, or invalid.
  * Removed fallback behaviors that previously allowed operation with known default credential values.
  * Tenant API keys and JWT signing secrets are now loaded from configured environment/settings values, with strict validation and clear errors when configuration is incomplete or malformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->