### PR TITLE
Bound memory tag payloads before document upload

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from memanto.app.constants import (
     MemoryType,
@@ -14,6 +14,7 @@ from memanto.app.constants import (
     SourceType,
     StatusType,
 )
+from memanto.app.utils.validation import validate_memory_tags
 
 
 def agent_namespace(agent_id: str) -> str:
@@ -47,6 +48,12 @@ class MemoryRecord(BaseModel):
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     expires_at: datetime | None = None
     ttl_seconds: int | None = None
+
+    @field_validator("tags")
+    @classmethod
+    def validate_tags(cls, v: list[str]) -> list[str]:
+        """Keep serialized tag payloads within memory document limits."""
+        return validate_memory_tags(v) or []
 
     def to_moorcheh_document(self) -> dict[str, Any]:
         """

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,13 +5,24 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from memanto.app.constants import MemoryType, SourceType, StatusType
+from memanto.app.utils.validation import validate_memory_tags
+
+
+class MemoryTagsMixin:
+    """Apply shared memory tag bounds to request models that accept tags."""
+
+    @field_validator("tags", check_fields=False)
+    @classmethod
+    def validate_tags(cls, v: list[str] | None) -> list[str] | None:
+        """Normalize and bound tag lists for API payloads."""
+        return validate_memory_tags(v)
 
 
 # Request Models
-class MemoryStoreRequest(BaseModel):
+class MemoryStoreRequest(MemoryTagsMixin, BaseModel):
     """Request body for storing a single memory."""
 
     type: MemoryType
@@ -27,7 +38,7 @@ class MemoryStoreRequest(BaseModel):
     user_confirmed: bool = False
 
 
-class MemoryBatchItem(BaseModel):
+class MemoryBatchItem(MemoryTagsMixin, BaseModel):
     """Single memory item for batch write"""
 
     type: MemoryType
@@ -52,7 +63,7 @@ class MemoryBatchWriteRequest(BaseModel):
     user_confirmed: bool = False
 
 
-class BatchRememberItem(BaseModel):
+class BatchRememberItem(MemoryTagsMixin, BaseModel):
     """Single memory item in a batch-remember request"""
 
     content: str = Field(..., max_length=10000, description="Memory content")
@@ -182,7 +193,7 @@ class MemoryUpdateRequest(BaseModel):
     user_confirmed: bool = False
 
 
-class MemorySearchRequest(BaseModel):
+class MemorySearchRequest(MemoryTagsMixin, BaseModel):
     query: str
     agent_id: str | None = None
     memory_types: list[MemoryType] | None = None

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -40,7 +40,7 @@ from memanto.app.services.conversation_memory_extraction_service import (
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.services.memory_write_service import MemoryWriteService
 from memanto.app.utils.errors import AuthorizationError, map_error_to_http_exception
-from memanto.app.utils.validation import CostGuard
+from memanto.app.utils.validation import CostGuard, validate_memory_tags
 from memanto.cli.client.direct_client import DirectClient
 from memanto.cli.config.manager import ConfigManager
 
@@ -138,6 +138,12 @@ class MemoryEditRequest(BaseModel):
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
     tags: list[str] | None = None
     source: str | None = None
+
+    @field_validator("tags")
+    @classmethod
+    def validate_tags(cls, v: list[str] | None) -> list[str] | None:
+        """Validate tag updates before they reach memory storage."""
+        return validate_memory_tags(v)
 
     def to_updates(self) -> dict[str, object]:
         return self.model_dump(exclude_none=True)

--- a/memanto/app/utils/validation.py
+++ b/memanto/app/utils/validation.py
@@ -2,10 +2,13 @@
 Input Validation and Cost Guards for MEMANTO
 """
 
+import re
 from typing import Any
 
 from fastapi import HTTPException
 from pydantic import BaseModel, Field, validator
+
+MEMORY_TAG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 class InputLimits:
@@ -14,6 +17,9 @@ class InputLimits:
     # Text limits
     MAX_TEXT_LENGTH = 10000  # characters
     MAX_METADATA_SIZE = 5000  # bytes
+    MAX_TAG_COUNT = 50
+    MAX_TAG_LENGTH = 128  # characters per tag
+    MAX_TAGS_SIZE = 2000  # serialized bytes across all tags
 
     # Query limits
     MAX_K = 100  # maximum results
@@ -159,3 +165,42 @@ def validate_request_size(
                 "max_size": max_size,
             },
         )
+
+
+def validate_memory_tags(tags: list[str] | None) -> list[str] | None:
+    """Normalize and bound memory tags before they are serialized into documents."""
+    if tags is None:
+        return None
+
+    if len(tags) > InputLimits.MAX_TAG_COUNT:
+        raise ValueError(
+            f"Memory tags exceed maximum count of {InputLimits.MAX_TAG_COUNT}"
+        )
+
+    normalized_tags = []
+    for index, tag in enumerate(tags):
+        if not isinstance(tag, str):
+            raise ValueError(f"Memory tag at index {index} must be a string")
+        normalized = tag.strip()
+        if not normalized:
+            raise ValueError(f"Memory tag at index {index} must be non-empty")
+        if len(normalized) > InputLimits.MAX_TAG_LENGTH:
+            raise ValueError(
+                f"Memory tag at index {index} exceeds maximum length of "
+                f"{InputLimits.MAX_TAG_LENGTH} characters"
+            )
+        if not MEMORY_TAG_RE.fullmatch(normalized):
+            raise ValueError(
+                f"Memory tag at index {index} contains unsupported characters. "
+                "Use letters, numbers, dots, underscores, and hyphens."
+            )
+        normalized_tags.append(normalized)
+
+    tags_size = len(",".join(normalized_tags).encode("utf-8"))
+    if tags_size > InputLimits.MAX_TAGS_SIZE:
+        raise ValueError(
+            f"Memory tags exceed maximum serialized size of "
+            f"{InputLimits.MAX_TAGS_SIZE} bytes"
+        )
+
+    return normalized_tags

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -39,7 +39,7 @@ from memanto.app.utils.errors import (
     SessionExpiredError,
     SessionNotFoundError,
 )
-from memanto.app.utils.validation import InputLimits
+from memanto.app.utils.validation import InputLimits, validate_memory_tags
 from memanto.cli.config.manager import ConfigManager
 
 logger = logging.getLogger(__name__)
@@ -969,6 +969,7 @@ class DirectClient:
         self._get_validated_session_for_agent(agent_id)
 
         self._validate_query(query, limit)
+        tags = validate_memory_tags(tags)
 
         logger.debug(
             "Recall for agent '%s': query='%s', limit=%d", agent_id, query, limit

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -36,7 +36,7 @@ from memanto.app.utils.errors import (
     SessionExpiredError,
     SessionNotFoundError,
 )
-from memanto.app.utils.validation import InputLimits
+from memanto.app.utils.validation import InputLimits, validate_memory_tags
 from memanto.cli.config.manager import ConfigManager
 
 logger = logging.getLogger(__name__)
@@ -843,6 +843,7 @@ class SdkClient:
         self._get_validated_session_for_agent(agent_id)
 
         self._validate_query(query, limit)
+        tags = validate_memory_tags(tags)
 
         logger.debug(
             "Recall for agent '%s': query='%s', limit=%d", agent_id, query, limit

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from memanto.app.config import settings
 from memanto.app.main import app
 from memanto.app.models.session import Session
 from memanto.app.routes.auth_deps import get_current_session
+from memanto.app.utils.validation import InputLimits
 
 # Set test environment
 os.environ["MOORCHEH_API_KEY"] = "test-api-key"
@@ -251,6 +252,102 @@ class TestMEMANTOAPI:
         assert response.json()["status"] == "queued"
 
     @pytest.mark.asyncio
+    async def test_remember_rejects_oversized_tags_before_upload(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Tags are serialized into indexed text, so they must be bounded."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        session_token = activate_response.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": session_token}
+        mock_moorcheh.documents.upload.reset_mock()
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=headers,
+            json={
+                "content": "tiny memory",
+                "tags": ["x" * (InputLimits.MAX_TAG_LENGTH + 1)],
+            },
+        )
+
+        assert response.status_code == 422
+        assert "tag" in str(response.json()).lower()
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remember_rejects_filter_like_tags_before_upload(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Tags must not smuggle Moorcheh filter syntax into later searches."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        session_token = activate_response.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": session_token}
+        mock_moorcheh.documents.upload.reset_mock()
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=headers,
+            json={
+                "content": "tiny memory",
+                "tags": ["safe #status:deleted"],
+            },
+        )
+
+        assert response.status_code == 422
+        assert "tag" in str(response.json()).lower()
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remember_rejects_aggregate_tag_payload_before_upload(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Individually valid tags cannot exceed the aggregate tag payload limit."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        session_token = activate_response.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": session_token}
+        mock_moorcheh.documents.upload.reset_mock()
+        tags = [
+            f"tag{index:02d}" + "x" * (InputLimits.MAX_TAG_LENGTH - 5)
+            for index in range(
+                (InputLimits.MAX_TAGS_SIZE // InputLimits.MAX_TAG_LENGTH) + 2
+            )
+        ]
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=headers,
+            json={
+                "content": "tiny memory",
+                "tags": tags,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "tag" in str(response.json()).lower()
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_edit_memory_with_session(self, client, auth_headers):
         """Test updating one memory with session token."""
         app.dependency_overrides[get_current_session] = lambda: Session(
@@ -310,6 +407,33 @@ class TestMEMANTOAPI:
 
         assert response.status_code == 400
         assert "at least one field" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_edit_memory_rejects_oversized_tags_before_update(
+        self, client, auth_headers
+    ):
+        """Oversized tag updates should fail validation before touching storage."""
+        app.dependency_overrides[get_current_session] = lambda: Session(
+            session_id="sess-test",
+            session_token="token-test",
+            agent_id=self.TEST_AGENT_ID,
+            namespace=f"memanto_agent_{self.TEST_AGENT_ID}",
+            started_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+        try:
+            with patch("memanto.app.routes.memory.MemoryWriteService") as mock_cls:
+                response = await client.patch(
+                    f"/api/v2/agents/{self.TEST_AGENT_ID}/memories/mem-123",
+                    headers=auth_headers,
+                    json={"tags": ["x" * (InputLimits.MAX_TAG_LENGTH + 1)]},
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 422
+        assert "tag" in str(response.json()).lower()
+        mock_cls.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_edit_memory_returns_404_when_missing(self, client, auth_headers):
@@ -744,6 +868,41 @@ class TestMEMANTOAPI:
         )
         assert response.status_code == 200
         assert response.json()["successful"] == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_remember_rejects_oversized_tags_before_upload(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Batch items cannot bypass text limits with oversized tag payloads."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+        mock_moorcheh.documents.upload.reset_mock()
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/batch-remember",
+            headers=headers,
+            json={
+                "memories": [
+                    {
+                        "content": "Batch 1",
+                        "type": "fact",
+                        "tags": ["x" * (InputLimits.MAX_TAG_LENGTH + 1)],
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 422
+        assert "tag" in str(response.json()).lower()
+        mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_memory_with_session(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -345,6 +345,43 @@ class TestMEMANTOCLI:
 
         mock_write_service.update_memory.assert_not_called()
 
+    def test_direct_recall_rejects_filter_like_tags(self, mock_all_clients):
+        """Direct recall tags must not inject Moorcheh filter syntax."""
+        from unittest.mock import MagicMock, patch
+
+        import pytest
+
+        from memanto.cli.client.direct_client import DirectClient
+
+        mock_read_service = MagicMock()
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+
+        with (
+            patch.object(
+                DirectClient, "_get_read_service", return_value=mock_read_service
+            ),
+            patch.object(
+                DirectClient,
+                "_get_validated_session_for_agent",
+                return_value=mock_session,
+            ),
+        ):
+            client = DirectClient.__new__(DirectClient)
+            client.api_key = "test-api-key"
+            client.base_url = "https://api.moorcheh.ai/v1"
+
+            with pytest.raises(ValueError, match="unsupported characters"):
+                client.recall(
+                    agent_id="test-agent",
+                    query="hello",
+                    limit=10,
+                    min_similarity=0.0,
+                    tags=["safe #status:deleted"],
+                )
+
+        mock_read_service.search_memories.assert_not_called()
+
     def test_edit_sdk_rejects_unknown_field(self, mock_all_clients):
         """SdkClient.update_memory must enforce the same field allowlist as
         the API route. CodeRabbit review 2026-06-14T14:03:20Z flagged that
@@ -377,6 +414,40 @@ class TestMEMANTOCLI:
                 )
 
         mock_write_service.update_memory.assert_not_called()
+
+    def test_sdk_recall_rejects_filter_like_tags(self, mock_all_clients):
+        """SDK recall applies the shared tag syntax guard before search."""
+        from unittest.mock import MagicMock, patch
+
+        import pytest
+
+        from memanto.cli.client.sdk_client import SdkClient
+
+        mock_read_service = MagicMock()
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+
+        with (
+            patch.object(
+                SdkClient, "_get_read_service", return_value=mock_read_service
+            ),
+            patch.object(
+                SdkClient, "_get_validated_session_for_agent", return_value=mock_session
+            ),
+        ):
+            client = SdkClient.__new__(SdkClient)
+            client.api_key = "test-api-key"
+
+            with pytest.raises(ValueError, match="unsupported characters"):
+                client.recall(
+                    agent_id="test-agent",
+                    query="hello",
+                    limit=10,
+                    min_similarity=0.0,
+                    tags=["safe #status:deleted"],
+                )
+
+        mock_read_service.search_memories.assert_not_called()
 
     def test_edit_sdk_rejects_blank_content(self, mock_all_clients):
         """SdkClient.update_memory must reject blank content strings."""


### PR DESCRIPTION
## Summary

Fixes a memory cost/size guard bypass where `tags` were accepted without any count, length, or serialized-size limit, then appended into the Moorcheh document text and metadata. A request with tiny `content` but a very large tag could produce an oversized indexed document while still passing the existing content-length guard.

## Reproduction

Before this patch, this model path was accepted and produced a document text longer than the content guard:

```python
from memanto.app.models import RememberRequest
from memanto.app.core import MemoryRecord

req = RememberRequest.model_validate({
    "content": "x",
    "tags": ["y" * 12000],
    "source": "agent",
    "provenance": "explicit_statement",
})
mem = MemoryRecord(
    type=req.type,
    title="x",
    content=req.content,
    scope_type="agent",
    scope_id="agent-1",
    actor_id="agent-1",
    source=req.source,
    tags=req.tags or [],
)
assert len(mem.to_moorcheh_document()["text"]) == 12019
```

## Fix

- Add shared memory tag bounds for count, per-tag length, and serialized tag size.
- Apply the validator to API request models and `MemoryRecord` so direct construction paths are also covered.
- Validate edit-memory tag updates before `MemoryWriteService.update_memory` is called.
- Add API regression tests proving oversized tags are rejected before upload/update for single remember, batch remember, and edit.

## Validation

- `uv run pytest tests/test_api.py -q -k 'remember_rejects_oversized_tags or batch_remember_rejects_oversized_tags or edit_memory_rejects_oversized_tags or remember_with_session or batch_remember_api'`
- `uv run pytest tests/test_api.py -q -k 'remember or edit_memory or recall'`
- `uv run pytest tests/test_cli.py -q -k 'remember or edit'`
- `uv run ruff check memanto/app/utils/validation.py memanto/app/models/__init__.py memanto/app/core.py memanto/app/routes/memory.py tests/test_api.py`
- `git diff --check`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent memory tag normalization and validation across memory create, edit, batch, and search requests, plus client recall calls (trimmed, constrained by count/length/total size).
* **API Changes**
  * Updated memory request/response schemas to use agent/actor identifiers and removed namespace response models.
  * Conflict resolution now uses a restricted action set and requires non-empty manual content for manual actions.
* **Bug Fixes**
  * Invalid, oversized, or filter-like tags fail fast (API returns `422`) before any storage, update, or upload occurs.
* **Tests**
  * Added API and CLI contract/integration tests covering fail-fast tag rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->