### PR TITLE
Normalize configured server URLs

### DIFF
--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -649,7 +649,6 @@ def status():
 
     # Configuration
     is_configured = config_manager.is_configured()
-    server_cfg = config_manager.get_server_config()
 
     cfg_table = Table(show_header=False, box=None, padding=(0, 2))
     cfg_table.add_column("Key", style="dim")
@@ -675,7 +674,7 @@ def status():
         except Exception:
             cfg_table.add_row("On-Prem Server", "[red]● offline[/red]")
 
-    server_url = f"http://{server_cfg['url']}:{server_cfg['port']}"
+    server_url = config_manager.get_server_url()
     if is_configured:
         cfg_table.add_row("Local REST API URL", server_url)
         if backend == Backend.CLOUD:

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -11,6 +11,7 @@ import importlib
 import json
 import os
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from dotenv import load_dotenv, set_key
 
@@ -276,6 +277,15 @@ class ConfigManager:
         server = self.load_yaml().get("server", {})
         host = server.get("url", "localhost")
         port = server.get("port", 8000)
+
+        host = str(host).strip() or "localhost"
+        if host.startswith(("http://", "https://")):
+            parsed = urlsplit(host)
+            netloc = parsed.netloc
+            if parsed.port is None:
+                netloc = f"{netloc}:{port}"
+            return urlunsplit((parsed.scheme, netloc, parsed.path.rstrip("/"), "", ""))
+
         return f"http://{host}:{port}"
 
     def get_server_config(self) -> dict:

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -282,7 +282,12 @@ class ConfigManager:
         if host.startswith(("http://", "https://")):
             parsed = urlsplit(host)
             netloc = parsed.netloc
-            if parsed.port is None:
+            try:
+                explicit_port = parsed.port
+            except ValueError:
+                explicit_port = None
+                netloc = parsed.hostname or "localhost"
+            if explicit_port is None:
                 netloc = f"{netloc}:{port}"
             return urlunsplit((parsed.scheme, netloc, parsed.path.rstrip("/"), "", ""))
 

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -273,7 +273,7 @@ class ConfigManager:
     # Convenience accessors
 
     def get_server_url(self) -> str:
-        """Get MEMANTO server URL."""
+        """Return the normalized local REST API URL from the server config."""
         server = self.load_yaml().get("server", {})
         host = server.get("url", "localhost")
         port = server.get("port", 8000)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -391,5 +391,33 @@ class TestMEMANTOArchitecture:
         print("   ✅ NO tenant_id in token!")
 
 
+class TestServerConfigUrl:
+    """Regression tests for local REST API URL formatting."""
+
+    def test_server_url_defaults_to_http_for_host_and_port(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.set_server_config("localhost", 8000)
+
+        assert manager.get_server_url() == "http://localhost:8000"
+
+    def test_server_url_preserves_configured_scheme(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.set_server_config("https://memanto.example", 443)
+
+        assert manager.get_server_url() == "https://memanto.example:443"
+
+    def test_server_url_does_not_duplicate_explicit_url_port(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.set_server_config("https://memanto.example:9443", 443)
+
+        assert manager.get_server_url() == "https://memanto.example:9443"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -395,6 +395,7 @@ class TestServerConfigUrl:
     """Regression tests for local REST API URL formatting."""
 
     def test_server_url_defaults_to_http_for_host_and_port(self, tmp_path):
+        """Ensure host and port configs default to an HTTP URL."""
         from memanto.cli.config.manager import ConfigManager
 
         manager = ConfigManager(config_dir=tmp_path)
@@ -403,6 +404,7 @@ class TestServerConfigUrl:
         assert manager.get_server_url() == "http://localhost:8000"
 
     def test_server_url_preserves_configured_scheme(self, tmp_path):
+        """Ensure configured HTTP or HTTPS schemes are preserved."""
         from memanto.cli.config.manager import ConfigManager
 
         manager = ConfigManager(config_dir=tmp_path)
@@ -411,6 +413,7 @@ class TestServerConfigUrl:
         assert manager.get_server_url() == "https://memanto.example:443"
 
     def test_server_url_does_not_duplicate_explicit_url_port(self, tmp_path):
+        """Ensure explicit URL ports are not duplicated."""
         from memanto.cli.config.manager import ConfigManager
 
         manager = ConfigManager(config_dir=tmp_path)
@@ -418,10 +421,13 @@ class TestServerConfigUrl:
 
         assert manager.get_server_url() == "https://memanto.example:9443"
 
-    @pytest.mark.parametrize("bad_url", ["http://localhost:abc", "http://localhost:999999"])
+    @pytest.mark.parametrize(
+        "bad_url", ["http://localhost:abc", "http://localhost:999999"]
+    )
     def test_server_url_falls_back_when_explicit_url_port_is_malformed(
         self, tmp_path, bad_url
     ):
+        """Ensure malformed explicit URL ports fall back to the configured port."""
         from memanto.cli.config.manager import ConfigManager
 
         manager = ConfigManager(config_dir=tmp_path)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -418,6 +418,17 @@ class TestServerConfigUrl:
 
         assert manager.get_server_url() == "https://memanto.example:9443"
 
+    @pytest.mark.parametrize("bad_url", ["http://localhost:abc", "http://localhost:999999"])
+    def test_server_url_falls_back_when_explicit_url_port_is_malformed(
+        self, tmp_path, bad_url
+    ):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.set_server_config(bad_url, 8000)
+
+        assert manager.get_server_url() == "http://localhost:8000"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary

This PR fixes a local REST API URL formatting bug in the CLI configuration path.

`ConfigManager.set_server_config()` can persist a full server URL through config/UI updates, but `get_server_url()` and `memanto status` always prepended `http://` and appended the configured port. A configured value like `https://memanto.example` therefore became `http://https://memanto.example:443`, and a URL with an explicit port could be displayed/probed with a duplicated or malformed address.

## Changes

- Normalize `ConfigManager.get_server_url()` so host-only values still default to `http://host:port`.
- Preserve explicitly configured `http://` or `https://` schemes.
- Avoid appending the config port when the URL already includes one.
- Make `memanto status` use the shared `get_server_url()` helper for the Local REST API display and health probe.
- Add regression coverage for host-only, scheme-only, and explicit-port server URLs.

## Validation

- `uv --native-tls run --group dev pytest tests/test_unit.py::TestServerConfigUrl -q`
- `uv --native-tls run --group dev ruff check memanto/cli/config/manager.py memanto/cli/commands/core.py tests/test_unit.py`
- `uv --native-tls run --group dev ruff format --check memanto/cli/config/manager.py memanto/cli/commands/core.py tests/test_unit.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the CLI “Configuration” display to use the normalized “Local REST API URL” consistently.
  * Normalize the configured server URL by trimming whitespace, defaulting empty values to `localhost`, and preserving `http`/`https` schemes and paths.
  * Improved port handling to prevent duplicate ports and properly handle malformed explicit ports.
  * Added regression test coverage for URL formatting, scheme preservation, explicit port behavior, and malformed-port fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->