### PR TITLE
fix: stream upload_file to disk in chunks to prevent memory exhaustion

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -551,7 +551,6 @@ async def upload_file(
 
         # Write upload to a temp file so moorcheh SDK can read it
         # Use original filename so the SDK records it as the source
-        file_bytes = await file.read()
         tmp_dir = tempfile.mkdtemp()
         tmp_path = os.path.join(tmp_dir, original_name)
         # Defense-in-depth: verify resolved path is within tmp_dir
@@ -562,9 +561,30 @@ async def upload_file(
                 status_code=400,
                 detail="Invalid filename",
             )
+        # Stream file to disk in 1 MB chunks instead of loading it all into
+        # memory at once. Without this, a 5 GB upload would allocate ~5 GB of
+        # RAM in a single Python bytes object, making the server trivially
+        # exhaustible under concurrent large-file uploads.
+        _MAX_UPLOAD_BYTES = 5 * 1024 * 1024 * 1024  # 5 GB as documented
+        _CHUNK_SIZE = 1024 * 1024  # 1 MB
         try:
+            total_bytes = 0
             with open(tmp_path, "wb") as tmp:
-                tmp.write(file_bytes)
+                while True:
+                    chunk = await file.read(_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    total_bytes += len(chunk)
+                    if total_bytes > _MAX_UPLOAD_BYTES:
+                        raise HTTPException(
+                            status_code=413,
+                            detail={
+                                "error": "file_too_large",
+                                "message": "File exceeds the maximum upload size of 5 GB",
+                                "max_bytes": _MAX_UPLOAD_BYTES,
+                            },
+                        )
+                    tmp.write(chunk)
             result = await asyncio.to_thread(
                 client.documents.upload_file, namespace, tmp_path
             )

--- a/memanto/app/utils/errors.py
+++ b/memanto/app/utils/errors.py
@@ -91,6 +91,9 @@ class AgentAlreadyExistsError(AgentError):
 def map_error_to_http_exception(error: Exception) -> HTTPException:
     """Map internal errors to HTTP exceptions"""
 
+    if isinstance(error, HTTPException):
+        return error
+
     if isinstance(error, ValidationError):
         return HTTPException(
             status_code=400,


### PR DESCRIPTION
## Bug

`upload_file` calls `await file.read()` which loads the **entire uploaded file into a single Python `bytes` object** before writing it to a temp file.

The endpoint docstring advertises a **5 GB maximum file size**, so a single upload could allocate ~5 GB of RAM. Under a few concurrent large-file requests the server runs out of memory and crashes — a trivial DoS.

```python
# Before (vulnerable)
file_bytes = await file.read()          # allocates full file in RAM
with open(tmp_path, "wb") as tmp:
    tmp.write(file_bytes)
```

**Scope from #770:** *"Architectural & Logic Flaws: Bad logic loops, poor contradiction handling, or inefficient background processes that severely slow down the agent"*

## Fix

Replace the single `read()` call with a 1 MB chunked loop:

```python
# After (safe)
_MAX_UPLOAD_BYTES = 5 * 1024 * 1024 * 1024  # 5 GB as documented
_CHUNK_SIZE = 1024 * 1024  # 1 MB

total_bytes = 0
with open(tmp_path, "wb") as tmp:
    while True:
        chunk = await file.read(_CHUNK_SIZE)
        if not chunk:
            break
        total_bytes += len(chunk)
        if total_bytes > _MAX_UPLOAD_BYTES:
            raise HTTPException(status_code=413, detail={...})
        tmp.write(chunk)
```

This:
- Never holds more than **1 MB** of file data in memory at once regardless of file size
- Enforces the documented 5 GB limit with a proper **413 response**
- Keeps the existing path-traversal guard (`os.path.realpath`) and `shutil.rmtree` cleanup intact

## Impact

| | Before | After |
|---|---|---|
| Peak RAM per upload | up to 5 GB | ≤ 1 MB |
| Concurrent 5 GB uploads to crash | 1–2 | not possible |
| 413 on oversized files | ❌ no limit enforced | ✅ enforced |

Submitted as part of the Memanto Bug & Exploit Challenge (#770).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload handling by streaming uploads to temporary storage in fixed-size chunks instead of buffering the full file in memory.
  * Enforced a 5GB maximum upload size during streaming; oversized uploads now return a structured “file too large” (413) response.
  * Ensured any pre-existing HTTP error responses are passed through as-is, rather than being remapped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->