### PR TITLE
Preserve underscored scope ids in namespace parsing

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -34,7 +34,7 @@ class MemoryScope(BaseModel):
         """Parse namespace back to scope"""
         from typing import cast
 
-        parts = namespace.split("_")
+        parts = namespace.split("_", 2)
         if len(parts) != 3 or parts[0] != "memanto":
             raise ValueError(f"Invalid MEMANTO namespace format: {namespace}")
         return cls(scope_type=cast(ScopeType, parts[1]), scope_id=parts[2])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -11,6 +11,7 @@ import jwt
 import pytest
 
 from memanto.app.config import settings
+from memanto.app.core import MemoryScope
 from memanto.app.models.session import AgentCreate, AgentPattern, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
@@ -365,6 +366,17 @@ class TestMEMANTOArchitecture:
 
         print(f"✅ V2 namespace format confirmed: {namespace}")
         print("   ✅ NO tenant_id required!")
+
+    def test_namespace_round_trip_preserves_underscored_scope_id(self):
+        """Agent IDs with underscores are allowed and must parse back intact."""
+        scope = MemoryScope(scope_type="agent", scope_id="sales_bot")
+        namespace = scope.to_namespace()
+
+        parsed = MemoryScope.from_namespace(namespace)
+
+        assert namespace == "memanto_agent_sales_bot"
+        assert parsed.scope_type == "agent"
+        assert parsed.scope_id == "sales_bot"
 
     def test_jwt_token_structure(self):
         """Verify JWT token contains correct fields"""


### PR DESCRIPTION
## Summary
- preserve the full scope_id when parsing MEMANTO namespaces with underscores
- add a regression test for round-tripping an allowed underscored agent id

## Root Cause
`AgentCreate` allows underscores in agent identifiers, so `sales_bot` is valid and produces the namespace `memanto_agent_sales_bot`. `MemoryScope.from_namespace()` split on every underscore and required exactly three parts, causing valid namespaces with underscored scope IDs to be rejected as invalid.

## Tests
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMEMANTOArchitecture::test_namespace_round_trip_preserves_underscored_scope_id -q`
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py -q`
- `.venv\Scripts\python.exe -m py_compile memanto/app/core.py tests/test_unit.py`

Related to #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace handling so identifiers containing underscores are preserved correctly.
  * Ensured namespace parsing still validates the expected format while supporting round-trip consistency.
* **Tests**
  * Added coverage for namespace round-tripping with underscore-containing identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->