### PR TITLE
Clear session state when deleting active agents

### DIFF
--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -166,6 +166,7 @@ async def delete_agent(
                 pass
 
         agent_service.delete_agent(agent_id)
+        get_session_service().delete_session(agent_id)
         return {
             "message": (
                 f"Agent '{agent_id}' successfully deleted"

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -417,7 +417,7 @@ class SessionService:
         active_link = self.sessions_dir / "active"
 
         # Remove existing active link
-        if active_link.exists():
+        if active_link.exists() or active_link.is_symlink():
             active_link.unlink()
 
         # Create new active marker
@@ -432,12 +432,38 @@ class SessionService:
     def _clear_active_session(self) -> None:
         """Clear active session marker"""
         active_link = self.sessions_dir / "active"
-        if active_link.exists():
+        if active_link.exists() or active_link.is_symlink():
             active_link.unlink()
 
     def clear_active_session(self) -> None:
         """Public alias: clear the active-session marker without ending the session."""
         self._clear_active_session()
+
+    def delete_session(self, agent_id: str) -> bool:
+        """
+        Remove persisted session state for an agent.
+
+        Used when an agent is deleted: the agent metadata is gone, so a saved
+        session for that agent must not remain usable through X-Session-Token.
+        """
+        active_link = self.sessions_dir / "active"
+        active_agent_id: str | None = None
+
+        if active_link.is_symlink():
+            active_agent_id = active_link.readlink().stem
+        elif active_link.exists():
+            with open(active_link) as f:
+                active_agent_id = f.read().strip()
+
+        session_file = self.sessions_dir / f"{agent_id}.json"
+        deleted = session_file.exists()
+        if deleted:
+            session_file.unlink()
+
+        if active_agent_id == agent_id:
+            self._clear_active_session()
+
+        return deleted
 
     def list_sessions(self) -> list[Session]:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -551,6 +551,38 @@ class TestMEMANTOAPI:
         mock_moorcheh.namespaces.delete.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_delete_active_agent_clears_session_state(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Deleting the active agent invalidates its local session state."""
+        agent_id = "delete-active"
+        await client.post(
+            "/api/v2/agents", headers=auth_headers, json={"agent_id": agent_id}
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{agent_id}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        response = await client.delete(
+            f"/api/v2/agents/{agent_id}", headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        status_resp = await client.get("/api/v2/status")
+        assert status_resp.status_code == 404
+
+        stale_headers = {**auth_headers, "X-Session-Token": token}
+        stale_write = await client.post(
+            f"/api/v2/agents/{agent_id}/remember",
+            headers=stale_headers,
+            json={"content": "This should not be accepted after agent deletion"},
+        )
+        assert stale_write.status_code == 404
+        assert stale_write.json()["detail"]["error"] == "SessionNotFound"
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_delete_agent_with_backup_delete(
         self, client, auth_headers, mock_moorcheh
     ):


### PR DESCRIPTION
## Summary
- remove persisted session state when an agent is deleted
- make active-session marker cleanup handle dangling symlinks as well as files
- add an API regression proving a deleted active agent no longer appears in `/api/v2/status` and its old `X-Session-Token` cannot write memory

## Why
`DELETE /api/v2/agents/{agent_id}` removed the local agent metadata, but left `~/.memanto/sessions/{agent_id}.json` and the `active` marker behind. After deleting an active agent, the backend could still report that deleted agent from `/api/v2/status`, and the old session token could continue to reach session-authenticated memory routes.

This is the backend persisted-session lifecycle fix. It is distinct from #846, which resets the TypeScript SDK's in-memory session cache after `deleteAgent()`.

Refs #770.

## Validation
- `uv run ruff check memanto/app/routes/sessions.py memanto/app/services/session_service.py tests/test_api.py`
- `uv run ruff format --check memanto/app/routes/sessions.py memanto/app/services/session_service.py tests/test_api.py`
- `uv run pytest tests/test_api.py::TestMEMANTOAPI::test_delete_active_agent_clears_session_state tests/test_api.py -q`
- `uv run pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting an active agent now also removes its local session state.
  * Active-session markers are cleaned up correctly, including when stored as symlinks.
  * After deletion, related session-based requests now fail as expected instead of using stale session data.

* **Tests**
  * Added coverage to verify that deleting an active agent clears session state and prevents further session-backed actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->