### PR TITLE
Normalize session datetimes before comparisons

### DIFF
--- a/memanto/app/models/session.py
+++ b/memanto/app/models/session.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from memanto.app.utils.temporal_helpers import utc_now
+from memanto.app.utils.temporal_helpers import as_utc_naive, utc_now
 
 
 class SessionStatus(str, Enum):
@@ -65,7 +65,7 @@ class Session(BaseModel):
 
     def is_expired(self) -> bool:
         """Check if session is expired"""
-        return utc_now() > self.expires_at
+        return utc_now() > as_utc_naive(self.expires_at)
 
     def is_active(self) -> bool:
         """Check if session is active"""
@@ -73,7 +73,7 @@ class Session(BaseModel):
 
     def time_remaining(self) -> timedelta:
         """Get time remaining in session"""
-        return self.expires_at - utc_now()
+        return as_utc_naive(self.expires_at) - utc_now()
 
 
 class SessionInfo(BaseModel):

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -452,4 +452,4 @@ class SessionService:
                 data = json.load(f)
                 sessions.append(Session(**data))
 
-        return sorted(sessions, key=lambda s: s.started_at, reverse=True)
+        return sorted(sessions, key=lambda s: as_utc_naive(s.started_at), reverse=True)

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -28,7 +28,7 @@ from memanto.app.utils.errors import (
     SessionNotFoundError,
 )
 from memanto.app.utils.ids import generate_id
-from memanto.app.utils.temporal_helpers import utc_now
+from memanto.app.utils.temporal_helpers import as_utc_naive, utc_now
 
 _session_service = None
 
@@ -161,7 +161,7 @@ class SessionService:
             token = SessionToken(**payload)
 
             # Validate expiration
-            if utc_now() > token.expires_at:
+            if utc_now() > as_utc_naive(token.expires_at):
                 raise SessionExpiredError(
                     f"Session {token.session_id} expired at {token.expires_at}"
                 )
@@ -239,7 +239,7 @@ class SessionService:
             raise SessionNotFoundError(f"No session found for agent {agent_id}")
 
         ended_at = utc_now()
-        duration = (ended_at - session.started_at).total_seconds() / 3600
+        duration = (ended_at - as_utc_naive(session.started_at)).total_seconds() / 3600
 
         # Update session status
         session.status = SessionStatus.TERMINATED

--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -13,6 +13,13 @@ def utc_now() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
+def as_utc_naive(dt: datetime) -> datetime:
+    """Normalize aware datetimes to the naive UTC format used in session storage."""
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+
 def parse_iso_timestamp(ts_str: str) -> datetime:
     """
     Parse an ISO formatted timestamp string into an aware UTC datetime object.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -119,6 +119,36 @@ class TestSessionService:
         assert payload.agent_id == "test-agent"
         assert payload.expires_at.tzinfo is not None
 
+    def test_list_sessions_handles_mixed_started_at_timezone(self, session_service):
+        """Session listing should sort mixed aware and naive started_at values."""
+        older_session = Session(
+            session_id="sess-older",
+            session_token="token-older",
+            agent_id="older-agent",
+            namespace="memanto_agent_older-agent",
+            started_at=datetime(2026, 3, 19, 13, 0, 0),
+            expires_at=datetime(2099, 3, 19, 20, 0, 0),
+            status=SessionStatus.ACTIVE,
+        )
+        newer_session = Session(
+            session_id="sess-newer",
+            session_token="token-newer",
+            agent_id="newer-agent",
+            namespace="memanto_agent_newer-agent",
+            started_at="2026-03-19T14:00:00Z",
+            expires_at="2099-03-19T20:00:00Z",
+            status=SessionStatus.ACTIVE,
+        )
+        session_service._save_session(older_session)
+        session_service._save_session(newer_session)
+
+        sessions = session_service.list_sessions()
+
+        assert [session.session_id for session in sessions] == [
+            "sess-newer",
+            "sess-older",
+        ]
+
     def test_validate_expired_session(self, session_service):
         """Test session validation fails for expired session"""
         # Create session with very short duration

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,14 +4,14 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
 
 from memanto.app.config import settings
-from memanto.app.models.session import AgentCreate, AgentPattern, SessionStatus
+from memanto.app.models.session import AgentCreate, AgentPattern, Session, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
 
@@ -81,6 +81,43 @@ class TestSessionService:
         assert token_payload.namespace == "memanto_agent_test-agent"
 
         print("✅ Session validation successful")
+
+    def test_session_status_handles_aware_expiration_timestamp(self):
+        """Session status helpers must handle ISO timestamps with a UTC timezone."""
+        session = Session(
+            session_id="sess-test",
+            session_token="token-test",
+            agent_id="test-agent",
+            namespace="memanto_agent_test-agent",
+            started_at="2026-03-19T14:00:00Z",
+            expires_at=(datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+            status=SessionStatus.ACTIVE,
+        )
+
+        assert session.is_expired() is False
+        assert session.is_active() is True
+        assert session.time_remaining().total_seconds() > 0
+
+    def test_validate_session_handles_aware_expiration_timestamp(self, session_service):
+        """JWT payloads with timezone-aware datetimes should validate cleanly."""
+        token = jwt.encode(
+            {
+                "agent_id": "test-agent",
+                "namespace": "memanto_agent_test-agent",
+                "session_id": "sess-test",
+                "started_at": "2026-03-19T14:00:00Z",
+                "expires_at": (
+                    datetime.now(timezone.utc) + timedelta(hours=1)
+                ).isoformat(),
+            },
+            session_service.secret_key,
+            algorithm="HS256",
+        )
+
+        payload = session_service.validate_session(token)
+
+        assert payload.agent_id == "test-agent"
+        assert payload.expires_at.tzinfo is not None
 
     def test_validate_expired_session(self, session_service):
         """Test session validation fails for expired session"""


### PR DESCRIPTION
## Summary
- normalize timezone-aware session datetimes before comparing or subtracting them
- apply the normalization to session status helpers, JWT validation, and ended-session duration calculation
- add regression tests for `Z`/timezone-aware session timestamps

## Root Cause
Session JSON and JWT payloads can contain ISO timestamps with a UTC timezone, such as `2026-03-19T20:00:00Z`. Pydantic parses those values as timezone-aware datetimes, but MEMANTO compares them with `utc_now()`, which intentionally returns a naive UTC datetime for legacy session storage. That raises `TypeError` in active-session checks and time-remaining calculations.

Reproduction on `main`:
```python
Session(
    session_id="sess-test",
    session_token="token-test",
    agent_id="agent",
    namespace="memanto_agent_agent",
    started_at="2026-03-19T14:00:00Z",
    expires_at="2099-03-19T20:00:00Z",
).is_expired()
```
This fails with `TypeError: can't compare offset-naive and offset-aware datetimes`.

## Tests
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestSessionService::test_session_status_handles_aware_expiration_timestamp tests/test_unit.py::TestSessionService::test_validate_session_handles_aware_expiration_timestamp -q`
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py -q`
- `.venv\Scripts\python.exe -m pytest tests/test_cli.py -q`
- `.venv\Scripts\python.exe -m py_compile memanto/app/utils/temporal_helpers.py memanto/app/models/session.py memanto/app/services/session_service.py tests/test_unit.py`
- `git diff --check`

Related to #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session expiration and remaining-time calculations to handle timezone-aware timestamps consistently.
  * Session validation now correctly compares dates even when stored values include UTC offsets.

* **Tests**
  * Added coverage for timezone-aware session expiry, activity checks, and token validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->