### PR TITLE
Reject blank answer and recall queries

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -172,6 +172,7 @@ class AnswerRequest(BaseModel):
     @field_validator("question")
     @classmethod
     def question_must_not_be_blank(cls, value: str) -> str:
+        """Reject questions that contain only whitespace."""
         if not value.strip():
             raise ValueError("question must be a non-empty string")
         return value

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,7 +5,7 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from memanto.app.constants import MemoryType, ScopeType, SourceType, StatusType
 
@@ -168,6 +168,13 @@ class AnswerRequest(BaseModel):
         None, description="AI model to use for generating the answer"
     )
     kiosk_mode: bool = Field(False, description="Kiosk mode setting")
+
+    @field_validator("question")
+    @classmethod
+    def question_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("question must be a non-empty string")
+        return value
 
 
 class MemoryUpdateRequest(BaseModel):

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -60,6 +60,7 @@ class RecallRequest(BaseModel):
     @field_validator("query")
     @classmethod
     def query_must_not_be_blank(cls, value: str) -> str:
+        """Reject recall queries that contain only whitespace."""
         if not value.strip():
             raise ValueError("query must be a non-empty string")
         return value

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -57,6 +57,13 @@ class RecallRequest(BaseModel):
     )
     type: list[str] | None = Field(default=None, description="Memory type filters")
 
+    @field_validator("query")
+    @classmethod
+    def query_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("query must be a non-empty string")
+        return value
+
 
 class RecallAsOfRequest(BaseModel):
     as_of: datetime = Field(

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -50,6 +50,8 @@ _config_manager = ConfigManager()
 
 
 class RecallRequest(BaseModel):
+    """Request body for semantic recall against an agent session."""
+
     query: str = Field(..., min_length=1, description="Search query")
     limit: int | None = Field(default=None, ge=1, description="Max results")
     min_similarity: float | None = Field(
@@ -67,6 +69,8 @@ class RecallRequest(BaseModel):
 
 
 class RecallAsOfRequest(BaseModel):
+    """Request body for point-in-time temporal recall."""
+
     as_of: datetime = Field(
         ...,
         description="Point-in-time — YYYY-MM-DD (defaults to end of day) or full ISO datetime e.g. 2025-11-01T14:30:00Z",
@@ -77,6 +81,7 @@ class RecallAsOfRequest(BaseModel):
     @field_validator("as_of", mode="before")
     @classmethod
     def parse_as_of(cls, v: object) -> datetime:
+        """Normalize date-only and ISO inputs to a timezone-aware timestamp."""
         if isinstance(v, datetime):
             return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
         if isinstance(v, date):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -466,6 +466,31 @@ class TestMEMANTOAPI:
         assert call_kwargs["ai_model"] == "anthropic.claude-sonnet-4-6"
 
     @pytest.mark.asyncio
+    async def test_answer_rejects_blank_question(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Whitespace-only questions should fail before calling Moorcheh."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/answer",
+            headers=headers,
+            json={"question": "   "},
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.answer.generate.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_recall_with_session(self, client, auth_headers, mock_moorcheh):
         """Test semantic recall with session token"""
         # Setup session
@@ -523,6 +548,31 @@ class TestMEMANTOAPI:
         assert response.status_code == 200
         call_kwargs = mock_moorcheh.similarity_search.query.call_args.kwargs
         assert "memory_type:fact" in call_kwargs["query"]
+
+    @pytest.mark.asyncio
+    async def test_recall_rejects_blank_query(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Whitespace-only recall queries should fail before calling Moorcheh."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall",
+            headers=headers,
+            json={"query": " \n\t "},
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.similarity_search.query.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_agent(self, client, auth_headers):


### PR DESCRIPTION
/claim #770

## Summary
- Reject whitespace-only `question` values in `/answer` requests.
- Reject whitespace-only `query` values in `/recall` requests.
- Add regression coverage proving these invalid inputs return `422` before Moorcheh is called.

## Why this matters
The CLI already rejects blank questions/queries, but the API accepted whitespace-only strings because they satisfied `min_length=1`. That allowed requests like `{"question": "   "}` or `{"query": " \n\t "}` to reach `answer.generate` / `similarity_search.query`, consuming backend resources and producing meaningless retrieval prompts.

## Verification
- `uv run --group dev ruff check memanto/app/models/__init__.py memanto/app/routes/memory.py tests/test_api.py`
- `uv run --group dev ruff format --check memanto/app/models/__init__.py memanto/app/routes/memory.py tests/test_api.py`
- `git diff --check`
- `uv run --group dev python -m pytest tests/test_api.py -q`

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for answer and recall requests by rejecting whitespace-only `question`/`query` values.
  * Invalid requests now fail fast with an HTTP `422` validation error instead of continuing processing.
* **Tests**
  * Added API contract tests to confirm blank/whitespace-only inputs are rejected.
  * Verified validation prevents any downstream client calls for both `/answer` and `/recall`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->