### PR TITLE
Restrict UI migration file imports to migrate directory

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -848,10 +848,21 @@ def _migrate_load_or_export(
     from memanto.cli.migrate.runner import load_export
 
     if file_path:
+        base_dir = _config_manager.get_migrate_dir(provider).resolve()
         path = Path(file_path).expanduser()
         if not path.exists() or not path.is_file():
             raise HTTPException(
                 status_code=400, detail=f"Export file not found: {file_path}"
+            )
+        path = path.resolve()
+        if path.suffix.lower() != ".json":
+            raise HTTPException(
+                status_code=400, detail="Migration export file must be JSON."
+            )
+        if path != base_dir and base_dir not in path.parents:
+            raise HTTPException(
+                status_code=400,
+                detail="Migration export file must be inside the Memanto migrate directory.",
             )
         return str(path), load_export(path)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1210,6 +1210,75 @@ class TestCWE200ApiKeyLeak:
         assert data["has_active_session"] is True
 
     @pytest.mark.asyncio
+    async def test_migrate_dry_run_rejects_export_file_outside_migrate_dir(
+        self, client, _mock_ui_config_manager, tmp_path
+    ):
+        """UI migration must not read arbitrary server-side JSON files."""
+        migrate_dir = tmp_path / ".memanto" / "migrate" / "mem0"
+        migrate_dir.mkdir(parents=True)
+        _mock_ui_config_manager.get_migrate_dir.return_value = migrate_dir
+
+        outside_file = tmp_path / "private-export.json"
+        outside_file.write_text(
+            json.dumps(
+                {
+                    "summary": {"memory_count": 1},
+                    "memories": [
+                        {
+                            "id": "secret-1",
+                            "memory": "server-side secret should not be previewed",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        resp = await client.post(
+            "/api/ui/migrate/dry-run",
+            json={"provider": "mem0", "file": str(outside_file)},
+        )
+
+        assert resp.status_code == 400
+        assert "migrate directory" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_migrate_dry_run_allows_export_file_inside_migrate_dir(
+        self, client, _mock_ui_config_manager, tmp_path
+    ):
+        """UI migration can still preview exports created in its own workspace."""
+        migrate_dir = tmp_path / ".memanto" / "migrate" / "mem0"
+        migrate_dir.mkdir(parents=True)
+        _mock_ui_config_manager.get_migrate_dir.return_value = migrate_dir
+
+        export_file = migrate_dir / "mem0_export.json"
+        export_file.write_text(
+            json.dumps(
+                {
+                    "summary": {"memory_count": 1},
+                    "memories": [
+                        {
+                            "id": "m1",
+                            "memory": "User prefers concise summaries",
+                            "categories": ["preferences"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        resp = await client.post(
+            "/api/ui/migrate/dry-run",
+            json={"provider": "mem0", "file": str(export_file)},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mapped_count"] == 1
+        assert data["sample"][0]["title"] == "User prefers concise summaries"
+
+    @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1279,6 +1279,37 @@ class TestCWE200ApiKeyLeak:
         assert data["sample"][0]["title"] == "User prefers concise summaries"
 
     @pytest.mark.asyncio
+    async def test_migrate_dry_run_rejects_symlink_escape_from_migrate_dir(
+        self, client, _mock_ui_config_manager, tmp_path
+    ):
+        """Resolved symlinks must not escape the migration workspace."""
+        migrate_dir = tmp_path / ".memanto" / "migrate" / "mem0"
+        migrate_dir.mkdir(parents=True)
+        _mock_ui_config_manager.get_migrate_dir.return_value = migrate_dir
+
+        outside_file = tmp_path / "private-export.json"
+        outside_file.write_text(
+            json.dumps(
+                {
+                    "summary": {"memory_count": 1},
+                    "memories": [{"id": "secret-1", "memory": "secret"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        symlink_file = migrate_dir / "linked-export.json"
+        symlink_file.symlink_to(outside_file)
+
+        resp = await client.post(
+            "/api/ui/migrate/dry-run",
+            json={"provider": "mem0", "file": str(symlink_file)},
+        )
+
+        assert resp.status_code == 400
+        assert "migrate directory" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(
         self, client, auth_headers, mock_moorcheh
     ):


### PR DESCRIPTION
## Summary

- Restrict UI migration dry-run/import file inputs to JSON exports inside Memanto's own migrate directory.
- Resolve and validate file paths before loading them so symlinks or absolute paths cannot escape that directory.
- Add regression coverage for both blocked outside files and allowed in-workspace exports.

## Security impact

The UI migration endpoints accept a server-side `file` path and pass it into the migration loader. Before this change, a client with access to the Memanto HTTP server could point `/api/ui/migrate/dry-run` at any readable local JSON file and have the UI route parse and expose mapped preview data.

This patch keeps the normal UI migration flow intact for exports generated by Memanto while preventing arbitrary local JSON reads.

## Tests

```bash
SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest tests/test_api.py -q -k 'migrate_dry_run or config_endpoint'
SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest tests/test_api.py -q -k 'CWE200ApiKeyLeak or FilenameSanitizationLogic'
```

Both commands pass locally.

## Bounty claim

/claim #770

This fixes a UI migration file-read bug where server-side `file` inputs for dry-run/import could load arbitrary readable JSON outside the Memanto migration workspace. The fix constrains migration file inputs to resolved `.json` files under `ConfigManager.get_migrate_dir(provider)` and adds regression tests for denied outside files plus allowed migration exports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for migration/export file inputs by requiring a `.json` suffix and ensuring the resolved file path stays within the configured migrate directory.
  * Added protection to reject symlink-based path escapes that point outside the allowed directory.
* **Tests**
  * Added dry-run API tests covering rejected exports outside the directory, successful exports inside it (including preview content), and symlink escape prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->