### PR TITLE
fix(ts): encode agent ids in REST paths

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -135,6 +135,7 @@ interface SessionRecord {
 export class Memanto {
   private readonly lifecycle: ServerLifecycle;
   private readonly agentId: string;
+  private readonly encodedAgentId: string;
   private readonly autoCreate: boolean;
   private sessionToken: string | null = null;
   private starting: Promise<void> | null = null;
@@ -142,6 +143,7 @@ export class Memanto {
   constructor(opts: MemantoOptions) {
     if (!opts.agentId) throw new Error("Memanto: agentId is required");
     this.agentId = opts.agentId;
+    this.encodedAgentId = encodeURIComponent(opts.agentId);
     this.autoCreate = opts.autoCreate ?? true;
     this.lifecycle = new ServerLifecycle(opts);
   }
@@ -151,7 +153,7 @@ export class Memanto {
   // ---------------------------------------------------------------------------
 
   async remember(input: RememberInput) {
-    return this.request("POST", `/api/v2/agents/${this.agentId}/remember`, {
+    return this.request("POST", `/api/v2/agents/${this.encodedAgentId}/remember`, {
       content: input.content,
       type: input.type,
       title: input.title,
@@ -165,7 +167,7 @@ export class Memanto {
   async batchRemember(items: BatchRememberItem[]) {
     return this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/batch-remember`,
+      `/api/v2/agents/${this.encodedAgentId}/batch-remember`,
       {
         memories: items.map((m) => ({
           content: m.content,
@@ -183,7 +185,7 @@ export class Memanto {
   async extractMemories(input: ExtractMemoriesInput) {
     return this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/remember/extract`,
+      `/api/v2/agents/${this.encodedAgentId}/remember/extract`,
       {
         messages: input.messages,
         dry_run: input.dryRun,
@@ -196,7 +198,7 @@ export class Memanto {
   async deleteMemory(memoryId: string) {
     return this.request(
       "DELETE",
-      `/api/v2/agents/${this.agentId}/memories/${encodeURIComponent(memoryId)}`,
+      `/api/v2/agents/${this.encodedAgentId}/memories/${encodeURIComponent(memoryId)}`,
     );
   }
 
@@ -207,7 +209,7 @@ export class Memanto {
     const blob = new Blob([new Uint8Array(bytes)]);
     form.append("file", blob, input.filename ?? basename(input.path));
     return this.requestMultipart(
-      `/api/v2/agents/${this.agentId}/upload-file`,
+      `/api/v2/agents/${this.encodedAgentId}/upload-file`,
       form,
     );
   }
@@ -217,7 +219,7 @@ export class Memanto {
   // ---------------------------------------------------------------------------
 
   async recall(input: RecallInput) {
-    return this.request("POST", `/api/v2/agents/${this.agentId}/recall`, {
+    return this.request("POST", `/api/v2/agents/${this.encodedAgentId}/recall`, {
       query: input.query,
       limit: input.limit,
       min_similarity: input.minSimilarity,
@@ -228,7 +230,7 @@ export class Memanto {
   async recallAsOf(input: RecallAsOfInput) {
     return this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/recall/as-of`,
+      `/api/v2/agents/${this.encodedAgentId}/recall/as-of`,
       { as_of: input.asOf, limit: input.limit, type: input.type },
     );
   }
@@ -236,7 +238,7 @@ export class Memanto {
   async recallChangedSince(input: RecallChangedSinceInput) {
     return this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/recall/changed-since`,
+      `/api/v2/agents/${this.encodedAgentId}/recall/changed-since`,
       { since: input.since, limit: input.limit, type: input.type },
     );
   }
@@ -244,13 +246,13 @@ export class Memanto {
   async recallRecent(input: RecallRecentInput = {}) {
     return this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/recall/recent`,
+      `/api/v2/agents/${this.encodedAgentId}/recall/recent`,
       { limit: input.limit, type: input.type },
     );
   }
 
   async answer(input: AnswerInput) {
-    return this.request("POST", `/api/v2/agents/${this.agentId}/answer`, {
+    return this.request("POST", `/api/v2/agents/${this.encodedAgentId}/answer`, {
       question: input.question,
       limit: input.limit,
       threshold: input.threshold,
@@ -267,7 +269,7 @@ export class Memanto {
   async dailySummary(input: DailySummaryInput = {}) {
     return this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/daily-summary`,
+      `/api/v2/agents/${this.encodedAgentId}/daily-summary`,
       { date: input.date, output_path: input.outputPath },
     );
   }
@@ -275,7 +277,7 @@ export class Memanto {
   async generateConflicts(input: ConflictDateInput = {}) {
     return this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/conflicts/generate`,
+      `/api/v2/agents/${this.encodedAgentId}/conflicts/generate`,
       { date: input.date },
     );
   }
@@ -284,14 +286,14 @@ export class Memanto {
     const qs = input.date ? `?date=${encodeURIComponent(input.date)}` : "";
     return this.request(
       "GET",
-      `/api/v2/agents/${this.agentId}/conflicts${qs}`,
+      `/api/v2/agents/${this.encodedAgentId}/conflicts${qs}`,
     );
   }
 
   async resolveConflict(input: ResolveConflictInput) {
     return this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/conflicts/resolve`,
+      `/api/v2/agents/${this.encodedAgentId}/conflicts/resolve`,
       {
         conflict_index: input.conflictIndex,
         action: input.action,
@@ -313,7 +315,7 @@ export class Memanto {
   }
 
   async getAgent() {
-    return this.request("GET", `/api/v2/agents/${this.agentId}`, undefined, {
+    return this.request("GET", `/api/v2/agents/${this.encodedAgentId}`, undefined, {
       requireSession: false,
     });
   }
@@ -335,7 +337,7 @@ export class Memanto {
   }
 
   async deleteAgent() {
-    return this.request("DELETE", `/api/v2/agents/${this.agentId}`, undefined, {
+    return this.request("DELETE", `/api/v2/agents/${this.encodedAgentId}`, undefined, {
       requireSession: false,
     });
   }
@@ -343,7 +345,7 @@ export class Memanto {
   async deactivate() {
     const result = await this.request(
       "POST",
-      `/api/v2/agents/${this.agentId}/deactivate`,
+      `/api/v2/agents/${this.encodedAgentId}/deactivate`,
     );
     this.sessionToken = null;
     this.starting = null;
@@ -387,7 +389,7 @@ export class Memanto {
 
   private async createAgentIfMissing(): Promise<void> {
     const baseUrl = this.lifecycle.baseUrl;
-    const res = await fetch(`${baseUrl}/api/v2/agents/${this.agentId}`);
+    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}`);
     if (res.ok) return;
     if (res.status !== 404) {
       throw await asError(res, "Failed to look up agent");
@@ -404,7 +406,7 @@ export class Memanto {
 
   private async activate(): Promise<void> {
     const baseUrl = this.lifecycle.baseUrl;
-    const res = await fetch(`${baseUrl}/api/v2/agents/${this.agentId}/activate`, {
+    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}/activate`, {
       method: "POST",
     });
     if (!res.ok) throw await asError(res, "Failed to activate agent");

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -10,11 +10,12 @@ interface Recorded {
   body: string;
 }
 
-function startFakeApi(): Promise<{
+function startFakeApi(agentId = "test-agent"): Promise<{
   url: string;
   recorded: Recorded[];
   close: () => void;
 }> {
+  const encodedAgentId = encodeURIComponent(agentId);
   return new Promise((resolve) => {
     const recorded: Recorded[] = [];
     const srv: Server = createServer((req, res) => {
@@ -33,10 +34,10 @@ function startFakeApi(): Promise<{
         };
 
         if (url === "/health") return reply(200, { status: "ok" });
-        if (url.startsWith("/api/v2/agents/test-agent/activate"))
+        if (url.startsWith(`/api/v2/agents/${encodedAgentId}/activate`))
           return reply(200, {
             session_token: "fake-token",
-            agent_id: "test-agent",
+            agent_id: agentId,
             session_id: "sess-1",
             namespace: "memanto_agent_test_agent",
             started_at: new Date().toISOString(),
@@ -44,14 +45,14 @@ function startFakeApi(): Promise<{
             status: "active",
             pattern: "default",
           });
-        if (url === "/api/v2/agents/test-agent" && req.method === "GET")
+        if (url === `/api/v2/agents/${encodedAgentId}` && req.method === "GET")
           return reply(404, { detail: "not found" });
         if (url === "/api/v2/agents" && req.method === "POST")
-          return reply(201, { agent_id: "test-agent" });
-        if (url === "/api/v2/agents/test-agent/remember")
+          return reply(201, { agent_id: agentId });
+        if (url === `/api/v2/agents/${encodedAgentId}/remember`)
           return reply(200, {
             memory_id: "mem-1",
-            agent_id: "test-agent",
+            agent_id: agentId,
             session_id: "sess-1",
             namespace: "memanto_agent_test_agent",
             status: "queued",
@@ -59,9 +60,9 @@ function startFakeApi(): Promise<{
             confidence: 0.9,
             type: "fact",
           });
-        if (url === "/api/v2/agents/test-agent/recall")
+        if (url === `/api/v2/agents/${encodedAgentId}/recall`)
           return reply(200, {
-            agent_id: "test-agent",
+            agent_id: agentId,
             session_id: "sess-1",
             query: "anything",
             memories: [],
@@ -126,5 +127,32 @@ describe("Memanto", () => {
 
   it("rejects empty agentId", () => {
     expect(() => new Memanto({ agentId: "" })).toThrow(/agentId is required/);
+  });
+
+  it("percent-encodes agentId in URL path segments", async () => {
+    const agentId = "team/alpha?mode=prod#frag";
+    const api = await startFakeApi(agentId);
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId, baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    await m.remember({ content: "Scoped agent ids must stay in one path segment" });
+
+    const encodedAgentId = encodeURIComponent(agentId);
+    expect(api.recorded.map((r) => r.url)).toContain(
+      `/api/v2/agents/${encodedAgentId}`,
+    );
+    expect(api.recorded.map((r) => r.url)).toContain(
+      `/api/v2/agents/${encodedAgentId}/activate`,
+    );
+    expect(api.recorded.map((r) => r.url)).toContain(
+      `/api/v2/agents/${encodedAgentId}/remember`,
+    );
+
+    const create = api.recorded.find(
+      (r) => r.method === "POST" && r.url === "/api/v2/agents",
+    );
+    expect(JSON.parse(create?.body ?? "{}")).toMatchObject({ agent_id: agentId });
   });
 });


### PR DESCRIPTION
## Summary
- percent-encode the TypeScript SDK agent id before inserting it into REST URL path segments
- keep the raw `agent_id` in create-agent JSON payloads
- add a regression test for agent IDs containing `/`, `?`, and `#`

## Bug / Impact
The TypeScript SDK interpolated `agentId` directly into paths such as `/api/v2/agents/${agentId}/remember`. Agent IDs containing reserved URL characters were split into extra path segments or query/fragment syntax, causing setup and recall/remember calls to hit the wrong route. In scoped memory workflows this is a usability and integrity issue: a valid logical agent id cannot reliably address its own memory namespace through the SDK.

Related to #770.

## Validation
- `npm test -- --run`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-specific API calls now safely handle special characters in agent IDs by encoding them in request URLs.
  * Added test coverage for agent IDs that require URL encoding.

* **Bug Fixes**
  * Fixed requests to agent memory, analysis, recall, and lifecycle endpoints so they use the correct encoded path segments.
  * Preserves the original agent ID when sending it in request bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->