### PR TITLE
Fail memory export on partial recall errors

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1408,6 +1408,7 @@ class DirectClient:
         from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
 
         memories_by_type: dict[str, list] = {}
+        export_errors: list[str] = []
 
         for mem_type in MEMORY_TYPE_ORDER:
             try:
@@ -1418,8 +1419,14 @@ class DirectClient:
                     type=[mem_type],
                 )
                 memories_by_type[mem_type] = result.get("memories", [])
-            except Exception:
-                memories_by_type[mem_type] = []
+            except Exception as exc:
+                export_errors.append(f"{mem_type}: {exc}")
+
+        if export_errors:
+            raise RuntimeError(
+                "Memory export failed; refusing to write a partial MEMORY.md: "
+                + "; ".join(export_errors)
+            )
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -346,6 +346,61 @@ class TestForgetEndToEnd:
         assert result["memory_id"] == "mem-xyz"
 
 
+class TestMemoryExport:
+    """Memory export must not silently replace local MEMORY.md cache with
+    partial data when one of the per-type recall requests fails."""
+
+    @pytest.fixture
+    def direct_client(self, tmp_path, monkeypatch, mock_moorcheh_for_tests):
+        from memanto.cli.client.direct_client import DirectClient
+
+        monkeypatch.setattr(
+            "memanto.app.services.agent_service.get_data_dir",
+            lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            "memanto.app.services.session_service.get_data_dir",
+            lambda: tmp_path,
+        )
+
+        client = DirectClient(api_key="test-key")
+        client._moorcheh = mock_moorcheh_for_tests
+        client.create_agent("test-agent", "tool", "export test")
+        client.activate_agent("test-agent", duration_hours=1)
+        return client
+
+    def test_export_memory_md_fails_before_writing_partial_export(
+        self, direct_client, tmp_path, monkeypatch
+    ):
+        from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
+
+        output_path = tmp_path / "MEMORY.md"
+
+        def fake_recall(*, type, **_kwargs):
+            if type == ["decision"]:
+                raise RuntimeError("backend unavailable")
+            return {
+                "memories": [
+                    {
+                        "title": f"{type[0]} memory",
+                        "content": "should not be written on partial failure",
+                        "type": type[0],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(direct_client, "recall", fake_recall)
+
+        assert "decision" in MEMORY_TYPE_ORDER
+        with pytest.raises(RuntimeError, match="decision.*backend unavailable"):
+            direct_client.export_memory_md(
+                "test-agent",
+                output_path=str(output_path),
+            )
+
+        assert not output_path.exists()
+
+
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""
 


### PR DESCRIPTION
Summary
- Stop memory export from silently swallowing per-type recall failures.
- Refuse to write MEMORY.md when any memory type cannot be fetched, so export/sync cannot overwrite local memory cache or project MEMORY.md with partial data.
- Add regression coverage proving a failed type recall aborts before creating the output file.

Impact
- Before this change, `memanto memory export` and the fresh-export path of `memanto memory sync` treated backend/search failures as empty sections.
- A transient API/backend failure could therefore replace a user's complete memory export with an incomplete or empty MEMORY.md while reporting success.
- This is a memory-integrity/data-loss issue rather than a formatting problem: downstream agents can lose instructions, goals, decisions, or other long-term context from their project memory file.

Validation
- `python -m pytest tests/test_unit.py::TestMemoryExport::test_export_memory_md_fails_before_writing_partial_export -q`
- `python -m pytest tests/test_unit.py::TestMemoryWriteServiceDelete tests/test_unit.py::TestForgetEndToEnd tests/test_unit.py::TestMemoryExport -q`
- `python -m pytest tests/test_unit.py -q`
- `python -m ruff check memanto\cli\client\direct_client.py tests\test_unit.py`
- `python -m py_compile memanto\cli\client\direct_client.py tests\test_unit.py`

BountyHub submission: #770 / Memanto Bug & Exploit Challenge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exporting memory now fails fast if any memory type cannot be retrieved, instead of writing a partial `MEMORY.md`.
  * Error details from failed memory retrievals are included in the export failure message.
  * Verified that no output file is created when an export error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->