### PR TITLE
Keep summary confidence values with memory blocks

### DIFF
--- a/memanto/app/services/summary_visualization_service.py
+++ b/memanto/app/services/summary_visualization_service.py
@@ -128,7 +128,6 @@ class SummaryVisualizationService:
                 continue
 
             headings = list(self._HEADING_RE.finditer(text))
-            confidences = list(self._CONFIDENCE_RE.finditer(text))
 
             for i, match in enumerate(headings):
                 ts_str, mem_type, title = match.groups()
@@ -137,11 +136,17 @@ class SummaryVisualizationService:
                 except ValueError:
                     continue
 
-                # Try to pair with the nearest confidence value
+                # Pair confidence with the current memory block only.
                 conf = 0.8  # default
-                if i < len(confidences):
+                block_end = (
+                    headings[i + 1].start() if i + 1 < len(headings) else len(text)
+                )
+                confidence_match = self._CONFIDENCE_RE.search(
+                    text, match.end(), block_end
+                )
+                if confidence_match:
                     try:
-                        conf = float(confidences[i].group(1))
+                        conf = float(confidence_match.group(1))
                     except (ValueError, IndexError):
                         pass
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,53 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestSummaryVisualizationService:
+    """Daily summary visualizations should keep per-memory metadata aligned."""
+
+    def test_confidence_lines_do_not_shift_across_memory_blocks(self, tmp_path):
+        from memanto.app.services.summary_visualization_service import (
+            SummaryVisualizationService,
+        )
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        summary_path = sessions_dir / "agent-a_2026-06-28_sess-1_summary.md"
+        summary_path.write_text(
+            "\n".join(
+                [
+                    "# Session Summary for agent-a",
+                    "",
+                    "### [2026-06-28 09:00:00] [FACT] Missing confidence",
+                    "- **Content**:",
+                    "> This block intentionally has no confidence line.",
+                    "",
+                    "---",
+                    "",
+                    "### [2026-06-28 10:00:00] [DECISION] Has confidence",
+                    "- **Confidence**: `0.42`",
+                    "- **Content**:",
+                    "> This block has its own confidence line.",
+                    "",
+                    "---",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        memories = SummaryVisualizationService()._parse_session_files(
+            "agent-a",
+            "2026-06-28",
+            sessions_dir,
+        )
+
+        assert [m["title"] for m in memories] == [
+            "Missing confidence",
+            "Has confidence",
+        ]
+        assert [m["confidence"] for m in memories] == [0.8, 0.42]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -281,6 +281,7 @@ class TestMemoryWriteServiceDelete:
         ],
     )
     def test_delete_memory_handles_backend_shapes(self, response, expected):
+        """Translate known backend delete responses into boolean outcomes."""
         from memanto.app.services.memory_write_service import MemoryWriteService
 
         client = MagicMock()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -292,6 +292,7 @@ class TestSummaryVisualizationService:
     """Daily summary visualizations should keep per-memory metadata aligned."""
 
     def test_confidence_lines_do_not_shift_across_memory_blocks(self, tmp_path):
+        """Missing confidence metadata must not consume the next block's value."""
         from memanto.app.services.summary_visualization_service import (
             SummaryVisualizationService,
         )


### PR DESCRIPTION
## Summary
- keep summary visualization confidence parsing scoped to each memory block
- prevent a later memory's `Confidence` line from being assigned to an earlier memory that omitted confidence metadata
- add a regression test covering a missing-confidence block followed by a block with explicit confidence

## Why
`SummaryVisualizationService._parse_session_files()` previously collected every confidence line in the file and paired them by heading index. If one memory block omitted `- **Confidence**`, the next block's confidence shifted upward, making the daily visualization report the wrong confidence distribution.

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestSummaryVisualizationService -q`
- `.venv\Scripts\python.exe -m pytest tests/test_unit.py -q`
- `.venv\Scripts\python.exe -m py_compile memanto\app\services\summary_visualization_service.py tests\test_unit.py`
- `git diff --check`

Bounty lane: moorcheh-ai/memanto#770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session summary parsing so each memory block retains its correct confidence value.
  * Prevented confidence from being incorrectly applied to the wrong memory block when confidence lines are missing.

* **Tests**
  * Added a regression test covering multi-block Markdown summaries to ensure titles and per-block confidence values are parsed and attributed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->