### PR TITLE
Validate recall memory type filters

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -49,6 +49,22 @@ router = APIRouter()
 _config_manager = ConfigManager()
 
 
+def _validate_memory_type_filters(value: list[str] | None) -> list[str] | None:
+    if value is None:
+        return value
+
+    invalid = [
+        memory_type for memory_type in value if memory_type not in VALID_MEMORY_TYPES
+    ]
+    if invalid:
+        valid_types = ", ".join(sorted(VALID_MEMORY_TYPES))
+        raise ValueError(
+            f"Invalid memory type filter(s): {', '.join(invalid)}. "
+            f"Must be one of: {valid_types}."
+        )
+    return value
+
+
 class RecallRequest(BaseModel):
     query: str = Field(..., min_length=1, description="Search query")
     limit: int | None = Field(default=None, ge=1, description="Max results")
@@ -56,6 +72,11 @@ class RecallRequest(BaseModel):
         default=None, ge=0.0, le=1.0, description="Minimum similarity score (0-1)"
     )
     type: list[str] | None = Field(default=None, description="Memory type filters")
+
+    @field_validator("type")
+    @classmethod
+    def type_filters_must_be_valid(cls, value: list[str] | None) -> list[str] | None:
+        return _validate_memory_type_filters(value)
 
 
 class RecallAsOfRequest(BaseModel):
@@ -65,6 +86,11 @@ class RecallAsOfRequest(BaseModel):
     )
     limit: int | None = Field(default=None, ge=1, description="Max results")
     type: list[str] | None = Field(default=None, description="Memory type filters")
+
+    @field_validator("type")
+    @classmethod
+    def type_filters_must_be_valid(cls, value: list[str] | None) -> list[str] | None:
+        return _validate_memory_type_filters(value)
 
     @field_validator("as_of", mode="before")
     @classmethod
@@ -100,6 +126,11 @@ class RecallChangedSinceRequest(BaseModel):
     limit: int | None = Field(default=None, ge=1, description="Max results")
     type: list[str] | None = Field(default=None, description="Memory type filters")
 
+    @field_validator("type")
+    @classmethod
+    def type_filters_must_be_valid(cls, value: list[str] | None) -> list[str] | None:
+        return _validate_memory_type_filters(value)
+
     @field_validator("since", mode="before")
     @classmethod
     def parse_since(cls, v: object) -> datetime:
@@ -129,6 +160,11 @@ class RecallChangedSinceRequest(BaseModel):
 class RecallRecentRequest(BaseModel):
     limit: int | None = Field(default=None, ge=1, description="Max results")
     type: list[str] | None = Field(default=None, description="Memory type filters")
+
+    @field_validator("type")
+    @classmethod
+    def type_filters_must_be_valid(cls, value: list[str] | None) -> list[str] | None:
+        return _validate_memory_type_filters(value)
 
 
 class MemoryEditRequest(BaseModel):

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -50,6 +50,7 @@ _config_manager = ConfigManager()
 
 
 def _validate_memory_type_filters(value: list[str] | None) -> list[str] | None:
+    """Validate optional memory type filters against supported memory types."""
     if value is None:
         return value
 
@@ -76,6 +77,7 @@ class RecallRequest(BaseModel):
     @field_validator("type")
     @classmethod
     def type_filters_must_be_valid(cls, value: list[str] | None) -> list[str] | None:
+        """Reject recall filters that are not supported memory types."""
         return _validate_memory_type_filters(value)
 
 
@@ -90,6 +92,7 @@ class RecallAsOfRequest(BaseModel):
     @field_validator("type")
     @classmethod
     def type_filters_must_be_valid(cls, value: list[str] | None) -> list[str] | None:
+        """Reject as-of recall filters that are not supported memory types."""
         return _validate_memory_type_filters(value)
 
     @field_validator("as_of", mode="before")
@@ -129,6 +132,7 @@ class RecallChangedSinceRequest(BaseModel):
     @field_validator("type")
     @classmethod
     def type_filters_must_be_valid(cls, value: list[str] | None) -> list[str] | None:
+        """Reject changed-since recall filters that are not supported memory types."""
         return _validate_memory_type_filters(value)
 
     @field_validator("since", mode="before")
@@ -164,6 +168,7 @@ class RecallRecentRequest(BaseModel):
     @field_validator("type")
     @classmethod
     def type_filters_must_be_valid(cls, value: list[str] | None) -> list[str] | None:
+        """Reject recent-recall filters that are not supported memory types."""
         return _validate_memory_type_filters(value)
 
 

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -67,6 +67,8 @@ def _validate_memory_type_filters(value: list[str] | None) -> list[str] | None:
 
 
 class RecallRequest(BaseModel):
+    """Request body for semantic recall against an agent session."""
+
     query: str = Field(..., min_length=1, description="Search query")
     limit: int | None = Field(default=None, ge=1, description="Max results")
     min_similarity: float | None = Field(
@@ -82,6 +84,8 @@ class RecallRequest(BaseModel):
 
 
 class RecallAsOfRequest(BaseModel):
+    """Request body for point-in-time temporal recall."""
+
     as_of: datetime = Field(
         ...,
         description="Point-in-time — YYYY-MM-DD (defaults to end of day) or full ISO datetime e.g. 2025-11-01T14:30:00Z",
@@ -98,6 +102,7 @@ class RecallAsOfRequest(BaseModel):
     @field_validator("as_of", mode="before")
     @classmethod
     def parse_as_of(cls, v: object) -> datetime:
+        """Normalize date-only and ISO inputs to a timezone-aware timestamp."""
         if isinstance(v, datetime):
             return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
         if isinstance(v, date):
@@ -122,6 +127,8 @@ class RecallAsOfRequest(BaseModel):
 
 
 class RecallChangedSinceRequest(BaseModel):
+    """Request body for temporal recall over memories changed since a timestamp."""
+
     since: datetime = Field(
         ...,
         description="Start of change window — YYYY-MM-DD (defaults to start of day) or full ISO datetime e.g. 2025-11-01T00:00:00Z",
@@ -138,6 +145,7 @@ class RecallChangedSinceRequest(BaseModel):
     @field_validator("since", mode="before")
     @classmethod
     def parse_since(cls, v: object) -> datetime:
+        """Normalize date-only and ISO inputs to a timezone-aware window start."""
         if isinstance(v, datetime):
             return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
         if isinstance(v, date):
@@ -162,6 +170,8 @@ class RecallChangedSinceRequest(BaseModel):
 
 
 class RecallRecentRequest(BaseModel):
+    """Request body for newest-first temporal recall."""
+
     limit: int | None = Field(default=None, ge=1, description="Max results")
     type: list[str] | None = Field(default=None, description="Memory type filters")
 
@@ -173,6 +183,8 @@ class RecallRecentRequest(BaseModel):
 
 
 class MemoryEditRequest(BaseModel):
+    """Request body for updating editable memory fields."""
+
     title: str | None = Field(default=None, max_length=100)
     content: str | None = Field(default=None, max_length=10000)
     type: str | None = None
@@ -181,6 +193,7 @@ class MemoryEditRequest(BaseModel):
     source: str | None = None
 
     def to_updates(self) -> dict[str, object]:
+        """Return only fields explicitly supplied by the API caller."""
         return self.model_dump(exclude_none=True)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -525,6 +525,31 @@ class TestMEMANTOAPI:
         assert "memory_type:fact" in call_kwargs["query"]
 
     @pytest.mark.asyncio
+    async def test_recall_rejects_invalid_type_filter(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Invalid type filters should fail before query construction."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall",
+            headers=headers,
+            json={"query": "test query", "type": ["fact #status:deleted"]},
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.similarity_search.query.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_get_agent(self, client, auth_headers):
         """Test getting agent details"""
         await client.post(
@@ -948,6 +973,45 @@ class TestMEMANTOAPI:
         )
         assert response.status_code == 200
         assert response.json()["temporal_mode"] == "changed_since"
+
+    @pytest.mark.asyncio
+    async def test_temporal_recall_rejects_invalid_type_filters(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Temporal recall type filters should use the same memory type contract."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        invalid_type = "fact #status:deleted"
+        requests = [
+            (
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/as-of",
+                {"as_of": "2025-01-01", "type": [invalid_type]},
+            ),
+            (
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/changed-since",
+                {"since": "2025-01-01", "type": [invalid_type]},
+            ),
+            (
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                {"type": [invalid_type]},
+            ),
+        ]
+
+        for url, payload in requests:
+            response = await client.post(url, headers=headers, json=payload)
+            assert response.status_code == 422
+
+        mock_moorcheh.similarity_search.query.assert_not_called()
+        mock_moorcheh.documents.fetch_text_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_recall_recent_api(self, client, auth_headers, mock_moorcheh):


### PR DESCRIPTION
/claim #770

## Summary
- Validate `type` filters against `VALID_MEMORY_TYPES` for `/recall`.
- Apply the same validation to `/recall/as-of`, `/recall/changed-since`, and `/recall/recent`.
- Add regression coverage proving invalid type filters return `422` before Moorcheh search/fetch calls run.

## Why this matters
Recall request models accepted arbitrary strings for `type`. Semantic recall later appends each value directly into Moorcheh's metadata filter syntax as `#memory_type:{value}`, so a value like `fact #status:deleted` changes the constructed search query instead of being rejected as an invalid memory type. Temporal recall paths used the same unvalidated field contract for fetch-side filtering.

This makes the API contract explicit: memory type filters must be one of the supported Memanto memory types.

## Verification
- `uv run --group dev python -m pytest tests/test_api.py::TestMEMANTOAPI::test_recall_accepts_type_filter tests/test_api.py::TestMEMANTOAPI::test_recall_rejects_invalid_type_filter tests/test_api.py::TestMEMANTOAPI::test_temporal_recall_rejects_invalid_type_filters tests/test_api.py::TestMEMANTOAPI::test_recall_temporal_api tests/test_api.py::TestMEMANTOAPI::test_recall_recent_api -q`
- `uv run --group dev ruff check memanto/app/routes/memory.py tests/test_api.py`
- `uv run --group dev ruff format --check memanto/app/routes/memory.py tests/test_api.py`
- `git diff --check`
- `uv run --group dev python -m pytest tests/test_api.py -q`

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of memory type filter values, ensuring invalid filter entries are consistently rejected across all recall endpoints (including time-based variants).
  * Requests using unsupported memory type filters now return a clear HTTP 422 validation error and stop before any recall processing occurs.

* **Tests**
  * Added API contract tests covering both standard `/recall` and time-based recall endpoints (`/recall/as-of`, `/recall/changed-since`, `/recall/recent`) to verify invalid filter handling and that downstream processing is not triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->