### PR TITLE
Fix multi-scope recall import path

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -175,7 +175,7 @@ class MemoryReadService:
             namespaces = []
             from typing import cast
 
-            from memanto.memanto.app.constants import ScopeType
+            from memanto.app.constants import ScopeType
 
             for scope_def in scopes:
                 scope = create_memory_scope(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,40 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceMultiScope:
+    """Multi-scope recall should build namespaces instead of failing on imports."""
+
+    def test_search_multi_scope_uses_canonical_constants_import(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [],
+            "execution_time": 0.01,
+        }
+
+        result = MemoryReadService(client).search_multi_scope(
+            query="timeline",
+            scopes=[
+                {"scope_type": "agent", "scope_id": "alpha"},
+                {"scope_type": "session", "scope_id": "s1"},
+            ],
+            limit=5,
+        )
+
+        assert result["searched_namespaces"] == [
+            "memanto_agent_alpha",
+            "memanto_session_s1",
+        ]
+        client.similarity_search.query.assert_called_once()
+        kwargs = client.similarity_search.query.call_args.kwargs
+        assert kwargs["namespaces"] == [
+            "memanto_agent_alpha",
+            "memanto_session_s1",
+        ]
+        assert kwargs["top_k"] == 5
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- Fix `search_multi_scope()` so it imports `ScopeType` from the canonical `memanto.app.constants` module.
- Add a regression test that exercises multi-scope namespace construction and backend search invocation.

## Bug / impact
`search_multi_scope()` currently imports `ScopeType` from `memanto.memanto.app.constants`, which does not exist in the installed package layout. Any multi-scope recall path fails before it can build namespaces or query Moorcheh.

## Tests
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMemoryReadServiceMultiScope -q`
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMemoryWriteServiceDelete tests/test_unit.py::TestMemoryReadServiceMultiScope -q`
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py -q`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how multi-scope memory search references the app’s constants, helping ensure searches use the intended namespaces.

* **Tests**
  * Added coverage for multi-scope memory search to verify the expected namespaces are sent, the search limit is applied, and the returned namespace list matches the query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->