### PR TITLE
fix(conflicts): resolve filtered UI entries by original index

### DIFF
--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -4335,16 +4335,17 @@
 
                 conflicts.forEach((c, i) => {
                     const ctype = (c.type || 'conflict').toUpperCase();
+                    const conflictIndex = Number.isInteger(c.conflict_index) ? c.conflict_index : i;
                     const explanation = c.explanation || c.reason || 'Conflicting information detected.';
 
                     html += `
-            <div class="conflict-card" id="conflict-${i}">
+            <div class="conflict-card" id="conflict-${conflictIndex}">
                 <div class="conflict-header">
                     <div>
                         <span class="conflict-type">${escHtml(ctype)}</span>
                         <span class="badge badge-warning" style="margin-left:8px">Unresolved</span>
                     </div>
-                    <span style="font-size:11px;color:var(--text-dim);font-family:var(--font-mono)">#${i}</span>
+                    <span style="font-size:11px;color:var(--text-dim);font-family:var(--font-mono)">#${conflictIndex}</span>
                 </div>
                 <p style="color:var(--text-secondary);font-size:13px;margin-bottom:16px;line-height:1.6">${escHtml(explanation)}</p>
                 <div class="conflict-memories">
@@ -4368,18 +4369,18 @@
                     </div>
                 </div>
                 <div class="conflict-actions">
-                    <button class="btn btn-sm btn-secondary" onclick="resolveConflict(${i}, '${data.agent_id}', '${data.date}', 'keep_old')">Keep Old</button>
-                    <button class="btn btn-sm btn-primary" onclick="resolveConflict(${i}, '${data.agent_id}', '${data.date}', 'keep_new')">Keep New</button>
-                    <button class="btn btn-sm btn-secondary" onclick="resolveConflict(${i}, '${data.agent_id}', '${data.date}', 'keep_both')">Keep Both</button>
-                    <button class="btn btn-sm btn-danger" onclick="resolveConflict(${i}, '${data.agent_id}', '${data.date}', 'remove_both')">Remove Both</button>
-                    <button class="btn btn-sm btn-secondary" onclick="showManualResolve(${i}, '${data.agent_id}', '${data.date}')">Manual</button>
+                    <button class="btn btn-sm btn-secondary" onclick="resolveConflict(${conflictIndex}, '${data.agent_id}', '${data.date}', 'keep_old')">Keep Old</button>
+                    <button class="btn btn-sm btn-primary" onclick="resolveConflict(${conflictIndex}, '${data.agent_id}', '${data.date}', 'keep_new')">Keep New</button>
+                    <button class="btn btn-sm btn-secondary" onclick="resolveConflict(${conflictIndex}, '${data.agent_id}', '${data.date}', 'keep_both')">Keep Both</button>
+                    <button class="btn btn-sm btn-danger" onclick="resolveConflict(${conflictIndex}, '${data.agent_id}', '${data.date}', 'remove_both')">Remove Both</button>
+                    <button class="btn btn-sm btn-secondary" onclick="showManualResolve(${conflictIndex}, '${data.agent_id}', '${data.date}')">Manual</button>
                 </div>
-                <div id="manual-${i}" style="display:none;margin-top:12px">
+                <div id="manual-${conflictIndex}" style="display:none;margin-top:12px">
                     <div class="form-group">
                         <label>Manual Replacement Content</label>
-                        <textarea id="manualContent-${i}" placeholder="Enter the correct merged content..." style="min-height:60px"></textarea>
+                        <textarea id="manualContent-${conflictIndex}" placeholder="Enter the correct merged content..." style="min-height:60px"></textarea>
                     </div>
-                    <button class="btn btn-sm btn-primary" onclick="resolveConflict(${i}, '${data.agent_id}', '${data.date}', 'manual', document.getElementById('manualContent-${i}').value)">Submit Manual Resolution</button>
+                    <button class="btn btn-sm btn-primary" onclick="resolveConflict(${conflictIndex}, '${data.agent_id}', '${data.date}', 'manual', document.getElementById('manualContent-${conflictIndex}').value)">Submit Manual Resolution</button>
                 </div>
             </div>`;
                 });

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1307,8 +1307,13 @@ class DirectClient:
         with open(json_path, encoding="utf-8") as f:
             all_conflicts = json.load(f)
 
-        # Return only unresolved conflicts
-        return [c for c in all_conflicts if not c.get("resolved", False)]
+        # Return only unresolved conflicts, preserving their original file index
+        # so UI callers can resolve the same item after filtering.
+        return [
+            {**c, "conflict_index": idx}
+            for idx, c in enumerate(all_conflicts)
+            if not c.get("resolved", False)
+        ]
 
     def resolve_conflict(
         self,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1176,8 +1176,13 @@ class SdkClient:
         with open(json_path, encoding="utf-8") as f:
             all_conflicts = json.load(f)
 
-        # Return only unresolved conflicts
-        return [c for c in all_conflicts if not c.get("resolved", False)]
+        # Return only unresolved conflicts, preserving their original file index
+        # so UI/API callers can resolve the same item after filtering.
+        return [
+            {**c, "conflict_index": idx}
+            for idx, c in enumerate(all_conflicts)
+            if not c.get("resolved", False)
+        ]
 
     def resolve_conflict(
         self,

--- a/tests/test_conflict_resolution.py
+++ b/tests/test_conflict_resolution.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import memanto.cli.client.direct_client as direct_client_module
+import memanto.cli.client.sdk_client as sdk_client_module
+from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.client.sdk_client import SdkClient
+
+
+class RecordingWriteService:
+    def __init__(self) -> None:
+        self.deleted: list[tuple[str, str]] = []
+
+    def delete_memory(self, memory_id: str, namespace: str) -> None:
+        self.deleted.append((memory_id, namespace))
+
+
+class ConflictTestClient(DirectClient):
+    def __init__(self) -> None:
+        super().__init__(api_key="test-key")
+        self.write_service = RecordingWriteService()
+
+    def _get_write_service(self):
+        return self.write_service
+
+
+def _write_conflict_report(home: Path, agent_id: str, date: str) -> Path:
+    conflict_dir = home / ".memanto" / "conflicts"
+    conflict_dir.mkdir(parents=True)
+    report_path = conflict_dir / f"{agent_id}_{date}_conflicts.json"
+    report_path.write_text(
+        json.dumps(
+            [
+                {
+                    "title": "already resolved",
+                    "old_memory_id": "old-0",
+                    "new_memory_id": "new-0",
+                    "resolved": True,
+                },
+                {
+                    "title": "visible conflict",
+                    "old_memory_id": "old-1",
+                    "new_memory_id": "new-1",
+                    "resolved": False,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return report_path
+
+
+@pytest.mark.parametrize(
+    ("client_cls", "client_module"),
+    [(DirectClient, direct_client_module), (SdkClient, sdk_client_module)],
+)
+def test_list_conflicts_preserves_original_conflict_index(
+    tmp_path, monkeypatch, client_cls, client_module
+):
+    agent_id = "agent-a"
+    date = "2026-05-08"
+    _write_conflict_report(tmp_path, agent_id, date)
+    monkeypatch.setattr(client_module.Path, "home", lambda: tmp_path)
+
+    conflicts = client_cls(api_key="test-key").list_conflicts(agent_id=agent_id, date=date)
+
+    assert len(conflicts) == 1
+    assert conflicts[0]["title"] == "visible conflict"
+    assert conflicts[0]["conflict_index"] == 1
+
+
+def test_resolve_visible_conflict_uses_original_index(tmp_path, monkeypatch):
+    agent_id = "agent-a"
+    date = "2026-05-08"
+    report_path = _write_conflict_report(tmp_path, agent_id, date)
+    monkeypatch.setattr(direct_client_module.Path, "home", lambda: tmp_path)
+
+    client = ConflictTestClient()
+    visible = client.list_conflicts(agent_id=agent_id, date=date)
+
+    result = client.resolve_conflict(
+        agent_id=agent_id,
+        date=date,
+        conflict_index=visible[0]["conflict_index"],
+        action="keep_new",
+    )
+
+    assert result["status"] == "resolved"
+    assert result["deleted"] == "old-1"
+    assert client.write_service.deleted == [("old-1", "memanto_agent_agent-a")]
+
+    stored_conflicts = json.loads(report_path.read_text(encoding="utf-8"))
+    assert stored_conflicts[0].get("resolution") != "keep_new"
+    assert stored_conflicts[1]["resolution"] == "keep_new"


### PR DESCRIPTION
## Summary
- include each unresolved conflict's original JSON-file index in `list_conflicts()` results
- make the web conflict UI resolve by that original index instead of the filtered display index
- add regression coverage for filtered conflict lists and resolve round-trips

## Flaw
The conflict list API only returned unresolved conflicts, so the web UI rendered a filtered array and sent that filtered array index back to `/api/ui/conflicts/resolve`. The resolver indexes into the full conflict report file. If an earlier conflict was already resolved, visible conflict `0` could refer to full-file conflict `1`, but the UI still sent `conflict_index: 0` and resolved the wrong record.

## Reproduction
1. Create a conflict report with conflict 0 already resolved and conflict 1 unresolved.
2. Open the web UI conflicts list for that agent/date.
3. The UI shows only the unresolved conflict as visible entry 0.
4. Click a resolution action.
5. Before this change, the backend received `conflict_index: 0`, so it marked or deleted memory for the already-resolved full-file entry instead of the visible unresolved conflict.

## Fix
`list_conflicts()` now returns unresolved conflicts with a `conflict_index` field that preserves each conflict's original full-report index. The web UI uses that value for card ids, manual-resolution ids, and resolve requests, falling back to the display index only for older data.

## Tests
- python -m pytest tests/test_conflict_resolution.py -q
- python -m pytest tests/test_conflict_resolution.py tests/test_api.py::TestMEMANTOAPI::test_conflicts_list_api tests/test_api.py::TestMEMANTOAPI::test_conflicts_resolve_api -q
- python -m ruff check tests/test_conflict_resolution.py memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py
- git diff --check

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conflict Resolution now shows stable conflict numbers, even when some conflicts are already resolved.
  * Actions and manual resolution inputs now stay aligned with the correct conflict entry.

* **Bug Fixes**
  * Improved conflict handling so resolving one item no longer shifts or mislabels others.
  * Conflict lists now preserve the original position of each unresolved item for more reliable resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->