### PR TITLE
Reject blank extraction messages

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -98,6 +98,7 @@ class ConversationMessage(BaseModel):
     @field_validator("role")
     @classmethod
     def role_must_not_be_blank(cls, value: str) -> str:
+        """Reject message roles that contain only whitespace."""
         if not value.strip():
             raise ValueError("role must be a non-empty string")
         return value
@@ -105,6 +106,7 @@ class ConversationMessage(BaseModel):
     @field_validator("content")
     @classmethod
     def content_must_not_be_blank(cls, value: str) -> str:
+        """Reject message content that contains only whitespace."""
         if not value.strip():
             raise ValueError("content must be a non-empty string")
         return value

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,7 +5,7 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from memanto.app.constants import MemoryType, ScopeType, SourceType, StatusType
 
@@ -94,6 +94,20 @@ class ConversationMessage(BaseModel):
 
     role: str = Field(..., min_length=1, max_length=50)
     content: str = Field(..., min_length=1, max_length=10000)
+
+    @field_validator("role")
+    @classmethod
+    def role_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("role must be a non-empty string")
+        return value
+
+    @field_validator("content")
+    @classmethod
+    def content_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("content must be a non-empty string")
+        return value
 
 
 class ExtractMemoriesRequest(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -837,6 +837,64 @@ class TestMEMANTOAPI:
         mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_extract_memories_rejects_blank_message_content(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Whitespace-only message content should fail before extraction."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        assert activate_resp.status_code == 200, activate_resp.text
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember/extract",
+            headers=headers,
+            json={
+                "dry_run": True,
+                "messages": [{"role": "user", "content": " \n\t "}],
+            },
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.answer.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extract_memories_rejects_blank_message_role(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Whitespace-only message roles should fail before extraction."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        assert activate_resp.status_code == 200, activate_resp.text
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember/extract",
+            headers=headers,
+            json={
+                "dry_run": True,
+                "messages": [{"role": " \t ", "content": "Useful memory."}],
+            },
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.answer.generate.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_extract_memories_from_conversation_stores_batch(
         self, client, auth_headers, mock_moorcheh
     ):


### PR DESCRIPTION
/claim #770

## Summary
- Reject whitespace-only conversation message `role` values for `/remember/extract`.
- Reject whitespace-only conversation message `content` values for `/remember/extract`.
- Add regression tests proving invalid extraction requests return `422` before `answer.generate` is called.

## Why this matters
`ConversationMessage` used `min_length=1`, so strings like `"   "` passed request validation. The extraction service later rejected those messages, but that happened inside the route's generic exception handling path instead of as a client request validation error. Moving the whitespace check to the request model makes invalid input fail consistently at the API boundary and avoids invoking the extraction backend.

## Verification
- `uv run --group dev python -m pytest tests/test_api.py::TestMEMANTOAPI::test_extract_memories_rejects_blank_message_content tests/test_api.py::TestMEMANTOAPI::test_extract_memories_rejects_blank_message_role tests/test_api.py::TestMEMANTOAPI::test_extract_memories_from_conversation_dry_run tests/test_api.py::TestMEMANTOAPI::test_extract_memories_from_conversation_stores_batch -q`
- `uv run --group dev ruff check memanto/app/models/__init__.py tests/test_api.py`
- `uv run --group dev ruff format --check memanto/app/models/__init__.py tests/test_api.py`
- `git diff --check`
- `uv run --group dev python -m pytest tests/test_api.py -q`

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation so conversation messages reject whitespace-only `role` and `content` after trimming.
  * Requests with blank message fields now fail fast with a clear validation error instead of continuing processing.
  * Added API contract tests to confirm extraction requests returning HTTP 422 do not trigger downstream generation calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->