### PR TITLE
fix: resolve timezone-aware created_at TypeError in compute_confidence

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -97,7 +97,7 @@ class MemoryRecord(BaseModel):
             "scope_id": self.scope_id,
             "actor_id": self.actor_id,
             "source": self.source,
-            "confidence": self.confidence,
+            "confidence": self.compute_confidence(),
             "status": self.status,
             # Provenance & Trust fields
             "provenance": self.provenance,

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -169,7 +169,10 @@ class MemoryRecord(BaseModel):
 
         # Age decay for preferences and observations (fresher = more trustworthy)
         if self.type in ["preference", "observation"]:
-            created_at_naive = self.created_at.replace(tzinfo=None) if self.created_at.tzinfo else self.created_at
+            created_at_naive = self.created_at
+            if created_at_naive.tzinfo:
+                from datetime import timezone
+                created_at_naive = created_at_naive.astimezone(timezone.utc).replace(tzinfo=None)
             age_days = (datetime.utcnow() - created_at_naive).days
             if age_days > 90:  # 3 months
                 age_penalty = 0.2
@@ -220,7 +223,10 @@ class MemoryRecord(BaseModel):
         - recommendation: str
         """
         computed_conf = self.compute_confidence()
-        created_at_naive = self.created_at.replace(tzinfo=None) if self.created_at.tzinfo else self.created_at
+        created_at_naive = self.created_at
+        if created_at_naive.tzinfo:
+            from datetime import timezone
+            created_at_naive = created_at_naive.astimezone(timezone.utc).replace(tzinfo=None)
         age_days = (datetime.utcnow() - created_at_naive).days
 
         # Determine trust level

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -169,7 +169,8 @@ class MemoryRecord(BaseModel):
 
         # Age decay for preferences and observations (fresher = more trustworthy)
         if self.type in ["preference", "observation"]:
-            age_days = (datetime.utcnow() - self.created_at).days
+            created_at_naive = self.created_at.replace(tzinfo=None) if self.created_at.tzinfo else self.created_at
+            age_days = (datetime.utcnow() - created_at_naive).days
             if age_days > 90:  # 3 months
                 age_penalty = 0.2
             elif age_days > 30:  # 1 month
@@ -219,7 +220,8 @@ class MemoryRecord(BaseModel):
         - recommendation: str
         """
         computed_conf = self.compute_confidence()
-        age_days = (datetime.utcnow() - self.created_at).days
+        created_at_naive = self.created_at.replace(tzinfo=None) if self.created_at.tzinfo else self.created_at
+        age_days = (datetime.utcnow() - created_at_naive).days
 
         # Determine trust level
         if computed_conf >= 0.8 and not self.contradiction_detected:

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -848,39 +848,38 @@ class MemoryReadService:
         if validated_at:
             formatted["validated_at"] = validated_at.isoformat()
 
-        # skip trust score computation reconstructs MemoryRecord and runs compute_confidence() + trust_score() per result. Skipped for speed.
-        ## Compute trust score if we have all required fields
-        # try:
-        ## Reconstruct MemoryRecord to use compute_confidence and trust_score methods
-        #     created_at_str = get_field("created_at")
-        #     created_at = datetime.fromisoformat(created_at_str.replace('Z', '+00:00')) if created_at_str else datetime.utcnow()
-        #     memory_rec = MemoryRecord(
-        #         id=item.get("id"),
-        #         type=get_field("memory_type", "memory_type") or "fact",
-        #         title="", # Not stored in search results
-        #         content=item.get("text", ""),
-        #         scope_type=get_field("scope_type") or "agent",
-        #         scope_id=get_field("scope_id") or "unknown",
-        #         actor_id=get_field("actor_id") or "unknown",
-        #         source=get_field("source") or "agent",
-        #         confidence=get_field("confidence") or 0.8,
-        #         status=get_field("status") or "active",
-        #         provenance=provenance,
-        #         validation_count=validation_count,
-        #         contradiction_detected=contradiction_detected,
-        #         created_at=created_at,
-        #         validated_at=validated_at
-        #     )
-        #     if superseded_by:
-        #         memory_rec.superseded_by = superseded_by
-        #     if supersedes:
-        #         memory_rec.supersedes = supersedes
+        # Compute trust score if we have all required fields
+        try:
+            # Reconstruct MemoryRecord to use compute_confidence and trust_score methods
+            created_at_str = get_field("created_at")
+            created_at = datetime.fromisoformat(created_at_str.replace('Z', '+00:00')) if created_at_str else datetime.utcnow()
+            memory_rec = self._memory_record_cls(
+                id=item.get("id"),
+                type=get_field("memory_type", "memory_type") or "fact",
+                title="",  # Not stored in search results
+                content=item.get("text", ""),
+                scope_type=get_field("scope_type") or "agent",
+                scope_id=get_field("scope_id") or "unknown",
+                actor_id=get_field("actor_id") or "unknown",
+                source=get_field("source") or "agent",
+                confidence=get_field("confidence") or 0.8,
+                status=get_field("status") or "active",
+                provenance=provenance,
+                validation_count=validation_count,
+                contradiction_detected=contradiction_detected,
+                created_at=created_at,
+                validated_at=validated_at
+            )
+            if superseded_by:
+                memory_rec.superseded_by = superseded_by
+            if supersedes:
+                memory_rec.supersedes = supersedes
 
-        # Add computed confidence and trust score
-        #     formatted["computed_confidence"] = memory_rec.compute_confidence()
-        #     formatted["trust_score"] = memory_rec.trust_score()
-        # except Exception as e:
-        ## If computation fails, just return basic formatted item
-        #     pass
+            # Add computed confidence and trust score
+            formatted["computed_confidence"] = memory_rec.compute_confidence()
+            formatted["trust_score"] = memory_rec.trust_score()
+        except Exception as e:
+            # If computation fails, just return basic formatted item
+            pass
 
         return formatted

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from moorcheh_sdk import MoorchehClient
 
-from memanto.app.core import MemoryRecord
+from memanto.app.core import MemoryRecord, ValidationPolicy
 from memanto.app.services.memory_parsing_service import MemoryParsingService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
@@ -54,13 +54,10 @@ class MemoryWriteService:
             # Add namespace
             namespace = memory.get_scope().to_namespace()
 
-            # skip validation for speed
-            ## Validate memory
-            # validation_result = self.validation_service.validate_memory(memory, context)
-            ## Use validated memory if modified
-            # if "memory" in validation_result:
-            #     memory = validation_result["memory"]
-            validation_result = {"action": "store", "reason": "MVP direct store"}
+            # Validate memory using ValidationPolicy
+            validation_result = ValidationPolicy.validate_memory(memory, context)
+            if validation_result.get("action") == "store_provisional":
+                memory = ValidationPolicy.make_provisional(memory)
 
             from typing import cast
 
@@ -148,16 +145,10 @@ class MemoryWriteService:
                         )
                         continue
 
-                    # skip validation for speed
-                    ## Validate memory
-                    # validation_result = self.validation_service.validate_memory(memory, context)
-                    ## Use validated memory if modified
-                    # if "memory" in validation_result:
-                    #     memory = validation_result["memory"]
-                    validation_result = {
-                        "action": "store",
-                        "reason": "MVP direct store",
-                    }
+                    # Validate memory using ValidationPolicy
+                    validation_result = ValidationPolicy.validate_memory(memory, context)
+                    if validation_result.get("action") == "store_provisional":
+                        memory = ValidationPolicy.make_provisional(memory)
 
                     from typing import cast
 

--- a/tests/test_bounty_validation_and_trust.py
+++ b/tests/test_bounty_validation_and_trust.py
@@ -91,6 +91,7 @@ def test_read_service_adds_computed_trust_metrics():
 
 def test_timezone_aware_created_at_does_not_raise_error():
     """Verify that timezone-aware created_at timestamps do not raise TypeError in compute_confidence or trust_score"""
+    from datetime import timezone
     memory = MemoryRecord(
         type="preference",
         title="test-pref",
@@ -100,7 +101,7 @@ def test_timezone_aware_created_at_does_not_raise_error():
         actor_id="user-123",
         source="user",
         confidence=0.9,
-        created_at=datetime.fromisoformat("2026-06-26T12:00:00+00:00")
+        created_at=datetime.now(timezone.utc)
     )
     
     # Should not raise TypeError: can't subtract offset-naive and offset-aware datetimes

--- a/tests/test_bounty_validation_and_trust.py
+++ b/tests/test_bounty_validation_and_trust.py
@@ -1,0 +1,89 @@
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+from memanto.app.core import MemoryRecord, ValidationPolicy
+from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def test_core_to_moorcheh_document_uses_computed_confidence():
+    """Verify that to_moorcheh_document uses compute_confidence() instead of raw self.confidence"""
+    memory = MemoryRecord(
+        type="preference",
+        title="test-pref",
+        content="I prefer light mode",
+        scope_type="agent",
+        scope_id="agent-abc",
+        actor_id="user-123",
+        source="user",
+        confidence=0.9,
+    )
+    
+    # Manually flag contradiction to trigger dynamic confidence adjustment
+    memory.detect_contradiction()
+    
+    doc = memory.to_moorcheh_document()
+    
+    # Expected confidence should be the penalized computed confidence: 0.9 * 0.3 = 0.27
+    assert doc["confidence"] == 0.27
+    assert doc["confidence"] != 0.9
+
+
+def test_write_service_enforces_validation_policy():
+    """Verify write service properly uses ValidationPolicy and registers provisional storage"""
+    client = MagicMock()
+    client.documents.upload.return_value = {"status": "success"}
+    
+    write_service = MemoryWriteService(client)
+    
+    # Storing a critical memory (fact) with default/medium confidence without context
+    memory = MemoryRecord(
+        type="fact",
+        title="test-fact",
+        content="This is a test fact",
+        scope_type="agent",
+        scope_id="agent-abc",
+        actor_id="user-123",
+        source="user",
+        confidence=0.8,
+    )
+    
+    result = write_service.store_memory(memory)
+    
+    # It should have run validation, noticed it requires confirmation,
+    # downgraded status to provisional, capped confidence to 0.5, and set TTL.
+    assert result["action"] == "store_provisional"
+    assert result["memory_status"] == "provisional"
+    assert result["confidence"] == 0.5
+
+
+def test_read_service_adds_computed_trust_metrics():
+    """Verify read service formats document and appends computed_confidence and trust_score"""
+    client = MagicMock()
+    read_service = MemoryReadService(client)
+    
+    # Reconstructed item from Moorcheh
+    item = {
+        "id": "mem-123",
+        "text": "[FACT] test-fact\n\nThis is a test fact",
+        "metadata": {
+            "memory_type": "fact",
+            "scope_type": "agent",
+            "scope_id": "agent-abc",
+            "actor_id": "user-123",
+            "source": "user",
+            "confidence": 0.9,
+            "status": "active",
+            "provenance": "explicit_statement",
+            "validation_count": 2,
+            "contradiction_detected": False,
+            "created_at": datetime.utcnow().isoformat(),
+        }
+    }
+    
+    formatted = read_service._format_memory_item(item)
+    
+    assert "computed_confidence" in formatted
+    assert "trust_score" in formatted
+    assert formatted["computed_confidence"] == 0.96  # 0.9 * 1.0 + 2 * 0.03
+    assert formatted["trust_score"]["trust_level"] == "high"

--- a/tests/test_bounty_validation_and_trust.py
+++ b/tests/test_bounty_validation_and_trust.py
@@ -87,3 +87,23 @@ def test_read_service_adds_computed_trust_metrics():
     assert "trust_score" in formatted
     assert formatted["computed_confidence"] == 0.96  # 0.9 * 1.0 + 2 * 0.03
     assert formatted["trust_score"]["trust_level"] == "high"
+
+
+def test_timezone_aware_created_at_does_not_raise_error():
+    """Verify that timezone-aware created_at timestamps do not raise TypeError in compute_confidence or trust_score"""
+    memory = MemoryRecord(
+        type="preference",
+        title="test-pref",
+        content="I prefer dark mode",
+        scope_type="agent",
+        scope_id="agent-abc",
+        actor_id="user-123",
+        source="user",
+        confidence=0.9,
+        created_at=datetime.fromisoformat("2026-06-26T12:00:00+00:00")
+    )
+    
+    # Should not raise TypeError: can't subtract offset-naive and offset-aware datetimes
+    assert memory.compute_confidence() == 0.9
+    assert memory.trust_score()["age_days"] >= 0
+


### PR DESCRIPTION
This PR fixes a critical bug in  and  where subtracting a timezone-aware  timestamp from the timezone-naive  raises a  (cannot subtract offset-naive and offset-aware datetimes). This bug caused the  and  to be silently omitted from formatted read responses whenever the memory had a timezone-aware timestamp. Added a test case in  to prevent regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory confidence and trust values are now calculated more consistently and displayed during memory viewing.
  * Some memories may now be saved provisionally when validation flags additional caution, with corresponding metadata.

* **Bug Fixes**
  * Fixed confidence/trust calculations for memories created with time zone information.
  * Improved the confidence stored in records to better match computed values used for filtering and search.

* **Tests**
  * Added coverage for confidence/trust, provisional validation behavior, and time zone handling edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->