### PR TITLE
Reject blank CLI batch memory content

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -689,7 +689,7 @@ class DirectClient:
         memory_records = []
         for i, item in enumerate(memories):
             raw_content = item.get("content", "")
-            if not raw_content:
+            if not isinstance(raw_content, str) or not raw_content.strip():
                 raise ValueError(f"Memory at index {i} has no content")
 
             raw_title = item.get("title")

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -517,7 +517,7 @@ class SdkClient:
         memory_records = []
         for i, item in enumerate(memories):
             raw_content = item.get("content", "")
-            if not raw_content:
+            if not isinstance(raw_content, str) or not raw_content.strip():
                 raise ValueError(f"Memory at index {i} has no content")
 
             raw_title = item.get("title")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -330,6 +330,40 @@ class TestMEMANTOCLI:
 
         mock_write_service.update_memory.assert_not_called()
 
+    def test_batch_direct_rejects_blank_content(self, mock_all_clients):
+        """DirectClient.batch_remember must reject whitespace-only content."""
+        from unittest.mock import MagicMock, patch
+
+        from memanto.cli.client.direct_client import DirectClient
+
+        mock_write_service = MagicMock()
+        mock_write_service.batch_store_memories.return_value = {"results": []}
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+
+        with (
+            patch.object(
+                DirectClient, "_get_write_service", return_value=mock_write_service
+            ),
+            patch.object(
+                DirectClient,
+                "_get_validated_session_for_agent",
+                return_value=mock_session,
+            ),
+        ):
+            client = DirectClient.__new__(DirectClient)
+            client.api_key = "test-api-key"
+            client.base_url = "https://api.moorcheh.ai/v1"
+            client.session_token = None
+            import pytest
+
+            with pytest.raises(ValueError, match="Memory at index 0 has no content"):
+                client.batch_remember(
+                    agent_id="test-agent", memories=[{"content": "   "}]
+                )
+
+        mock_write_service.batch_store_memories.assert_not_called()
+
     def test_edit_sdk_rejects_unknown_field(self, mock_all_clients):
         """SdkClient.update_memory must enforce the same field allowlist as
         the API route. CodeRabbit review 2026-06-14T14:03:20Z flagged that
@@ -393,6 +427,37 @@ class TestMEMANTOCLI:
                 )
 
         mock_write_service.update_memory.assert_not_called()
+
+    def test_batch_sdk_rejects_blank_content(self, mock_all_clients):
+        """SdkClient.batch_remember must reject whitespace-only content."""
+        from unittest.mock import MagicMock, patch
+
+        from memanto.cli.client.sdk_client import SdkClient
+
+        mock_write_service = MagicMock()
+        mock_write_service.batch_store_memories.return_value = {"results": []}
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+
+        with (
+            patch.object(
+                SdkClient, "_get_write_service", return_value=mock_write_service
+            ),
+            patch.object(
+                SdkClient, "_get_validated_session_for_agent", return_value=mock_session
+            ),
+        ):
+            client = SdkClient.__new__(SdkClient)
+            client.api_key = "test-api-key"
+            client.session_token = None
+            import pytest
+
+            with pytest.raises(ValueError, match="Memory at index 0 has no content"):
+                client.batch_remember(
+                    agent_id="test-agent", memories=[{"content": "   "}]
+                )
+
+        mock_write_service.batch_store_memories.assert_not_called()
 
     def test_edit_sdk_normalizes_confidence_and_accepts_valid_payload(
         self, mock_all_clients


### PR DESCRIPTION
## Summary
- reject whitespace-only `content` items in `DirectClient.batch_remember()` and `SdkClient.batch_remember()`
- add regression tests proving blank batch items are rejected before `batch_store_memories()` is called

## Why
PR #842 covers API request models, but the CLI client batch paths still only checked `if not raw_content`. That means a batch JSON item like `{ "content": "   " }` could bypass the CLI clients and reach the write service, while single-memory writes and memory updates already enforce non-blank content.

Refs #770

## Tests
- `uv run --group dev python -m pytest tests/test_cli.py::TestMEMANTOCLI::test_batch_direct_rejects_blank_content tests/test_cli.py::TestMEMANTOCLI::test_batch_sdk_rejects_blank_content tests/test_cli.py::TestMEMANTOCLI::test_memory_batch_remember -q`
- `uv run --group dev python -m pytest tests/test_cli.py -q`
- `uv run --group dev ruff check memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_cli.py`
- `uv run --group dev ruff format --check memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_cli.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory input validation so blank or whitespace-only content is now rejected consistently.
  * Prevents invalid items from being sent when saving memories through either client path.
* **Tests**
  * Added coverage for blank-content validation in both client flows.
  * Verified that invalid input stops processing before any write action occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->