### PR TITLE
fix: preserve temporal context in memory extraction (timeline amnesia)

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -4,10 +4,10 @@ MEMANTO Core Architecture - Namespace Strategy & Memory Records
 
 import re
 import uuid
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from memanto.app.constants import (
     MemoryType,
@@ -67,8 +67,24 @@ class MemoryRecord(BaseModel):
     validation_count: int = 0  # Number of times validated/confirmed
     contradiction_detected: bool = False  # Flag for contradictions
 
-    # Event date — when the fact/event occurred (YYYY-MM-DD), distinct from system timestamps
-    event_date: str | None = None
+    # Event date — when the fact/event occurred, distinct from system timestamps
+    event_date: date | None = None
+
+    @field_validator("event_date", mode="before")
+    @classmethod
+    def _parse_event_date(cls, v: Any) -> date | None:
+        if v is None:
+            return None
+        if isinstance(v, date):
+            return v
+        if isinstance(v, str):
+            try:
+                return date.fromisoformat(v)
+            except ValueError:
+                raise ValueError(
+                    f"event_date must be a valid YYYY-MM-DD date, got '{v}'"
+                )
+        raise ValueError(f"event_date must be a string or date, got {type(v)}")
 
     # Timestamps (auto-populated by server)
     created_at: datetime = Field(default_factory=datetime.utcnow)
@@ -127,7 +143,7 @@ class MemoryRecord(BaseModel):
         if self.validated_at:
             document["validated_at"] = self.validated_at.isoformat()
         if self.event_date:
-            document["event_date"] = self.event_date
+            document["event_date"] = self.event_date.isoformat()
 
         return document
 

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -67,6 +67,9 @@ class MemoryRecord(BaseModel):
     validation_count: int = 0  # Number of times validated/confirmed
     contradiction_detected: bool = False  # Flag for contradictions
 
+    # Event date — when the fact/event occurred (YYYY-MM-DD), distinct from system timestamps
+    event_date: str | None = None
+
     # Timestamps (auto-populated by server)
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
@@ -123,6 +126,8 @@ class MemoryRecord(BaseModel):
             document["supersedes"] = self.supersedes
         if self.validated_at:
             document["validated_at"] = self.validated_at.isoformat()
+        if self.event_date:
+            document["event_date"] = self.event_date
 
         return document
 

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -466,6 +466,7 @@ async def extract_memories_from_conversation(
                 tags=["conversation-extract"],
                 source=item["source"],
                 provenance=cast(ProvenanceType, item["provenance"]),
+                event_date=item.get("date"),
             )
             memory_records.append(memory)
 

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -95,13 +95,18 @@ class ConversationMemoryExtractionService:
         )
 
     def _footer_prompt(self) -> str:
+        from datetime import date
+
+        today = date.today().isoformat()
         return (
             "Return only JSON. The JSON must be an array of objects with keys: "
             "type, title, content, confidence, date. "
             "Confidence must be 0.0 to 1.0. "
+            f"Today's date is {today}. "
             "date is an optional ISO-8601 date string (YYYY-MM-DD) representing "
             "when the event or fact occurred — infer it from relative expressions "
-            "like 'yesterday', 'last Tuesday', 'two weeks ago', or explicit dates. "
+            "like 'yesterday', 'last Tuesday', 'two weeks ago', or explicit dates "
+            f"anchored to today ({today}). "
             "Omit the date key entirely when no temporal context is present."
         )
 

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -97,7 +97,12 @@ class ConversationMemoryExtractionService:
     def _footer_prompt(self) -> str:
         return (
             "Return only JSON. The JSON must be an array of objects with keys: "
-            "type, title, content, confidence. Confidence must be 0.0 to 1.0."
+            "type, title, content, confidence, date. "
+            "Confidence must be 0.0 to 1.0. "
+            "date is an optional ISO-8601 date string (YYYY-MM-DD) representing "
+            "when the event or fact occurred — infer it from relative expressions "
+            "like 'yesterday', 'last Tuesday', 'two weeks ago', or explicit dates. "
+            "Omit the date key entirely when no temporal context is present."
         )
 
     def _parse_json_answer(self, answer: str) -> Any:
@@ -157,16 +162,26 @@ class ConversationMemoryExtractionService:
                 continue
             seen.add(key)
 
-            normalized.append(
-                {
-                    "type": memory_type,
-                    "title": title,
-                    "content": content,
-                    "confidence": confidence,
-                    "source": "conversation",
-                    "provenance": "inferred",
-                }
-            )
+            candidate: dict[str, Any] = {
+                "type": memory_type,
+                "title": title,
+                "content": content,
+                "confidence": confidence,
+                "source": "conversation",
+                "provenance": "inferred",
+            }
+
+            # Preserve temporal context — without this, relative date expressions
+            # ("yesterday", "last Tuesday") are silently discarded, causing timeline
+            # amnesia: the memory system records WHAT happened but not WHEN.
+            raw_date = item.get("date")
+            if raw_date and isinstance(raw_date, str):
+                date_str = raw_date.strip()
+                import re as _re
+                if _re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+                    candidate["date"] = date_str
+
+            normalized.append(candidate)
             if len(normalized) >= max_memories:
                 break
 

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -166,15 +166,18 @@ class ConversationMemoryExtractionService:
 
             # Parse and validate date before dedup so the key captures temporal
             # context: the same event on different dates must produce distinct
-            # memories, not collapse into one. fromisoformat() rejects impossible
-            # dates (e.g. 2026-99-99) that a bare YYYY-MM-DD regex would accept.
+            # memories, not collapse into one. The regex enforces strict
+            # YYYY-MM-DD format (rejects 20260625, 2026-W26-4, datetimes),
+            # then fromisoformat() rejects impossible calendar dates like 2026-99-99.
             raw_date = item.get("date")
             validated_date: str | None = None
             if raw_date and isinstance(raw_date, str):
-                try:
-                    validated_date = _date.fromisoformat(raw_date.strip()).isoformat()
-                except ValueError:
-                    pass
+                date_str = raw_date.strip()
+                if re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+                    try:
+                        validated_date = _date.fromisoformat(date_str).isoformat()
+                    except ValueError:
+                        pass
 
             key = (memory_type, re.sub(r"\s+", " ", content).lower(), validated_date)
             if key in seen:

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -134,8 +134,10 @@ class ConversationMemoryExtractionService:
         if not isinstance(parsed, list):
             raise ValueError("Memory extraction response must be a JSON array")
 
+        from datetime import date as _date
+
         normalized: list[dict[str, Any]] = []
-        seen: set[tuple[str | None, str]] = set()
+        seen: set[tuple[str | None, str, str | None]] = set()
 
         for item in parsed:
             if not isinstance(item, dict):
@@ -162,7 +164,19 @@ class ConversationMemoryExtractionService:
                 confidence = 0.8
             confidence = max(0.0, min(confidence, 1.0))
 
-            key = (memory_type, re.sub(r"\s+", " ", content).lower())
+            # Parse and validate date before dedup so the key captures temporal
+            # context: the same event on different dates must produce distinct
+            # memories, not collapse into one. fromisoformat() rejects impossible
+            # dates (e.g. 2026-99-99) that a bare YYYY-MM-DD regex would accept.
+            raw_date = item.get("date")
+            validated_date: str | None = None
+            if raw_date and isinstance(raw_date, str):
+                try:
+                    validated_date = _date.fromisoformat(raw_date.strip()).isoformat()
+                except ValueError:
+                    pass
+
+            key = (memory_type, re.sub(r"\s+", " ", content).lower(), validated_date)
             if key in seen:
                 continue
             seen.add(key)
@@ -176,15 +190,8 @@ class ConversationMemoryExtractionService:
                 "provenance": "inferred",
             }
 
-            # Preserve temporal context — without this, relative date expressions
-            # ("yesterday", "last Tuesday") are silently discarded, causing timeline
-            # amnesia: the memory system records WHAT happened but not WHEN.
-            raw_date = item.get("date")
-            if raw_date and isinstance(raw_date, str):
-                date_str = raw_date.strip()
-                import re as _re
-                if _re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
-                    candidate["date"] = date_str
+            if validated_date is not None:
+                candidate["date"] = validated_date
 
             normalized.append(candidate)
             if len(normalized) >= max_memories:

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -203,11 +203,15 @@ def test_footer_prompt_anchors_relative_dates_to_today():
     """_footer_prompt must include today's date so relative expressions resolve correctly."""
     from datetime import date
 
+    # Capture the date window before and after the call to avoid a midnight-rollover
+    # flake where the date advances between the _footer_prompt() call and date.today().
+    date_before = date.today().isoformat()
     service = ConversationMemoryExtractionService(client=None)
     footer = service._footer_prompt()
-    today = date.today().isoformat()
-    assert today in footer, (
-        f"_footer_prompt does not include today's date ({today}) — "
+    date_after = date.today().isoformat()
+
+    assert date_before in footer or date_after in footer, (
+        f"_footer_prompt does not include today's date (expected {date_before} or {date_after}) — "
         "the LLM cannot reliably resolve relative expressions like 'yesterday' "
         "without a reference point (nondeterministic inference)."
     )

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -95,3 +95,105 @@ def test_extract_requires_messages():
 
     with pytest.raises(ValueError, match="at least one message"):
         service.extract(namespace="memanto_agent_test", messages=[])
+
+
+# ── Timeline Amnesia regression tests ─────────────────────────────────────────
+# Bug: _footer_prompt did not ask for a "date" field, so temporal context from
+# relative expressions ("yesterday", "last Tuesday") was silently discarded.
+# The extracted memory stored WHAT happened but never WHEN.
+
+def test_temporal_context_preserved_when_date_provided():
+    """Extracted memory must carry the date when the LLM infers one."""
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "event",
+            "title": "Doctor appointment",
+            "content": "User had a doctor appointment.",
+            "confidence": 0.95,
+            "date": "2026-06-26"
+          }
+        ]
+        """
+    )
+    service = ConversationMemoryExtractionService(client)
+    results = service.extract(
+        namespace="memanto_agent_test",
+        messages=[
+            {"role": "user", "content": "I had a doctor appointment yesterday."},
+            {"role": "assistant", "content": "I hope it went well!"},
+        ],
+    )
+    assert len(results) == 1
+    # Without the fix this key would be absent — timeline amnesia.
+    assert results[0].get("date") == "2026-06-26", (
+        "Temporal context lost: 'yesterday' was in the conversation but the "
+        "extracted memory carries no date field (timeline amnesia)."
+    )
+
+
+def test_temporal_context_absent_when_no_date():
+    """When the LLM returns no date the candidate must not grow a spurious key."""
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "preference",
+            "title": "Dark mode preference",
+            "content": "User prefers dark mode.",
+            "confidence": 0.9
+          }
+        ]
+        """
+    )
+    service = ConversationMemoryExtractionService(client)
+    results = service.extract(
+        namespace="memanto_agent_test",
+        messages=[
+            {"role": "user", "content": "I always use dark mode."},
+            {"role": "assistant", "content": "Got it, I will remember that."},
+        ],
+    )
+    assert len(results) == 1
+    assert "date" not in results[0], "Spurious date key added when no date was present."
+
+
+def test_malformed_date_is_rejected():
+    """Non-ISO-8601 date strings must be silently ignored rather than stored."""
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "event",
+            "title": "Team lunch",
+            "content": "User had a team lunch.",
+            "confidence": 0.8,
+            "date": "last Tuesday"
+          }
+        ]
+        """
+    )
+    service = ConversationMemoryExtractionService(client)
+    results = service.extract(
+        namespace="memanto_agent_test",
+        messages=[
+            {"role": "user", "content": "We had a team lunch last Tuesday."},
+            {"role": "assistant", "content": "Sounds fun!"},
+        ],
+    )
+    assert len(results) == 1
+    assert "date" not in results[0], (
+        "Raw relative string 'last Tuesday' must not be stored as date — "
+        "only resolved ISO-8601 dates are valid."
+    )
+
+
+def test_footer_prompt_requests_date_field():
+    """_footer_prompt must instruct the LLM to extract a date field."""
+    service = ConversationMemoryExtractionService(client=None)
+    footer = service._footer_prompt()
+    assert "date" in footer, (
+        "_footer_prompt does not mention 'date' — the LLM will never produce "
+        "temporal context, causing systematic timeline amnesia."
+    )

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -229,6 +229,36 @@ def test_impossible_calendar_date_is_rejected():
     )
 
 
+def test_non_dashed_iso_date_is_rejected():
+    """Dates like 20260625 or 2026-W26-4 pass fromisoformat() but must be rejected."""
+    for bad_date in ["20260625", "2026-W26-4", "2026-06-25T10:00:00"]:
+        client = FakeClient(
+            f"""
+            [
+              {{
+                "type": "event",
+                "title": "Some event",
+                "content": "Something happened.",
+                "confidence": 0.8,
+                "date": "{bad_date}"
+              }}
+            ]
+            """
+        )
+        service = ConversationMemoryExtractionService(client)
+        results = service.extract(
+            namespace="memanto_agent_test",
+            messages=[
+                {"role": "user", "content": "Something happened."},
+                {"role": "assistant", "content": "OK."},
+            ],
+        )
+        assert "date" not in results[0], (
+            f"Non-dashed ISO form '{bad_date}' should be rejected — "
+            "only strict YYYY-MM-DD is accepted."
+        )
+
+
 def test_same_event_different_dates_are_not_deduplicated():
     """Identical content on different dates must yield two distinct memories."""
     client = FakeClient(

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -197,3 +197,17 @@ def test_footer_prompt_requests_date_field():
         "_footer_prompt does not mention 'date' — the LLM will never produce "
         "temporal context, causing systematic timeline amnesia."
     )
+
+
+def test_footer_prompt_anchors_relative_dates_to_today():
+    """_footer_prompt must include today's date so relative expressions resolve correctly."""
+    from datetime import date
+
+    service = ConversationMemoryExtractionService(client=None)
+    footer = service._footer_prompt()
+    today = date.today().isoformat()
+    assert today in footer, (
+        f"_footer_prompt does not include today's date ({today}) — "
+        "the LLM cannot reliably resolve relative expressions like 'yesterday' "
+        "without a reference point (nondeterministic inference)."
+    )

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -199,6 +199,75 @@ def test_footer_prompt_requests_date_field():
     )
 
 
+def test_impossible_calendar_date_is_rejected():
+    """Dates that pass YYYY-MM-DD regex but aren't real (e.g. 2026-99-99) must be dropped."""
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "event",
+            "title": "Impossible event",
+            "content": "Something happened.",
+            "confidence": 0.8,
+            "date": "2026-99-99"
+          }
+        ]
+        """
+    )
+    service = ConversationMemoryExtractionService(client)
+    results = service.extract(
+        namespace="memanto_agent_test",
+        messages=[
+            {"role": "user", "content": "Something happened."},
+            {"role": "assistant", "content": "OK."},
+        ],
+    )
+    assert len(results) == 1
+    assert "date" not in results[0], (
+        "Impossible date '2026-99-99' passed regex validation but must be "
+        "rejected by calendar-aware parsing."
+    )
+
+
+def test_same_event_different_dates_are_not_deduplicated():
+    """Identical content on different dates must yield two distinct memories."""
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "event",
+            "title": "Morning run",
+            "content": "User went for a morning run.",
+            "confidence": 0.9,
+            "date": "2026-06-25"
+          },
+          {
+            "type": "event",
+            "title": "Morning run",
+            "content": "User went for a morning run.",
+            "confidence": 0.9,
+            "date": "2026-06-26"
+          }
+        ]
+        """
+    )
+    service = ConversationMemoryExtractionService(client)
+    results = service.extract(
+        namespace="memanto_agent_test",
+        messages=[
+            {"role": "user", "content": "I went for a run yesterday and today."},
+            {"role": "assistant", "content": "Great habit!"},
+        ],
+        max_memories=5,
+    )
+    assert len(results) == 2, (
+        "Same event on different dates was incorrectly deduplicated — "
+        "the date must be part of the dedup key."
+    )
+    dates = {r["date"] for r in results}
+    assert dates == {"2026-06-25", "2026-06-26"}
+
+
 def test_footer_prompt_anchors_relative_dates_to_today():
     """_footer_prompt must include today's date so relative expressions resolve correctly."""
     from datetime import date


### PR DESCRIPTION
## Bug: Timeline Amnesia in Conversation Memory Extraction

### What's broken

When a user mentions a time-relative expression — *"I had a doctor appointment **yesterday**"*, *"we launched **last Tuesday**"*, *"I met John **two weeks ago**"* — the extraction service discards the temporal context entirely.

The agent records **WHAT** happened but never **WHEN**.

This makes it impossible to:
- Answer *"what did I do last week?"*
- Detect contradictions across time
- Build any meaningful timeline of user events

### Root cause

**`_footer_prompt` never asked for a date field** — so the LLM had no reason to produce temporal information. And **`_normalize_candidates` never read or forwarded a date** even if the LLM somehow included one.

### Fix

- `_footer_prompt` now requests an optional ISO-8601 `date` field and instructs the LLM to infer it from relative expressions like "yesterday", "last Tuesday", "two weeks ago"
- `_normalize_candidates` propagates `date` when it is a valid `YYYY-MM-DD` string; malformed strings like *"last Tuesday"* are silently rejected — only resolved dates are stored

### Reproduction

```python
# FAILS before fix — "date" key is absent (timeline amnesia)
results = service.extract(
    namespace="memanto_agent_test",
    messages=[
        {"role": "user", "content": "I had a doctor appointment yesterday."},
        {"role": "assistant", "content": "I hope it went well!"},
    ],
)
assert results[0].get("date") == "2026-06-26"  # KeyError — date was never extracted
```

### Tests added (4 new, all passing)

- `test_temporal_context_preserved_when_date_provided`
- `test_temporal_context_absent_when_no_date`
- `test_malformed_date_is_rejected`
- `test_footer_prompt_requests_date_field`

```
tests/test_conversation_memory_extraction.py .......   7 passed in 0.58s
```

### No breaking changes
`date` is a new optional key — callers that don't use it are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation memory extraction can now capture and retain an `event_date` (`YYYY-MM-DD`) when provided by the model.
  * Stored memory output now includes `event_date` when available.
* **Bug Fixes**
  * Malformed, non-ISO, or calendar-invalid date text is no longer saved as a date.
  * Deduplication is now date-aware, so the same event on different dates is treated separately.
* **Tests**
  * Added “Timeline Amnesia” regression tests for date preservation/omission, prompt anchoring, and invalid-date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->