### PR TITLE
Preserve imported memory timestamps

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -34,6 +34,13 @@ class MemoryWriteService:
             self._namespace_service = NamespaceService(self.client)
         return self._namespace_service
 
+    def _apply_timestamps(self, memory: MemoryRecord, now: datetime) -> None:
+        """Apply server timestamps while preserving imported source chronology."""
+        if memory.provenance == "imported":
+            return
+        memory.created_at = now
+        memory.updated_at = now
+
     def store_memory(
         self, memory: MemoryRecord, context: dict[str, Any] | None = None
     ) -> dict[str, Any]:
@@ -43,10 +50,8 @@ class MemoryWriteService:
             if not memory.id:
                 memory.id = generate_memory_id()
 
-            # Enforce server-side timestamps (never trust client)
             now = datetime.utcnow()
-            memory.created_at = now
-            memory.updated_at = now
+            self._apply_timestamps(memory, now)
 
             # Auto parse memory type
             memory = self._parser.parse_memory(memory)
@@ -124,9 +129,7 @@ class MemoryWriteService:
                     if not memory.id:
                         memory.id = generate_memory_id()
 
-                    # Enforce server-side timestamps (never trust client)
-                    memory.created_at = now
-                    memory.updated_at = now
+                    self._apply_timestamps(memory, now)
 
                     memory = self._parser.parse_memory(memory)
 

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -2,7 +2,7 @@
 Memory Write Service
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -12,6 +12,12 @@ from memanto.app.core import MemoryRecord
 from memanto.app.services.memory_parsing_service import MemoryParsingService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
+
+
+def _as_utc_naive(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 class MemoryWriteService:
@@ -37,6 +43,8 @@ class MemoryWriteService:
     def _apply_timestamps(self, memory: MemoryRecord, now: datetime) -> None:
         """Apply server timestamps while preserving imported source chronology."""
         if memory.provenance == "imported":
+            memory.created_at = _as_utc_naive(memory.created_at)
+            memory.updated_at = _as_utc_naive(memory.updated_at)
             return
         memory.created_at = now
         memory.updated_at = now

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,7 +4,7 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import jwt
@@ -344,6 +344,60 @@ class TestForgetEndToEnd:
         result = client.delete_memory(agent_id="test-agent", memory_id="mem-xyz")
         assert result["status"] == "deleted"
         assert result["memory_id"] == "mem-xyz"
+
+
+class TestMemoryWriteServiceTimestamps:
+    """Imported memories should keep source chronology during migration."""
+
+    def test_batch_store_preserves_imported_created_at(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "success"}
+        service = MemoryWriteService(client)
+        source_created = datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+        memory = MemoryRecord(
+            title="Imported fact",
+            content="Original imported memory",
+            scope_type="agent",
+            scope_id="test-agent",
+            actor_id="test-agent",
+            source="mem0",
+            provenance="imported",
+            created_at=source_created,
+        )
+
+        service.batch_store_memories([memory])
+
+        uploaded = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded["created_at"].startswith("2020-01-02T03:04:05")
+
+    def test_batch_store_overrides_non_imported_created_at(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "success"}
+        service = MemoryWriteService(client)
+        source_created = datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+        memory = MemoryRecord(
+            title="User fact",
+            content="Fresh user memory",
+            scope_type="agent",
+            scope_id="test-agent",
+            actor_id="test-agent",
+            source="user",
+            provenance="explicit_statement",
+            created_at=source_created,
+        )
+
+        service.batch_store_memories([memory])
+
+        uploaded = client.documents.upload.call_args.kwargs["documents"][0]
+        assert not uploaded["created_at"].startswith("2020-01-02T03:04:05")
 
 
 class TestMEMANTOArchitecture:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -359,6 +359,7 @@ class TestMemoryWriteServiceTimestamps:
         source_created = datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
 
         memory = MemoryRecord(
+            type="preference",
             title="Imported fact",
             content="Original imported memory",
             scope_type="agent",
@@ -372,7 +373,10 @@ class TestMemoryWriteServiceTimestamps:
         service.batch_store_memories([memory])
 
         uploaded = client.documents.upload.call_args.kwargs["documents"][0]
-        assert uploaded["created_at"].startswith("2020-01-02T03:04:05")
+        assert uploaded["created_at"] == "2020-01-02T03:04:05"
+        assert memory.created_at.tzinfo is None
+        memory.compute_confidence()
+        memory.trust_score()
 
     def test_batch_store_overrides_non_imported_created_at(self):
         from memanto.app.core import MemoryRecord
@@ -394,10 +398,14 @@ class TestMemoryWriteServiceTimestamps:
             created_at=source_created,
         )
 
+        before_store = datetime.utcnow()
         service.batch_store_memories([memory])
+        after_store = datetime.utcnow()
 
         uploaded = client.documents.upload.call_args.kwargs["documents"][0]
         assert not uploaded["created_at"].startswith("2020-01-02T03:04:05")
+        parsed_created_at = datetime.fromisoformat(uploaded["created_at"])
+        assert before_store <= parsed_created_at <= after_store
 
 
 class TestMEMANTOArchitecture:


### PR DESCRIPTION
## Summary
- preserve source `created_at` / `updated_at` timestamps for imported memories
- keep server-side timestamp overwrites for normal user-created memories
- add regression coverage for both imported and non-imported batch writes

## Root Cause
The migrate mappers carry provider timestamps into each mapped memory as `created_at` and `updated_at`, and the CLI batch path explicitly forwards those per-item timestamp overrides for the migration flow. However, `MemoryWriteService.batch_store_memories()` unconditionally replaced every memory's timestamps with `datetime.utcnow()` before upload, so imported memories lost their original source chronology.

Reproduction on `main`:
```python
source_created = datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
memory = MemoryRecord(
    title="Imported fact",
    content="Original imported memory",
    scope_type="agent",
    scope_id="agent",
    actor_id="agent",
    source="mem0",
    provenance="imported",
    created_at=source_created,
)
MemoryWriteService(client).batch_store_memories([memory])
```
The uploaded document's `created_at` becomes the current server time instead of `2020-01-02T03:04:05+00:00`.

## Tests
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMemoryWriteServiceTimestamps::test_batch_store_preserves_imported_created_at tests/test_unit.py::TestMemoryWriteServiceTimestamps::test_batch_store_overrides_non_imported_created_at -q`
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py -q`
- `.venv\Scripts\python.exe -m pytest tests/test_cli.py -q`
- `.venv\Scripts\python.exe -m py_compile memanto/app/services/memory_write_service.py tests/test_unit.py`
- `git diff --check`

Related to #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling when saving memories: imported items now keep their original `created_at`/`updated_at` (converted to timezone-naive), while newly created items use the current save time.
  * Ensured batch uploads apply consistent timestamping rules across all items.

* **Tests**
  * Added unit tests validating timestamp behavior during batch memory storage for both imported and non-imported memories, including timezone-naive handling and time-window verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->