### PR TITLE
Validate configured server ports

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -121,6 +121,14 @@ async def update_ui_config(updates: dict):
             detail=f"Cannot update keys: {', '.join(rejected)}. Allowed: {', '.join(allowed_keys)}",
         )
 
+    if "server" in updates and isinstance(updates["server"], dict):
+        server_updates = updates["server"]
+        if "port" in server_updates:
+            try:
+                server_updates["port"] = _validate_server_port(server_updates["port"])
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     if "schedule_time" in updates:
         _config_manager.set_schedule_time(updates["schedule_time"])
 
@@ -142,13 +150,7 @@ async def update_ui_config(updates: dict):
         data = _config_manager.load_yaml()
         if "server" not in data:
             data["server"] = {}
-        server_updates = dict(updates["server"])
-        if "port" in server_updates:
-            try:
-                server_updates["port"] = _validate_server_port(server_updates["port"])
-            except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-        data["server"].update(server_updates)
+        data["server"].update(updates["server"])
         _config_manager.save_yaml(data)
 
     if "answer" in updates and isinstance(updates["answer"], dict):

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -17,7 +17,7 @@ from fastapi.staticfiles import StaticFiles
 from memanto.app.clients.backend import Backend
 from memanto.app.config import settings
 from memanto.cli.client.direct_client import DirectClient
-from memanto.cli.config.manager import ConfigManager
+from memanto.cli.config.manager import ConfigManager, _validate_server_port
 from memanto.cli.connect.agent_registry import AGENT_REGISTRY, list_agents
 from memanto.cli.connect.engine import install_agent, remove_agent
 
@@ -142,7 +142,13 @@ async def update_ui_config(updates: dict):
         data = _config_manager.load_yaml()
         if "server" not in data:
             data["server"] = {}
-        data["server"].update(updates["server"])
+        server_updates = dict(updates["server"])
+        if "port" in server_updates:
+            try:
+                server_updates["port"] = _validate_server_port(server_updates["port"])
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+        data["server"].update(server_updates)
         _config_manager.save_yaml(data)
 
     if "answer" in updates and isinstance(updates["answer"], dict):

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -29,6 +29,21 @@ def _normalize_duplicated_api_key(key: str) -> str:
     return key
 
 
+def _validate_server_port(port) -> int:
+    """Return a valid TCP port or raise ValueError."""
+    if isinstance(port, bool):
+        raise ValueError("server port must be an integer between 1 and 65535")
+    try:
+        validated = int(port)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("server port must be an integer between 1 and 65535") from exc
+    if isinstance(port, float) and not port.is_integer():
+        raise ValueError("server port must be an integer between 1 and 65535")
+    if validated < 1 or validated > 65535:
+        raise ValueError("server port must be an integer between 1 and 65535")
+    return validated
+
+
 class ConfigManager:
     """Manages MEMANTO CLI configuration.
 
@@ -419,11 +434,12 @@ class ConfigManager:
 
     def set_server_config(self, url: str, port: int) -> None:
         """Set fallback server configuration."""
+        validated_port = _validate_server_port(port)
         data = self.load_yaml()
         if "server" not in data:
             data["server"] = {}
         data["server"]["url"] = url
-        data["server"]["port"] = port
+        data["server"]["port"] = validated_port
         self.save_yaml(data)
 
     def set_cli_config(self, interactive_mode: bool, smart_parse: bool) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1224,6 +1224,20 @@ class TestCWE200ApiKeyLeak:
         _mock_ui_config_manager.save_yaml.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_config_update_rejects_invalid_server_port_before_other_saves(
+        self, client, _mock_ui_config_manager
+    ):
+        response = await client.patch(
+            "/api/ui/config",
+            json={"schedule_time": "09:00", "server": {"port": 70000}},
+        )
+
+        assert response.status_code == 400
+        assert "server port" in response.json()["detail"]
+        _mock_ui_config_manager.set_schedule_time.assert_not_called()
+        _mock_ui_config_manager.save_yaml.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_config_update_normalizes_server_port(
         self, client, _mock_ui_config_manager
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1210,6 +1210,35 @@ class TestCWE200ApiKeyLeak:
         assert data["has_active_session"] is True
 
     @pytest.mark.asyncio
+    async def test_config_update_rejects_invalid_server_port(
+        self, client, _mock_ui_config_manager
+    ):
+        _mock_ui_config_manager.load_yaml.return_value = {"server": {}}
+
+        response = await client.patch(
+            "/api/ui/config", json={"server": {"url": "localhost", "port": 70000}}
+        )
+
+        assert response.status_code == 400
+        assert "server port" in response.json()["detail"]
+        _mock_ui_config_manager.save_yaml.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_config_update_normalizes_server_port(
+        self, client, _mock_ui_config_manager
+    ):
+        _mock_ui_config_manager.load_yaml.return_value = {"server": {}}
+
+        response = await client.patch(
+            "/api/ui/config", json={"server": {"url": "localhost", "port": "8000"}}
+        )
+
+        assert response.status_code == 200
+        _mock_ui_config_manager.save_yaml.assert_called_once_with(
+            {"server": {"url": "localhost", "port": 8000}}
+        )
+
+    @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -391,5 +391,26 @@ class TestMEMANTOArchitecture:
         print("   ✅ NO tenant_id in token!")
 
 
+class TestServerConfigValidation:
+    """Regression tests for local REST API server config validation."""
+
+    def test_set_server_config_persists_integer_port(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.set_server_config("localhost", "8000")
+
+        assert manager.get_server_config()["port"] == 8000
+
+    @pytest.mark.parametrize("invalid_port", [0, 65536, "abc", 1.5, True])
+    def test_set_server_config_rejects_invalid_port(self, tmp_path, invalid_port):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+
+        with pytest.raises(ValueError, match="server port"):
+            manager.set_server_config("localhost", invalid_port)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary

This PR validates the configured local REST API server port before it is persisted.

The Web UI config endpoint currently accepts `server.port` verbatim, and `ConfigManager.set_server_config()` also stores the provided port without checking that it is a usable TCP port. Invalid values such as `70000`, `0`, `abc`, `1.5`, or `true` can therefore be saved into `~/.memanto/config.yaml` and later break status/serve flows with malformed or out-of-range port values.

## Changes

- Add shared server port validation in the CLI config manager.
- Normalize string integer ports such as `"8000"` to `8000`.
- Reject booleans, non-integers, and values outside `1..65535`.
- Make `/api/ui/config` reject invalid `server.port` updates with HTTP 400 before saving.
- Add regression coverage for both direct config writes and UI config updates.

## Validation

- `uv --native-tls run --group dev pytest tests/test_unit.py::TestServerConfigValidation tests/test_api.py::TestCWE200ApiKeyLeak::test_config_update_rejects_invalid_server_port tests/test_api.py::TestCWE200ApiKeyLeak::test_config_update_normalizes_server_port -q`
- `uv --native-tls run --group dev ruff check memanto/cli/config/manager.py memanto/app/ui/routes/ui_router.py tests/test_unit.py tests/test_api.py`
- `uv --native-tls run --group dev ruff format --check memanto/cli/config/manager.py memanto/app/ui/routes/ui_router.py tests/test_unit.py tests/test_api.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for server port settings to reject invalid values (including booleans, floats, and out-of-range numbers) and to accept numeric strings by normalizing them to integers.
  * Prevented invalid UI server configuration changes from being saved; requests now return a clear HTTP 400 error when the port is invalid.
* **Tests**
  * Added API and unit test coverage for valid/invalid server port updates, including normalization and error-message assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->