### PR TITLE
Fix TypeScript SDK status bootstrap

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -351,7 +351,9 @@ export class Memanto {
   }
 
   async status() {
-    return this.request("GET", `/api/v2/status`);
+    return this.request("GET", `/api/v2/status`, undefined, {
+      requireSession: false,
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -33,6 +33,17 @@ function startFakeApi(): Promise<{
         };
 
         if (url === "/health") return reply(200, { status: "ok" });
+        if (url === "/api/v2/status" && req.method === "GET")
+          return reply(200, {
+            session_id: "existing-session",
+            agent_id: "existing-agent",
+            namespace: "memanto_agent_existing_agent",
+            started_at: new Date().toISOString(),
+            expires_at: new Date(Date.now() + 3600_000).toISOString(),
+            status: "active",
+            pattern: "default",
+            time_remaining_seconds: 3600,
+          });
         if (url.startsWith("/api/v2/agents/test-agent/activate"))
           return reply(200, {
             session_token: "fake-token",
@@ -122,6 +133,24 @@ describe("Memanto", () => {
 
     const res = await m.recall({ query: "coffee" });
     expect(res).toMatchObject({ count: 0 });
+  });
+
+  it("reads status without bootstrapping an agent session", async () => {
+    const api = await startFakeApi();
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    const res = await m.status();
+    expect(res).toMatchObject({
+      session_id: "existing-session",
+      agent_id: "existing-agent",
+    });
+    expect(api.recorded.map((r) => `${r.method} ${r.url}`)).toEqual([
+      "GET /api/v2/status",
+    ]);
+    expect(api.recorded[0]?.headers["x-session-token"]).toBeUndefined();
   });
 
   it("rejects empty agentId", () => {


### PR DESCRIPTION
## Summary
- make the TypeScript SDK `status()` call `/api/v2/status` without requiring a session
- add a regression test proving `status()` only performs `GET /api/v2/status` and does not send `X-Session-Token`

## Why
The server-side `/api/v2/status` route reads the current active session from local state and does not require auth parameters. The SDK method was using the default session-scoped request path, so a read-only status check first looked up/created the configured agent and activated a new session before reading status.

Refs #770

## Tests
- `npm test -- --run test/memanto.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the status check so it works without requiring an active session.
  * Status requests now complete successfully without sending a session token, returning the expected session and agent details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->