### PR TITLE
fix: eliminate cross-tenant session leak in LangGraph nodes

### DIFF
--- a/integrations/langgraph/langgraph_memanto/nodes.py
+++ b/integrations/langgraph/langgraph_memanto/nodes.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from typing import Any
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
@@ -23,6 +24,44 @@ def _extract_text_content(content: Any) -> str:
     return str(content)
 
 
+class _PerAgentClientCache:
+    """Thread-safe cache of per-agent-id SdkClient instances.
+
+    Each agent_id gets its own SdkClient so that concurrent LangGraph runs for
+    different tenants never share session_token / agent_id state.  Without this
+    isolation, a concurrent _do_setup("bob") would clobber the shared client's
+    session_token while agent "alice" is mid-request, causing cross-tenant auth
+    failures or silent data leaks.
+    """
+
+    def __init__(self, template_client: SdkClient) -> None:
+        self._api_key = template_client.api_key
+        self._clients: dict[str, SdkClient] = {}
+        self._lock = threading.Lock()
+
+    def get(self, agent_id: str) -> SdkClient:
+        with self._lock:
+            if agent_id not in self._clients:
+                self._clients[agent_id] = SdkClient(api_key=self._api_key)
+            return self._clients[agent_id]
+
+
+def _do_setup(agent_client: SdkClient, resolved_agent_id: str) -> None:
+    """Ensure agent exists and activate a session on *agent_client*.
+
+    Uses the caller-supplied per-agent client, not a shared one, so mutations
+    to session_token / agent_id stay scoped to a single tenant.
+    """
+    try:
+        agent_client.create_agent(agent_id=resolved_agent_id, pattern="tool")
+    except Exception:
+        pass
+    try:
+        agent_client.activate_agent(resolved_agent_id, duration_hours=6)
+    except Exception:
+        pass
+
+
 def create_recall_node(
     client: SdkClient,
     agent_id: str | None = None,
@@ -34,17 +73,7 @@ def create_recall_node(
     This node extracts the query from the most recent human message in the state
     and retrieves relevant memories from Memanto.
     """
-
-    def _do_setup(resolved_agent_id: str):
-        try:
-            client.create_agent(agent_id=resolved_agent_id, pattern="tool")
-        except Exception:
-            pass
-        try:
-            result = client.activate_agent(resolved_agent_id, duration_hours=6)
-            client.session_token = result.get("session_token")
-        except Exception:
-            pass
+    _cache = _PerAgentClientCache(client)
 
     def recall_node(
         state: dict, config: RunnableConfig | None = None
@@ -74,17 +103,19 @@ def create_recall_node(
                 return {output_key: None}
             return {"messages": []}
 
+        agent_client = _cache.get(resolved_agent_id)
+
         try:
             # First try assuming the session is already active (saves an API call)
-            result = client.recall(
+            result = agent_client.recall(
                 agent_id=resolved_agent_id,
                 query=query,
             )
         except Exception:
             # If there's an error (e.g. no active session), try to setup and retry
-            _do_setup(resolved_agent_id)
+            _do_setup(agent_client, resolved_agent_id)
             try:
-                result = client.recall(
+                result = agent_client.recall(
                     agent_id=resolved_agent_id,
                     query=query,
                 )
@@ -141,17 +172,7 @@ def create_remember_node(
 
     This node extracts the latest messages and stores them in Memanto.
     """
-
-    def _do_setup(resolved_agent_id: str):
-        try:
-            client.create_agent(agent_id=resolved_agent_id, pattern="tool")
-        except Exception:
-            pass
-        try:
-            result = client.activate_agent(resolved_agent_id, duration_hours=6)
-            client.session_token = result.get("session_token")
-        except Exception:
-            pass
+    _cache = _PerAgentClientCache(client)
 
     def remember_node(
         state: dict, config: RunnableConfig | None = None
@@ -191,9 +212,11 @@ def create_remember_node(
         content = "\n\n".join(messages_to_remember)
         title = content if len(content) <= 50 else content[:47] + "..."
 
+        agent_client = _cache.get(resolved_agent_id)
+
         try:
             # First try assuming the session is already active
-            client.remember(
+            agent_client.remember(
                 agent_id=resolved_agent_id,
                 memory_type=None,
                 title=title,
@@ -203,9 +226,9 @@ def create_remember_node(
             )
         except Exception:
             # If there's an error, try to setup and retry
-            _do_setup(resolved_agent_id)
+            _do_setup(agent_client, resolved_agent_id)
             try:
-                client.remember(
+                agent_client.remember(
                     agent_id=resolved_agent_id,
                     memory_type=None,
                     title=title,

--- a/integrations/langgraph/langgraph_memanto/nodes.py
+++ b/integrations/langgraph/langgraph_memanto/nodes.py
@@ -5,12 +5,14 @@ from typing import Any
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 
+from memanto.app.utils.errors import SessionError
 from memanto.cli.client.sdk_client import SdkClient
 
 logger = logging.getLogger(__name__)
 
 
 def _extract_text_content(content: Any) -> str:
+    """Return plain-text from a LangChain message content value."""
     if isinstance(content, str):
         return content
     elif isinstance(content, list):
@@ -32,14 +34,20 @@ class _PerAgentClientCache:
     isolation, a concurrent _do_setup("bob") would clobber the shared client's
     session_token while agent "alice" is mid-request, causing cross-tenant auth
     failures or silent data leaks.
+
+    The cache is intentionally unbounded: in a typical LangGraph deployment the
+    number of distinct agent IDs active in a single process is naturally bounded
+    by the number of concurrent tenants, so unbounded growth is not a concern.
     """
 
     def __init__(self, template_client: SdkClient) -> None:
+        """Initialise cache, extracting the API key from *template_client*."""
         self._api_key = template_client.api_key
         self._clients: dict[str, SdkClient] = {}
         self._lock = threading.Lock()
 
     def get(self, agent_id: str) -> SdkClient:
+        """Return the SdkClient for *agent_id*, creating one on first access."""
         with self._lock:
             if agent_id not in self._clients:
                 self._clients[agent_id] = SdkClient(api_key=self._api_key)
@@ -224,8 +232,9 @@ def create_remember_node(
                 source="langgraph-node",
                 provenance="explicit_statement",
             )
-        except Exception:
-            # If there's an error, try to setup and retry
+        except SessionError:
+            # SessionError is always raised before any write completes, so
+            # retrying after _do_setup cannot produce duplicate memories.
             _do_setup(agent_client, resolved_agent_id)
             try:
                 agent_client.remember(
@@ -238,6 +247,10 @@ def create_remember_node(
                 )
             except Exception as inner_e:
                 logger.error(f"Remember failed after setup: {inner_e}")
+        except Exception as e:
+            # Non-session errors may occur after the write has started; do not
+            # retry to avoid storing duplicate memories.
+            logger.error(f"Remember failed: {e}")
         return {"messages": []}
 
     return remember_node

--- a/integrations/langgraph/langgraph_memanto/nodes.py
+++ b/integrations/langgraph/langgraph_memanto/nodes.py
@@ -43,31 +43,45 @@ class _PerAgentClientCache:
     def __init__(self, template_client: SdkClient) -> None:
         """Initialise cache, extracting the API key from *template_client*."""
         self._api_key = template_client.api_key
-        self._clients: dict[str, SdkClient] = {}
+        self._clients: dict[str, tuple[SdkClient, threading.Lock]] = {}
         self._lock = threading.Lock()
 
-    def get(self, agent_id: str) -> SdkClient:
-        """Return the SdkClient for *agent_id*, creating one on first access."""
+    def get(self, agent_id: str) -> tuple[SdkClient, threading.Lock]:
+        """Return the SdkClient and setup lock for *agent_id*, creating them on first access."""
         with self._lock:
             if agent_id not in self._clients:
-                self._clients[agent_id] = SdkClient(api_key=self._api_key)
+                self._clients[agent_id] = (
+                    SdkClient(api_key=self._api_key),
+                    threading.Lock(),
+                )
             return self._clients[agent_id]
 
 
-def _do_setup(agent_client: SdkClient, resolved_agent_id: str) -> None:
+def _do_setup(agent_client: SdkClient, resolved_agent_id: str, agent_lock: threading.Lock) -> None:
     """Ensure agent exists and activate a session on *agent_client*.
 
     Uses the caller-supplied per-agent client, not a shared one, so mutations
-    to session_token / agent_id stay scoped to a single tenant.
+    to session_token / agent_id stay scoped to a single tenant. Concurrent
+    calls for the same agent_id are serialized, and secondary callers will
+    skip setup if the first caller successfully established a session.
     """
-    try:
-        agent_client.create_agent(agent_id=resolved_agent_id, pattern="tool")
-    except Exception:
-        pass
-    try:
-        agent_client.activate_agent(resolved_agent_id, duration_hours=6)
-    except Exception:
-        pass
+    with agent_lock:
+        # Check if another thread already activated the session while we waited
+        if agent_client.agent_id == resolved_agent_id and agent_client.session_token:
+            try:
+                agent_client.get_session_info()
+                return
+            except Exception:
+                pass
+
+        try:
+            agent_client.create_agent(agent_id=resolved_agent_id, pattern="tool")
+        except Exception:
+            pass
+        try:
+            agent_client.activate_agent(resolved_agent_id, duration_hours=6)
+        except Exception:
+            pass
 
 
 def create_recall_node(
@@ -111,7 +125,7 @@ def create_recall_node(
                 return {output_key: None}
             return {"messages": []}
 
-        agent_client = _cache.get(resolved_agent_id)
+        agent_client, agent_lock = _cache.get(resolved_agent_id)
 
         try:
             # First try assuming the session is already active (saves an API call)
@@ -121,7 +135,7 @@ def create_recall_node(
             )
         except Exception:
             # If there's an error (e.g. no active session), try to setup and retry
-            _do_setup(agent_client, resolved_agent_id)
+            _do_setup(agent_client, resolved_agent_id, agent_lock)
             try:
                 result = agent_client.recall(
                     agent_id=resolved_agent_id,
@@ -220,7 +234,7 @@ def create_remember_node(
         content = "\n\n".join(messages_to_remember)
         title = content if len(content) <= 50 else content[:47] + "..."
 
-        agent_client = _cache.get(resolved_agent_id)
+        agent_client, agent_lock = _cache.get(resolved_agent_id)
 
         try:
             # First try assuming the session is already active
@@ -235,7 +249,7 @@ def create_remember_node(
         except SessionError:
             # SessionError is always raised before any write completes, so
             # retrying after _do_setup cannot produce duplicate memories.
-            _do_setup(agent_client, resolved_agent_id)
+            _do_setup(agent_client, resolved_agent_id, agent_lock)
             try:
                 agent_client.remember(
                     agent_id=resolved_agent_id,

--- a/integrations/langgraph/tests/test_nodes.py
+++ b/integrations/langgraph/tests/test_nodes.py
@@ -266,7 +266,7 @@ def test_concurrent_recall_nodes_do_not_share_session_state():
     # Locate _cache by name to stay stable if the closure layout changes.
     freevars = recall_node.__code__.co_freevars
     cache = recall_node.__closure__[freevars.index("_cache")].cell_contents
-    cache._clients = per_agent_mocks.copy()
+    cache._clients = {k: (v, threading.Lock()) for k, v in per_agent_mocks.items()}
 
     barrier = threading.Barrier(len(agent_ids))
     results: list[tuple[str, dict]] = []

--- a/integrations/langgraph/tests/test_nodes.py
+++ b/integrations/langgraph/tests/test_nodes.py
@@ -1,7 +1,17 @@
-from unittest.mock import MagicMock
+import threading
+from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-from langgraph_memanto.nodes import create_recall_node, create_remember_node
+from langgraph_memanto.nodes import (
+    _PerAgentClientCache,
+    create_recall_node,
+    create_remember_node,
+)
+
+# All tests that use a MagicMock client need to patch the SdkClient constructor
+# inside nodes.py so that _PerAgentClientCache returns the original mock instead
+# of trying to create a real SdkClient (which would raise SessionError).
+_PATCH = "langgraph_memanto.nodes.SdkClient"
 
 
 def test_recall_node():
@@ -15,7 +25,8 @@ def test_recall_node():
 
     state = {"messages": [HumanMessage(content="What is my name?")]}
 
-    result = node(state)
+    with patch(_PATCH, return_value=client):
+        result = node(state)
 
     assert "messages" in result
     assert len(result["messages"]) == 1
@@ -37,7 +48,8 @@ def test_remember_node():
 
     state = {"messages": [HumanMessage(content="My name is Bob.")]}
 
-    result = node(state)
+    with patch(_PATCH, return_value=client):
+        result = node(state)
 
     assert result == {"messages": []}
 
@@ -63,8 +75,9 @@ def test_dynamic_agent_id_from_config():
 
     state = {"messages": [HumanMessage(content="Hello")]}
 
-    recall(state, config=config)
-    remember(state, config=config)
+    with patch(_PATCH, return_value=client):
+        recall(state, config=config)
+        remember(state, config=config)
 
     client.recall.assert_called_once_with(agent_id="dynamic-user-123", query="Hello")
     client.remember.assert_called_once_with(
@@ -94,7 +107,8 @@ def test_recall_no_results():
     node = create_recall_node(client=client, agent_id="test-agent")
 
     state = {"messages": [HumanMessage(content="hello")]}
-    result = node(state)
+    with patch(_PATCH, return_value=client):
+        result = node(state)
 
     assert result == {"messages": []}
 
@@ -106,7 +120,8 @@ def test_recall_handles_error_gracefully():
     node = create_recall_node(client=client, agent_id="test-agent")
 
     state = {"messages": [HumanMessage(content="hello")]}
-    result = node(state)
+    with patch(_PATCH, return_value=client):
+        result = node(state)
 
     assert result == {"messages": []}
 
@@ -123,7 +138,8 @@ def test_recall_output_key():
     )
 
     state = {"messages": [HumanMessage(content="What do you remember?")]}
-    result = node(state)
+    with patch(_PATCH, return_value=client):
+        result = node(state)
 
     assert "messages" not in result
     assert "my_memory_context" in result
@@ -141,7 +157,8 @@ def test_remember_both_human_and_ai():
         "messages": [HumanMessage(content="I like pizza"), AIMessage(content="Got it!")]
     }
 
-    result = node(state)
+    with patch(_PATCH, return_value=client):
+        result = node(state)
     assert result == {"messages": []}
 
     assert client.remember.call_count == 1
@@ -172,7 +189,8 @@ def test_remember_handles_error_gracefully():
 
     state = {"messages": [HumanMessage(content="hello")]}
 
-    result = node(state)
+    with patch(_PATCH, return_value=client):
+        result = node(state)
     assert result == {"messages": []}
 
 
@@ -189,3 +207,88 @@ def test_skips_when_no_agent_id():
 
     client.recall.assert_not_called()
     client.remember.assert_not_called()
+
+
+# ── Cross-tenant session leak regression tests ────────────────────────────────
+# Bug: _do_setup mutated client.session_token / client.agent_id on the shared
+# SdkClient instance. Concurrent runs for different agent_ids raced on these
+# fields — the last writer won, causing auth failures or cross-tenant data leaks.
+# Fix: each agent_id gets its own SdkClient via _PerAgentClientCache.
+
+
+def test_per_agent_client_cache_returns_distinct_clients():
+    """Each agent_id must get a different SdkClient instance."""
+    template = MagicMock(spec=["api_key"])
+    template.api_key = "test-key"
+
+    alice_mock = MagicMock()
+    bob_mock = MagicMock()
+    mocks = iter([alice_mock, bob_mock])
+
+    with patch(_PATCH, side_effect=lambda api_key: next(mocks)):
+        cache = _PerAgentClientCache(template)
+        alice_client = cache.get("alice")
+        bob_client = cache.get("bob")
+        alice_client_again = cache.get("alice")
+
+    assert alice_client is not bob_client, "Different agent_ids must get different clients"
+    assert alice_client is alice_client_again, "Same agent_id must always get the same client"
+
+
+def test_concurrent_recall_nodes_do_not_share_session_state():
+    """Concurrent recall calls for different agent_ids must not interfere.
+
+    Regression test for the cross-tenant session leak: before the fix,
+    _do_setup wrote to client.session_token on the shared instance, so the last
+    concurrent writer would clobber all other agents' sessions.
+    """
+    agent_ids = ["alice", "bob", "carol", "dave"]
+
+    # Build one mock per agent — each returns only its own memories.
+    per_agent_mocks: dict[str, MagicMock] = {}
+    for aid in agent_ids:
+        m = MagicMock()
+        m.api_key = "test-key"
+        m.recall.return_value = {
+            "memories": [
+                {"title": f"Memory of {aid}", "content": f"data:{aid}", "type": "fact"}
+            ]
+        }
+        per_agent_mocks[aid] = m
+
+    template_client = MagicMock()
+    template_client.api_key = "test-key"
+
+    recall_node = create_recall_node(template_client, agent_id_from_config="agent_id")
+
+    # Inject per-agent mocks so each cache.get(agent_id) returns the right mock.
+    cache = recall_node.__closure__[0].cell_contents
+    cache._clients = per_agent_mocks.copy()
+
+    barrier = threading.Barrier(len(agent_ids))
+    results: list[tuple[str, dict]] = []
+    lock = threading.Lock()
+
+    def run_recall(aid: str) -> None:
+        barrier.wait()  # all threads start simultaneously
+        state = {"messages": [HumanMessage(content=f"Hello I am {aid}")]}
+        config = {"configurable": {"agent_id": aid}}
+        result = recall_node(state, config=config)
+        with lock:
+            results.append((aid, result))
+
+    threads = [threading.Thread(target=run_recall, args=(aid,)) for aid in agent_ids]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == len(agent_ids)
+    for aid, result in results:
+        msgs = result.get("messages", [])
+        assert msgs, f"agent '{aid}' got no memories — possible cross-tenant failure"
+        memory_text = msgs[0].content
+        assert f"data:{aid}" in memory_text, (
+            f"agent '{aid}' received wrong memories — cross-tenant leak detected.\n"
+            f"Got: {memory_text}"
+        )

--- a/integrations/langgraph/tests/test_nodes.py
+++ b/integrations/langgraph/tests/test_nodes.py
@@ -2,6 +2,7 @@ import threading
 from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from memanto.app.utils.errors import SessionError as MementoSessionError
 from langgraph_memanto.nodes import (
     _PerAgentClientCache,
     create_recall_node,
@@ -262,7 +263,9 @@ def test_concurrent_recall_nodes_do_not_share_session_state():
     recall_node = create_recall_node(template_client, agent_id_from_config="agent_id")
 
     # Inject per-agent mocks so each cache.get(agent_id) returns the right mock.
-    cache = recall_node.__closure__[0].cell_contents
+    # Locate _cache by name to stay stable if the closure layout changes.
+    freevars = recall_node.__code__.co_freevars
+    cache = recall_node.__closure__[freevars.index("_cache")].cell_contents
     cache._clients = per_agent_mocks.copy()
 
     barrier = threading.Barrier(len(agent_ids))
@@ -292,3 +295,44 @@ def test_concurrent_recall_nodes_do_not_share_session_state():
             f"agent '{aid}' received wrong memories — cross-tenant leak detected.\n"
             f"Got: {memory_text}"
         )
+
+
+def test_remember_retries_only_on_session_error():
+    """SessionError triggers _do_setup + retry; other exceptions do not retry.
+
+    Regression for the broad-except bug: before the fix, any exception (including
+    post-write network errors) would trigger a retry, potentially storing duplicate
+    memories. Now only SessionError — which SdkClient always raises before writing —
+    triggers the retry path.
+    """
+    client = MagicMock()
+    client.activate_agent.return_value = {"session_token": "mock-token"}
+
+    # First call raises SessionError (pre-write), second call succeeds.
+    client.remember.side_effect = [MementoSessionError("no active session"), None]
+
+    node = create_remember_node(client=client, agent_id="test-agent")
+    state = {"messages": [HumanMessage(content="hello")]}
+
+    with patch(_PATCH, return_value=client):
+        result = node(state)
+
+    assert result == {"messages": []}
+    assert client.activate_agent.call_count == 1, "setup must trigger on SessionError"
+    assert client.remember.call_count == 2, "remember must be retried after setup"
+
+
+def test_remember_does_not_retry_on_generic_error():
+    """A non-session exception must NOT trigger a retry (avoids duplicate writes)."""
+    client = MagicMock()
+    client.remember.side_effect = RuntimeError("network timeout")
+
+    node = create_remember_node(client=client, agent_id="test-agent")
+    state = {"messages": [HumanMessage(content="hello")]}
+
+    with patch(_PATCH, return_value=client):
+        result = node(state)
+
+    assert result == {"messages": []}
+    assert client.activate_agent.call_count == 0, "setup must NOT trigger on non-session error"
+    assert client.remember.call_count == 1, "remember must NOT be retried on non-session error"


### PR DESCRIPTION
Fixes #884

## Root cause

`create_recall_node` and `create_remember_node` shared a single `SdkClient` instance and called `_do_setup()` on it when a session was missing. `_do_setup` mutated `client.session_token` and `client.agent_id` — process-wide mutable state.

Under concurrent load with different `agent_id`s, the last writer won:

```
T0  alice → _do_setup("alice") → client.session_token = TOKEN_A, client.agent_id = "alice"
T1  bob   → _do_setup("bob")   → client.session_token = TOKEN_B, client.agent_id = "bob"   ← clobbers alice
T2  alice → recall(agent_id="alice") → self.agent_id ("bob") != "alice" → SessionError or data leak
```

## Fix

Introduce `_PerAgentClientCache` — a thread-safe `dict[agent_id, SdkClient]`. Each `agent_id` gets its own isolated `SdkClient` so `session_token`/`agent_id` state is never shared across tenants.

## Tests

- `test_per_agent_client_cache_returns_distinct_clients` — isolation verified
- `test_concurrent_recall_nodes_do_not_share_session_state` — 4 threads simultaneously; each must receive only its own memories

```
13 passed in 0.17s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Memanto-backed LangGraph recall/remember by isolating client/session state per agent, preventing cross-agent session or memory interference during concurrent runs.
  * Enhanced retry behavior: recall retries on errors after re-initializing agent state; remember now retries only for session-expired cases to avoid duplicate memory writes.

* **Tests**
  * Added regression coverage for per-agent client isolation, parallel execution behavior, and session-expiration-only retry semantics for remember operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->