### PR TITLE
fix(conflicts): keep unresolved when deletion fails

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1363,6 +1363,7 @@ class DirectClient:
 
         write_service = self._get_write_service()
         result_details = {"action": action}
+        delete_failures: list[str] = []
 
         if action == "keep_old":
             # Keep old, delete new
@@ -1371,7 +1372,7 @@ class DirectClient:
                     write_service.delete_memory(new_id, namespace)
                     result_details["deleted"] = new_id
                 except Exception as e:
-                    result_details["warning"] = f"Could not delete new memory: {e}"
+                    delete_failures.append(f"new memory {new_id}: {e}")
 
         elif action == "keep_new":
             # Keep new, delete old
@@ -1380,7 +1381,7 @@ class DirectClient:
                     write_service.delete_memory(old_id, namespace)
                     result_details["deleted"] = old_id
                 except Exception as e:
-                    result_details["warning"] = f"Could not delete old memory: {e}"
+                    delete_failures.append(f"old memory {old_id}: {e}")
 
         elif action == "keep_both":
             # No-op — both memories remain active
@@ -1394,9 +1395,7 @@ class DirectClient:
                         write_service.delete_memory(mem_id, namespace)
                         result_details[f"deleted_{label}"] = mem_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        delete_failures.append(f"{label} memory {mem_id}: {e}")
 
         elif action == "manual":
             if not manual_content:
@@ -1409,9 +1408,14 @@ class DirectClient:
                         write_service.delete_memory(mem_id, namespace)
                         result_details[f"deleted_{label}"] = mem_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+
+            if delete_failures:
+                failures = "; ".join(delete_failures)
+                raise ValueError(
+                    "Could not resolve conflict because required memory deletion "
+                    f"failed: {failures}"
+                )
 
             # Store the manual replacement
             mem_type = manual_type or conflict.get("type", "fact")
@@ -1442,6 +1446,13 @@ class DirectClient:
             )
             store_result = write_service.store_memory(memory)
             result_details["new_memory_id"] = store_result.get("id")
+
+        if delete_failures:
+            failures = "; ".join(delete_failures)
+            raise ValueError(
+                "Could not resolve conflict because required memory deletion "
+                f"failed: {failures}"
+            )
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1365,23 +1365,30 @@ class DirectClient:
         result_details = {"action": action}
         delete_failures: list[str] = []
 
+        def delete_required_memory(
+            mem_id: str | None, label: str, result_key: str
+        ) -> None:
+            if not mem_id:
+                return
+            try:
+                deleted = write_service.delete_memory(mem_id, namespace)
+            except Exception as e:
+                delete_failures.append(f"{label} memory {mem_id}: {e}")
+                return
+
+            if not deleted:
+                delete_failures.append(f"{label} memory {mem_id}: not deleted")
+                return
+
+            result_details[result_key] = mem_id
+
         if action == "keep_old":
             # Keep old, delete new
-            if new_id:
-                try:
-                    write_service.delete_memory(new_id, namespace)
-                    result_details["deleted"] = new_id
-                except Exception as e:
-                    delete_failures.append(f"new memory {new_id}: {e}")
+            delete_required_memory(new_id, "new", "deleted")
 
         elif action == "keep_new":
             # Keep new, delete old
-            if old_id:
-                try:
-                    write_service.delete_memory(old_id, namespace)
-                    result_details["deleted"] = old_id
-                except Exception as e:
-                    delete_failures.append(f"old memory {old_id}: {e}")
+            delete_required_memory(old_id, "old", "deleted")
 
         elif action == "keep_both":
             # No-op — both memories remain active
@@ -1390,12 +1397,7 @@ class DirectClient:
         elif action == "remove_both":
             # Delete both memories
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+                delete_required_memory(mem_id, label, f"deleted_{label}")
 
         elif action == "manual":
             if not manual_content:
@@ -1403,12 +1405,7 @@ class DirectClient:
 
             # Delete both, store manual replacement
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+                delete_required_memory(mem_id, label, f"deleted_{label}")
 
             if delete_failures:
                 failures = "; ".join(delete_failures)

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1231,6 +1231,7 @@ class SdkClient:
 
         write_service = self._get_write_service()
         result_details: dict[str, Any] = {"action": action}
+        delete_failures: list[str] = []
 
         if action == "keep_old":
             if new_id:
@@ -1238,7 +1239,7 @@ class SdkClient:
                     write_service.delete_memory(new_id, namespace)
                     result_details["deleted"] = new_id
                 except Exception as e:
-                    result_details["warning"] = f"Could not delete new memory: {e}"
+                    delete_failures.append(f"new memory {new_id}: {e}")
 
         elif action == "keep_new":
             if old_id:
@@ -1246,7 +1247,7 @@ class SdkClient:
                     write_service.delete_memory(old_id, namespace)
                     result_details["deleted"] = old_id
                 except Exception as e:
-                    result_details["warning"] = f"Could not delete old memory: {e}"
+                    delete_failures.append(f"old memory {old_id}: {e}")
 
         elif action == "keep_both":
             result_details["note"] = "Both memories kept as-is"
@@ -1258,9 +1259,7 @@ class SdkClient:
                         write_service.delete_memory(mem_id, namespace)
                         result_details[f"deleted_{label}"] = mem_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        delete_failures.append(f"{label} memory {mem_id}: {e}")
 
         elif action == "manual":
             if not manual_content:
@@ -1273,9 +1272,14 @@ class SdkClient:
                         write_service.delete_memory(mem_id, namespace)
                         result_details[f"deleted_{label}"] = mem_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+
+            if delete_failures:
+                failures = "; ".join(delete_failures)
+                raise ValueError(
+                    "Could not resolve conflict because required memory deletion "
+                    f"failed: {failures}"
+                )
 
             # Store the manual replacement
             mem_type = manual_type or conflict.get("type", "fact")
@@ -1305,6 +1309,13 @@ class SdkClient:
             )
             store_result = write_service.store_memory(memory)
             result_details["new_memory_id"] = store_result.get("id")
+
+        if delete_failures:
+            failures = "; ".join(delete_failures)
+            raise ValueError(
+                "Could not resolve conflict because required memory deletion "
+                f"failed: {failures}"
+            )
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1233,33 +1233,35 @@ class SdkClient:
         result_details: dict[str, Any] = {"action": action}
         delete_failures: list[str] = []
 
+        def delete_required_memory(
+            mem_id: str | None, label: str, result_key: str
+        ) -> None:
+            if not mem_id:
+                return
+            try:
+                deleted = write_service.delete_memory(mem_id, namespace)
+            except Exception as e:
+                delete_failures.append(f"{label} memory {mem_id}: {e}")
+                return
+
+            if not deleted:
+                delete_failures.append(f"{label} memory {mem_id}: not deleted")
+                return
+
+            result_details[result_key] = mem_id
+
         if action == "keep_old":
-            if new_id:
-                try:
-                    write_service.delete_memory(new_id, namespace)
-                    result_details["deleted"] = new_id
-                except Exception as e:
-                    delete_failures.append(f"new memory {new_id}: {e}")
+            delete_required_memory(new_id, "new", "deleted")
 
         elif action == "keep_new":
-            if old_id:
-                try:
-                    write_service.delete_memory(old_id, namespace)
-                    result_details["deleted"] = old_id
-                except Exception as e:
-                    delete_failures.append(f"old memory {old_id}: {e}")
+            delete_required_memory(old_id, "old", "deleted")
 
         elif action == "keep_both":
             result_details["note"] = "Both memories kept as-is"
 
         elif action == "remove_both":
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+                delete_required_memory(mem_id, label, f"deleted_{label}")
 
         elif action == "manual":
             if not manual_content:
@@ -1267,12 +1269,7 @@ class SdkClient:
 
             # Delete both, store manual replacement
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+                delete_required_memory(mem_id, label, f"deleted_{label}")
 
             if delete_failures:
                 failures = "; ".join(delete_failures)

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -1,0 +1,111 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _write_conflict_report(tmp_path, agent_id, date):
+    conflicts_dir = tmp_path / ".memanto" / "conflicts"
+    conflicts_dir.mkdir(parents=True)
+    report_path = conflicts_dir / f"{agent_id}_{date}_conflicts.json"
+    report_path.write_text(
+        json.dumps(
+            [
+                {
+                    "type": "conflict",
+                    "title": "Deployment region mismatch",
+                    "old_memory_id": "old-memory",
+                    "new_memory_id": "new-memory",
+                    "old_content": "Deploy to us-east-1",
+                    "new_content": "Deploy to eu-west-1",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return report_path
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        ("memanto.cli.client.direct_client", "DirectClient"),
+        ("memanto.cli.client.sdk_client", "SdkClient"),
+    ],
+)
+def test_conflict_stays_unresolved_when_required_delete_fails(
+    module_path, class_name, tmp_path, monkeypatch
+):
+    client_module = pytest.importorskip(module_path)
+    client_class = getattr(client_module, class_name)
+    monkeypatch.setattr(
+        client_module.Path,
+        "home",
+        classmethod(lambda cls: tmp_path),
+    )
+
+    agent_id = "test-agent"
+    date = "2026-05-08"
+    report_path = _write_conflict_report(tmp_path, agent_id, date)
+
+    write_service = MagicMock()
+    write_service.delete_memory.side_effect = RuntimeError("backend unavailable")
+
+    client = client_class(api_key="test-key")
+    client._get_write_service = lambda: write_service
+
+    with pytest.raises(ValueError, match="required memory deletion failed"):
+        client.resolve_conflict(
+            agent_id=agent_id,
+            date=date,
+            conflict_index=0,
+            action="keep_old",
+        )
+
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted[0].get("resolved", False) is False
+    assert "resolution" not in persisted[0]
+    write_service.delete_memory.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        ("memanto.cli.client.direct_client", "DirectClient"),
+        ("memanto.cli.client.sdk_client", "SdkClient"),
+    ],
+)
+def test_manual_conflict_resolution_does_not_store_replacement_after_delete_failure(
+    module_path, class_name, tmp_path, monkeypatch
+):
+    client_module = pytest.importorskip(module_path)
+    client_class = getattr(client_module, class_name)
+    monkeypatch.setattr(
+        client_module.Path,
+        "home",
+        classmethod(lambda cls: tmp_path),
+    )
+
+    agent_id = "test-agent"
+    date = "2026-05-08"
+    report_path = _write_conflict_report(tmp_path, agent_id, date)
+
+    write_service = MagicMock()
+    write_service.delete_memory.side_effect = RuntimeError("backend unavailable")
+
+    client = client_class(api_key="test-key")
+    client._get_write_service = lambda: write_service
+
+    with pytest.raises(ValueError, match="required memory deletion failed"):
+        client.resolve_conflict(
+            agent_id=agent_id,
+            date=date,
+            conflict_index=0,
+            action="manual",
+            manual_content="Deploy to us-east-1 unless failover is active",
+        )
+
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted[0].get("resolved", False) is False
+    assert "resolution" not in persisted[0]
+    write_service.store_memory.assert_not_called()

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -119,8 +119,9 @@ def test_conflict_stays_unresolved_when_required_delete_returns_false(
         ("memanto.cli.client.sdk_client", "SdkClient"),
     ],
 )
+@pytest.mark.parametrize("delete_result", [RuntimeError("backend unavailable"), False])
 def test_manual_conflict_resolution_does_not_store_replacement_after_delete_failure(
-    module_path, class_name, tmp_path, monkeypatch
+    module_path, class_name, delete_result, tmp_path, monkeypatch
 ):
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
@@ -135,7 +136,10 @@ def test_manual_conflict_resolution_does_not_store_replacement_after_delete_fail
     report_path = _write_conflict_report(tmp_path, agent_id, date)
 
     write_service = MagicMock()
-    write_service.delete_memory.side_effect = RuntimeError("backend unavailable")
+    if isinstance(delete_result, Exception):
+        write_service.delete_memory.side_effect = delete_result
+    else:
+        write_service.delete_memory.return_value = delete_result
 
     client = client_class(api_key="test-key")
     client._get_write_service = lambda: write_service

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -18,6 +18,8 @@ def _write_conflict_report(tmp_path, agent_id, date):
                     "new_memory_id": "new-memory",
                     "old_content": "Deploy to us-east-1",
                     "new_content": "Deploy to eu-west-1",
+                    "resolved": False,
+                    "resolution": None,
                 }
             ]
         ),
@@ -63,8 +65,50 @@ def test_conflict_stays_unresolved_when_required_delete_fails(
         )
 
     persisted = json.loads(report_path.read_text(encoding="utf-8"))
-    assert persisted[0].get("resolved", False) is False
-    assert "resolution" not in persisted[0]
+    assert persisted[0]["resolved"] is False
+    assert persisted[0]["resolution"] is None
+    write_service.delete_memory.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        ("memanto.cli.client.direct_client", "DirectClient"),
+        ("memanto.cli.client.sdk_client", "SdkClient"),
+    ],
+)
+def test_conflict_stays_unresolved_when_required_delete_returns_false(
+    module_path, class_name, tmp_path, monkeypatch
+):
+    client_module = pytest.importorskip(module_path)
+    client_class = getattr(client_module, class_name)
+    monkeypatch.setattr(
+        client_module.Path,
+        "home",
+        classmethod(lambda cls: tmp_path),
+    )
+
+    agent_id = "test-agent"
+    date = "2026-05-08"
+    report_path = _write_conflict_report(tmp_path, agent_id, date)
+
+    write_service = MagicMock()
+    write_service.delete_memory.return_value = False
+
+    client = client_class(api_key="test-key")
+    client._get_write_service = lambda: write_service
+
+    with pytest.raises(ValueError, match="required memory deletion failed"):
+        client.resolve_conflict(
+            agent_id=agent_id,
+            date=date,
+            conflict_index=0,
+            action="keep_old",
+        )
+
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted[0]["resolved"] is False
+    assert persisted[0]["resolution"] is None
     write_service.delete_memory.assert_called_once()
 
 
@@ -106,6 +150,6 @@ def test_manual_conflict_resolution_does_not_store_replacement_after_delete_fail
         )
 
     persisted = json.loads(report_path.read_text(encoding="utf-8"))
-    assert persisted[0].get("resolved", False) is False
-    assert "resolution" not in persisted[0]
+    assert persisted[0]["resolved"] is False
+    assert persisted[0]["resolution"] is None
     write_service.store_memory.assert_not_called()

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -1,3 +1,5 @@
+"""Regression tests for conflict-resolution cleanup failures."""
+
 import json
 from unittest.mock import MagicMock
 
@@ -5,6 +7,7 @@ import pytest
 
 
 def _write_conflict_report(tmp_path, agent_id, date):
+    """Create a production-shaped conflict report for resolution tests."""
     conflicts_dir = tmp_path / ".memanto" / "conflicts"
     conflicts_dir.mkdir(parents=True)
     report_path = conflicts_dir / f"{agent_id}_{date}_conflicts.json"
@@ -38,6 +41,7 @@ def _write_conflict_report(tmp_path, agent_id, date):
 def test_conflict_stays_unresolved_when_required_delete_fails(
     module_path, class_name, tmp_path, monkeypatch
 ):
+    """Keep the persisted conflict unresolved when deletion raises."""
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
     monkeypatch.setattr(
@@ -80,6 +84,7 @@ def test_conflict_stays_unresolved_when_required_delete_fails(
 def test_conflict_stays_unresolved_when_required_delete_returns_false(
     module_path, class_name, tmp_path, monkeypatch
 ):
+    """Keep the persisted conflict unresolved when deletion returns false."""
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
     monkeypatch.setattr(
@@ -123,6 +128,7 @@ def test_conflict_stays_unresolved_when_required_delete_returns_false(
 def test_manual_conflict_resolution_does_not_store_replacement_after_delete_failure(
     module_path, class_name, delete_result, tmp_path, monkeypatch
 ):
+    """Block manual replacement storage until required deletions succeed."""
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- stop conflict resolution from marking a report entry as resolved when required memory deletion fails
- apply the same behavior to both `DirectClient` and `SdkClient`
- add regression coverage for `keep_old` and `manual` resolutions after backend delete failures

## Flaw
`resolve_conflict()` catches `delete_memory()` failures as warnings, then still writes `resolved: true` and `resolution` back to the local conflict report. For actions such as `keep_old`, `keep_new`, `remove_both`, and `manual`, deletion is the operation that actually enforces the requested resolution.

If that delete fails, the underlying memory remains active while the conflict disappears from future `list_conflicts()` results because unresolved lists filter out entries with `resolved: true`. The `manual` path could also create a replacement memory while both conflicting originals remain.

## Reproduction
1. Create a conflict report with `old_memory_id` and `new_memory_id`.
2. Make the backend delete call fail, for example due to a transient backend error or unavailable API.
3. Call `resolve_conflict(..., action="keep_old")`.
4. Before this change, the JSON report was still marked `resolved: true`, hiding an unresolved conflict even though the new memory was not deleted.

## Fix
The clients now collect required deletion failures and raise `ValueError` before writing the report as resolved. The `manual` action also aborts before storing a replacement if required cleanup failed, so users do not get a third memory layered on top of unresolved originals.

## Tests
- `python -m pytest tests/test_conflict_resolution_delete_failures.py -q`
- `python -m pytest tests/test_conflict_resolution_delete_failures.py tests/test_api.py::TestMEMANTOAPI::test_conflicts_resolve_api -q`
- `python -m pytest tests/test_unit.py -q`
- `python -m pytest tests/test_cli.py::TestMEMANTOCLI::test_conflicts_list -q`
- `python -m ruff check memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_conflict_resolution_delete_failures.py`
- `python -m py_compile memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_conflict_resolution_delete_failures.py`
- `git diff --check`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conflict resolution now fails fast when required memory cleanup doesn’t fully succeed, for both supported client modes.
  * If required deletions raise errors or report failure, conflicts are not marked as resolved and resolution details are not written.
  * Manual conflict resolution no longer stores replacement content when required deletions fail.

* **Tests**
  * Added coverage to confirm `keep_old` and `manual` actions raise an error and leave conflict reports unresolved when required deletions either raise or return unsuccessful results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->