### PR TITLE
Validate editable answer config

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -154,15 +154,16 @@ async def update_ui_config(updates: dict):
         if _config_manager.get_backend() == Backend.ON_PREM:
             _update_onprem_answer(ans)
         else:
-            _config_manager.set_answer_config(
-                model=ans.get("model"),
-                temperature=float(ans["temperature"]) if "temperature" in ans else None,
-                answer_limit=int(ans["answer_limit"])
-                if "answer_limit" in ans
-                else None,
-                threshold=float(ans["threshold"]) if "threshold" in ans else None,
-                kiosk_mode=bool(ans["kiosk_mode"]) if "kiosk_mode" in ans else None,
-            )
+            try:
+                _config_manager.set_answer_config(
+                    model=ans.get("model"),
+                    temperature=ans.get("temperature"),
+                    answer_limit=ans.get("answer_limit"),
+                    threshold=ans.get("threshold"),
+                    kiosk_mode=ans.get("kiosk_mode") if "kiosk_mode" in ans else None,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     if "recall" in updates and isinstance(updates["recall"], dict):
         rec = updates["recall"]

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -29,6 +29,34 @@ def _normalize_duplicated_api_key(key: str) -> str:
     return key
 
 
+def _validate_int_range(name: str, value, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer between {minimum} and {maximum}")
+    try:
+        validated = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be an integer between {minimum} and {maximum}"
+        ) from exc
+    if isinstance(value, float) and not value.is_integer():
+        raise ValueError(f"{name} must be an integer between {minimum} and {maximum}")
+    if validated < minimum or validated > maximum:
+        raise ValueError(f"{name} must be an integer between {minimum} and {maximum}")
+    return validated
+
+
+def _validate_float_range(name: str, value, minimum: float, maximum: float) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    try:
+        validated = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}") from exc
+    if validated < minimum or validated > maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return validated
+
+
 class ConfigManager:
     """Manages MEMANTO CLI configuration.
 
@@ -350,12 +378,20 @@ class ConfigManager:
         if model is not None:
             answer["model"] = model
         if temperature is not None:
-            answer["temperature"] = temperature
+            answer["temperature"] = _validate_float_range(
+                "temperature", temperature, 0.0, 2.0
+            )
         if answer_limit is not None:
-            answer["answer_limit"] = answer_limit
+            answer["answer_limit"] = _validate_int_range(
+                "answer_limit", answer_limit, 1, 50
+            )
         if threshold is not None:
-            answer["threshold"] = threshold
+            answer["threshold"] = _validate_float_range(
+                "threshold", threshold, 0.0, 1.0
+            )
         if kiosk_mode is not None:
+            if not isinstance(kiosk_mode, bool):
+                raise ValueError("kiosk_mode must be a boolean")
             answer["kiosk_mode"] = bool(kiosk_mode)
 
         self.save_yaml(data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1210,6 +1210,53 @@ class TestCWE200ApiKeyLeak:
         assert data["has_active_session"] is True
 
     @pytest.mark.asyncio
+    async def test_config_update_rejects_invalid_answer_config(
+        self, client, _mock_ui_config_manager
+    ):
+        _mock_ui_config_manager.set_answer_config.side_effect = ValueError(
+            "temperature must be between 0.0 and 2.0"
+        )
+
+        response = await client.patch(
+            "/api/ui/config", json={"answer": {"temperature": 3}}
+        )
+
+        assert response.status_code == 400
+        assert "temperature" in response.json()["detail"]
+        _mock_ui_config_manager.set_answer_config.assert_called_once_with(
+            model=None,
+            temperature=3,
+            answer_limit=None,
+            threshold=None,
+            kiosk_mode=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_config_update_passes_answer_values_to_validated_setter(
+        self, client, _mock_ui_config_manager
+    ):
+        response = await client.patch(
+            "/api/ui/config",
+            json={
+                "answer": {
+                    "temperature": "0.2",
+                    "answer_limit": "20",
+                    "threshold": "0.4",
+                    "kiosk_mode": False,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        _mock_ui_config_manager.set_answer_config.assert_called_once_with(
+            model=None,
+            temperature="0.2",
+            answer_limit="20",
+            threshold="0.4",
+            kiosk_mode=False,
+        )
+
+    @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -391,5 +391,47 @@ class TestMEMANTOArchitecture:
         print("   ✅ NO tenant_id in token!")
 
 
+class TestAnswerConfigValidation:
+    """Regression tests for user-editable answer config."""
+
+    def test_set_answer_config_normalizes_numeric_values(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.set_answer_config(
+            temperature="0.2",
+            answer_limit="20",
+            threshold="0.4",
+            kiosk_mode=True,
+        )
+
+        answer = manager.get_answer_config()
+        assert answer["temperature"] == 0.2
+        assert answer["answer_limit"] == 20
+        assert answer["threshold"] == 0.4
+        assert answer["kiosk_mode"] is True
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("temperature", -0.1),
+            ("temperature", 2.1),
+            ("answer_limit", 0),
+            ("answer_limit", 51),
+            ("answer_limit", 1.5),
+            ("threshold", -0.1),
+            ("threshold", 1.1),
+            ("kiosk_mode", "false"),
+        ],
+    )
+    def test_set_answer_config_rejects_invalid_values(self, tmp_path, field, value):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+
+        with pytest.raises(ValueError, match=field):
+            manager.set_answer_config(**{field: value})
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary

This PR validates user-editable answer configuration before it is persisted.

The Web UI config endpoint currently coerces answer values before saving, and `ConfigManager.set_answer_config()` stores those values without range/type checks. Invalid values such as `temperature: 3`, `answer_limit: 0`, `threshold: 1.5`, or string booleans such as `"false"` can therefore be written into config and later break answer generation or silently change behavior.

## Changes

- Validate answer `temperature` as a float in `0.0..2.0`.
- Validate `answer_limit` as an integer in `1..50`.
- Validate answer `threshold` as a float in `0.0..1.0`.
- Require an actual boolean for `kiosk_mode`.
- Preserve numeric string support by normalizing values inside the validated config setter.
- Make `/api/ui/config` return HTTP 400 when answer config is invalid instead of persisting it.
- Add unit and API regression coverage.

## Validation

- `uv --native-tls run --group dev pytest tests/test_unit.py::TestAnswerConfigValidation tests/test_api.py::TestCWE200ApiKeyLeak::test_config_update_rejects_invalid_answer_config tests/test_api.py::TestCWE200ApiKeyLeak::test_config_update_passes_answer_values_to_validated_setter -q`
- `uv --native-tls run --group dev ruff check memanto/cli/config/manager.py memanto/app/ui/routes/ui_router.py tests/test_unit.py tests/test_api.py`
- `uv --native-tls run --group dev ruff format --check memanto/cli/config/manager.py memanto/app/ui/routes/ui_router.py tests/test_unit.py tests/test_api.py`
- `git diff --check`
