### PR TITLE
Validate memory export limits before recall loop

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1480,6 +1480,8 @@ class DirectClient:
         Returns:
             Dict with ``output_path``, ``total_memories``, ``per_type_counts``.
         """
+        self._validate_export_limit(limit_per_type)
+
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
 
@@ -1624,3 +1626,13 @@ class DirectClient:
             raise ValueError("Search query must be a non-empty string")
         if not 1 <= limit <= 100:
             raise ValueError(f"Limit must be between 1 and 100, got {limit}")
+
+    @staticmethod
+    def _validate_export_limit(limit_per_type: int) -> None:
+        """Validate per-type export limits before querying every memory type."""
+        if not isinstance(limit_per_type, int) or isinstance(limit_per_type, bool):
+            raise ValueError("limit_per_type must be an integer between 1 and 100")
+        if not 1 <= limit_per_type <= 100:
+            raise ValueError(
+                f"limit_per_type must be between 1 and 100, got {limit_per_type}"
+            )

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1339,6 +1339,8 @@ class SdkClient:
         Returns:
             Dict with ``output_path``, ``total_memories``, ``per_type_counts``.
         """
+        self._validate_export_limit(limit_per_type)
+
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
 
@@ -1466,3 +1468,13 @@ class SdkClient:
             raise ValueError("Search query must be a non-empty string")
         if not 1 <= limit <= 100:
             raise ValueError(f"Limit must be between 1 and 100, got {limit}")
+
+    @staticmethod
+    def _validate_export_limit(limit_per_type: int) -> None:
+        """Validate per-type export limits before querying every memory type."""
+        if not isinstance(limit_per_type, int) or isinstance(limit_per_type, bool):
+            raise ValueError("limit_per_type must be an integer between 1 and 100")
+        if not 1 <= limit_per_type <= 100:
+            raise ValueError(
+                f"limit_per_type must be between 1 and 100, got {limit_per_type}"
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -772,6 +772,32 @@ class TestMEMANTOCLI:
         assert result.exit_code == 0
         assert "Exported 5 memories" in result.stdout
 
+    @pytest.mark.parametrize("client_name", ["DirectClient", "SdkClient"])
+    @pytest.mark.parametrize("bad_limit", [0, 101, "10", True])
+    def test_memory_export_rejects_invalid_limit_before_session_lookup(
+        self, mock_all_clients, client_name, bad_limit
+    ):
+        """Invalid export limits must fail fast instead of producing empty exports.
+
+        The export path queries every memory type with ``query='*'`` and
+        swallowed per-type recall errors. Without upfront validation, bad
+        limits like 0 or 101 could be masked as a successful zero-memory
+        export, destabilizing downstream MEMORY.md syncs.
+        """
+        from unittest.mock import patch
+
+        if client_name == "DirectClient":
+            from memanto.cli.client.direct_client import DirectClient as Client
+        else:
+            from memanto.cli.client.sdk_client import SdkClient as Client
+
+        client = Client.__new__(Client)
+        with patch.object(Client, "_get_validated_session_for_agent") as session_mock:
+            with pytest.raises(ValueError, match="limit_per_type"):
+                client.export_memory_md("test-agent", limit_per_type=bad_limit)
+
+        session_mock.assert_not_called()
+
     def test_memory_sync(self, mock_all_clients):
         """Test 'memanto memory sync'"""
         mock_all_clients.sync_memory_to_project.return_value = {


### PR DESCRIPTION
## Summary

/claim #770

Fixes a memory export integrity bug where invalid `limit_per_type` values could be forwarded into the per-memory-type recall loop. Because `export_memory_md` intentionally catches per-type recall failures, invalid limits such as `0`, `101`, `"10"`, or `true` could be masked as a successful zero-memory export and then propagated to `MEMORY.md` syncs.

## Impact

A bad caller or config path could silently produce empty/partial exported memory files instead of failing locally. That undermines memory integrity and can make downstream agents believe an agent has no memories.

## Changes

- Added upfront `limit_per_type` validation for both `DirectClient` and `SdkClient` export paths.
- Rejects non-integer/bool and out-of-range values before session lookup or backend calls.
- Added regression coverage for both clients proving invalid export limits fail fast and do not perform session lookup.

## Validation

```text
python3 -m pytest tests/test_cli.py::TestMEMANTOCLI::test_memory_export_rejects_invalid_limit_before_session_lookup tests/test_cli.py::TestMEMANTOCLI::test_memory_export tests/test_cli.py::TestMEMANTOCLI::test_memory_sync -q
python3 -m pytest tests/test_cli.py tests/test_unit.py -q
python3 -m ruff check memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_cli.py
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exporting memories now checks the per-type limit up front and returns a clear error for invalid values.
  * Invalid limits such as `0`, `101`, text values, and booleans are now rejected consistently.
  * Export validation now fails fast before any session lookup or export work begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->