### PR TITLE
Validate editable session config

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -124,7 +124,9 @@ async def update_ui_config(updates: dict):
     if "schedule_time" in updates:
         _config_manager.set_schedule_time(updates["schedule_time"])
 
-    if "session" in updates and isinstance(updates["session"], dict):
+    if "session" in updates:
+        if not isinstance(updates["session"], dict):
+            raise HTTPException(status_code=400, detail="session must be an object")
         try:
             _config_manager.set_session_config(updates["session"])
         except ValueError as exc:

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -125,11 +125,10 @@ async def update_ui_config(updates: dict):
         _config_manager.set_schedule_time(updates["schedule_time"])
 
     if "session" in updates and isinstance(updates["session"], dict):
-        data = _config_manager.load_yaml()
-        if "session" not in data:
-            data["session"] = {}
-        data["session"].update(updates["session"])
-        _config_manager.save_yaml(data)
+        try:
+            _config_manager.set_session_config(updates["session"])
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     if "cli" in updates and isinstance(updates["cli"], dict):
         data = _config_manager.load_yaml()

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -29,6 +29,50 @@ def _normalize_duplicated_api_key(key: str) -> str:
     return key
 
 
+_SESSION_CONFIG_LIMITS = {
+    "default_duration_hours": (1, 168),
+    "extend_threshold_minutes": (1, 1440),
+    "warn_before_expiry_minutes": (1, 1440),
+    "auto_renew_interval_hours": (1, 168),
+}
+_SESSION_CONFIG_BOOLEANS = {"auto_extend", "auto_renew_enabled"}
+
+
+def _validate_positive_int_config(name: str, value, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer between {minimum} and {maximum}")
+    try:
+        validated = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be an integer between {minimum} and {maximum}"
+        ) from exc
+    if isinstance(value, float) and not value.is_integer():
+        raise ValueError(f"{name} must be an integer between {minimum} and {maximum}")
+    if validated < minimum or validated > maximum:
+        raise ValueError(f"{name} must be an integer between {minimum} and {maximum}")
+    return validated
+
+
+def _validate_session_config(updates: dict) -> dict:
+    """Validate user-editable session config updates."""
+    allowed = set(_SESSION_CONFIG_LIMITS) | _SESSION_CONFIG_BOOLEANS
+    rejected = set(updates) - allowed
+    if rejected:
+        raise ValueError(f"unknown session config keys: {', '.join(sorted(rejected))}")
+
+    validated = {}
+    for key, value in updates.items():
+        if key in _SESSION_CONFIG_LIMITS:
+            minimum, maximum = _SESSION_CONFIG_LIMITS[key]
+            validated[key] = _validate_positive_int_config(key, value, minimum, maximum)
+        elif key in _SESSION_CONFIG_BOOLEANS:
+            if not isinstance(value, bool):
+                raise ValueError(f"{key} must be a boolean")
+            validated[key] = value
+    return validated
+
+
 class ConfigManager:
     """Manages MEMANTO CLI configuration.
 
@@ -358,6 +402,13 @@ class ConfigManager:
         if kiosk_mode is not None:
             answer["kiosk_mode"] = bool(kiosk_mode)
 
+        self.save_yaml(data)
+
+    def set_session_config(self, updates: dict) -> None:
+        """Set validated session config values."""
+        data = self.load_yaml()
+        session = data.setdefault("session", {})
+        session.update(_validate_session_config(updates))
         self.save_yaml(data)
 
     def get_recall_config(self) -> dict:

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -56,6 +56,9 @@ def _validate_positive_int_config(name: str, value, minimum: int, maximum: int) 
 
 def _validate_session_config(updates: dict) -> dict:
     """Validate user-editable session config updates."""
+    if not isinstance(updates, dict):
+        raise ValueError("session config must be an object")
+
     allowed = set(_SESSION_CONFIG_LIMITS) | _SESSION_CONFIG_BOOLEANS
     rejected = set(updates) - allowed
     if rejected:
@@ -408,6 +411,8 @@ class ConfigManager:
         """Set validated session config values."""
         data = self.load_yaml()
         session = data.setdefault("session", {})
+        if not isinstance(session, dict):
+            raise ValueError("stored session config must be an object")
         session.update(_validate_session_config(updates))
         self.save_yaml(data)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1230,6 +1230,20 @@ class TestCWE200ApiKeyLeak:
         _mock_ui_config_manager.save_yaml.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_config_update_rejects_non_object_session_config(
+        self, client, _mock_ui_config_manager
+    ):
+        response = await client.patch(
+            "/api/ui/config",
+            json={"session": "bad"},
+        )
+
+        assert response.status_code == 400
+        assert "session must be an object" in response.json()["detail"]
+        _mock_ui_config_manager.set_session_config.assert_not_called()
+        _mock_ui_config_manager.save_yaml.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_config_update_accepts_valid_session_config(
         self, client, _mock_ui_config_manager
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1210,6 +1210,45 @@ class TestCWE200ApiKeyLeak:
         assert data["has_active_session"] is True
 
     @pytest.mark.asyncio
+    async def test_config_update_validates_session_config(
+        self, client, _mock_ui_config_manager
+    ):
+        _mock_ui_config_manager.set_session_config.side_effect = ValueError(
+            "default_duration_hours must be an integer between 1 and 168"
+        )
+
+        response = await client.patch(
+            "/api/ui/config",
+            json={"session": {"default_duration_hours": 0}},
+        )
+
+        assert response.status_code == 400
+        assert "default_duration_hours" in response.json()["detail"]
+        _mock_ui_config_manager.set_session_config.assert_called_once_with(
+            {"default_duration_hours": 0}
+        )
+        _mock_ui_config_manager.save_yaml.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_config_update_accepts_valid_session_config(
+        self, client, _mock_ui_config_manager
+    ):
+        response = await client.patch(
+            "/api/ui/config",
+            json={
+                "session": {
+                    "default_duration_hours": 12,
+                    "auto_renew_enabled": False,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        _mock_ui_config_manager.set_session_config.assert_called_once_with(
+            {"default_duration_hours": 12, "auto_renew_enabled": False}
+        )
+
+    @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -431,6 +431,17 @@ class TestSessionConfigValidation:
         with pytest.raises(ValueError):
             manager.set_session_config({key: value})
 
+    def test_set_session_config_rejects_corrupt_stored_session(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.save_yaml({"session": "bad"})
+
+        with pytest.raises(ValueError, match="stored session config must be an object"):
+            manager.set_session_config({"default_duration_hours": 12})
+
+        assert manager.load_yaml()["session"] == "bad"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -391,5 +391,46 @@ class TestMEMANTOArchitecture:
         print("   ✅ NO tenant_id in token!")
 
 
+class TestSessionConfigValidation:
+    """Regression tests for user-editable session config."""
+
+    def test_set_session_config_normalizes_integer_fields(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.set_session_config(
+            {
+                "default_duration_hours": "12",
+                "extend_threshold_minutes": "45",
+                "auto_renew_enabled": False,
+            }
+        )
+
+        session = manager.get_session_config()
+        assert session["default_duration_hours"] == 12
+        assert session["extend_threshold_minutes"] == 45
+        assert session["auto_renew_enabled"] is False
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("default_duration_hours", 0),
+            ("default_duration_hours", 169),
+            ("extend_threshold_minutes", "abc"),
+            ("warn_before_expiry_minutes", 1.5),
+            ("auto_renew_interval_hours", True),
+            ("auto_extend", "false"),
+            ("unexpected", 1),
+        ],
+    )
+    def test_set_session_config_rejects_invalid_values(self, tmp_path, key, value):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+
+        with pytest.raises(ValueError):
+            manager.set_session_config({key: value})
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary

This PR validates user-editable session configuration before it is persisted.

The Web UI config endpoint currently writes the `session` object directly into `~/.memanto/config.yaml`. Invalid values such as `default_duration_hours: 0`, `warn_before_expiry_minutes: 1.5`, string booleans such as `"false"`, or unknown session keys can therefore be saved and later break session activation/renewal behavior or create invalid timing semantics.

## Changes

- Add a validated `ConfigManager.set_session_config()` path.
- Normalize integer-like session fields such as `"12"` to `12`.
- Reject booleans where integer fields are expected.
- Reject non-integer, out-of-range, and unknown session config values.
- Require actual booleans for `auto_extend` and `auto_renew_enabled`.
- Route `/api/ui/config` session updates through the validated config manager method.
- Add unit and API regression coverage.

## Validation

- `uv --native-tls run --group dev pytest tests/test_unit.py::TestSessionConfigValidation tests/test_api.py::TestCWE200ApiKeyLeak::test_config_update_validates_session_config tests/test_api.py::TestCWE200ApiKeyLeak::test_config_update_accepts_valid_session_config -q`
- `uv --native-tls run --group dev ruff check memanto/cli/config/manager.py memanto/app/ui/routes/ui_router.py tests/test_unit.py tests/test_api.py`
- `uv --native-tls run --group dev ruff format --check memanto/cli/config/manager.py memanto/app/ui/routes/ui_router.py tests/test_unit.py tests/test_api.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for `session` configuration updates, including rejecting non-object payloads and unknown/invalid settings.
  * Returns clearer HTTP 400 errors for invalid `session` values and ensures corrupted stored session data is detected.
  * Persisting session changes is now consistent, with numeric-like inputs normalized and boolean toggles strictly enforced.
* **Tests**
  * Expanded API and added unit test coverage for valid updates, invalid values, non-object payloads, and corrupted stored configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->