### PR TITLE
fix: namespace parsing crash on underscore scope_ids + TTL timezone mismatch TypeError

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -31,13 +31,21 @@ class MemoryScope(BaseModel):
 
     @classmethod
     def from_namespace(cls, namespace: str) -> "MemoryScope":
-        """Parse namespace back to scope"""
+        """Parse namespace back to scope.
+
+        Uses maxsplit=2 so that scope_id values containing underscores
+        are preserved correctly.  E.g. ``memanto_user_john_doe`` parses
+        to scope_type=``user``, scope_id=``john_doe``.
+        """
         from typing import cast
 
-        parts = namespace.split("_")
-        if len(parts) != 3 or parts[0] != "memanto":
+        if not namespace.startswith("memanto_"):
             raise ValueError(f"Invalid MEMANTO namespace format: {namespace}")
-        return cls(scope_type=cast(ScopeType, parts[1]), scope_id=parts[2])
+        remainder = namespace[len("memanto_"):]
+        parts = remainder.split("_", maxsplit=1)
+        if len(parts) != 2:
+            raise ValueError(f"Invalid MEMANTO namespace format: {namespace}")
+        return cls(scope_type=cast(ScopeType, parts[0]), scope_id=parts[1])
 
 
 class MemoryRecord(BaseModel):

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -627,14 +627,24 @@ class MemoryReadService:
             try:
                 if isinstance(expires_at, str):
                     expires_dt = parse_iso_timestamp(expires_at)
-                    # Only include if not expired
-                    if expires_dt > now:
-                        filtered.append(result)
+                    # Handle both timezone-aware and naive datetimes.
+                    # MemoryRecord.created_at uses datetime.utcnow() (naive)
+                    # while this function uses datetime.now(timezone.utc) (aware).
+                    # Comparing aware vs naive raises TypeError, so we normalize.
+                    if expires_dt.tzinfo is None:
+                        # Naive datetime — compare with naive now
+                        naive_now = datetime.utcnow()
+                        if expires_dt > naive_now:
+                            filtered.append(result)
+                    else:
+                        # Aware datetime — compare with aware now
+                        if expires_dt > now:
+                            filtered.append(result)
                 else:
                     # If expires_at is already datetime or not parseable, keep it
                     filtered.append(result)
-            except (ValueError, AttributeError):
-                # If we can't parse, keep the memory (fail open)
+            except (ValueError, AttributeError, TypeError):
+                # If we can't parse or compare, keep the memory (fail open)
                 filtered.append(result)
 
         return filtered

--- a/tests/test_namespace_ttl_bugs.py
+++ b/tests/test_namespace_ttl_bugs.py
@@ -1,0 +1,123 @@
+"""
+Regression tests for namespace parsing and TTL timezone bugs.
+
+Bug 1: MemoryScope.from_namespace() crashes when scope_id contains underscores.
+  - namespace "memanto_user_john_doe" would split into 4 parts and raise ValueError
+  - Fix: use split("_", maxsplit=1) on the remainder after "memanto_"
+
+Bug 2: _filter_expired_memories() raises TypeError when comparing timezone-aware
+  datetime.now(timezone.utc) with naive datetime.utcnow() used by MemoryRecord.
+  - Fix: normalize both to the same timezone awareness before comparison
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+from memanto.app.core import MemoryScope
+
+
+class TestFromNamespaceUnderscoreBug:
+    """Regression tests for from_namespace with underscore-containing scope_id."""
+
+    def test_simple_scope_id(self):
+        """Basic case: scope_id without underscores works as before."""
+        scope = MemoryScope.from_namespace("memanto_user_123")
+        assert scope.scope_type == "user"
+        assert scope.scope_id == "123"
+
+    def test_scope_id_with_underscore(self):
+        """scope_id containing underscores should not break parsing."""
+        scope = MemoryScope.from_namespace("memanto_user_john_doe")
+        assert scope.scope_type == "user"
+        assert scope.scope_id == "john_doe"
+
+    def test_scope_id_with_multiple_underscores(self):
+        """scope_id with multiple underscores should be preserved fully."""
+        scope = MemoryScope.from_namespace("memanto_agent_my_bot_v2")
+        assert scope.scope_type == "agent"
+        assert scope.scope_id == "my_bot_v2"
+
+    def test_roundtrip_with_underscore_scope_id(self):
+        """to_namespace -> from_namespace roundtrip preserves scope_id."""
+        original = MemoryScope(scope_type="user", scope_id="complex_id_123_456")
+        namespace = original.to_namespace()
+        parsed = MemoryScope.from_namespace(namespace)
+        assert parsed.scope_type == original.scope_type
+        assert parsed.scope_id == original.scope_id
+
+    def test_invalid_namespace_no_prefix(self):
+        """Namespaces without memanto_ prefix should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid MEMANTO namespace"):
+            MemoryScope.from_namespace("other_user_123")
+
+    def test_invalid_namespace_empty(self):
+        """Empty namespace should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid MEMANTO namespace"):
+            MemoryScope.from_namespace("")
+
+    def test_invalid_namespace_only_prefix(self):
+        """Namespace with only the prefix should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid MEMANTO namespace"):
+            MemoryScope.from_namespace("memanto_")
+
+
+class TestTTLTimezoneMismatch:
+    """Regression tests for TTL filtering with mixed timezone awareness."""
+
+    def _make_read_service(self):
+        """Create a MemoryReadService with a mock client."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+        return MemoryReadService(MagicMock())
+
+    def test_naive_expires_at_not_expired(self):
+        """Naive datetime expires_at in the future should be kept."""
+        service = self._make_read_service()
+        future = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+        results = [{"id": "1", "expires_at": future}]
+        filtered = service._filter_expired_memories(results)
+        assert len(filtered) == 1
+
+    def test_naive_expires_at_expired(self):
+        """Naive datetime expires_at in the past should be filtered out."""
+        service = self._make_read_service()
+        past = (datetime.utcnow() - timedelta(hours=1)).isoformat()
+        results = [{"id": "1", "expires_at": past}]
+        filtered = service._filter_expired_memories(results)
+        assert len(filtered) == 0
+
+    def test_aware_expires_at_not_expired(self):
+        """Timezone-aware expires_at in the future should be kept."""
+        service = self._make_read_service()
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        results = [{"id": "1", "expires_at": future}]
+        filtered = service._filter_expired_memories(results)
+        assert len(filtered) == 1
+
+    def test_aware_expires_at_expired(self):
+        """Timezone-aware expires_at in the past should be filtered out."""
+        service = self._make_read_service()
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        results = [{"id": "1", "expires_at": past}]
+        filtered = service._filter_expired_memories(results)
+        assert len(filtered) == 0
+
+    def test_no_expires_at_kept(self):
+        """Memories without expires_at should always be kept."""
+        service = self._make_read_service()
+        results = [{"id": "1"}, {"id": "2", "expires_at": None}]
+        filtered = service._filter_expired_memories(results)
+        assert len(filtered) == 2
+
+    def test_mixed_naive_and_aware(self):
+        """Mix of naive and aware datetimes should not raise TypeError."""
+        service = self._make_read_service()
+        naive_future = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+        aware_past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        results = [
+            {"id": "1", "expires_at": naive_future},
+            {"id": "2", "expires_at": aware_past},
+        ]
+        filtered = service._filter_expired_memories(results)
+        assert len(filtered) == 1
+        assert filtered[0]["id"] == "1"


### PR DESCRIPTION
## Bug Bounty Submission (#770)

### Bug 1: `MemoryScope.from_namespace()` crashes when `scope_id` contains underscores

**Impact:** Any user/agent with an underscore in their ID (e.g. `john_doe`, `my_bot_v2`) triggers an unhandled `ValueError` during namespace roundtrip. This breaks memory retrieval for all such users.

**Root cause:** `namespace.split("_")` requires exactly 3 parts. `memanto_user_john_doe` splits into 4 parts → `ValueError`.

**Fix:** Use `split("_", maxsplit=1)` on the remainder after the `memanto_` prefix, preserving the full scope_id.

### Bug 2: `_filter_expired_memories()` raises `TypeError` on mixed timezone awareness

**Impact:** When `expires_at` is stored as a naive datetime (via `datetime.utcnow()` in `MemoryRecord`) but the filter compares against `datetime.now(timezone.utc)` (aware), Python raises `TypeError: can't compare offset-naive and offset-aware datetimes`. This crashes memory retrieval for any memory with a TTL.

**Root cause:** `MemoryRecord.created_at` uses `datetime.utcnow()` (naive) while `_filter_expired_memories` uses `datetime.now(timezone.utc)` (aware). Comparing them raises `TypeError`.

**Fix:** Check `tzinfo` and normalize both sides to the same awareness before comparison. Also added `TypeError` to the exception handler.

### Tests

13 regression tests in `tests/test_namespace_ttl_bugs.py`:
- 7 tests for namespace parsing (simple, underscore, multiple underscores, roundtrip, invalid cases)
- 6 tests for TTL filtering (naive/aware future/past, no expires_at, mixed naive+aware)

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace handling so identifiers with underscores are parsed correctly and invalid formats are rejected more reliably.
  * Fixed memory expiration checks to work consistently with both timezone-aware and timezone-naive dates.
  * Reduced the chance of unexpected filtering errors when expiration values are missing or malformed.

* **Tests**
  * Added regression coverage for namespace parsing edge cases.
  * Added regression coverage for TTL expiration behavior across mixed datetime formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->