### PR TITLE
Enforce upload file size limit

### DIFF
--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -12,6 +12,7 @@ from moorcheh_sdk.exceptions import AuthenticationError, NamespaceNotFound
 from memanto.app import __version__
 from memanto.app.clients.backend import Backend, parse_backend
 from memanto.app.config import settings
+from memanto.app.middleware.body_size_limit import RequestBodyLimitMiddleware
 from memanto.app.routes import health, sessions
 from memanto.app.ui.routes.ui_router import mount_ui_static
 from memanto.app.ui.routes.ui_router import router as ui_router
@@ -71,6 +72,8 @@ app = FastAPI(
     redoc_url="/redoc",
     lifespan=lifespan,
 )
+
+app.add_middleware(RequestBodyLimitMiddleware)
 
 # Add CORS middleware
 app.add_middleware(

--- a/memanto/app/middleware/__init__.py
+++ b/memanto/app/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""Application middleware."""

--- a/memanto/app/middleware/body_size_limit.py
+++ b/memanto/app/middleware/body_size_limit.py
@@ -10,6 +10,11 @@ from memanto.app.upload_limits import (
 )
 
 
+class _RequestBodyTooLarge(Exception):
+    def __init__(self, request_size: int) -> None:
+        self.request_size = request_size
+
+
 class RequestBodyLimitMiddleware:
     """Reject oversized HTTP request bodies before route handlers run."""
 
@@ -36,15 +41,32 @@ class RequestBodyLimitMiddleware:
             except ValueError:
                 request_size = 0
             if request_size > self.max_request_body_size:
-                response = JSONResponse(
-                    status_code=413,
-                    content={
-                        "detail": file_too_large_detail(
-                            request_size, self.max_upload_size
-                        )
-                    },
-                )
+                response = self._too_large_response(request_size)
                 await response(scope, receive, send)
                 return
 
-        await self.app(scope, receive, send)
+        streamed_size = 0
+
+        async def limited_receive():
+            nonlocal streamed_size
+
+            message = await receive()
+            if message["type"] == "http.request":
+                streamed_size += len(message.get("body", b""))
+                if streamed_size > self.max_request_body_size:
+                    raise _RequestBodyTooLarge(streamed_size)
+            return message
+
+        try:
+            await self.app(scope, limited_receive, send)
+        except _RequestBodyTooLarge as exc:
+            response = self._too_large_response(exc.request_size)
+            await response(scope, receive, send)
+
+    def _too_large_response(self, request_size: int) -> JSONResponse:
+        return JSONResponse(
+            status_code=413,
+            content={
+                "detail": file_too_large_detail(request_size, self.max_upload_size)
+            },
+        )

--- a/memanto/app/middleware/body_size_limit.py
+++ b/memanto/app/middleware/body_size_limit.py
@@ -1,0 +1,50 @@
+"""ASGI request body size limiting middleware."""
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from memanto.app.upload_limits import (
+    MAX_REQUEST_BODY_SIZE,
+    MAX_UPLOAD_FILE_SIZE,
+    file_too_large_detail,
+)
+
+
+class RequestBodyLimitMiddleware:
+    """Reject oversized HTTP request bodies before route handlers run."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        max_request_body_size: int = MAX_REQUEST_BODY_SIZE,
+        max_upload_size: int = MAX_UPLOAD_FILE_SIZE,
+    ) -> None:
+        self.app = app
+        self.max_request_body_size = max_request_body_size
+        self.max_upload_size = max_upload_size
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = {name.lower(): value for name, value in scope.get("headers", [])}
+        content_length = headers.get(b"content-length")
+        if content_length is not None:
+            try:
+                request_size = int(content_length)
+            except ValueError:
+                request_size = 0
+            if request_size > self.max_request_body_size:
+                response = JSONResponse(
+                    status_code=413,
+                    content={
+                        "detail": file_too_large_detail(
+                            request_size, self.max_upload_size
+                        )
+                    },
+                )
+                await response(scope, receive, send)
+                return
+
+        await self.app(scope, receive, send)

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -39,6 +39,11 @@ from memanto.app.services.conversation_memory_extraction_service import (
 )
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.upload_limits import (
+    MAX_UPLOAD_FILE_SIZE,
+    UPLOAD_CHUNK_SIZE,
+    file_too_large_detail,
+)
 from memanto.app.utils.errors import AuthorizationError, map_error_to_http_exception
 from memanto.app.utils.validation import CostGuard
 from memanto.cli.client.direct_client import DirectClient
@@ -47,8 +52,6 @@ from memanto.cli.config.manager import ConfigManager
 router = APIRouter()
 
 _config_manager = ConfigManager()
-MAX_UPLOAD_FILE_SIZE = 5 * 1024 * 1024 * 1024  # 5GB
-UPLOAD_CHUNK_SIZE = 1024 * 1024
 
 
 class RecallRequest(BaseModel):
@@ -555,12 +558,7 @@ async def upload_file(
         if file_size_hint is not None and file_size_hint > MAX_UPLOAD_FILE_SIZE:
             raise HTTPException(
                 status_code=413,
-                detail={
-                    "error": "file_too_large",
-                    "message": f"File exceeds maximum size of {MAX_UPLOAD_FILE_SIZE} bytes",
-                    "actual_size": file_size_hint,
-                    "max_size": MAX_UPLOAD_FILE_SIZE,
-                },
+                detail=file_too_large_detail(file_size_hint),
             )
 
         tmp_dir = tempfile.mkdtemp()
@@ -581,12 +579,7 @@ async def upload_file(
                     if total_size > MAX_UPLOAD_FILE_SIZE:
                         raise HTTPException(
                             status_code=413,
-                            detail={
-                                "error": "file_too_large",
-                                "message": f"File exceeds maximum size of {MAX_UPLOAD_FILE_SIZE} bytes",
-                                "actual_size": total_size,
-                                "max_size": MAX_UPLOAD_FILE_SIZE,
-                            },
+                            detail=file_too_large_detail(total_size),
                         )
                     tmp.write(chunk)
             result = await asyncio.to_thread(

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -47,6 +47,8 @@ from memanto.cli.config.manager import ConfigManager
 router = APIRouter()
 
 _config_manager = ConfigManager()
+MAX_UPLOAD_FILE_SIZE = 5 * 1024 * 1024 * 1024  # 5GB
+UPLOAD_CHUNK_SIZE = 1024 * 1024
 
 
 class RecallRequest(BaseModel):
@@ -549,9 +551,18 @@ async def upload_file(
     try:
         namespace = session.namespace
 
-        # Write upload to a temp file so moorcheh SDK can read it
-        # Use original filename so the SDK records it as the source
-        file_bytes = await file.read()
+        file_size_hint = getattr(file, "size", None)
+        if file_size_hint is not None and file_size_hint > MAX_UPLOAD_FILE_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail={
+                    "error": "file_too_large",
+                    "message": f"File exceeds maximum size of {MAX_UPLOAD_FILE_SIZE} bytes",
+                    "actual_size": file_size_hint,
+                    "max_size": MAX_UPLOAD_FILE_SIZE,
+                },
+            )
+
         tmp_dir = tempfile.mkdtemp()
         tmp_path = os.path.join(tmp_dir, original_name)
         # Defense-in-depth: verify resolved path is within tmp_dir
@@ -563,8 +574,21 @@ async def upload_file(
                 detail="Invalid filename",
             )
         try:
+            total_size = 0
             with open(tmp_path, "wb") as tmp:
-                tmp.write(file_bytes)
+                while chunk := await file.read(UPLOAD_CHUNK_SIZE):
+                    total_size += len(chunk)
+                    if total_size > MAX_UPLOAD_FILE_SIZE:
+                        raise HTTPException(
+                            status_code=413,
+                            detail={
+                                "error": "file_too_large",
+                                "message": f"File exceeds maximum size of {MAX_UPLOAD_FILE_SIZE} bytes",
+                                "actual_size": total_size,
+                                "max_size": MAX_UPLOAD_FILE_SIZE,
+                            },
+                        )
+                    tmp.write(chunk)
             result = await asyncio.to_thread(
                 client.documents.upload_file, namespace, tmp_path
             )
@@ -583,6 +607,8 @@ async def upload_file(
             "message": result.get("message", ""),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 

--- a/memanto/app/upload_limits.py
+++ b/memanto/app/upload_limits.py
@@ -1,0 +1,19 @@
+"""Shared upload size limits."""
+
+MAX_UPLOAD_FILE_SIZE = 5 * 1024 * 1024 * 1024  # 5GB
+UPLOAD_CHUNK_SIZE = 1024 * 1024
+MULTIPART_FORM_OVERHEAD_SIZE = 100_000
+MAX_REQUEST_BODY_SIZE = MAX_UPLOAD_FILE_SIZE + MULTIPART_FORM_OVERHEAD_SIZE
+
+
+def file_too_large_detail(
+    actual_size: int,
+    max_size: int = MAX_UPLOAD_FILE_SIZE,
+) -> dict[str, int | str]:
+    """Return the API detail payload for oversized uploads."""
+    return {
+        "error": "file_too_large",
+        "message": f"File exceeds maximum size of {max_size} bytes",
+        "actual_size": actual_size,
+        "max_size": max_size,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1131,6 +1131,33 @@ class TestMEMANTOAPI:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_upload_file_rejects_oversized_file(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Oversized uploads should fail before reaching Moorcheh."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        with patch("memanto.app.routes.memory.MAX_UPLOAD_FILE_SIZE", 5):
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+                headers=headers,
+                files={"file": ("notes.txt", b"123456", "text/plain")},
+            )
+
+        assert response.status_code == 413
+        assert response.json()["detail"]["error"] == "file_too_large"
+        mock_moorcheh.documents.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_upload_file_requires_session(self, client, auth_headers):
         """Test that upload requires a valid session token"""
         await client.post(

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -1,8 +1,10 @@
 """Tests for request body size limiting middleware."""
 
 import asyncio
+import json
 
 from memanto.app.middleware.body_size_limit import RequestBodyLimitMiddleware
+from memanto.app.upload_limits import file_too_large_detail
 
 
 def test_rejects_streamed_body_without_content_length():
@@ -47,3 +49,6 @@ def test_rejects_streamed_body_without_content_length():
 
     assert sent_messages[0]["type"] == "http.response.start"
     assert sent_messages[0]["status"] == 413
+    assert json.loads(sent_messages[1]["body"]) == {
+        "detail": file_too_large_detail(actual_size=6, max_size=5)
+    }

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -1,0 +1,49 @@
+"""Tests for request body size limiting middleware."""
+
+import asyncio
+
+from memanto.app.middleware.body_size_limit import RequestBodyLimitMiddleware
+
+
+def test_rejects_streamed_body_without_content_length():
+    """Chunked requests without Content-Length should still be limited."""
+    sent_messages = []
+
+    async def app(scope, receive, send):
+        while True:
+            message = await receive()
+            if message["type"] == "http.request" and not message.get(
+                "more_body", False
+            ):
+                break
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = RequestBodyLimitMiddleware(
+        app,
+        max_request_body_size=5,
+        max_upload_size=5,
+    )
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/upload",
+        "headers": [],
+    }
+    chunks = iter(
+        [
+            {"type": "http.request", "body": b"123", "more_body": True},
+            {"type": "http.request", "body": b"456", "more_body": False},
+        ]
+    )
+
+    async def receive():
+        return next(chunks)
+
+    async def send(message):
+        sent_messages.append(message)
+
+    asyncio.run(middleware(scope, receive, send))
+
+    assert sent_messages[0]["type"] == "http.response.start"
+    assert sent_messages[0]["status"] == 413

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,36 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestRequestBodyLimitMiddleware:
+    def test_rejects_oversized_content_length_before_route(self):
+        """Oversized requests should be rejected before endpoint execution."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from memanto.app.middleware.body_size_limit import RequestBodyLimitMiddleware
+
+        app = FastAPI()
+        called = False
+
+        @app.post("/upload")
+        async def upload():
+            nonlocal called
+            called = True
+            return {"ok": True}
+
+        app.add_middleware(
+            RequestBodyLimitMiddleware,
+            max_request_body_size=5,
+            max_upload_size=5,
+        )
+
+        response = TestClient(app).post("/upload", content=b"123456")
+
+        assert response.status_code == 413
+        assert response.json()["detail"]["error"] == "file_too_large"
+        assert called is False
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- add an explicit 5GB upload limit for `/upload-file`
- reject oversize files with HTTP 413 before calling the Moorcheh upload API
- stream uploads to the temporary file in chunks instead of reading the whole file into memory
- add API regression coverage for oversize uploads

## Root cause
The upload route documented a maximum file size but accepted uploads without checking the actual size. It also used `await file.read()` to load the entire file into memory before writing to disk, so an oversized request could consume process memory and still be forwarded to the backend.

## Validation
- `python -m pytest tests/test_api.py::TestMEMANTOAPI::test_upload_file_rejects_oversized_file -q`
- `python -m pytest tests/test_api.py::TestMEMANTOAPI::test_upload_file_with_session tests/test_api.py::TestMEMANTOAPI::test_upload_file_unsupported_extension tests/test_api.py::TestMEMANTOAPI::test_upload_file_rejects_oversized_file tests/test_api.py::TestMEMANTOAPI::test_upload_file_requires_session tests/test_api.py::TestCWE200ApiKeyLeak::test_traversal_filename_is_sanitized tests/test_api.py::TestCWE200ApiKeyLeak::test_absolute_path_filename_is_sanitized -q`
- `python -m pytest tests/test_api.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 5GB maximum upload limit with early rejection (HTTP 413).
  * Uploads are streamed while writing temporary data, aborting once the limit is exceeded.
  * Oversized uploads now return consistent, API-friendly error details.

* **New Features**
  * Added request body size limiting middleware to reject oversized HTTP requests before reaching upload handlers.

* **Tests**
  * Added API and middleware unit tests to verify HTTP 413 responses for oversized uploads and streamed bodies without a Content-Length header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->