### PR TITLE
harden UI session token handling

### DIFF
--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,7 +4,7 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
-from fastapi import Header, HTTPException
+from fastapi import Cookie, Header, HTTPException, Response
 
 from memanto.app.models.session import Session
 from memanto.app.services.session_service import get_session_service
@@ -14,6 +14,24 @@ from memanto.app.utils.errors import (
     SessionNotFoundError,
     map_error_to_http_exception,
 )
+
+SESSION_COOKIE_NAME = "memanto_session_token"
+
+
+def set_session_cookie(response: Response, session_token: str) -> None:
+    """Store the browser UI session token outside JavaScript-readable state."""
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        session_token,
+        httponly=True,
+        samesite="strict",
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    """Clear the browser UI session cookie."""
+    response.delete_cookie(SESSION_COOKIE_NAME, path="/")
 
 
 def get_moorcheh_api_key() -> str:
@@ -55,7 +73,10 @@ def verify_moorcheh_api_key() -> str:
     return get_moorcheh_api_key()
 
 
-def get_current_session(x_session_token: str | None = Header(None)) -> Session:
+def get_current_session(
+    x_session_token: str | None = Header(None),
+    session_cookie: str | None = Cookie(None, alias=SESSION_COOKIE_NAME),
+) -> Session:
     """
     Get and validate current session
 
@@ -68,7 +89,8 @@ def get_current_session(x_session_token: str | None = Header(None)) -> Session:
     Raises:
         HTTPException: If session is invalid or expired
     """
-    if not x_session_token:
+    session_token = x_session_token or session_cookie
+    if not session_token:
         raise HTTPException(
             status_code=401, detail="Missing session token. Use X-Session-Token header."
         )
@@ -76,7 +98,7 @@ def get_current_session(x_session_token: str | None = Header(None)) -> Session:
     session_service = get_session_service()
 
     try:
-        token_payload = session_service.validate_session(x_session_token)
+        token_payload = session_service.validate_session(session_token)
 
         # Get session from storage
         session = session_service.get_session(token_payload.agent_id)

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -7,7 +7,7 @@ Replaces tenant_id with Moorcheh API key-based authentication.
 
 import asyncio
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from memanto.app.clients import moorcheh as moorcheh_clients
 from memanto.app.config import settings
@@ -34,9 +34,11 @@ router = APIRouter()
 # Commented to avoid triggering ruff linter
 from memanto.app.routes import memory  # noqa: E402
 from memanto.app.routes.auth_deps import (  # noqa: E402
+    clear_session_cookie,
     get_current_session,
     get_moorcheh_api_key,
     get_session_service,
+    set_session_cookie,
     verify_moorcheh_api_key,
 )
 
@@ -188,6 +190,7 @@ async def delete_agent(
 @router.post("/agents/{agent_id}/activate", response_model=Session)
 async def activate_agent(
     agent_id: str,
+    response: Response,
     moorcheh_api_key: str = Depends(verify_moorcheh_api_key),
 ):
     """
@@ -216,6 +219,7 @@ async def activate_agent(
             pattern=agent.pattern,
             duration_hours=duration_hours,
         )
+        set_session_cookie(response, session.session_token)
 
         # Update agent stats
         agent_service.update_agent_stats(
@@ -233,6 +237,7 @@ async def activate_agent(
 @router.post("/agents/{agent_id}/deactivate", response_model=SessionSummary)
 async def deactivate_agent(
     agent_id: str,
+    response: Response,
     session: Session = Depends(get_current_session),
     _server_api_key: str = Depends(verify_moorcheh_api_key),
 ):
@@ -251,6 +256,7 @@ async def deactivate_agent(
 
     try:
         summary = get_session_service().end_session(agent_id)
+        clear_session_cookie(response)
         return summary
     except SessionNotFoundError as e:
         raise map_error_to_http_exception(e)

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -10,12 +10,13 @@ import time
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Response
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from memanto.app.clients.backend import Backend
 from memanto.app.config import settings
+from memanto.app.routes.auth_deps import clear_session_cookie, set_session_cookie
 from memanto.cli.client.direct_client import DirectClient
 from memanto.cli.config.manager import ConfigManager
 from memanto.cli.connect.agent_registry import AGENT_REGISTRY, list_agents
@@ -56,7 +57,7 @@ def _build_ui_direct_client() -> DirectClient | None:
 
 
 @router.get("/api/ui/config")
-async def get_ui_config():
+async def get_ui_config(response: Response):
     """
     Get current MEMANTO configuration for the Web UI.
 
@@ -73,6 +74,10 @@ async def get_ui_config():
     active_agent_id, active_session_token = _config_manager.get_active_session()
     backend = _config_manager.get_backend().value
     onprem_cfg = _config_manager.get_onprem_config()
+    if active_session_token:
+        set_session_cookie(response, active_session_token)
+    else:
+        clear_session_cookie(response)
 
     return {
         "api_key_configured": bool(api_key),
@@ -99,7 +104,6 @@ async def get_ui_config():
         "recall": recall_cfg,
         "schedule_time": schedule_time,
         "active_agent_id": active_agent_id,
-        "session_token": active_session_token,
         "has_active_session": bool(active_session_token),
         "ui_mode": settings.MEMANTO_UI_MODE,
     }

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2657,7 +2657,7 @@
             const headers = { 'Content-Type': 'application/json' };
             if (S.apiKey) headers['Authorization'] = `Bearer ${S.apiKey}`;
             if (S.token) headers['X-Session-Token'] = S.token;
-            const opts = { method, headers };
+            const opts = { method, headers, credentials: 'same-origin' };
             if (body) opts.body = JSON.stringify(body);
             const res = await fetch(path, opts);
             if (!res.ok) {
@@ -2668,6 +2668,10 @@
             }
             if (res.status === 204) return null;
             return res.json();
+        }
+
+        function hasActiveSession() {
+            return !!(S.agentId && (S.token || (S.config && S.config.has_active_session)));
         }
 
         // Toast
@@ -2805,7 +2809,7 @@
             try {
                 S.config = await api('GET', '/api/ui/config');
                 S.agentId = S.config.active_agent_id;
-                S.token = S.config.session_token;
+                S.token = null;
                 if (S.config.api_key_configured) {
                     S.apiKey = S.config.api_key || null;
                 }
@@ -2926,12 +2930,12 @@
             if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner"></span> Activating...'; }
             try {
                 const session = await api('POST', `/api/v2/agents/${agentId}/activate`);
-                // Adopt the new session so all subsequent operations use it
+                // Adopt the active session; browser calls authenticate via the
+                // HttpOnly same-origin cookie set by the server.
                 S.agentId = session.agent_id;
-                S.token = session.session_token;
+                S.token = null;
                 if (S.config) {
                     S.config.active_agent_id = session.agent_id;
-                    S.config.session_token = session.session_token;
                     S.config.has_active_session = true;
                 }
                 // Invalidate cached views tied to the previous agent
@@ -2955,7 +2959,6 @@
                 S.token = null;
                 if (S.config) {
                     S.config.active_agent_id = null;
-                    S.config.session_token = null;
                     S.config.has_active_session = false;
                 }
                 S._explorerLoaded = false;
@@ -3026,7 +3029,7 @@
                 profile.innerHTML = '<p style="color:var(--text-dim)">No active agent. <a href="#" onclick="goToPage(\'agents\');return false" style="color:var(--accent);text-decoration:none">Go to the Agents page</a> to activate one.</p>';
             }
 
-            if (S.token && S.agentId) {
+            if (hasActiveSession()) {
                 try {
                     const sess = await api('GET', '/api/v2/status');
                     const hrs = Math.floor((sess.time_remaining_seconds || 0) / 3600);
@@ -3110,7 +3113,7 @@
         // PLAYGROUND - REMEMBER
         // ================================================================
         async function doRemember() {
-            if (!S.agentId || !S.token) { toast('No active agent/session. Activate via CLI first.', 'error'); return; }
+            if (!hasActiveSession()) { toast('No active agent/session. Activate via CLI first.', 'error'); return; }
             const content = document.getElementById('remContent').value.trim();
             if (!content) { toast('Memory content is required', 'error'); return; }
             const title = document.getElementById('remTitle').value.trim() || (content.length > 47 ? content.substring(0, 47) + '...' : content);
@@ -3141,7 +3144,7 @@
         // PLAYGROUND - ANSWER (RAG)
         // ================================================================
         async function doAnswer() {
-            if (!S.agentId || !S.token) { toast('No active agent/session', 'error'); return; }
+            if (!hasActiveSession()) { toast('No active agent/session', 'error'); return; }
             const input = document.getElementById('askInput');
             const q = input.value.trim();
             if (!q) return;
@@ -3169,7 +3172,7 @@
         // PLAYGROUND - RECALL
         // ================================================================
         async function doRecall() {
-            if (!S.agentId || !S.token) { toast('No active agent/session', 'error'); return; }
+            if (!hasActiveSession()) { toast('No active agent/session', 'error'); return; }
             const q = document.getElementById('recQuery').value.trim();
             if (!q) { toast('Search query is required', 'error'); return; }
             const body = { query: q, limit: parseInt(document.getElementById('recLimit').value) || 10 };
@@ -3194,7 +3197,7 @@
         const MAX_UPLOAD_BYTES = 5 * 1024 * 1024 * 1024; // 5GB — mirrors the backend/SDK limit
 
         async function doUpload() {
-            if (!S.agentId || !S.token) { toast('No active agent/session. Activate an agent first.', 'error'); return; }
+            if (!hasActiveSession()) { toast('No active agent/session. Activate an agent first.', 'error'); return; }
             const input = document.getElementById('uplFile');
             const file = input.files && input.files[0];
             if (!file) { toast('Choose a file to upload', 'error'); return; }
@@ -3221,7 +3224,7 @@
             btn.disabled = true; btn.innerHTML = '<span class="spinner"></span> Uploading...';
             out.innerHTML = '';
             try {
-                const res = await fetch(`/api/v2/agents/${S.agentId}/upload-file`, { method: 'POST', headers, body: fd });
+                const res = await fetch(`/api/v2/agents/${S.agentId}/upload-file`, { method: 'POST', headers, body: fd, credentials: 'same-origin' });
                 const data = await res.json().catch(() => ({ detail: res.statusText }));
                 if (!res.ok) {
                     let msg = data.detail || res.statusText;
@@ -3340,7 +3343,7 @@
         // MEMORY EXPLORER
         // ================================================================
         async function loadExplorer(asOfDate) {
-            if (!S.agentId || !S.token) {
+            if (!hasActiveSession()) {
                 document.getElementById('explorerTable').innerHTML = '<p style="color:var(--text-dim);padding:20px">No active agent. <a href="#" onclick="goToPage(\'agents\');return false" style="color:var(--accent);text-decoration:none">Go to the Agents page</a> to activate one.</p>';
                 return;
             }
@@ -3449,7 +3452,7 @@
         // full refetch.
         async function forgetMemory(memoryId, btn, ev) {
             if (ev) { ev.stopPropagation(); ev.preventDefault(); }
-            if (!S.agentId || !S.token) { toast('No active agent/session', 'error'); return; }
+            if (!hasActiveSession()) { toast('No active agent/session', 'error'); return; }
             if (!memoryId) { toast('Memory ID missing', 'error'); return; }
             const ok = await confirmDialog({
                 title: 'Forget memory?',
@@ -3618,7 +3621,7 @@
         }
 
         async function fetchRecentMemories() {
-            if (!S.agentId || !S.token) return;
+            if (!hasActiveSession()) return;
             try {
                 const res = await api('POST', `/api/v2/agents/${S.agentId}/recall/recent`, {});
                 S.history = res.memories || [];
@@ -3627,7 +3630,7 @@
 
         async function loadHistory() {
             const box = document.getElementById('historyContent');
-            if (!S.agentId || !S.token) {
+            if (!hasActiveSession()) {
                 box.innerHTML = '<p style="color:var(--text-dim);padding:20px">No active agent. <a href="#" onclick="goToPage(\'agents\');return false" style="color:var(--accent);text-decoration:none">Go to the Agents page</a> to activate one.</p>';
                 return;
             }
@@ -4430,7 +4433,7 @@
         // ANALYTICS
         // ================================================================
         async function loadAnalytics() {
-            if (!S.agentId || !S.token) {
+            if (!hasActiveSession()) {
                 document.getElementById('analyticsCards').innerHTML = '<p style="color:var(--text-dim);padding:20px">Activate an agent to see analytics</p>';
                 return;
             }
@@ -4634,7 +4637,7 @@
                 </button>
             `).join('');
 
-            const noActiveSession = !S.agentId || !S.token;
+            const noActiveSession = !hasActiveSession();
             const agentBanner = noActiveSession
                 ? `<div class="mig-error-banner" style="margin-bottom:18px">No active agent/session. <a href="#" onclick="goToPage('agents');return false" style="color:inherit;text-decoration:underline">Activate one</a> before importing.</div>`
                 : '';
@@ -4683,7 +4686,7 @@
                         </div>`}
                     <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:18px">
                         <button class="btn btn-secondary" onclick="runMigratePreview()">Preview (dry run)</button>
-                        <button class="btn btn-primary" onclick="runMigrateImport()" ${(S.agentId && S.token) ? '' : 'disabled style="opacity:0.5;cursor:not-allowed"'}>Import now</button>
+                        <button class="btn btn-primary" onclick="runMigrateImport()" ${hasActiveSession() ? '' : 'disabled style="opacity:0.5;cursor:not-allowed"'}>Import now</button>
                     </div>
                 </div>
             `;
@@ -4790,7 +4793,7 @@
         }
 
         async function runMigrateImport() {
-            if (!S.agentId || !S.token) { toast('Activate an agent/session first', 'error'); return; }
+            if (!hasActiveSession()) { toast('Activate an agent/session first', 'error'); return; }
             const body = migrateBody();
             if (!body) return;
             const ok = await confirmDialog({
@@ -5016,7 +5019,7 @@
         async function loadConnectionMemories(conn) {
             const box = document.getElementById('connMemories');
             if (!box) return;
-            if (!S.agentId || !S.token) {
+            if (!hasActiveSession()) {
                 box.innerHTML = '<p style="color:var(--text-dim);padding:12px 0;font-size:13px">No active Memanto agent. <a href="#" onclick="goToPage(\'agents\');return false" style="color:var(--accent);text-decoration:none">Activate one</a> to see memories from this connection.</p>';
                 return;
             }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1191,6 +1191,30 @@ class TestCWE200ApiKeyLeak:
         assert "api_key" not in data
 
     @pytest.mark.asyncio
+    async def test_config_endpoint_does_not_return_session_token(
+        self, client, _mock_ui_config_manager
+    ):
+        """The UI config response must not expose reusable session credentials."""
+        resp = await client.get("/api/ui/config")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "session_token" not in data
+
+    @pytest.mark.asyncio
+    async def test_config_endpoint_sets_httponly_session_cookie(
+        self, client, _mock_ui_config_manager
+    ):
+        """Existing active sessions are restored for the UI via an HttpOnly cookie."""
+        resp = await client.get("/api/ui/config")
+        assert resp.status_code == 200
+
+        cookie = resp.headers.get("set-cookie", "")
+        assert "memanto_session_token=tok_abc" in cookie
+        assert "HttpOnly" in cookie
+        assert "SameSite=strict" in cookie
+
+    @pytest.mark.asyncio
     async def test_config_endpoint_still_has_api_key_status_fields(
         self, client, _mock_ui_config_manager
     ):
@@ -1208,6 +1232,56 @@ class TestCWE200ApiKeyLeak:
         # Session status field should be present (replaces sensitive session_token)
         assert "has_active_session" in data
         assert data["has_active_session"] is True
+
+    @pytest.mark.asyncio
+    async def test_activate_sets_httponly_session_cookie(self, client, auth_headers):
+        """Activation should also store the session token in an HttpOnly cookie."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+
+        resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        assert resp.status_code == 200
+
+        token = resp.json()["session_token"]
+        cookie = resp.headers.get("set-cookie", "")
+        assert f"memanto_session_token={token}" in cookie
+        assert "HttpOnly" in cookie
+        assert "SameSite=strict" in cookie
+
+    @pytest.mark.asyncio
+    async def test_memory_routes_accept_session_cookie(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Browser UI calls can authenticate with the HttpOnly session cookie."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        assert activate_resp.status_code == 200
+        token = activate_resp.json()["session_token"]
+        client.cookies.set("memanto_session_token", token)
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=auth_headers,
+            json={
+                "content": "cookie authenticated memory",
+                "type": "fact",
+                "confidence": 0.9,
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["agent_id"] == self.TEST_AGENT_ID
 
     @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(


### PR DESCRIPTION
## Summary

- remove the active `session_token` from `GET /api/ui/config` JSON responses;
- restore browser UI sessions through an `HttpOnly`, `SameSite=Strict` cookie;
- set and clear the cookie during session activation/deactivation;
- keep `X-Session-Token` support for existing API and CLI clients;
- update the UI so it no longer persists the session credential in shared UI state.

## Security finding

At this PR's base commit, `GET /api/ui/config` had no authentication dependency and returned both:

- `active_agent_id`, identifying the route scope; and
- `session_token`, a reusable JWT bearer credential.

Evidence: [pre-fix UI config route](https://github.com/moorcheh-ai/memanto/blob/92acef27b7f7464ddf80295cc925266d6e3efbae/memanto/app/ui/routes/ui_router.py#L58-L103).

When a Memanto instance was reachable and had an active session, an unauthenticated HTTP client could obtain those two values and replay the token as:

```http
X-Session-Token: <session_token>
```

The session dependency accepted that header, validated the JWT, and loaded the corresponding agent session. Memory routes using the dependency included recall, remember, edit, upload, and delete operations:

- [session-token validation](https://github.com/moorcheh-ai/memanto/blob/92acef27b7f7464ddf80295cc925266d6e3efbae/memanto/app/routes/auth_deps.py#L58-L96)
- [remember](https://github.com/moorcheh-ai/memanto/blob/92acef27b7f7464ddf80295cc925266d6e3efbae/memanto/app/routes/memory.py#L146-L168)
- [edit](https://github.com/moorcheh-ai/memanto/blob/92acef27b7f7464ddf80295cc925266d6e3efbae/memanto/app/routes/memory.py#L323-L350)
- [delete and recall](https://github.com/moorcheh-ai/memanto/blob/92acef27b7f7464ddf80295cc925266d6e3efbae/memanto/app/routes/memory.py#L590-L650)

This created confidentiality and integrity risk for the active agent's memory namespace.

## Realistic preconditions

This is not a claim that every installation was publicly exposed. Exploitation required:

1. a live, reachable Memanto HTTP service;
2. an active session;
3. a still-valid token and corresponding stored session.

The repository nevertheless shipped network-reachable deployment paths: `HOST` defaulted to `0.0.0.0`, the Docker image bound to `0.0.0.0`, and Compose published host port `8000`. Firewall, NAT, reverse-proxy, and explicit loopback configuration still determine real exposure.

The configured default session duration was six hours, although the useful replay window is deployment- and lifecycle-dependent.

## Fix

This PR removes the bearer token from the bootstrap JSON and moves browser session continuity to a cookie that is:

- `HttpOnly`, preventing `document.cookie` access;
- `SameSite=Strict`, limiting cross-site cookie inclusion;
- accepted by the existing session dependency alongside `X-Session-Token`.

The config response no longer includes the token, and the browser UI no longer persists the token from config or activation responses in shared state. Existing non-browser clients retain the header contract.

## Scope and landed result

This PR is browser credential-exposure and cookie-authentication hardening. Its own head did not add authorization to `/api/ui/config`; a direct HTTP client able to reach that endpoint could still observe a `Set-Cookie` response header. Its cookie helper also did not hardcode `Secure`, preserving the repository's plain-HTTP default.

The final integration occurred through merged aggregate PR [#1398](https://github.com/moorcheh-ai/memanto/pull/1398). That newer integration base already contained separate loopback-only UI-route enforcement, and the integrator adapted the cookie to become `Secure` on HTTPS. Those complementary controls strengthen the landed result; #843 supplies the missing config-JSON removal, HttpOnly delivery, shared UI-state cleanup, and cookie-authentication component.

## Distinction from #1423

Merged PR [#1423](https://github.com/moorcheh-ai/memanto/pull/1423) is complementary, not a duplicate.

- **#843:** credential delivery and browser exposure—remove the active token from UI bootstrap JSON and use an HttpOnly cookie.
- **#1423:** management authorization—require a matching management credential or loopback origin for agent lifecycle endpoints and `/api/v2/status`.

#1423 did not change `/api/ui/config` or the UI's JavaScript credential handling. Conversely, #843 did not implement the management authorization gate. They protect distinct security boundaries.

## Validation

Regression coverage verifies:

1. config omits `session_token`;
2. existing sessions issue an `HttpOnly`, `SameSite=Strict` cookie;
3. activation issues the protected cookie;
4. memory routes accept cookie-based session authentication without `X-Session-Token`.

Original validation recorded for the PR:

- `.venv/bin/python -m pytest tests/test_api.py -q`;
- `.venv/bin/python -m pytest tests -q` — live E2E skipped because no real Moorcheh API key was configured;
- `.venv/bin/python -m ruff check .`;
- `git diff --check`.

### Isolated before/after revalidation — 30 July 2026

The comparison used an in-process ASGI client, `agent-demo` and `dummy-token`. The two outbound TCP connection paths used by the validation environment were patched to fail closed. No live service or real credential was used.

| Revision | Observed result |
| --- | --- |
| Base `92acef2` | HTTP 200; `session_token` present in JSON and matched the supplied dummy value; no session cookie. |
| Integrated `34aae8a` | HTTP 200; `session_token` absent from JSON; cookie contained the dummy value with `HttpOnly` and `SameSite=Strict`. |

- four focused #843 regressions: **4 passed**, 0 failed, 0 skipped;
- complete `tests/test_api.py`: **89 passed**, 0 failed, 0 skipped;
- explicit API `X-Session-Token` compatibility check: **1 passed**, 0 failed, 0 skipped.

This was local ASGI validation, not a production or real-browser audit. It did not test public routing, reverse-proxy TLS termination, a live Moorcheh backend, or an installed CLI end to end. On local HTTP the integrated cookie is intentionally not `Secure`; the API suite verifies that it becomes `Secure` over HTTPS. The `X-Session-Token` path used by API/CLI clients remains present, but this revalidation explicitly exercised only the API header path.

## Human review and disclosure

I am not a cybersecurity specialist or a senior developer. I personally reviewed the relevant code before and after the fix, the meaning of the tests, the practical preconditions, and the limits stated above. Codex helped me run and record the isolated validation and express the technical details accurately. I understand what was exposed, what conditions were required, and what the fix changes; the review and responsibility for this submission are mine.

## Public technical explanation

https://www.reddit.com/r/AI_Agents/comments/1va0dj0/comment/p0og5c8/

Refs #770
