### PR TITLE
reject blank memory content

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,9 +5,15 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from memanto.app.constants import MemoryType, ScopeType, SourceType, StatusType
+
+
+def _validate_non_blank_content(value: str) -> str:
+    if not value.strip():
+        raise ValueError("Memory content must be a non-empty string")
+    return value
 
 
 # Request Models
@@ -27,6 +33,11 @@ class MemoryStoreRequest(BaseModel):
     ttl_seconds: int | None = None
     user_confirmed: bool = False
 
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, value: str) -> str:
+        return _validate_non_blank_content(value)
+
 
 class MemoryBatchItem(BaseModel):
     """Single memory item for batch write"""
@@ -40,6 +51,11 @@ class MemoryBatchItem(BaseModel):
     tags: list[str] = Field(default_factory=list)
     ttl_seconds: int | None = None
     id: str | None = None  # Optional custom ID
+
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, value: str) -> str:
+        return _validate_non_blank_content(value)
 
 
 class MemoryBatchWriteRequest(BaseModel):
@@ -72,6 +88,11 @@ class BatchRememberItem(BaseModel):
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",
     )
+
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, value: str) -> str:
+        return _validate_non_blank_content(value)
 
 
 class RememberRequest(BatchRememberItem):

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -11,6 +11,7 @@ from memanto.app.constants import MemoryType, ScopeType, SourceType, StatusType
 
 
 def _validate_non_blank_content(value: str) -> str:
+    """Reject whitespace-only memory content before it reaches storage."""
     if not value.strip():
         raise ValueError("Memory content must be a non-empty string")
     return value
@@ -36,6 +37,7 @@ class MemoryStoreRequest(BaseModel):
     @field_validator("content")
     @classmethod
     def validate_content(cls, value: str) -> str:
+        """Ensure stored memories contain useful non-blank content."""
         return _validate_non_blank_content(value)
 
 
@@ -55,6 +57,7 @@ class MemoryBatchItem(BaseModel):
     @field_validator("content")
     @classmethod
     def validate_content(cls, value: str) -> str:
+        """Ensure batch memory items contain useful non-blank content."""
         return _validate_non_blank_content(value)
 
 
@@ -92,6 +95,7 @@ class BatchRememberItem(BaseModel):
     @field_validator("content")
     @classmethod
     def validate_content(cls, value: str) -> str:
+        """Ensure session memory writes contain useful non-blank content."""
         return _validate_non_blank_content(value)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -673,6 +673,31 @@ class TestMEMANTOAPI:
         assert uploaded_doc["memory_type"] == "preference"
 
     @pytest.mark.asyncio
+    async def test_remember_rejects_blank_content(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Blank memories should not be accepted into the memory store."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=headers,
+            json={"content": "   "},
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_global_status_no_active_session(self, client):
         """Test GET /api/v2/status returns 404 when no session is active"""
         response = await client.get("/api/v2/status")
@@ -708,6 +733,31 @@ class TestMEMANTOAPI:
         )
         assert response.status_code == 200
         assert response.json()["successful"] == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_remember_rejects_blank_content(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Batch memory writes should reject blank items before storage."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/batch-remember",
+            headers=headers,
+            json={"memories": [{"content": "   "}]},
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_memory_with_session(


### PR DESCRIPTION
## Summary

Reject blank memory content before it reaches the memory write path.

The CLI clients already validate that memory content is non-empty, but the API request models accepted whitespace-only strings for `remember` and `batch-remember`. That allowed empty memory cards to be stored, which degrades memory quality and can pollute retrieval results with meaningless records.

## Reproduction

Single-memory path:

1. Activate an agent session.
2. POST to `/api/v2/agents/{agent_id}/remember` with:

   ```json
   { "content": "   " }
   ```

3. Before this change, the endpoint returned `200` and called `documents.upload`.

Batch path:

1. Activate an agent session.
2. POST to `/api/v2/agents/{agent_id}/batch-remember` with:

   ```json
   { "memories": [{ "content": "   " }] }
   ```

3. Before this change, the endpoint returned `200` and called `documents.upload`.

## Fix

- Add shared non-blank content validation to memory write request models.
- Apply it to single memory writes, batch write items, and the v2 `remember` / `batch-remember` models.
- Add API regression tests proving blank content is rejected before storage while normal remember/batch flows still pass.

## Tests

```bash
.venv/bin/python -m pytest tests/test_api.py::TestMEMANTOAPI::test_remember_body_type_is_respected tests/test_api.py::TestMEMANTOAPI::test_remember_auto_parses_type_when_omitted tests/test_api.py::TestMEMANTOAPI::test_remember_rejects_blank_content tests/test_api.py::TestMEMANTOAPI::test_batch_remember_api tests/test_api.py::TestMEMANTOAPI::test_batch_remember_rejects_blank_content -q
.venv/bin/python -m ruff check memanto/app/models/__init__.py tests/test_api.py
git diff --check
```

Refs #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or whitespace-only `content` is now rejected for single and batch memory creation requests.
  * Invalid inputs return a validation error (HTTP 422) instead of being accepted.
* **Tests**
  * Added API contract tests to confirm blank content is rejected for both `/remember` and `/batch-remember`.
  * Verified rejected requests do not trigger downstream document upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->