### PR TITLE
fix upload file size fallback

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -573,12 +573,16 @@ async def upload_file(
 
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
+        file_size = result.get("fileSize")
+        if file_size is None:
+            file_size = result.get("file_size")
+
         return {
             "agent_id": agent_id,
             "session_id": session.session_id,
             "namespace": namespace,
             "file_name": original_name,
-            "file_size": result.get("fileSize"),
+            "file_size": file_size,
             "status": "uploaded" if result.get("success") else "failed",
             "message": result.get("message", ""),
         }

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -798,14 +798,17 @@ class SdkClient:
             namespace_name=namespace,
             file_path=path,
         )
+        file_size = result.get("fileSize")
+        if file_size is None:
+            file_size = result.get("file_size", 0)
 
         return {
             "agent_id": agent_id,
             "namespace": namespace,
             "success": result.get("success", False),
             "message": result.get("message", ""),
-            "file_name": result.get("fileName", path.name),
-            "file_size": result.get("fileSize", 0),
+            "file_name": result.get("fileName") or result.get("file_name", path.name),
+            "file_size": file_size,
         }
 
     def recall(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1104,7 +1104,42 @@ class TestMEMANTOAPI:
         data = response.json()
         assert data["agent_id"] == self.TEST_AGENT_ID
         assert data["file_name"] == "notes.txt"
+        assert data["file_size"] == 1024
         assert data["status"] == "uploaded"
+
+    @pytest.mark.asyncio
+    async def test_upload_file_accepts_snake_case_file_size(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """On-prem upload adapter returns file_size instead of fileSize."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        mock_moorcheh.documents.upload_file.return_value = {
+            "success": True,
+            "message": "File uploaded successfully",
+            "file_name": "notes.txt",
+            "file_size": 2048,
+        }
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+            headers=headers,
+            files={"file": ("notes.txt", b"on-prem payload", "text/plain")},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["file_name"] == "notes.txt"
+        assert data["file_size"] == 2048
 
     @pytest.mark.asyncio
     async def test_upload_file_unsupported_extension(self, client, auth_headers):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -441,6 +441,41 @@ class TestMEMANTOCLI:
         assert forwarded_updates["tags"] == ["a", "b"]
         assert result["status"] == "updated"
 
+    def test_upload_file_sdk_accepts_snake_case_file_size(
+        self, tmp_path, mock_all_clients
+    ):
+        """SdkClient.upload_file must preserve on-prem file_size metadata."""
+        from unittest.mock import MagicMock, patch
+
+        from memanto.cli.client.sdk_client import SdkClient
+
+        upload_path = tmp_path / "notes.txt"
+        upload_path.write_text("on-prem payload", encoding="utf-8")
+
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+
+        mock_moorcheh = MagicMock()
+        mock_moorcheh.documents.upload_file.return_value = {
+            "success": True,
+            "message": "File uploaded successfully",
+            "file_name": "notes.txt",
+            "file_size": 2048,
+        }
+
+        with (
+            patch.object(
+                SdkClient, "_get_validated_session_for_agent", return_value=mock_session
+            ),
+            patch.object(SdkClient, "_get_moorcheh", return_value=mock_moorcheh),
+        ):
+            client = SdkClient.__new__(SdkClient)
+            client.api_key = "test-api-key"
+            result = client.upload_file("test-agent", str(upload_path))
+
+        assert result["file_name"] == "notes.txt"
+        assert result["file_size"] == 2048
+
     def test_recall(self, mock_all_clients):
         """Test 'memanto recall'"""
         mock_all_clients.recall.return_value = {


### PR DESCRIPTION
## Summary

Fixes an upload response mismatch between the cloud SDK shape and the on-prem adapter shape.

The REST upload endpoint and `SdkClient.upload_file()` only read camelCase `fileSize`, but the on-prem adapter returns snake_case `file_size`. As a result, successful on-prem uploads can report `file_size: null` through the API and `file_size: 0` through the SDK even when the backend returned the real byte size.

## Reproduction

API path:

1. Mock `documents.upload_file()` to return:

   ```python
   {
       "success": True,
       "message": "File uploaded successfully",
       "file_name": "notes.txt",
       "file_size": 2048,
   }
   ```

2. POST a valid `.txt` file to `/api/v2/agents/{agent_id}/upload-file`.
3. Before this change, the response had `file_size: null`.

SDK path:

1. Mock the backend-aware Moorcheh client to return the same snake_case upload response.
2. Call `SdkClient.upload_file(...)`.
3. Before this change, the result had `file_size: 0`.

## Fix

- Preserve camelCase `fileSize` for the cloud SDK response shape.
- Fall back to snake_case `file_size` for the on-prem adapter response shape.
- Apply the fallback in both the REST route and the SDK client.
- Add regression coverage for both response shapes.

## Tests

```bash
.venv/bin/python -m pytest tests/test_api.py::TestMEMANTOAPI::test_upload_file_with_session tests/test_api.py::TestMEMANTOAPI::test_upload_file_accepts_snake_case_file_size tests/test_cli.py::TestMEMANTOCLI::test_upload_file_sdk_accepts_snake_case_file_size -q
.venv/bin/python -m pytest tests/test_api.py -k upload_file -q
.venv/bin/python -m ruff check memanto/app/routes/memory.py memanto/cli/client/sdk_client.py tests/test_api.py tests/test_cli.py
git diff --check
```

Refs #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload responses to consistently return the correct file name and file size, even when the upstream service uses different key names.
  * Added support for snake_case file size values in both the API and CLI upload flows.

* **Tests**
  * Expanded upload test coverage to verify file size and status values.
  * Added new tests for upload responses that use snake_case metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->