### PR TITLE
chore: update discord links to use memanto redirect

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,7 +265,7 @@ Rules:
 
 ## Community
 
-- **Discord**: [Join our server](https://discord.gg/CyxRFQSQ3p) — the best place for quick questions and discussions
+- **Discord**: [Join our server](https://memanto.ai/discord) — the best place for quick questions and discussions
 - **GitHub Issues**: https://github.com/moorcheh-ai/memanto/issues — bugs and feature requests
 - **Email**: support@moorcheh.ai — for anything that doesn't fit the above
 - **Docs**: https://docs.memanto.ai

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/CyxRFQSQ3p">
+  <a href="https://memanto.ai/discord">
     <img src="https://img.shields.io/badge/Join-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join Discord">
   </a>
   <a href="https://www.youtube.com/watch?v=vEtOaoweIG4">
@@ -246,7 +246,7 @@ Full endpoint reference is available at [docs.memanto.ai/api](https://docs.meman
 
 Have questions or feedback? We're here to help:
 - **Docs**: [https://docs.memanto.ai](https://docs.memanto.ai)
-- **Discord**: [Join our Discord server](https://discord.gg/CyxRFQSQ3p)
+- **Discord**: [Join our Discord server](https://memanto.ai/discord)
 - **Email**: support@moorcheh.ai
 - **X / Twitter**: [@moorcheh_ai](https://x.com/moorcheh_ai)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project’s Discord community link to a new, consistent URL in the contributing guide and README.
  * Replaced outdated invite links in multiple places so users are directed to the current community page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->