### PR TITLE
Fix as-of memory expiry filtering

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -268,7 +268,9 @@ class MemoryReadService:
                     "temporal_mode": "as_of",
                 }
 
-            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            all_memories = self._fetch_all_memories(
+                namespaces, type=type, tags=tags, enforce_ttl=False
+            )
             all_memories = self._apply_temporal_filter(
                 all_memories, created_before=as_of_date
             )
@@ -444,6 +446,7 @@ class MemoryReadService:
         namespaces: list[str],
         type: list[str] | None = None,
         tags: list[str] | None = None,
+        enforce_ttl: bool = True,
     ) -> list[dict[str, Any]]:
         """
         List all stored memories across the given namespaces via Moorcheh's
@@ -492,7 +495,9 @@ class MemoryReadService:
 
             memories.append(formatted)
 
-        return self._filter_expired_memories(memories)
+        if enforce_ttl:
+            return self._filter_expired_memories(memories)
+        return memories
 
     def _build_filtered_query(
         self,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,40 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceTemporal:
+    """Regression coverage for point-in-time memory retrieval."""
+
+    def test_search_as_of_includes_memory_valid_then_but_expired_now(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "mem-valid-then",
+                    "text": "[FACT] Historical access\n\nUser had beta access.",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "scope_type": "agent",
+                        "scope_id": "agent-1",
+                        "status": "active",
+                        "created_at": "2000-01-01T00:00:00Z",
+                        "updated_at": "2000-01-01T00:00:00Z",
+                        "expires_at": "2000-02-01T00:00:00Z",
+                    },
+                }
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        result = MemoryReadService(client).search_as_of(
+            "2000-01-15T00:00:00Z", "agent-1"
+        )
+
+        assert result["total_found"] == 1
+        assert result["results"][0]["id"] == "mem-valid-then"
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- let `search_as_of` retrieve expired-now memories before applying point-in-time validity checks
- keep default TTL enforcement for current/recent memory fetch paths
- add a regression test for memories that were valid at the requested historical date but expired later

## Root cause
`search_as_of` calls `_fetch_all_memories`, and `_fetch_all_memories` always filtered expired memories against the current wall-clock time. That dropped memories that are expired today even when they were still valid at the requested `as_of_date`, so historical recall could lose the exact state it was supposed to reconstruct.

## Validation
- `python -m pytest tests/test_unit.py::TestMemoryReadServiceTemporal::test_search_as_of_includes_memory_valid_then_but_expired_now -q`
- `python -m pytest tests/test_unit.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-based memory search so results are evaluated against the requested “as of” timestamp more accurately.
  * Fixed an issue where valid memories could be incorrectly excluded when their expiration time falls after the requested date.
* **Tests**
  * Added regression coverage for memory searches using historical timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->