### PR TITLE
Validate remember provenance values

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,9 +5,15 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
-from memanto.app.constants import MemoryType, ScopeType, SourceType, StatusType
+from memanto.app.constants import (
+    VALID_PROVENANCE_TYPES,
+    MemoryType,
+    ScopeType,
+    SourceType,
+    StatusType,
+)
 
 
 # Request Models
@@ -72,6 +78,16 @@ class BatchRememberItem(BaseModel):
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",
     )
+
+    @field_validator("provenance")
+    @classmethod
+    def provenance_must_be_valid(cls, value: str) -> str:
+        if value not in VALID_PROVENANCE_TYPES:
+            valid_provenance = ", ".join(sorted(VALID_PROVENANCE_TYPES))
+            raise ValueError(
+                f"Invalid provenance '{value}'. Must be one of: {valid_provenance}."
+            )
+        return value
 
 
 class RememberRequest(BatchRememberItem):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -673,6 +673,34 @@ class TestMEMANTOAPI:
         assert uploaded_doc["memory_type"] == "preference"
 
     @pytest.mark.asyncio
+    async def test_remember_rejects_invalid_provenance(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Single remember should reject unknown provenance values before upload."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=headers,
+            json={
+                "content": "Invalid provenance should not be stored",
+                "provenance": "guessed",
+            },
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_global_status_no_active_session(self, client):
         """Test GET /api/v2/status returns 404 when no session is active"""
         response = await client.get("/api/v2/status")
@@ -708,6 +736,39 @@ class TestMEMANTOAPI:
         )
         assert response.status_code == 200
         assert response.json()["successful"] == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_remember_rejects_invalid_provenance(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Batch remember should reject unknown provenance values before upload."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/batch-remember",
+            headers=headers,
+            json={
+                "memories": [
+                    {
+                        "content": "Invalid provenance should not be batched",
+                        "type": "fact",
+                        "provenance": "guessed",
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_memory_with_session(


### PR DESCRIPTION
/claim #770

## Summary
- Validate `/remember` provenance values against `VALID_PROVENANCE_TYPES` at the request model layer.
- Apply the same validation to each `/batch-remember` item through the shared `BatchRememberItem` model.
- Add regression tests proving invalid provenance payloads return `422` before document upload is called.

## Why this matters
The CLI/direct clients already reject unknown provenance values before constructing a `MemoryRecord`, but the REST request model accepted arbitrary strings. Invalid values then reached `MemoryRecord(provenance=...)`, where Pydantic rejects them inside the route's generic exception handling path instead of as a normal request validation error.

This aligns the REST API with the existing client contract and keeps invalid remember/batch-remember payloads from reaching the write path.

## Verification
- `uv run --group dev python -m pytest tests/test_api.py::TestMEMANTOAPI::test_remember_body_type_is_respected tests/test_api.py::TestMEMANTOAPI::test_remember_auto_parses_type_when_omitted tests/test_api.py::TestMEMANTOAPI::test_remember_rejects_invalid_provenance tests/test_api.py::TestMEMANTOAPI::test_batch_remember_api tests/test_api.py::TestMEMANTOAPI::test_batch_remember_rejects_invalid_provenance -q`
- `uv run --group dev ruff check memanto/app/models/__init__.py tests/test_api.py`
- `uv run --group dev ruff format --check memanto/app/models/__init__.py tests/test_api.py`
- `git diff --check`
- `uv run --group dev python -m pytest tests/test_api.py -q`

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation so memory provenance must match one of the supported values.
  * Requests with an invalid provenance are now rejected with a clear error instead of being processed.
  * Both single and batch memory endpoints now return HTTP 422 for invalid provenance, preventing unsupported data from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->