### PR TITLE
fix(security): require API key for agent lifecycle routes (#770)

### DIFF
--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,6 +4,8 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
+import hmac
+
 from fastapi import Header, HTTPException
 
 from memanto.app.models.session import Session
@@ -46,13 +48,58 @@ def get_moorcheh_api_key() -> str:
     )
 
 
-def verify_moorcheh_api_key() -> str:
-    """
-    Return configured Moorcheh API key.
+def _extract_request_api_key(
+    authorization: str | None,
+    x_api_key: str | None,
+) -> str | None:
+    """Extract an API key from supported request headers."""
+    if x_api_key:
+        return x_api_key.strip()
+    if authorization:
+        scheme, _, value = authorization.partition(" ")
+        if scheme.lower() == "bearer" and value.strip():
+            return value.strip()
+    return None
 
-    Runtime connectivity is validated at startup and via /health.
+
+def verify_moorcheh_api_key(
+    authorization: str | None = Header(default=None),
+    x_api_key: str | None = Header(default=None),
+) -> str:
     """
-    return get_moorcheh_api_key()
+    Verify that the caller supplied the configured Moorcheh API key.
+
+    Agent lifecycle routes mint session tokens and can delete local/remote
+    namespaces, so they must authenticate the request itself instead of only
+    checking that the server has a configured outbound Moorcheh key.
+    """
+    configured_key = get_moorcheh_api_key()
+    provided_key = _extract_request_api_key(authorization, x_api_key)
+
+    if configured_key == "on-prem":
+        from memanto.app.config import settings
+
+        expected_key = settings.MOORCHEH_API_KEY.strip()
+        if not expected_key:
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "Server misconfigured: MOORCHEH_API_KEY is not set for API "
+                    "authentication"
+                ),
+            )
+    else:
+        expected_key = configured_key.strip()
+
+    if not provided_key:
+        raise HTTPException(
+            status_code=401,
+            detail="Missing API key. Use Authorization: Bearer <MOORCHEH_API_KEY> or X-API-Key.",
+        )
+    if not hmac.compare_digest(provided_key, expected_key):
+        raise HTTPException(status_code=403, detail="Invalid API key")
+
+    return configured_key
 
 
 def get_current_session(x_session_token: str | None = Header(None)) -> Session:

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -35,7 +35,6 @@ router = APIRouter()
 from memanto.app.routes import memory  # noqa: E402
 from memanto.app.routes.auth_deps import (  # noqa: E402
     get_current_session,
-    get_moorcheh_api_key,
     get_session_service,
     verify_moorcheh_api_key,
 )
@@ -78,7 +77,7 @@ async def _namespace_item_counts(moorcheh_api_key: str) -> dict[str, int]:
 
 @router.post("/agents", response_model=AgentInfo, status_code=201)
 async def create_agent(
-    agent_create: AgentCreate, moorcheh_api_key: str = Depends(get_moorcheh_api_key)
+    agent_create: AgentCreate, moorcheh_api_key: str = Depends(verify_moorcheh_api_key)
 ):
     """
     Create a new MEMANTO agent
@@ -257,11 +256,12 @@ async def deactivate_agent(
 
 
 @router.get("/status", response_model=SessionInfo)
-async def get_status():
+async def get_status(_server_api_key: str = Depends(verify_moorcheh_api_key)):
     """
     Get current active session status.
 
-    No parameters required — reads the active session from local state.
+    Requires the configured Moorcheh API key and reads the active session from
+    local state.
     """
     session = get_session_service().get_active_session()
     if session is None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -159,15 +159,30 @@ class TestMEMANTOAPI:
         assert "metadata" not in data
 
     @pytest.mark.asyncio
-    async def test_create_agent_without_authorization_header(self, client):
-        """Test creating a new agent using server-configured API key"""
+    async def test_create_agent_requires_authorization_header(self, client):
+        """Creating a new agent requires a request API key."""
         payload = {
             "agent_id": "server-key-agent",
             "pattern": "support",
         }
         response = await client.post("/api/v2/agents", json=payload)
+        assert response.status_code == 401
+        assert "Missing API key" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_agent_accepts_x_api_key_header(self, client):
+        """X-API-Key is accepted as an alternative to Authorization."""
+        payload = {
+            "agent_id": "x-api-key-agent",
+            "pattern": "support",
+        }
+        response = await client.post(
+            "/api/v2/agents",
+            headers={"X-API-Key": settings.MOORCHEH_API_KEY},
+            json=payload,
+        )
         assert response.status_code == 201
-        assert response.json()["agent_id"] == "server-key-agent"
+        assert response.json()["agent_id"] == "x-api-key-agent"
 
     @pytest.mark.asyncio
     async def test_create_agent_fails_when_server_key_missing(self, client):
@@ -208,6 +223,22 @@ class TestMEMANTOAPI:
         assert "session_token" in data
         assert "session_id" in data
         assert data["agent_id"] == self.TEST_AGENT_ID
+
+    @pytest.mark.asyncio
+    async def test_activate_session_requires_authorization_header(
+        self, client, auth_headers
+    ):
+        """Unauthenticated callers cannot mint a session token."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID, "pattern": "support"},
+        )
+
+        response = await client.post(f"/api/v2/agents/{self.TEST_AGENT_ID}/activate")
+
+        assert response.status_code == 401
+        assert "session_token" not in response.text
 
     @pytest.mark.asyncio
     async def test_remember_with_session(self, client, auth_headers, mock_moorcheh):
@@ -499,7 +530,7 @@ class TestMEMANTOAPI:
             f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
         )
 
-        response = await client.get("/api/v2/status")
+        response = await client.get("/api/v2/status", headers=auth_headers)
         assert response.status_code == 200
         data = response.json()
         assert data["agent_id"] == self.TEST_AGENT_ID


### PR DESCRIPTION
/claim #770

## Summary

The V2 agent lifecycle routes were documented as requiring the server `MOORCHEH_API_KEY`, but the route dependency only checked that the server had a configured outbound key. As a result, unauthenticated callers could reach lifecycle operations such as creating/listing/deleting agents and activating an agent session.

This PR makes the request authentication match the documented contract: callers must provide the configured key via `Authorization: Bearer <MOORCHEH_API_KEY>` or `X-API-Key` before lifecycle routes can create agents, list agents, delete agents, activate sessions, deactivate sessions, or read `/api/v2/status`.

## Reproduction

The new regression tests capture the previously unsafe behavior:

- `test_create_agent_requires_authorization_header`: unauthenticated `POST /api/v2/agents` now returns `401` instead of creating an agent.
- `test_activate_session_requires_authorization_header`: unauthenticated `POST /api/v2/agents/{agent_id}/activate` now returns `401` and never returns a `session_token`.
- `test_create_agent_accepts_x_api_key_header`: verifies the documented `X-API-Key` alternative still works.

## Fix

- `verify_moorcheh_api_key` now extracts a request key from `Authorization: Bearer ...` or `X-API-Key` and compares it to the configured server key with `hmac.compare_digest`.
- `create_agent` now uses the same verifier as the other lifecycle endpoints.
- `GET /api/v2/status` is also protected because it exposes active session metadata.
- On-prem deployments fail closed unless an operator configures `MOORCHEH_API_KEY` as the local HTTP admin key.
- The existing `TestCWE200ApiKeyLeak` filename-sanitization tests now define the agent id constant they already referenced, so the full API test module passes.

## Validation

```bash
python -m pytest tests/test_api.py -q
# 57 passed

python -m pytest tests/test_unit.py -q
# 23 passed

python -m ruff check memanto/app/routes/auth_deps.py memanto/app/routes/sessions.py tests/test_api.py
# All checks passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API-protected agent creation and status endpoints now require a Moorcheh API key using either `Authorization: Bearer <key>` or `X-API-Key`.

* **Bug Fixes**
  * Requests without a provided API key are rejected with a clear unauthorized response; mismatched keys are rejected with a forbidden response using constant-time comparison.

* **Tests**
  * Added coverage to ensure agent creation and session activation fail without auth headers, accept `X-API-Key`, and that global status requests include auth headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->