### PR TITLE
Reset TypeScript session after deleteAgent

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -334,10 +334,17 @@ export class Memanto {
     return (await res.json()) as unknown;
   }
 
+  /** Delete the bound agent and clear any cached session for it. */
   async deleteAgent() {
-    return this.request("DELETE", `/api/v2/agents/${this.agentId}`, undefined, {
-      requireSession: false,
-    });
+    const result = await this.request(
+      "DELETE",
+      `/api/v2/agents/${this.agentId}`,
+      undefined,
+      { requireSession: false },
+    );
+    this.sessionToken = null;
+    this.starting = null;
+    return result;
   }
 
   async deactivate() {

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -48,6 +48,8 @@ function startFakeApi(): Promise<{
           return reply(404, { detail: "not found" });
         if (url === "/api/v2/agents" && req.method === "POST")
           return reply(201, { agent_id: "test-agent" });
+        if (url === "/api/v2/agents/test-agent" && req.method === "DELETE")
+          return reply(200, { agent_id: "test-agent", deleted: true });
         if (url === "/api/v2/agents/test-agent/remember")
           return reply(200, {
             memory_id: "mem-1",
@@ -122,6 +124,27 @@ describe("Memanto", () => {
 
     const res = await m.recall({ query: "coffee" });
     expect(res).toMatchObject({ count: 0 });
+  });
+
+  it("rebootstraps after deleting the active agent", async () => {
+    const api = await startFakeApi();
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    await m.remember({ content: "Het likes coffee" });
+    await m.deleteAgent();
+    api.recorded.length = 0;
+
+    await m.remember({ content: "Het likes tea" });
+
+    expect(api.recorded.map((r) => `${r.method} ${r.url}`)).toEqual([
+      "GET /api/v2/agents/test-agent",
+      "POST /api/v2/agents",
+      "POST /api/v2/agents/test-agent/activate",
+      "POST /api/v2/agents/test-agent/remember",
+    ]);
   });
 
   it("rejects empty agentId", () => {


### PR DESCRIPTION
## Summary
- clear the TypeScript SDK cached session state after `deleteAgent()` succeeds
- add a regression test proving the next memory write reboots through lookup/create/activate instead of reusing the deleted agent's stale session token

## Why
`deactivate()` and `close()` already clear the local session cache, but `deleteAgent()` returned after the DELETE request while leaving `sessionToken` populated. A long-lived SDK instance could then skip `ensureReady()` and send the old token on the next agent-scoped call, even though the current agent was just deleted.

This is the TypeScript SDK counterpart to the Python-client stale-session class of issues; it does not touch the Python client paths covered by #822.

Refs #770

## Tests
- `npm test -- --run test/memanto.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting the active agent now fully resets the client session, allowing the app to continue cleanly afterward.
  * Following agent deletion, subsequent actions correctly re-establish the agent and resume the expected request flow.
  * Agent deletion now consistently returns the expected result.
* **Tests**
  * Updated the fake API for DELETE requests and added coverage for the “delete active agent then bootstrap again” scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->