### PR TITLE
Bug: Memory validation completely disabled — all memories stored without integrity checks

### DIFF
--- a/docs/bounty_reports/disabled_validation.md
+++ b/docs/bounty_reports/disabled_validation.md
@@ -1,0 +1,68 @@
+# Bug Report: Memory validation completely disabled — all memories stored without integrity checks
+
+## Summary
+
+The `MemoryWriteService` has all memory validation commented out in both `store_memory()` and `batch_store_memories()`. The `ValidationPolicy` class exists in `core.py` but is never called. This means **all memories are stored without any integrity checks, contradiction detection, or poisoning prevention**.
+
+## Affected Files
+
+- `memanto/app/services/memory_write_service.py` — lines 57-63 and 151-160
+- `memanto/app/core.py` — `ValidationPolicy` class exists but is never invoked
+
+## Severity
+
+**High** — Memory integrity is a core security concern. Without validation:
+- Contradictory memories can be stored without detection
+- Memory poisoning attacks are possible (malicious content stored as "validated")
+- The `compute_confidence()` and `trust_score()` methods in `MemoryRecord` are rendered meaningless because `validation_count` is always 0
+- The `provenance` field never upgrades from "inferred" to "validated"
+
+## Root Cause
+
+Lines 57-63 of `memory_write_service.py`:
+```python
+# skip validation for speed
+## Validate memory
+# validation_result = self.validation_service.validate_memory(memory, context)
+## Use validated memory if modified
+# if "memory" in validation_result:
+#     memory = validation_result["memory"]
+validation_result = {"action": "store", "reason": "MVP direct store"}
+```
+
+The same pattern is repeated in `batch_store_memories()` at lines 151-160.
+
+Additionally, in `memory_read_service.py` lines 851-884, the trust score computation is also commented out:
+```python
+# skip trust score computation reconstructs MemoryRecord and runs compute_confidence() + trust_score() per result. Skipped for speed.
+```
+
+This means `computed_confidence` and `trust_score` are never populated in search results, making it impossible for consumers to distinguish high-trust memories from low-trust ones.
+
+## Reproduction
+
+```python
+from memanto.app.services.memory_write_service import MemoryWriteService
+
+# Any memory is stored without validation, regardless of content
+# The validation_service exists but is never called
+# Contradictory memories can coexist without detection
+```
+
+## Impact
+
+1. **Security**: Memory poisoning — an attacker can inject false memories that are stored with the same trust level as validated ones
+2. **Integrity**: Contradictory memories coexist without detection — the `contradiction_detected` field is never set
+3. **Trust**: `compute_confidence()` returns incorrect values because `validation_count` is always 0
+4. **Retrieval quality**: Search results lack `computed_confidence` and `trust_score`, so consumers cannot filter by trust
+
+## Proposed Fix
+
+### Option A: Re-enable validation (recommended)
+Uncomment the validation calls in both `store_memory()` and `batch_store_memories()`, and ensure `self.validation_service` is properly initialized.
+
+### Option B: Make validation configurable
+Add a `VALIDATION_ENABLED` setting (already exists in config as `AUTO_PARSE_ENABLED` pattern) that defaults to `True` in production and `False` only in development/benchmarking.
+
+### Trust score computation
+Re-enable the trust score computation in `_format_memory_item()` or move it to a lazy property that's only computed when accessed.

--- a/tests/failing_tests/test_disabled_validation.py
+++ b/tests/failing_tests/test_disabled_validation.py
@@ -1,0 +1,51 @@
+"""
+Regression test for disabled memory validation.
+
+Verifies that:
+1. The validation_service attribute exists on MemoryWriteService
+2. store_memory() calls validation when validation is enabled
+3. Contradictory memories are flagged when validation is active
+"""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+def test_validation_service_exists():
+    """MemoryWriteService should have a validation_service attribute."""
+    from memanto.app.services.memory_write_service import MemoryWriteService
+    # We can't fully instantiate without a Moorcheh client, but we can
+    # verify the class structure expects a validation service.
+    import inspect
+    source = inspect.getsource(MemoryWriteService.store_memory)
+    # The validation call should NOT be commented out
+    assert "validation_service.validate_memory" in source, (
+        "Validation is commented out in store_memory() — memories are stored "
+        "without integrity checks, contradiction detection, or poisoning prevention."
+    )
+
+
+def test_batch_validation_service_exists():
+    """batch_store_memories should also call validation."""
+    from memanto.app.services.memory_write_service import MemoryWriteService
+    import inspect
+    source = inspect.getsource(MemoryWriteService.batch_store_memories)
+    assert "validation_service.validate_memory" in source, (
+        "Validation is commented out in batch_store_memories() — batch memories "
+        "are stored without integrity checks."
+    )
+
+
+def test_trust_score_not_commented():
+    """_format_memory_item should compute trust scores, not skip them."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+    import inspect
+    source = inspect.getsource(MemoryReadService._format_memory_item)
+    # The trust score computation should not be entirely commented out
+    # Count commented lines vs active lines in the trust score section
+    lines = source.split('\\n')
+    has_active_trust = any('trust_score' in line and not line.strip().startswith('#') for line in lines)
+    assert has_active_trust, (
+        "Trust score computation is commented out in _format_memory_item() — "
+        "search results lack computed_confidence and trust_score fields."
+    )


### PR DESCRIPTION
## Summary

The `MemoryWriteService` has all memory validation commented out in both `store_memory()` and `batch_store_memories()`. The `ValidationPolicy` class exists in `core.py` but is never called. Additionally, trust score computation in `_format_memory_item()` is commented out.

## Impact

- **Security**: Memory poisoning — false memories stored with same trust as validated ones
- **Integrity**: Contradictory memories coexist without detection
- **Trust**: `compute_confidence()` returns incorrect values (validation_count always 0)
- **Retrieval**: Search results lack `computed_confidence` and `trust_score`

## Reproduction

See `docs/bounty_reports/disabled_validation.md` for full report and `tests/failing_tests/test_disabled_validation.py` for regression tests.

## Proposed Fix

- Re-enable validation calls in `store_memory()` and `batch_store_memories()`
- Re-enable trust score computation in `_format_memory_item()`
- Or make validation configurable via a `VALIDATION_ENABLED` setting

Addresses #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a bug report describing a validation and trust-scoring issue affecting stored memories and search results.

* **Tests**
  * Added regression coverage to help catch future cases where memory validation or trust-related output is unintentionally disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->