### PR TITLE
Fix namespace parsing for scope IDs containing underscores

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -34,7 +34,7 @@ class MemoryScope(BaseModel):
         """Parse namespace back to scope"""
         from typing import cast
 
-        parts = namespace.split("_")
+        parts = namespace.split("_", 2)
         if len(parts) != 3 or parts[0] != "memanto":
             raise ValueError(f"Invalid MEMANTO namespace format: {namespace}")
         return cls(scope_type=cast(ScopeType, parts[1]), scope_id=parts[2])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -349,6 +349,18 @@ class TestForgetEndToEnd:
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""
 
+    def test_namespace_roundtrip_preserves_ids_with_underscores(self):
+        """Scope IDs may contain underscores and must round-trip losslessly."""
+        from memanto.app.core import MemoryScope, parse_namespace
+
+        scope = MemoryScope(scope_type="agent", scope_id="customer_support_v2")
+        namespace = scope.to_namespace()
+
+        assert namespace == "memanto_agent_customer_support_v2"
+        parsed = parse_namespace(namespace)
+        assert parsed.scope_type == "agent"
+        assert parsed.scope_id == "customer_support_v2"
+
     def test_no_tenant_id_in_namespace(self):
         """Verify namespace format does NOT include tenant_id"""
         from memanto.app.services.session_service import SessionService


### PR DESCRIPTION
## Summary
- Fix `MemoryScope.from_namespace` so namespace parsing preserves scope IDs that contain underscores
- Add a regression test covering round-trip conversion for `memanto_agent_customer_support_v2`

## Bug / impact
`MemoryScope.to_namespace()` emits `memanto_{scope_type}_{scope_id}` and `validate_namespace_format()` permits underscores in `scope_id`, but `from_namespace()` used `namespace.split("_")`. Any valid scope ID such as `customer_support_v2` produced more than three parts and raised `ValueError`, breaking namespace round-tripping and downstream retrieval/validation flows for common agent/session IDs.

## Verification
- `python3 -m pytest tests/test_unit.py tests/test_memory_parsing.py -q`
- `python3 -m ruff check memanto/app/core.py tests/test_unit.py`

Relates to #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed namespace parsing so scope IDs containing underscores are preserved correctly when converting to and from namespace strings.

* **Tests**
  * Added coverage to verify underscore-containing scope IDs round-trip without losing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->