### PR TITLE
Validate conflict resolution requests

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -3,9 +3,9 @@ MEMANTO API Models
 """
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from memanto.app.constants import MemoryType, ScopeType, SourceType, StatusType
 
@@ -133,9 +133,14 @@ class ConflictResolveRequest(BaseModel):
     """Request body for resolving a conflict"""
 
     conflict_index: int = Field(..., ge=0, description="Conflict index to resolve")
-    action: str = Field(
+    action: Literal[
+        "keep_old", "keep_new", "keep_both", "remove_both", "manual"
+    ] = Field(
         ...,
-        description="Resolution action: keep_old, keep_new, keep_both, remove_both, manual",
+        description=(
+            "Resolution action: keep_old, keep_new, keep_both, "
+            "remove_both, manual"
+        ),
     )
     date: str | None = Field(
         None, description="Conflict report date (YYYY-MM-DD). Defaults to today."
@@ -146,6 +151,14 @@ class ConflictResolveRequest(BaseModel):
     manual_type: str | None = Field(
         None, description="Optional memory type for manual action"
     )
+
+    @model_validator(mode="after")
+    def validate_manual_resolution(self) -> "ConflictResolveRequest":
+        if self.action == "manual" and not (
+            self.manual_content and self.manual_content.strip()
+        ):
+            raise ValueError("manual_content is required when action is 'manual'")
+        return self
 
 
 class AnswerRequest(BaseModel):

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -123,14 +123,13 @@ class ConflictResolveRequest(BaseModel):
     """Request body for resolving a conflict"""
 
     conflict_index: int = Field(..., ge=0, description="Conflict index to resolve")
-    action: Literal[
-        "keep_old", "keep_new", "keep_both", "remove_both", "manual"
-    ] = Field(
-        ...,
-        description=(
-            "Resolution action: keep_old, keep_new, keep_both, "
-            "remove_both, manual"
-        ),
+    action: Literal["keep_old", "keep_new", "keep_both", "remove_both", "manual"] = (
+        Field(
+            ...,
+            description=(
+                "Resolution action: keep_old, keep_new, keep_both, remove_both, manual"
+            ),
+        )
     )
     date: str | None = Field(
         None, description="Conflict report date (YYYY-MM-DD). Defaults to today."

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1106,9 +1106,7 @@ class TestMEMANTOAPI:
         assert data["action"] == "keep_new"
 
     @pytest.mark.asyncio
-    async def test_conflicts_resolve_rejects_invalid_action(
-        self, client, auth_headers
-    ):
+    async def test_conflicts_resolve_rejects_invalid_action(self, client, auth_headers):
         """Invalid conflict actions should fail validation before business logic."""
         await client.post(
             "/api/v2/agents",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1106,36 +1106,6 @@ class TestMEMANTOAPI:
         assert data["action"] == "keep_new"
 
     @pytest.mark.asyncio
-    async def test_conflicts_resolve_rejects_invalid_action(
-        self, client, auth_headers
-    ):
-        """Invalid conflict actions should fail validation before business logic."""
-        await client.post(
-            "/api/v2/agents",
-            headers=auth_headers,
-            json={"agent_id": self.TEST_AGENT_ID},
-        )
-        activate_resp = await client.post(
-            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
-        )
-        token = activate_resp.json()["session_token"]
-        headers = {**auth_headers, "X-Session-Token": token}
-
-        with patch("memanto.app.routes.memory.DirectClient") as mock_client_cls:
-            response = await client.post(
-                f"/api/v2/agents/{self.TEST_AGENT_ID}/conflicts/resolve",
-                headers=headers,
-                json={
-                    "date": "2026-05-08",
-                    "conflict_index": 0,
-                    "action": "delete_everything",
-                },
-            )
-
-        assert response.status_code == 422
-        mock_client_cls.return_value.resolve_conflict.assert_not_called()
-
-    @pytest.mark.asyncio
     async def test_conflicts_resolve_requires_manual_content(
         self, client, auth_headers
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1106,6 +1106,36 @@ class TestMEMANTOAPI:
         assert data["action"] == "keep_new"
 
     @pytest.mark.asyncio
+    async def test_conflicts_resolve_rejects_invalid_action(
+        self, client, auth_headers
+    ):
+        """Invalid conflict actions should fail validation before business logic."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        with patch("memanto.app.routes.memory.DirectClient") as mock_client_cls:
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/conflicts/resolve",
+                headers=headers,
+                json={
+                    "date": "2026-05-08",
+                    "conflict_index": 0,
+                    "action": "delete_everything",
+                },
+            )
+
+        assert response.status_code == 422
+        mock_client_cls.return_value.resolve_conflict.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_conflicts_resolve_requires_manual_content(
         self, client, auth_headers
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1070,6 +1070,66 @@ class TestMEMANTOAPI:
         assert data["action"] == "keep_new"
 
     @pytest.mark.asyncio
+    async def test_conflicts_resolve_rejects_invalid_action(
+        self, client, auth_headers
+    ):
+        """Invalid conflict actions should fail validation before business logic."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        with patch("memanto.app.routes.memory.DirectClient") as mock_client_cls:
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/conflicts/resolve",
+                headers=headers,
+                json={
+                    "date": "2026-05-08",
+                    "conflict_index": 0,
+                    "action": "delete_everything",
+                },
+            )
+
+        assert response.status_code == 422
+        mock_client_cls.return_value.resolve_conflict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_conflicts_resolve_requires_manual_content(
+        self, client, auth_headers
+    ):
+        """Manual conflict resolution needs replacement content."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        with patch("memanto.app.routes.memory.DirectClient") as mock_client_cls:
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/conflicts/resolve",
+                headers=headers,
+                json={
+                    "date": "2026-05-08",
+                    "conflict_index": 0,
+                    "action": "manual",
+                },
+            )
+
+        assert response.status_code == 422
+        mock_client_cls.return_value.resolve_conflict.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_upload_file_with_session(self, client, auth_headers, mock_moorcheh):
         """Test file upload to agent's memory namespace"""
         # Setup agent and session

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -410,10 +410,12 @@ class TestMEMANTOArchitecture:
         print(f"   Fields: {list(payload.keys())}")
         print("   ✅ NO tenant_id in token!")
 
+
 def test_conflict_report_handles_non_object_json_items(tmp_path, monkeypatch):
     """Malformed conflict-item schemas should be preserved instead of crashing."""
     import json
     from unittest.mock import MagicMock
+
     from memanto.app.services import daily_analysis_service as module
 
     sessions_dir = tmp_path / "sessions"
@@ -440,12 +442,13 @@ def test_conflict_report_handles_non_object_json_items(tmp_path, monkeypatch):
     assert result["status"] == "success"
     assert result["conflict_count"] == 1
 
-    conflicts_path = tmp_path / ".memanto" / "conflicts" / (
-        "agent-1_2026-06-28_conflicts.json"
+    conflicts_path = (
+        tmp_path / ".memanto" / "conflicts" / ("agent-1_2026-06-28_conflicts.json")
     )
     conflicts = json.loads(conflicts_path.read_text(encoding="utf-8"))
     assert conflicts[0]["title"] == "Unparsed conflict report"
     assert conflicts[0]["description"] == '["not an object", 1]'
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary
- validate conflict resolution actions at the request-model layer
- require non-empty `manual_content` when `action` is `manual`
- add API coverage proving invalid requests return 422 and do not reach the business layer

## Root cause
`ConflictResolveRequest.action` was a free-form string even though only five actions are supported. Invalid actions and missing manual replacement content were rejected later by `DirectClient.resolve_conflict` as `ValueError`, which the route mapped to a generic 500 response instead of a client validation error.

## Validation
- `python -m pytest tests/test_api.py::TestMEMANTOAPI::test_conflicts_resolve_api tests/test_api.py::TestMEMANTOAPI::test_conflicts_resolve_rejects_invalid_action tests/test_api.py::TestMEMANTOAPI::test_conflicts_resolve_requires_manual_content -q`
- `python -m pytest tests/test_api.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened conflict resolution validation so only supported resolution actions are accepted.
  * Manual conflict resolution now requires replacement content and rejects blank submissions.
  * Invalid conflict resolution requests return clear validation errors before any processing occurs.
* **Tests**
  * Added a contract test for resolving conflicts with `action="manual"` when required content is missing, verifying a `422` response and no further handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->