### PR TITLE
fix: update session service to log metadata locally along with memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <div align="center">
-  <h1>Your agents focus. Memanto remembers.</h1>
+  <h1>Memory that AI Agents Love!</h1>
 </div>
 
 <h2 align="center">
-  <em>A companion memory agent with its own intelligence that keeps your agents focused on their tasks.</em>
+  <em>A companion memory agent that lets your agents focus and improve while you keep ownership of everything they learn.</em>
 </h2>
 
 <p align="center">

--- a/docs/CLI_USER_GUIDE.md
+++ b/docs/CLI_USER_GUIDE.md
@@ -20,7 +20,7 @@
 
 ## Introduction
 
-MEMANTO CLI provides a command-line interface for interacting with MEMANTO (Your agents focus. Memanto remembers.). It enables you to:
+MEMANTO CLI provides a command-line interface for interacting with MEMANTO (Memory that AI Agents Love!). It enables you to:
 
 - Create and manage AI agents
 - Store and retrieve agent memories

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -8,7 +8,7 @@
 
 ## What is MEMANTO?
 
-MEMANTO (Your agents focus. Memanto remembers.) is a production-ready FastAPI service that gives your AI agents persistent memory across conversations, sessions, and workflows.
+MEMANTO (Memory that AI Agents Love!) is a production-ready FastAPI service that gives your AI agents persistent memory across conversations, sessions, and workflows.
 
 **Think of it as**: A PostgreSQL database, but optimized for AI agents - with semantic search, AI-powered summarization, and built specifically for agent workflows.
 

--- a/memanto/__init__.py
+++ b/memanto/__init__.py
@@ -1,3 +1,3 @@
 """
-Memanto - Your agents focus. Memanto remembers.
+Memanto - Memory that AI Agents Love!
 """

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -64,7 +64,7 @@ async def lifespan(_: FastAPI):
 
 # Create FastAPI app
 app = FastAPI(
-    title="Memanto - Your agents focus. Memanto remembers.",
+    title="Memanto - Memory that AI Agents Love!",
     description="A memory layer service for agentic AI systems using Moorcheh SDK",
     version=__version__,
     docs_url="/docs",
@@ -97,7 +97,7 @@ mount_ui_static(app)
 async def root():
     return {
         "service": "MEMANTO",
-        "description": "A companion memory agent with its own intelligence that keeps your agents focused on their tasks.",
+        "description": "A companion memory agent that lets your agents focus and improve while you keep ownership of everything they learn.",
         "version": __version__,
         "docs": "/docs",
     }

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -362,6 +362,12 @@ class SessionService:
         title = getattr(memory_record, "title", "Untitled")
         content = getattr(memory_record, "content", "")
         confidence = getattr(memory_record, "confidence", 1.0)
+        # Fall back to the record's own id so the ID is logged on every path
+        memory_id = memory_id or getattr(memory_record, "id", None)
+        source = getattr(memory_record, "source", None)
+        provenance = getattr(memory_record, "provenance", None)
+        status = getattr(memory_record, "status", None)
+        tags = getattr(memory_record, "tags", None)
 
         with open(summary_file, "a", encoding="utf-8") as f:
             if write_header:
@@ -373,6 +379,14 @@ class SessionService:
             if memory_id:
                 f.write(f"- **Memory ID**: `{memory_id}`\n")
             f.write(f"- **Confidence**: `{confidence}`\n")
+            if status:
+                f.write(f"- **Status**: `{status}`\n")
+            if source:
+                f.write(f"- **Source**: `{source}`\n")
+            if provenance:
+                f.write(f"- **Provenance**: `{provenance}`\n")
+            if tags:
+                f.write(f"- **Tags**: {', '.join(f'`{t}`' for t in tags)}\n")
             f.write("- **Content**:\n")
             f.write(f"> {content.replace(chr(10), chr(10) + '> ')}\n\n")
             f.write("---\n\n")

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Memanto Dashboard — Your agents focus. Memanto remembers.</title>
+    <title>Memanto Dashboard — Memory that AI Agents Love!</title>
     <meta name="description" content="MEMANTO Web UI Dashboard for managing agentic AI memory">
     <link rel="icon" type="image/x-icon" href="/ui/static/favicon.ico">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"

--- a/memanto/cli/commands/_shared.py
+++ b/memanto/cli/commands/_shared.py
@@ -53,7 +53,7 @@ from memanto.cli.ui.theme import (  # noqa: F401
 # Initialize Typer app and console
 app = typer.Typer(
     name="memanto",
-    help="MEMANTO CLI - Your agents focus. Memanto remembers.",
+    help="MEMANTO CLI - Memory that AI Agents Love!",
     add_completion=False,
 )
 console = Console()

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -599,7 +599,7 @@ def main_callback(
         is_eager=True,
     ),
 ):
-    """MEMANTO CLI - Your agents focus. Memanto remembers."""
+    """MEMANTO CLI - Memory that AI Agents Love!"""
     if ctx.invoked_subcommand is None:
         # Print logo
         print_logo()
@@ -630,7 +630,7 @@ def status():
     console.print(
         Panel.fit(
             f"[{BOLD_PRIMARY}]MEMANTO Status Dashboard[/{BOLD_PRIMARY}]\n"
-            f"Your agents focus. Memanto remembers.  •  v{memanto_version}",
+            f"Memory that AI Agents Love!  •  v{memanto_version}",
             border_style=PRIMARY,
         )
     )

--- a/memanto/cli/ui/display.py
+++ b/memanto/cli/ui/display.py
@@ -86,7 +86,7 @@ def print_logo() -> None:
 
     # Tagline
     tagline = Text()
-    tagline.append("  Your agents focus. Memanto remembers.\n", style="bold white")
+    tagline.append("  Memory that AI Agents Love!\n", style="bold white")
     tagline.append("  powered by ", style="dim")
     tagline.append("moorcheh.ai", style=BOLD_PRIMARY)
     console.print(tagline)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "memanto"
 dynamic = ["version"]
-description = "A companion memory agent with its own intelligence that keeps your agents focused on their tasks."
+description = "A companion memory agent that lets your agents focus and improve while you keep ownership of everything they learn."
 authors = [{ name = "Majid Fekri", email = "majid.fekri@edgeaiinnovations.com" }]
 requires-python = ">=3.10,<4"
 readme = "README.md"

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Memanto - Memory that AI Agents Love!",
+    "title": "Memanto - Your agents focus. Memanto remembers.",
     "description": "A memory layer service for agentic AI systems using Moorcheh SDK",
-    "version": "0.1.4.dev132+g29f7ca7"
+    "version": "0.2.4.dev12+g0e7dd4f.d20260623"
   },
   "paths": {
     "/health": {
@@ -192,6 +192,216 @@
                 "schema": {
                   "$ref": "#/components/schemas/BatchRememberResponse"
                 }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/agents/{agent_id}/memories/{memory_id}": {
+      "patch": {
+        "tags": [
+          "Sessions & Agents",
+          "Memory Operations"
+        ],
+        "summary": "Edit Memory",
+        "description": "Update one memory in the active agent's namespace (Session-based).\n\nRequires:\n- X-Session-Token: {session_token}\n\nThe session must be for the specified agent_id.",
+        "operationId": "edit_memory_api_v2_agents__agent_id__memories__memory_id__patch",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Memory Id"
+            }
+          },
+          {
+            "name": "x-session-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemoryEditRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Sessions & Agents",
+          "Memory Operations"
+        ],
+        "summary": "Delete Memory",
+        "description": "Delete one memory from the active agent namespace.\n\nRequires:\n- X-Session-Token: {session_token}\n\nThe session must be for the specified agent_id.",
+        "operationId": "delete_memory_api_v2_agents__agent_id__memories__memory_id__delete",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Memory Id"
+            }
+          },
+          {
+            "name": "x-session-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/agents/{agent_id}/remember/extract": {
+      "post": {
+        "tags": [
+          "Sessions & Agents",
+          "Memory Operations"
+        ],
+        "summary": "Extract Memories From Conversation",
+        "description": "Extract typed memory candidates from chat-style conversation turns.\n\nRequires:\n- X-Session-Token: {session_token}\n\nWhen dry_run is true, candidates are returned without writing. Otherwise the\ncandidates are persisted through the same batch memory path used by\n/batch-remember.",
+        "operationId": "extract_memories_from_conversation_api_v2_agents__agent_id__remember_extract_post",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "x-session-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Session-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExtractMemoriesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           },
@@ -1792,6 +2002,90 @@
         }
       }
     },
+    "/api/ui/migrate/dry-run": {
+      "post": {
+        "tags": [
+          "Web UI"
+        ],
+        "summary": "Migrate Dry Run",
+        "description": "Preview a migration without writing.\n\nBody: ``{provider, file?, api_key?}``. Returns the mapped row count,\ntype breakdown, compact savings metrics, and a small sample of the\nmapped payloads so the UI can preview what would be imported.",
+        "operationId": "migrate_dry_run_api_ui_migrate_dry_run_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Body"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ui/migrate/import": {
+      "post": {
+        "tags": [
+          "Web UI"
+        ],
+        "summary": "Migrate Import",
+        "description": "Run an end-to-end migration.\n\nBody: ``{provider, file?, api_key?, agent_id?}``. Loads-or-exports,\nmaps, chunks at 100/req, and writes via ``DirectClient.batch_remember``.\nReturns numeric summary only — no LLM narrative.",
+        "operationId": "migrate_import_api_ui_migrate_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Body"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "summary": "Root",
@@ -2366,6 +2660,29 @@
         "title": "ConflictResolveRequest",
         "description": "Request body for resolving a conflict"
       },
+      "ConversationMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Role"
+          },
+          "content": {
+            "type": "string",
+            "maxLength": 10000,
+            "minLength": 1,
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "ConversationMessage",
+        "description": "Chat-style message used for conversation memory extraction."
+      },
       "DailySummaryRequest": {
         "properties": {
           "date": {
@@ -2395,6 +2712,52 @@
         },
         "type": "object",
         "title": "DailySummaryRequest"
+      },
+      "ExtractMemoriesRequest": {
+        "properties": {
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationMessage"
+            },
+            "type": "array",
+            "maxItems": 200,
+            "minItems": 1,
+            "title": "Messages",
+            "description": "Conversation turns to extract durable memories from"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run",
+            "description": "When true, return candidates without storing them",
+            "default": false
+          },
+          "max_memories": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1,
+            "title": "Max Memories",
+            "description": "Maximum candidate memories to extract",
+            "default": 20
+          },
+          "ai_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ai Model",
+            "description": "Optional model override for extraction"
+          }
+        },
+        "type": "object",
+        "required": [
+          "messages"
+        ],
+        "title": "ExtractMemoriesRequest",
+        "description": "Request body for extracting typed memories from conversation turns."
       },
       "HTTPValidationError": {
         "properties": {
@@ -2436,6 +2799,85 @@
           "moorcheh_connected"
         ],
         "title": "HealthResponse"
+      },
+      "MemoryEditRequest": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 10000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 1,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "title": "MemoryEditRequest"
       },
       "MemoryItem": {
         "properties": {

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Memanto - Your agents focus. Memanto remembers.",
+    "title": "Memanto - Memory that AI Agents Love!",
     "description": "A memory layer service for agentic AI systems using Moorcheh SDK",
     "version": "0.2.4.dev12+g0e7dd4f.d20260623"
   },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,7 +126,7 @@ class TestMEMANTOCLI:
         """Test 'memanto --help'"""
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "Your agents focus. Memanto remembers." in result.stdout
+        assert "Memory that AI Agents Love!" in result.stdout
 
     def test_status_command(self, mock_all_clients):
         """Test 'memanto status'"""


### PR DESCRIPTION
- update local log structure to store metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to edit and delete memories, and to extract candidate memories from conversation messages.
  * Added UI migration endpoints to preview migrations (dry run) and to perform imports.
  * Session summary logging now includes richer per-memory details (status, source, provenance, and tags).
* **Bug Fixes**
  * Improved session summary completeness by capturing additional available metadata, including a fallback memory identifier when needed.
* **Documentation / Branding**
  * Updated Memanto copy and app/CLI/website titles across the README, guides, dashboard, and CLI help output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->