### PR TITLE
fix(migrate): make imported memory ids stable across retries

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -720,7 +720,7 @@ class DirectClient:
                 "source": item.get("source") or "user",
                 "provenance": provenance,
             }
-            for opt_key in ("source_ref", "created_at", "updated_at"):
+            for opt_key in ("id", "source_ref", "created_at", "updated_at"):
                 val = item.get(opt_key)
                 if val is not None:
                     kwargs[opt_key] = val

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -549,7 +549,7 @@ class SdkClient:
                 "source": item.get("source") or "user",
                 "provenance": provenance,
             }
-            for opt_key in ("source_ref", "created_at", "updated_at"):
+            for opt_key in ("id", "source_ref", "created_at", "updated_at"):
                 val = item.get(opt_key)
                 if val is not None:
                     kwargs[opt_key] = val

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -19,7 +19,9 @@ can surface them as the "what migrating saves you" preview.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -28,6 +30,7 @@ from typing import Any, cast
 from memanto.cli.migrate.mappers import MAPPERS, type_breakdown
 
 BATCH_LIMIT = 100
+MIGRATION_ID_NAMESPACE = uuid.UUID("c96c2be1-42c1-4db0-a4b3-55a040f7b74c")
 
 
 @dataclass
@@ -73,6 +76,34 @@ def map_export(provider: str, export: dict[str, Any]) -> list[dict[str, Any]]:
 def chunked(items: list[dict[str, Any]], size: int = BATCH_LIMIT):
     for i in range(0, len(items), size):
         yield items[i : i + size]
+
+
+def _content_fingerprint(row: dict[str, Any]) -> str:
+    payload = {
+        "title": row.get("title"),
+        "content": row.get("content"),
+        "source": row.get("source"),
+        "tags": row.get("tags") or [],
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+
+def _stable_import_id(provider: str, agent_id: str, row: dict[str, Any]) -> str:
+    """Build a retry-stable memory id for one migrated source row."""
+    source_ref = row.get("source_ref")
+    if source_ref:
+        source_identity = f"source_ref:{source_ref}"
+    else:
+        source_identity = f"content:{_content_fingerprint(row)}"
+
+    return str(
+        uuid.uuid5(
+            MIGRATION_ID_NAMESPACE,
+            f"agent:{agent_id}:provider:{provider}:{source_identity}",
+        )
+    )
 
 
 def write_preview(rows: list[dict[str, Any]], dest: Path) -> Path:
@@ -124,6 +155,9 @@ def run_migration(
 
     if dry_run or not rows:
         return summary, rows
+
+    for row in rows:
+        row.setdefault("id", _stable_import_id(provider, agent_id, row))
 
     batches = list(chunked(rows, BATCH_LIMIT))
     summary.batches = len(batches)

--- a/tests/test_migrate_runner.py
+++ b/tests/test_migrate_runner.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any
+
+from memanto.cli.migrate.runner import run_migration
+
+
+class RecordingClient:
+    def __init__(self, fail_calls: set[int] | None = None) -> None:
+        self.fail_calls = fail_calls or set()
+        self.calls: list[list[dict[str, Any]]] = []
+
+    def batch_remember(
+        self, agent_id: str, memories: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        call_number = len(self.calls) + 1
+        self.calls.append([dict(memory) for memory in memories])
+        if call_number in self.fail_calls:
+            raise RuntimeError("transient import failure")
+        return {
+            "successful": len(memories),
+            "failed": 0,
+            "results": [{"id": memory.get("id")} for memory in memories],
+        }
+
+
+def _mem0_export(count: int) -> dict[str, Any]:
+    return {
+        "memories": [
+            {
+                "id": f"mem-{idx}",
+                "memory": f"Imported memory {idx}",
+                "categories": ["work"],
+            }
+            for idx in range(count)
+        ]
+    }
+
+
+def test_migration_retry_reuses_stable_import_ids_after_partial_failure():
+    export = _mem0_export(101)
+    first_client = RecordingClient(fail_calls={2})
+
+    first_summary, _ = run_migration(
+        provider="mem0",
+        export=export,
+        client=first_client,
+        agent_id="agent-a",
+        dry_run=False,
+    )
+
+    assert first_summary.imported == 100
+    assert first_summary.failed == 1
+
+    retry_client = RecordingClient()
+    retry_summary, _ = run_migration(
+        provider="mem0",
+        export=export,
+        client=retry_client,
+        agent_id="agent-a",
+        dry_run=False,
+    )
+
+    assert retry_summary.imported == 101
+    first_batch_ids = [memory.get("id") for memory in first_client.calls[0]]
+    retry_batch_ids = [memory.get("id") for memory in retry_client.calls[0]]
+    assert first_batch_ids == retry_batch_ids
+    assert all(first_batch_ids)
+
+
+def test_migration_import_ids_are_scoped_to_agent():
+    export = _mem0_export(1)
+    agent_a = RecordingClient()
+    agent_b = RecordingClient()
+
+    run_migration(
+        provider="mem0",
+        export=export,
+        client=agent_a,
+        agent_id="agent-a",
+        dry_run=False,
+    )
+    run_migration(
+        provider="mem0",
+        export=export,
+        client=agent_b,
+        agent_id="agent-b",
+        dry_run=False,
+    )
+
+    agent_a_id = agent_a.calls[0][0].get("id")
+    agent_b_id = agent_b.calls[0][0].get("id")
+
+    assert agent_a_id != agent_b_id


### PR DESCRIPTION
## Summary
- assign retry-stable UUIDv5 ids to mapped migration rows before batch import
- scope imported ids by target agent, provider, and source identity/content fingerprint
- pass caller-provided ids through both CLI clients so migration retries target the same records

## Flaw
A transient failure after an earlier migration chunk succeeds can leave imported memories committed. Retrying the same export previously submitted those already-imported rows without ids, so each retry generated fresh memory ids and created duplicate imported memories.

## Reproduction
1. Prepare a Mem0 export with more than 100 memories so migration runs in multiple batches.
2. Let the first batch succeed and force the second batch to raise a transient error.
3. Retry the same migration after the transient error is gone.
4. Before this change, the first 100 source records are submitted again without stable ids, so the write path assigns new ids and duplicates the already-imported memories.

## Fix
The migration runner now assigns deterministic ids before batching. Rows with a provider `source_ref` use that stable source identity; rows without one fall back to a content fingerprint. The id namespace includes the target agent and provider so imports remain retry-safe without colliding across agents. Both CLI clients now forward caller-provided ids into `MemoryRecord`.

## Tests
- python -m pytest tests/test_migrate_runner.py -q
- python -m ruff check tests/test_migrate_runner.py memanto/cli/migrate/runner.py memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py
- git diff --check

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch imports can now preserve item IDs when provided, helping keep records consistent across writes and migrations.
  * Migration imports now generate stable, repeatable IDs for items that don’t already have one.

* **Bug Fixes**
  * Improved retry behavior during migrations so partially imported items keep the same ID on subsequent attempts.
  * Import IDs are now scoped per agent, reducing the chance of collisions between different sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->