### PR TITLE
Normalize parsed timestamps to UTC

### DIFF
--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -26,7 +26,7 @@ def parse_iso_timestamp(ts_str: str) -> datetime:
 
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    return dt
+    return dt.astimezone(timezone.utc)
 
 
 def format_local_time(ts) -> str:

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -1,0 +1,17 @@
+from datetime import timezone
+
+from memanto.app.utils.temporal_helpers import parse_iso_timestamp
+
+
+def test_parse_iso_timestamp_normalizes_offset_to_utc():
+    parsed = parse_iso_timestamp("2026-01-15T08:30:00-05:00")
+
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"
+
+
+def test_parse_iso_timestamp_assumes_naive_values_are_utc():
+    parsed = parse_iso_timestamp("2026-01-15T13:30:00")
+
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"


### PR DESCRIPTION
## Summary
- Normalize ISO timestamps with non-UTC offsets to UTC in `parse_iso_timestamp`.
- Preserve existing behavior that treats naive timestamps as UTC.
- Add regression tests for offset and naive timestamp parsing.

## Bug / Impact
`parse_iso_timestamp()` documents that it returns an aware UTC datetime, but offset inputs such as `2026-01-15T08:30:00-05:00` previously kept their original timezone. That can make temporal recall/timeline comparisons inconsistent when memories arrive with mixed offsets.

## Tests
- `.venv/bin/python -m pytest tests/test_temporal_helpers.py -q`
- `.venv/bin/python -m pytest tests/test_unit.py -q`

Fixes #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ISO timestamps are now consistently normalized to UTC.
  * Timestamps with an explicit timezone offset are converted to `+00:00`.
  * Timestamp strings without a timezone are treated as UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->