### PR TITLE
Preserve tag-like memory content paragraphs

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -657,30 +657,27 @@ class MemoryReadService:
         content = raw_text
 
         if raw_text:
-            lines = raw_text.split("\n\n", 2)  # Split into at most 3 parts
-            first_line = lines[0] if lines else ""
+            first_line, separator, body = raw_text.partition("\n\n")
 
             # Extract title: strip the "[TYPE] " prefix from first line
 
             title_match = re.match(r"^\[.*?\]\s*(.*)$", first_line)
             if title_match:
                 title = title_match.group(1).strip()
-                # Content is the rest after the first line (skip tags section)
-                if len(lines) > 1:
-                    # Check if last part is tags
-                    remaining = lines[1:]
-                    content_parts = []
-                    for part in remaining:
-                        if part.startswith("Tags: "):
-                            continue
-                        content_parts.append(part)
-                    content = "\n\n".join(content_parts) if content_parts else ""
-                else:
-                    content = ""
+                content = body if separator else ""
+                if tags:
+                    before_tags, tag_separator, tag_text = content.rpartition(
+                        "\n\nTags: "
+                    )
+                    if tag_separator:
+                        parsed_tags = [tag.strip() for tag in tag_text.split(",")]
+                        metadata_tags = [str(tag).strip() for tag in tags]
+                        if parsed_tags == metadata_tags:
+                            content = before_tags
             else:
                 # No [TYPE] prefix — use first line as title, rest as content
                 title = first_line.strip()
-                content = "\n\n".join(lines[1:]) if len(lines) > 1 else ""
+                content = body if separator else ""
 
         # Build basic formatted item
         formatted = {

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -16,12 +16,16 @@ from memanto.app.utils.errors import MemoryError
 
 
 class MemoryReadService:
+    """Read and format memories from Moorcheh-backed namespaces."""
+
     def __init__(self, moorcheh_client: "MoorchehClient"):
+        """Create a memory reader for the provided Moorcheh client."""
         self.client = moorcheh_client
         self._namespace_service = None
 
     @property
     def namespace_service(self):
+        """Lazily construct the namespace service used for read queries."""
         if self._namespace_service is None:
             from memanto.app.services.namespace_service import NamespaceService
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,37 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceFormatting:
+    """Regression coverage for formatting Moorcheh document text."""
+
+    def test_tag_like_content_paragraphs_are_preserved(self):
+        """Keep user-authored body paragraphs that look like serialized tags."""
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        memory = MemoryRecord(
+            type="fact",
+            title="Runbook note",
+            content=(
+                "Before deploy, capture the current feature flags.\n\n"
+                "Tags: this is part of the runbook body, not metadata.\n\n"
+                "Then record the rollback owner."
+            ),
+            scope_type="agent",
+            scope_id="ops-agent",
+            actor_id="ops-agent",
+            source="agent",
+            tags=["deploy", "runbook"],
+        )
+
+        formatted = MemoryReadService(MagicMock())._format_memory_item(
+            memory.to_moorcheh_document()
+        )
+
+        assert formatted["content"] == memory.content
+        assert formatted["tags"] == ["deploy", "runbook"]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -304,8 +304,7 @@ class TestMemoryReadServiceFormatting:
                 "Tags: this is part of the runbook body, not metadata.\n\n"
                 "Then record the rollback owner."
             ),
-            scope_type="agent",
-            scope_id="ops-agent",
+            agent_id="ops-agent",
             actor_id="ops-agent",
             source="agent",
             tags=["deploy", "runbook"],


### PR DESCRIPTION
Bounty submission for #770.

## Summary
Fixes a memory-integrity parsing bug in `MemoryReadService._format_memory_item`: when a stored memory body contained its own paragraph starting with `Tags: `, the reader treated that paragraph as serialized tag metadata and dropped the rest of the content during recall/get/update flows.

## Reproduction
1. Create a memory whose body contains a real paragraph such as `Tags: this is part of the runbook body, not metadata.`.
2. Store it with actual metadata tags, for example `['deploy', 'runbook']`, so `MemoryRecord.to_moorcheh_document()` appends its normal trailing tags block.
3. Read the document back through `_format_memory_item()`.
4. Before this fix, the returned `content` stopped at the first paragraph and lost the user-authored `Tags: ...` paragraph plus everything after it.

## Fix
The formatter now splits the title/body only once, then removes only the trailing `Tags: ...` block when it exactly matches the metadata tags. User-authored body paragraphs that happen to start with `Tags: ` are preserved.

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMemoryReadServiceFormatting::test_tag_like_content_paragraphs_are_preserved -q`
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py -q`
- `.venv\Scripts\python.exe -m pytest tests/test_api.py -q`
- `.venv\Scripts\python.exe -m ruff check memanto\app\services\memory_read_service.py tests\test_unit.py`
- `.venv\Scripts\python.exe -m py_compile memanto\app\services\memory_read_service.py tests\test_unit.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory entry display formatting when the body contains tag-like “Tags:” sections.
  * More reliably separates the title from the body and avoids removing legitimate content that includes “Tags:” text.
  * Keeps the extracted tag information consistent with the stored memory metadata.
* **Tests**
  * Added unit-test coverage for memory formatting that contains tag-like “Tags:” content in the body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->