### PR TITLE
Filter secrets from extracted memories

### DIFF
--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -20,6 +20,16 @@ class ConversationMemoryExtractionService:
     MAX_MESSAGES = 200
     MAX_MEMORIES = 100
     MAX_CONTENT_CHARS = 12_000
+    SECRET_PATTERNS = [
+        re.compile(
+            r"\b(?:api[_ -]?key|password|passwd|secret|token|access[_ -]?token|client[_ -]?secret|private[_ -]?key)\b\s*[:=]\s*\S{6,}",
+            re.IGNORECASE,
+        ),
+        re.compile(r"\bsk-[A-Za-z0-9_-]{10,}\b"),
+        re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{10,}\b"),
+        re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+        re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    ]
 
     def __init__(self, client: Any) -> None:
         self.client = client
@@ -145,6 +155,8 @@ class ConversationMemoryExtractionService:
 
             title = str(item.get("title") or content[:80]).strip()
             title = title[:100]
+            if self._contains_secret(title) or self._contains_secret(content):
+                continue
 
             try:
                 confidence = float(item.get("confidence", 0.8))
@@ -174,3 +186,6 @@ class ConversationMemoryExtractionService:
             raise ValueError("Memory extraction produced no usable candidates")
 
         return normalized
+
+    def _contains_secret(self, text: str) -> bool:
+        return any(pattern.search(text) for pattern in self.SECRET_PATTERNS)

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -80,6 +80,36 @@ def test_extract_conversation_memories_normalizes_candidates():
     assert "user:" in client.answer.call_kwargs["query"]
 
 
+def test_extract_filters_secret_candidates():
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "fact",
+            "title": "Production credential",
+            "content": "The production api_key=sk-testsecret123456 should be remembered.",
+            "confidence": 0.99
+          },
+          {
+            "type": "instruction",
+            "title": "Review preference",
+            "content": "The user wants concise pull request summaries.",
+            "confidence": 0.8
+          }
+        ]
+        """
+    )
+
+    candidates = ConversationMemoryExtractionService(client).extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Keep PR summaries concise."}],
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["title"] == "Review preference"
+    assert "api_key" not in candidates[0]["content"]
+
+
 def test_extract_rejects_non_json_answers():
     service = ConversationMemoryExtractionService(FakeClient("not json"))
 


### PR DESCRIPTION
## Summary
- add deterministic secret-pattern filtering to conversation memory extraction
- skip extracted candidates that contain credential-like values in the title or content
- add regression coverage for a model response that mixes a credential candidate with a safe memory

## Root cause
The extraction prompt told the model not to return secrets, but `_normalize_candidates` trusted the model output completely. If the answer-generation step returned an API key, token, password, or similar credential anyway, the candidate could be persisted as long-term memory.

## Validation
- `python -m pytest tests/test_conversation_memory_extraction.py -q`
- `python -m pytest tests/test_api.py::TestMEMANTOAPI::test_extract_memories_from_conversation_dry_run tests/test_api.py::TestMEMANTOAPI::test_extract_memories_from_conversation_stores_batch -q`