### PR TITLE
Reject invalid temporal recall backend requests

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1630,5 +1630,5 @@ class DirectClient:
     @staticmethod
     def _validate_recall_limit(limit: int) -> None:
         """Validate recall result limits before backend calls."""
-        if not isinstance(limit, int) or not 1 <= limit <= 100:
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
             raise ValueError(f"Limit must be an integer between 1 and 100, got {limit}")

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1016,6 +1016,7 @@ class DirectClient:
         """
         if limit is None:
             limit = ConfigManager().get_recall_config()["limit"]
+        self._validate_recall_limit(limit)
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
@@ -1055,6 +1056,7 @@ class DirectClient:
         """
         if limit is None:
             limit = ConfigManager().get_recall_config()["limit"]
+        self._validate_recall_limit(limit)
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
@@ -1092,6 +1094,7 @@ class DirectClient:
         """
         if limit is None:
             limit = ConfigManager().get_recall_config()["limit"]
+        self._validate_recall_limit(limit)
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
@@ -1622,5 +1625,10 @@ class DirectClient:
         """Validate search parameters."""
         if not query or not query.strip():
             raise ValueError("Search query must be a non-empty string")
-        if not 1 <= limit <= 100:
-            raise ValueError(f"Limit must be between 1 and 100, got {limit}")
+        DirectClient._validate_recall_limit(limit)
+
+    @staticmethod
+    def _validate_recall_limit(limit: int) -> None:
+        """Validate recall result limits before backend calls."""
+        if not isinstance(limit, int) or not 1 <= limit <= 100:
+            raise ValueError(f"Limit must be an integer between 1 and 100, got {limit}")

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -889,6 +889,7 @@ class SdkClient:
         """
         if limit is None:
             limit = ConfigManager().get_recall_config()["limit"]
+        self._validate_recall_limit(limit)
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
@@ -928,6 +929,7 @@ class SdkClient:
         """
         if limit is None:
             limit = ConfigManager().get_recall_config()["limit"]
+        self._validate_recall_limit(limit)
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
@@ -965,6 +967,7 @@ class SdkClient:
         """
         if limit is None:
             limit = ConfigManager().get_recall_config()["limit"]
+        self._validate_recall_limit(limit)
 
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
@@ -1464,5 +1467,10 @@ class SdkClient:
         """Validate search parameters."""
         if not query or not query.strip():
             raise ValueError("Search query must be a non-empty string")
-        if not 1 <= limit <= 100:
-            raise ValueError(f"Limit must be between 1 and 100, got {limit}")
+        SdkClient._validate_recall_limit(limit)
+
+    @staticmethod
+    def _validate_recall_limit(limit: int) -> None:
+        """Validate recall result limits before backend calls."""
+        if not isinstance(limit, int) or not 1 <= limit <= 100:
+            raise ValueError(f"Limit must be an integer between 1 and 100, got {limit}")

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1472,5 +1472,5 @@ class SdkClient:
     @staticmethod
     def _validate_recall_limit(limit: int) -> None:
         """Validate recall result limits before backend calls."""
-        if not isinstance(limit, int) or not 1 <= limit <= 100:
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
             raise ValueError(f"Limit must be an integer between 1 and 100, got {limit}")

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -376,6 +376,8 @@ class ConfigManager:
         data = self.load_yaml()
         recall = data.setdefault("recall", {})
         if limit is not None:
+            if not isinstance(limit, int) or not 1 <= limit <= 100:
+                raise ValueError("limit must be an integer between 1 and 100")
             recall["limit"] = limit
         if min_similarity is not None:
             if (

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -376,7 +376,7 @@ class ConfigManager:
         data = self.load_yaml()
         recall = data.setdefault("recall", {})
         if limit is not None:
-            if not isinstance(limit, int) or not 1 <= limit <= 100:
+            if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
                 raise ValueError("limit must be an integer between 1 and 100")
             recall["limit"] = limit
         if min_similarity is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -501,7 +501,7 @@ class TestMEMANTOCLI:
             ("recall_changed_since", {"since": "2026-06-27T00:00:00Z"}),
         ],
     )
-    @pytest.mark.parametrize("bad_limit", [0, 101, 1.5, "10"])
+    @pytest.mark.parametrize("bad_limit", [0, 101, 1.5, "10", True])
     def test_temporal_recall_rejects_invalid_limit_before_backend(
         self, client_class_path, method_name, args, bad_limit
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -486,6 +486,51 @@ class TestMEMANTOCLI:
         assert result.exit_code != 0
         assert "multiple temporal query modes" in result.stdout
 
+    @pytest.mark.parametrize(
+        "client_class_path",
+        [
+            "memanto.cli.client.direct_client.DirectClient",
+            "memanto.cli.client.sdk_client.SdkClient",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "method_name,args",
+        [
+            ("recall_recent", {}),
+            ("recall_as_of", {"as_of": "2026-06-27T00:00:00Z"}),
+            ("recall_changed_since", {"since": "2026-06-27T00:00:00Z"}),
+        ],
+    )
+    @pytest.mark.parametrize("bad_limit", [0, 101, 1.5, "10"])
+    def test_temporal_recall_rejects_invalid_limit_before_backend(
+        self, client_class_path, method_name, args, bad_limit
+    ):
+        """Temporal recall paths must not forward invalid limits to storage."""
+        module_name, class_name = client_class_path.rsplit(".", 1)
+        module = __import__(module_name, fromlist=[class_name])
+        client_class = getattr(module, class_name)
+        client = client_class.__new__(client_class)
+        read_service = MagicMock()
+
+        with (
+            patch.object(
+                client_class,
+                "_get_validated_session_for_agent",
+                return_value=MagicMock(),
+            ),
+            patch.object(client_class, "_get_read_service", return_value=read_service),
+        ):
+            with pytest.raises(ValueError, match="Limit must be an integer"):
+                getattr(client, method_name)(
+                    agent_id="test-agent",
+                    limit=bad_limit,
+                    **args,
+                )
+
+        read_service.search_recent.assert_not_called()
+        read_service.search_as_of.assert_not_called()
+        read_service.search_changed_since.assert_not_called()
+
     def test_forget_force(self, mock_all_clients):
         """Test 'memanto forget --force' deletes a memory without prompting."""
         mock_all_clients.delete_memory.return_value = {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -361,6 +361,9 @@ class TestRecallConfigValidation:
         with pytest.raises(ValueError, match="limit must be an integer"):
             manager.set_recall_config(limit=1.5)
 
+        with pytest.raises(ValueError, match="limit must be an integer"):
+            manager.set_recall_config(limit=True)
+
     def test_set_recall_config_accepts_valid_limit(self, tmp_path):
         from memanto.cli.config.manager import ConfigManager
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -346,6 +346,30 @@ class TestForgetEndToEnd:
         assert result["memory_id"] == "mem-xyz"
 
 
+class TestRecallConfigValidation:
+    def test_set_recall_config_rejects_invalid_limit(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+
+        with pytest.raises(ValueError, match="limit must be an integer"):
+            manager.set_recall_config(limit=0)
+
+        with pytest.raises(ValueError, match="limit must be an integer"):
+            manager.set_recall_config(limit=101)
+
+        with pytest.raises(ValueError, match="limit must be an integer"):
+            manager.set_recall_config(limit=1.5)
+
+    def test_set_recall_config_accepts_valid_limit(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.set_recall_config(limit=25)
+
+        assert manager.get_recall_config()["limit"] == 25
+
+
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""
 


### PR DESCRIPTION
## Summary

/claim #770

Fixes a temporal recall correctness bug where `recall_recent`, `recall_as_of`, and `recall_changed_since` accepted invalid `limit` values and let them cross the backend boundary. Standard query recall already validated limits via `_validate_query`, but the temporal recall paths do not have a search query and bypassed that guard.

This also validates persisted `recall.limit` values in `ConfigManager.set_recall_config`, so an invalid local default cannot later be replayed into temporal recall as a malformed backend request.

## Impact

Temporal recall modes should either issue a well-formed bounded read request or fail locally with a clear error. Before this change, invalid limits such as `0`, `101`, `1.5`, or `"10"` could reach backend/search code from temporal recall paths. That made temporal recall behavior inconsistent with standard recall and allowed bad config state to become invalid backend-boundary requests.

## Changes

- Added `_validate_recall_limit` to both CLI clients.
- Reused it from standard recall via `_validate_query`.
- Applied it before backend calls in:
  - `recall_recent`
  - `recall_as_of`
  - `recall_changed_since`
- Added config-time validation for `ConfigManager.set_recall_config(limit=...)`.
- Added regression tests proving invalid temporal recall limits are rejected before the read service is called.

## Validation

```text
uv --native-tls run --group dev pytest tests/test_cli.py::TestMEMANTOCLI::test_temporal_recall_rejects_invalid_limit_before_backend tests/test_unit.py::TestRecallConfigValidation -q
26 passed

uv --native-tls run --group dev ruff check memanto/cli/config/manager.py memanto/cli/client/sdk_client.py memanto/cli/client/direct_client.py tests/test_cli.py tests/test_unit.py
passed

uv --native-tls run --group dev ruff format --check memanto/cli/config/manager.py memanto/cli/client/sdk_client.py memanto/cli/client/direct_client.py tests/test_cli.py tests/test_unit.py
passed

git diff --check
passed
```