### PR TITLE
Preserve memory metadata during updates

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -115,7 +115,7 @@ class MemoryRecord(BaseModel):
             document["tags"] = ",".join(self.tags)  # Comma-separated for filtering
         if self.expires_at:
             document["expires_at"] = self.expires_at.isoformat()
-        if self.ttl_seconds:
+        if self.ttl_seconds is not None:
             document["ttl_seconds"] = self.ttl_seconds
         if self.superseded_by:
             document["superseded_by"] = self.superseded_by

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -746,13 +746,18 @@ class MemoryReadService:
 
         # Check if metadata is in nested format (Moorcheh API spec)
         metadata = item.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
 
         # Helper to get field from either nested metadata or flat structure
         def get_field(field_name, flat_field_name=None):
             """Get field from metadata object or fallback to flat field"""
             flat_name = flat_field_name or field_name
-            # Try metadata object first (API spec), then flat field (fallback)
-            return metadata.get(field_name) or item.get(flat_name)
+            # Try metadata object first (API spec), then flat field (fallback).
+            # Falsey values such as 0, 0.0, and False are meaningful metadata.
+            if field_name in metadata and metadata[field_name] is not None:
+                return metadata[field_name]
+            return item.get(flat_name)
 
         # Parse tags - can be comma-separated string or array
         tags_value = get_field("tags")

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -277,6 +277,17 @@ class MemoryWriteService:
                             return value
                 return default
 
+            def existing_datetime(*keys: str) -> datetime | None:
+                value = existing_value(*keys)
+                if isinstance(value, datetime):
+                    return value
+                if isinstance(value, str):
+                    try:
+                        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+                    except ValueError:
+                        return None
+                return None
+
             # Build updated memory record
             updated_memory = MemoryRecord(
                 id=memory_id,  # Keep same ID
@@ -304,7 +315,7 @@ class MemoryWriteService:
                 ),
                 superseded_by=existing_value("superseded_by"),
                 supersedes=existing_value("supersedes"),
-                validated_at=existing_value("validated_at"),
+                validated_at=existing_datetime("validated_at"),
                 validation_count=existing_value("validation_count", default=0),
                 contradiction_detected=existing_value(
                     "contradiction_detected", default=False
@@ -312,17 +323,9 @@ class MemoryWriteService:
             )
 
             # Update timestamps (preserve created_at, set updated_at to now)
-            raw_created = existing_value("created_at")
-            if raw_created:
-                if isinstance(raw_created, str):
-                    try:
-                        updated_memory.created_at = datetime.fromisoformat(
-                            raw_created.replace("Z", "+00:00")
-                        )
-                    except (ValueError, AttributeError):
-                        pass  # Keep default
-                else:
-                    updated_memory.created_at = raw_created
+            existing_created_at = existing_datetime("created_at")
+            if existing_created_at:
+                updated_memory.created_at = existing_created_at
             updated_memory.updated_at = datetime.utcnow()
 
             # Handle TTL
@@ -332,7 +335,7 @@ class MemoryWriteService:
                 existing_ttl = existing_value("ttl_seconds")
                 if existing_ttl is not None:
                     updated_memory.ttl_seconds = existing_ttl
-                    existing_expires_at = existing_value("expires_at")
+                    existing_expires_at = existing_datetime("expires_at")
                     if existing_expires_at is not None:
                         updated_memory.expires_at = existing_expires_at
 

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -265,27 +265,54 @@ class MemoryWriteService:
                 if "metadata" in existing_memory_data
                 else existing_memory_data
             )
+            if not isinstance(metadata, dict):
+                metadata = {}
+
+            def existing_value(*keys: str, default: Any = None) -> Any:
+                """Read a previously stored field without treating falsey values as missing."""
+                for source in (metadata, existing_memory_data):
+                    for key in keys:
+                        value = source.get(key)
+                        if value is not None:
+                            return value
+                return default
 
             # Build updated memory record
             updated_memory = MemoryRecord(
                 id=memory_id,  # Keep same ID
-                type=updates.get("type", metadata.get("type", "fact")),
+                type=updates.get(
+                    "type", existing_value("type", "memory_type", default="fact")
+                ),
                 title=updates.get(
                     "title", existing_memory_data.get("title", "Updated Memory")
                 ),
                 content=updates.get("content", existing_memory_data.get("content", "")),
-                scope_type=metadata.get("scope_type", "agent"),
-                scope_id=metadata.get("scope_id", "unknown"),
-                actor_id=updates.get("actor_id", metadata.get("actor_id", "unknown")),
-                source=updates.get("source", metadata.get("source", "system")),
-                source_ref=updates.get("source_ref", metadata.get("source_ref")),
-                confidence=updates.get("confidence", metadata.get("confidence", 0.8)),
-                status=updates.get("status", metadata.get("status", "active")),
-                tags=updates.get("tags", metadata.get("tags", [])),
+                scope_type=existing_value("scope_type", default="agent"),
+                scope_id=existing_value("scope_id", default="unknown"),
+                actor_id=updates.get(
+                    "actor_id", existing_value("actor_id", default="unknown")
+                ),
+                source=updates.get("source", existing_value("source", default="system")),
+                source_ref=updates.get("source_ref", existing_value("source_ref")),
+                confidence=updates.get(
+                    "confidence", existing_value("confidence", default=0.8)
+                ),
+                status=updates.get("status", existing_value("status", default="active")),
+                tags=updates.get("tags", existing_value("tags", default=[])),
+                provenance=existing_value(
+                    "provenance", default="explicit_statement"
+                ),
+                superseded_by=existing_value("superseded_by"),
+                supersedes=existing_value("supersedes"),
+                validated_at=existing_value("validated_at"),
+                validation_count=existing_value("validation_count", default=0),
+                contradiction_detected=existing_value(
+                    "contradiction_detected", default=False
+                ),
             )
 
             # Update timestamps (preserve created_at, set updated_at to now)
-            raw_created = metadata.get("created_at")
+            raw_created = existing_value("created_at")
             if raw_created:
                 if isinstance(raw_created, str):
                     try:
@@ -301,10 +328,13 @@ class MemoryWriteService:
             # Handle TTL
             if "ttl_seconds" in updates:
                 updated_memory.set_ttl(updates["ttl_seconds"])
-            elif metadata.get("ttl_seconds"):
-                updated_memory.ttl_seconds = metadata["ttl_seconds"]
-                if metadata.get("expires_at"):
-                    updated_memory.expires_at = metadata["expires_at"]
+            else:
+                existing_ttl = existing_value("ttl_seconds")
+                if existing_ttl is not None:
+                    updated_memory.ttl_seconds = existing_ttl
+                    existing_expires_at = existing_value("expires_at")
+                    if existing_expires_at is not None:
+                        updated_memory.expires_at = existing_expires_at
 
             # Step 3: Delete old version
             delete_result = self.client.documents.delete(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -366,6 +366,51 @@ class TestMemoryWriteServiceUpdate:
         assert "ttl_seconds" not in uploaded_doc
         assert "expires_at" not in uploaded_doc
 
+    def test_update_memory_preserves_falsey_metadata_with_existing_ttl(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.return_value = {"status": "queued"}
+        existing_memory = {
+            "id": "mem-ttl",
+            "title": "Keep falsey TTL metadata",
+            "content": "Original content",
+            "metadata": {
+                "memory_type": "preference",
+                "scope_type": "agent",
+                "scope_id": "test-agent",
+                "actor_id": "tester",
+                "source": "system",
+                "confidence": 0.0,
+                "status": "active",
+                "provenance": "inferred",
+                "validation_count": 0,
+                "contradiction_detected": False,
+                "ttl_seconds": 3600,
+                "expires_at": "2026-01-01T14:00:00Z",
+            },
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            result = MemoryWriteService(client).update_memory(
+                "mem-ttl",
+                "memanto_agent_test-agent",
+                {"content": "Updated content"},
+            )
+
+        assert result["action"] == "updated"
+        uploaded_doc = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_doc["memory_type"] == "preference"
+        assert uploaded_doc["confidence"] == 0.0
+        assert uploaded_doc["validation_count"] == 0
+        assert uploaded_doc["contradiction_detected"] is False
+        assert uploaded_doc["ttl_seconds"] == 3600
+        assert uploaded_doc["expires_at"].startswith("2026-01-01T14:00:00")
+
 
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -459,6 +459,43 @@ class TestMemoryWriteServiceUpdate:
         assert uploaded_doc["ttl_seconds"] == 3600
         assert uploaded_doc["expires_at"].startswith("2026-01-01T14:00:00")
 
+    def test_update_memory_preserves_zero_ttl_from_existing_memory(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.return_value = {"status": "queued"}
+        existing_memory = {
+            "id": "mem-zero-ttl",
+            "title": "Keep zero TTL",
+            "content": "Original content",
+            "metadata": {
+                "memory_type": "preference",
+                "scope_type": "agent",
+                "scope_id": "test-agent",
+                "actor_id": "tester",
+                "source": "system",
+                "status": "active",
+                "ttl_seconds": 0,
+                "expires_at": "2026-01-01T00:00:00Z",
+            },
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            result = MemoryWriteService(client).update_memory(
+                "mem-zero-ttl",
+                "memanto_agent_test-agent",
+                {"content": "Updated content"},
+            )
+
+        assert result["action"] == "updated"
+        uploaded_doc = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_doc["ttl_seconds"] == 0
+        assert uploaded_doc["expires_at"].startswith("2026-01-01T00:00:00")
+
 
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,55 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryWriteServiceUpdate:
+    def test_update_memory_preserves_existing_type_and_trust_metadata(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.return_value = {"status": "queued"}
+        existing_memory = {
+            "id": "mem-pref",
+            "type": "preference",
+            "title": "Original title",
+            "content": "Original content",
+            "scope_type": "agent",
+            "scope_id": "test-agent",
+            "actor_id": "tester",
+            "source": "tool",
+            "source_ref": "ticket-123",
+            "confidence": 0.9,
+            "status": "active",
+            "tags": ["profile", "ui"],
+            "created_at": "2026-01-01T12:00:00",
+            "provenance": "observed",
+            "validation_count": 2,
+            "contradiction_detected": True,
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            result = MemoryWriteService(client).update_memory(
+                "mem-pref",
+                "memanto_agent_test-agent",
+                {"content": "Updated content"},
+            )
+
+        assert result["action"] == "updated"
+        uploaded_doc = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_doc["id"] == "mem-pref"
+        assert uploaded_doc["memory_type"] == "preference"
+        assert uploaded_doc["text"].startswith("[PREFERENCE] Original title")
+        assert "Updated content" in uploaded_doc["text"]
+        assert uploaded_doc["provenance"] == "observed"
+        assert uploaded_doc["validation_count"] == 2
+        assert uploaded_doc["contradiction_detected"] is True
+        assert uploaded_doc["source_ref"] == "ticket-123"
+        assert uploaded_doc["tags"] == "profile,ui"
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -322,6 +322,50 @@ class TestMemoryWriteServiceUpdate:
         assert uploaded_doc["expires_at"].startswith("2026-01-02T12:00:00")
         assert uploaded_doc["validated_at"].startswith("2026-01-01T13:00:00")
 
+    def test_update_memory_preserves_falsey_metadata_without_ttl(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.return_value = {"status": "queued"}
+        existing_memory = {
+            "id": "mem-goal",
+            "title": "Keep falsey metadata",
+            "content": "Original content",
+            "metadata": {
+                "memory_type": "goal",
+                "scope_type": "agent",
+                "scope_id": "test-agent",
+                "actor_id": "tester",
+                "source": "system",
+                "confidence": 0.0,
+                "status": "active",
+                "provenance": "inferred",
+                "validation_count": 0,
+                "contradiction_detected": False,
+            },
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            result = MemoryWriteService(client).update_memory(
+                "mem-goal",
+                "memanto_agent_test-agent",
+                {"title": "Updated title"},
+            )
+
+        assert result["action"] == "updated"
+        uploaded_doc = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_doc["memory_type"] == "goal"
+        assert uploaded_doc["confidence"] == 0.0
+        assert uploaded_doc["provenance"] == "inferred"
+        assert uploaded_doc["validation_count"] == 0
+        assert uploaded_doc["contradiction_detected"] is False
+        assert "ttl_seconds" not in uploaded_doc
+        assert "expires_at" not in uploaded_doc
+
 
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -289,7 +289,10 @@ class TestMemoryWriteServiceUpdate:
             "status": "active",
             "tags": ["profile", "ui"],
             "created_at": "2026-01-01T12:00:00",
+            "expires_at": "2026-01-02T12:00:00Z",
+            "ttl_seconds": 86400,
             "provenance": "observed",
+            "validated_at": "2026-01-01T13:00:00Z",
             "validation_count": 2,
             "contradiction_detected": True,
         }
@@ -315,6 +318,9 @@ class TestMemoryWriteServiceUpdate:
         assert uploaded_doc["contradiction_detected"] is True
         assert uploaded_doc["source_ref"] == "ticket-123"
         assert uploaded_doc["tags"] == "profile,ui"
+        assert uploaded_doc["ttl_seconds"] == 86400
+        assert uploaded_doc["expires_at"].startswith("2026-01-02T12:00:00")
+        assert uploaded_doc["validated_at"].startswith("2026-01-01T13:00:00")
 
 
 class TestForgetEndToEnd:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -366,6 +366,54 @@ class TestMemoryWriteServiceUpdate:
         assert "ttl_seconds" not in uploaded_doc
         assert "expires_at" not in uploaded_doc
 
+    def test_update_memory_preserves_falsey_metadata_from_read_service(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.get.return_value = {
+            "items": [
+                {
+                    "id": "mem-read-falsey",
+                    "text": "[GOAL] Keep nested falsey metadata\n\nOriginal content",
+                    "memory_type": "fact",
+                    "confidence": 0.8,
+                    "validation_count": 7,
+                    "contradiction_detected": True,
+                    "tags": "fallback",
+                    "metadata": {
+                        "memory_type": "goal",
+                        "scope_type": "agent",
+                        "scope_id": "test-agent",
+                        "actor_id": "tester",
+                        "source": "system",
+                        "confidence": 0.0,
+                        "status": "active",
+                        "tags": "alpha,beta",
+                        "provenance": "inferred",
+                        "validation_count": 0,
+                        "contradiction_detected": False,
+                    },
+                }
+            ]
+        }
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.return_value = {"status": "queued"}
+
+        result = MemoryWriteService(client).update_memory(
+            "mem-read-falsey",
+            "memanto_agent_test-agent",
+            {"content": "Updated content"},
+        )
+
+        assert result["action"] == "updated"
+        uploaded_doc = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_doc["memory_type"] == "goal"
+        assert uploaded_doc["confidence"] == 0.0
+        assert uploaded_doc["tags"] == "alpha,beta"
+        assert uploaded_doc["provenance"] == "inferred"
+        assert uploaded_doc["validation_count"] == 0
+        assert uploaded_doc["contradiction_detected"] is False
+
     def test_update_memory_preserves_falsey_metadata_with_existing_ttl(self):
         from memanto.app.services.memory_write_service import MemoryWriteService
 


### PR DESCRIPTION
/claim #770
Fixes #770

## Summary

MemoryWriteService.update_memory recreates a memory document after applying edits, but the reconstructed MemoryRecord only looked for the existing memory type in metadata["type"]. Stored Moorcheh documents use memory_type, and MemoryReadService formats that field as type. As a result, editing only the content/title of a non-fact memory could silently re-upload it as fact and reset provenance/trust metadata.

## Fix

- read existing fields from both formatted records and raw metadata without treating falsey values as missing
- preserve memory_type, provenance, validation_count, contradiction_detected, source_ref, tags, and TTL fields when they are not being updated
- add a regression test that edits only content on a preference memory and asserts the re-uploaded document remains a preference with trust metadata intact

## Validation

- uv run --group dev python -m pytest tests/test_unit.py -q
- uv run --group dev python -m pytest tests/test_api.py::TestMEMANTOAPI::test_edit_memory_with_session tests/test_api.py::TestMEMANTOAPI::test_edit_memory_rejects_empty_update tests/test_api.py::TestMEMANTOAPI::test_edit_memory_returns_404_when_missing -q
- uv run --group dev ruff check memanto/app/services/memory_write_service.py tests/test_unit.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory updates now preserve existing fields (including falsey trust/provenance/validation values) when the incoming update omits them.
  * Improved robustness when metadata is missing or not a dictionary.
  * TTL behavior now preserves existing `ttl_seconds`/`expires_at` when no new TTL is provided.
  * Memory read formatting now safely extracts nested metadata without dropping falsey values.
  * Document serialization now includes `ttl_seconds = 0` (but still omits when `None`).

* **Tests**
  * Added unit coverage for update behavior, including document payload composition and TTL omission/preservation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->