### PR TITLE
Isolate MCP client sessions per agent

### DIFF
--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -87,9 +87,9 @@ class MemantoLifecycle:
         """
         with self._lock:
             client = self._clients.get(agent_id)
-            if client is None:
+            is_new_client = client is None
+            if is_new_client:
                 client = SdkClient(api_key=self._settings.api_key_value())
-                self._clients[agent_id] = client
 
             if agent_id not in self._ensured_agents:
                 self._ensure_agent_exists_locked(client, agent_id)
@@ -101,6 +101,9 @@ class MemantoLifecycle:
             ):
                 self._activate_locked(client, agent_id)
                 self._activated_agents.add(agent_id)
+
+            if is_new_client:
+                self._clients[agent_id] = client
 
         return client
 

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -42,7 +42,8 @@ class MemantoLifecycle:
 
     def __init__(self, settings: MCPServerSettings) -> None:
         self._settings = settings
-        self._client = SdkClient(api_key=settings.api_key_value())
+        self._admin_client = SdkClient(api_key=settings.api_key_value())
+        self._clients: dict[str, SdkClient] = {}
         self._activated_agents: set[str] = set()
         self._ensured_agents: set[str] = set()
         self._lock = threading.Lock()
@@ -53,8 +54,8 @@ class MemantoLifecycle:
 
     @property
     def client(self) -> SdkClient:
-        """The shared Memanto SDK client."""
-        return self._client
+        """An SDK client for agent administration calls."""
+        return self._admin_client
 
     @property
     def settings(self) -> MCPServerSettings:
@@ -76,25 +77,32 @@ class MemantoLifecycle:
             "configured. Either pass agent_id explicitly or set the env var."
         )
 
-    def ensure_ready(self, agent_id: str) -> str:
+    def ensure_ready(self, agent_id: str) -> SdkClient:
         """Make sure the agent exists and a session is active for it.
 
-        Returns the resolved agent_id (mostly a convenience so callers can
-        chain ``ensure_ready(resolve_agent_id(...))``).
+        Returns an agent-scoped SDK client. ``SdkClient`` stores the active
+        session token on the instance, so sharing one client across multiple
+        concurrent MCP tool calls can make agents overwrite each other's
+        session state.
         """
         with self._lock:
+            client = self._clients.get(agent_id)
+            if client is None:
+                client = SdkClient(api_key=self._settings.api_key_value())
+                self._clients[agent_id] = client
+
             if agent_id not in self._ensured_agents:
-                self._ensure_agent_exists_locked(agent_id)
+                self._ensure_agent_exists_locked(client, agent_id)
                 self._ensured_agents.add(agent_id)
 
             if (
                 agent_id not in self._activated_agents
-                or self._client.agent_id != agent_id
+                or client.agent_id != agent_id
             ):
-                self._activate_locked(agent_id)
+                self._activate_locked(client, agent_id)
                 self._activated_agents.add(agent_id)
 
-        return agent_id
+        return client
 
     def shutdown(self) -> None:
         """Best-effort cleanup. Sessions can outlive the process safely."""
@@ -107,9 +115,9 @@ class MemantoLifecycle:
     # Internals
     # ------------------------------------------------------------------ #
 
-    def _ensure_agent_exists_locked(self, agent_id: str) -> None:
+    def _ensure_agent_exists_locked(self, client: SdkClient, agent_id: str) -> None:
         try:
-            self._client.get_agent(agent_id)
+            client.get_agent(agent_id)
             logger.debug("Agent '%s' exists.", agent_id)
             return
         except AgentNotFoundError:
@@ -128,7 +136,7 @@ class MemantoLifecycle:
             self._settings.agent_pattern,
         )
         try:
-            self._client.create_agent(
+            client.create_agent(
                 agent_id=agent_id,
                 pattern=self._settings.agent_pattern,
                 description="Auto-created by memanto-mcp",
@@ -137,9 +145,9 @@ class MemantoLifecycle:
             # Race: another caller created it between our get_agent and create.
             logger.debug("Agent '%s' was created concurrently.", agent_id)
 
-    def _activate_locked(self, agent_id: str) -> None:
+    def _activate_locked(self, client: SdkClient, agent_id: str) -> None:
         try:
-            self._client.activate_agent(
+            client.activate_agent(
                 agent_id=agent_id,
                 duration_hours=self._settings.session_duration_hours,
             )

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -41,6 +41,7 @@ class MemantoLifecycle:
     """Owns the long-lived SdkClient and per-agent session bookkeeping."""
 
     def __init__(self, settings: MCPServerSettings) -> None:
+        """Initialize admin and per-agent client state."""
         self._settings = settings
         self._admin_client = SdkClient(api_key=settings.api_key_value())
         self._clients: dict[str, SdkClient] = {}
@@ -119,6 +120,7 @@ class MemantoLifecycle:
     # ------------------------------------------------------------------ #
 
     def _ensure_agent_exists_locked(self, client: SdkClient, agent_id: str) -> None:
+        """Verify an agent exists, auto-creating it when configured."""
         try:
             client.get_agent(agent_id)
             logger.debug("Agent '%s' exists.", agent_id)
@@ -149,6 +151,7 @@ class MemantoLifecycle:
             logger.debug("Agent '%s' was created concurrently.", agent_id)
 
     def _activate_locked(self, client: SdkClient, agent_id: str) -> None:
+        """Activate a Memanto session on the provided agent-scoped client."""
         try:
             client.activate_agent(
                 agent_id=agent_id,

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -139,12 +139,16 @@ class AnswerResult(BaseModel):
 
 
 class BatchRememberItemResult(BaseModel):
+    """Result for one item in a batch memory write."""
+
     id: str | None = None
     status: str
     error: str | None = None
 
 
 class BatchRememberResult(BaseModel):
+    """Response returned by the batch_remember MCP tool."""
+
     status: str
     agent_id: str
     namespace: str | None = None
@@ -156,6 +160,8 @@ class BatchRememberResult(BaseModel):
 
 
 class AgentInfoResult(BaseModel):
+    """Agent metadata returned by MCP admin tools."""
+
     status: str
     agent_id: str | None = None
     namespace: str | None = None
@@ -166,6 +172,8 @@ class AgentInfoResult(BaseModel):
 
 
 class AgentListResult(BaseModel):
+    """Collection response for listing Memanto agents."""
+
     status: str
     count: int = 0
     agents: list[dict[str, Any]] = Field(default_factory=list)
@@ -313,6 +321,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = "mcp-agent",
         agent_id: AgentIdField = None,
     ) -> RememberResult:
+        """Store a single memory for the resolved agent."""
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
             client = lifecycle.ensure_ready(resolved)
@@ -375,6 +384,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ],
         agent_id: AgentIdField = None,
     ) -> BatchRememberResult:
+        """Validate and store multiple memories for the resolved agent."""
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
             # Validate before round-trip so we fail fast with a clear error.
@@ -485,6 +495,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Search memories semantically for the resolved agent."""
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
             client = lifecycle.ensure_ready(resolved)
@@ -540,6 +551,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Return the most recent memories for the resolved agent."""
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
             client = lifecycle.ensure_ready(resolved)
@@ -596,6 +608,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Recall memories that were valid at a point in time."""
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
             client = lifecycle.ensure_ready(resolved)
@@ -653,6 +666,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Recall memories changed after the supplied timestamp."""
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
             client = lifecycle.ensure_ready(resolved)
@@ -729,6 +743,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = False,
         agent_id: AgentIdField = None,
     ) -> AnswerResult:
+        """Answer a question using memories from the resolved agent."""
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
             client = lifecycle.ensure_ready(resolved)
@@ -796,6 +811,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             Field(default=None, description="Optional human-readable description."),
         ] = None,
     ) -> AgentInfoResult:
+        """Create a Memanto agent through the admin client."""
         try:
             agent = lifecycle.client.create_agent(
                 agent_id=agent_id, pattern=pattern, description=description
@@ -827,6 +843,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         description="List every Memanto agent visible to the current API key.",
     )
     def list_agents() -> AgentListResult:
+        """List available Memanto agents through the admin client."""
         try:
             agents = lifecycle.client.list_agents()
             return AgentListResult(status="ok", count=len(agents), agents=agents)
@@ -843,6 +860,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             str, Field(description="Agent id to look up.", min_length=1)
         ],
     ) -> AgentInfoResult:
+        """Fetch one Memanto agent by identifier."""
         try:
             agent = lifecycle.client.get_agent(agent_id)
             return AgentInfoResult(
@@ -878,6 +896,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             str, Field(description="Agent id to delete.", min_length=1)
         ],
     ) -> AgentInfoResult:
+        """Delete one Memanto agent by identifier."""
         try:
             lifecycle.client.delete_agent(agent_id)
             return AgentInfoResult(status="ok", agent_id=agent_id, message="deleted")

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -314,13 +314,14 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RememberResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
             resolved_title = title or (
                 content[: _MAX_TITLE_LENGTH - 3] + "..."
                 if len(content) > _MAX_TITLE_LENGTH
                 else content
             )
-            result = lifecycle.client.remember(
+            result = client.remember(
                 agent_id=resolved,
                 memory_type=type,
                 title=resolved_title,
@@ -375,7 +376,8 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> BatchRememberResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
             # Validate before round-trip so we fail fast with a clear error.
             for i, item in enumerate(memories):
                 if not isinstance(item, dict):
@@ -399,7 +401,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                         f"Choose one of: {sorted(VALID_PROVENANCE_TYPES)}"
                     )
 
-            result = lifecycle.client.batch_remember(
+            result = client.batch_remember(
                 agent_id=resolved,
                 memories=memories,
             )
@@ -484,8 +486,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.recall(
                 agent_id=resolved,
                 query=query,
                 limit=limit,
@@ -538,8 +541,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_recent(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.recall_recent(
                 agent_id=resolved,
                 limit=limit,
                 type=list(type) if type else None,
@@ -593,8 +597,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_as_of(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.recall_as_of(
                 agent_id=resolved,
                 as_of=as_of,
                 limit=limit,
@@ -649,8 +654,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_changed_since(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.recall_changed_since(
                 agent_id=resolved,
                 since=since,
                 limit=limit,
@@ -724,8 +730,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> AnswerResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.answer(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.answer(
                 agent_id=resolved,
                 question=question,
                 limit=limit,

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -377,7 +377,6 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
     ) -> BatchRememberResult:
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
-            client = lifecycle.ensure_ready(resolved)
             # Validate before round-trip so we fail fast with a clear error.
             for i, item in enumerate(memories):
                 if not isinstance(item, dict):
@@ -401,6 +400,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                         f"Choose one of: {sorted(VALID_PROVENANCE_TYPES)}"
                     )
 
+            client = lifecycle.ensure_ready(resolved)
             result = client.batch_remember(
                 agent_id=resolved,
                 memories=memories,

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -77,6 +77,7 @@ class ToolRegistry:
         """Return a decorator that stores the tool by name."""
 
         def decorator(fn):
+            """Store one decorated tool function and return it unchanged."""
             self.tools[name] = fn
             return fn
 

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from memanto.app.utils.errors import AgentNotFoundError
 from memanto_mcp.config import MCPServerSettings
 from memanto_mcp.lifecycle import MemantoLifecycle
+from memanto_mcp.tools import register_tools
 
 
 class FakeSdkClient:
@@ -17,6 +19,8 @@ class FakeSdkClient:
     """
 
     instances: list["FakeSdkClient"] = []
+    missing_agents: set[str] = set()
+    fail_activate_agents: set[str] = set()
 
     def __init__(self, api_key: str) -> None:
         """Record constructor calls and initialize mutable session state."""
@@ -28,7 +32,9 @@ class FakeSdkClient:
         FakeSdkClient.instances.append(self)
 
     def get_agent(self, agent_id: str) -> dict[str, str]:
-        """Pretend the requested agent already exists."""
+        """Pretend the requested agent exists unless configured missing."""
+        if agent_id in FakeSdkClient.missing_agents:
+            raise AgentNotFoundError(f"Agent '{agent_id}' not found")
         return {"agent_id": agent_id}
 
     def create_agent(
@@ -42,6 +48,8 @@ class FakeSdkClient:
         self, agent_id: str, duration_hours: int | None = None
     ) -> dict[str, str]:
         """Mutate instance session state like the real SdkClient does."""
+        if agent_id in FakeSdkClient.fail_activate_agents:
+            raise RuntimeError("activation failed")
         self.agent_id = agent_id
         self.session_token = f"token-for-{agent_id}"
         self.activated_agents.append(agent_id)
@@ -56,12 +64,31 @@ class FakeSdkClient:
         return {"memory_id": f"mem-{agent_id}", "status": "ok"}
 
 
+class ToolRegistry:
+    """Tiny FastMCP stand-in that captures decorated tool functions."""
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, name: str, description: str):
+        """Return a decorator that stores the tool by name."""
+
+        def decorator(fn):
+            self.tools[name] = fn
+            return fn
+
+        return decorator
+
+
 def test_ensure_ready_uses_distinct_clients_per_agent(
     fake_api_key: str, monkeypatch
 ) -> None:
     """Different MCP agents must not share SdkClient session state."""
     monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
     FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = set()
+    FakeSdkClient.fail_activate_agents = set()
 
     lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
 
@@ -79,6 +106,8 @@ def test_repeated_agent_reuses_its_scoped_client(fake_api_key: str, monkeypatch)
     """Repeated calls for one agent should reuse that agent's client."""
     monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
     FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = set()
+    FakeSdkClient.fail_activate_agents = set()
 
     lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
 
@@ -87,3 +116,68 @@ def test_repeated_agent_reuses_its_scoped_client(fake_api_key: str, monkeypatch)
 
     assert first is second
     assert first.activated_agents == ["agent-a"]
+
+
+def test_missing_agent_is_created_with_scoped_client(
+    fake_api_key: str, monkeypatch
+) -> None:
+    """Auto-create should happen on the same scoped client returned later."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = {"agent-a"}
+    FakeSdkClient.fail_activate_agents = set()
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    client = lifecycle.ensure_ready("agent-a")
+
+    assert client.created_agents == ["agent-a"]
+    assert client.activated_agents == ["agent-a"]
+    assert lifecycle.ensure_ready("agent-a") is client
+
+
+def test_failed_first_activation_does_not_cache_new_client(
+    fake_api_key: str, monkeypatch
+) -> None:
+    """A failed readiness check should not leave a new scoped client cached."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = set()
+    FakeSdkClient.fail_activate_agents = {"agent-a"}
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    try:
+        lifecycle.ensure_ready("agent-a")
+    except Exception:
+        pass
+
+    failed_client = FakeSdkClient.instances[-1]
+    FakeSdkClient.fail_activate_agents = set()
+    recovered_client = lifecycle.ensure_ready("agent-a")
+
+    assert recovered_client is not failed_client
+    assert recovered_client.activated_agents == ["agent-a"]
+
+
+def test_batch_remember_validates_before_lifecycle_side_effects(
+    fake_api_key: str, monkeypatch
+) -> None:
+    """Invalid batch payloads should fail before creating or activating agents."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = set()
+    FakeSdkClient.fail_activate_agents = set()
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+    registry = ToolRegistry()
+    register_tools(registry, lifecycle)
+
+    result = registry.tools["batch_remember"](
+        memories=[{"content": "   "}],
+        agent_id="agent-a",
+    )
+
+    assert result.status == "error"
+    # Only the admin client from lifecycle construction should exist.
+    assert len(FakeSdkClient.instances) == 1

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -1,0 +1,82 @@
+"""Lifecycle tests for agent-scoped MCP clients."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from memanto_mcp.config import MCPServerSettings
+from memanto_mcp.lifecycle import MemantoLifecycle
+
+
+class FakeSdkClient:
+    """Small stateful stand-in for SdkClient.
+
+    The real SdkClient stores ``agent_id`` and ``session_token`` on the client
+    instance. These tests make that mutable state visible without hitting the
+    network.
+    """
+
+    instances: list["FakeSdkClient"] = []
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self.agent_id: str | None = None
+        self.session_token: str | None = None
+        self.created_agents: list[str] = []
+        self.activated_agents: list[str] = []
+        FakeSdkClient.instances.append(self)
+
+    def get_agent(self, agent_id: str) -> dict[str, str]:
+        return {"agent_id": agent_id}
+
+    def create_agent(
+        self, agent_id: str, pattern: str = "tool", description: str | None = None
+    ) -> dict[str, str]:
+        self.created_agents.append(agent_id)
+        return {"agent_id": agent_id, "pattern": pattern}
+
+    def activate_agent(
+        self, agent_id: str, duration_hours: int | None = None
+    ) -> dict[str, str]:
+        self.agent_id = agent_id
+        self.session_token = f"token-for-{agent_id}"
+        self.activated_agents.append(agent_id)
+        return {"agent_id": agent_id, "session_token": self.session_token}
+
+    def remember(self, *, agent_id: str, **_: Any) -> dict[str, str]:
+        if self.agent_id != agent_id:
+            raise AssertionError(
+                f"client for {self.agent_id!r} used for {agent_id!r}"
+            )
+        return {"memory_id": f"mem-{agent_id}", "status": "ok"}
+
+
+def test_ensure_ready_uses_distinct_clients_per_agent(
+    fake_api_key: str, monkeypatch
+) -> None:
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    agent_a_client = lifecycle.ensure_ready("agent-a")
+    agent_b_client = lifecycle.ensure_ready("agent-b")
+
+    assert agent_a_client is not agent_b_client
+    assert agent_a_client.agent_id == "agent-a"
+    assert agent_b_client.agent_id == "agent-b"
+    assert agent_a_client.remember(agent_id="agent-a")["memory_id"] == "mem-agent-a"
+    assert agent_b_client.remember(agent_id="agent-b")["memory_id"] == "mem-agent-b"
+
+
+def test_repeated_agent_reuses_its_scoped_client(fake_api_key: str, monkeypatch) -> None:
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    first = lifecycle.ensure_ready("agent-a")
+    second = lifecycle.ensure_ready("agent-a")
+
+    assert first is second
+    assert first.activated_agents == ["agent-a"]

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from memanto.app.utils.errors import AgentNotFoundError
 from memanto_mcp.config import MCPServerSettings
 from memanto_mcp.lifecycle import MemantoLifecycle
@@ -147,16 +149,16 @@ def test_failed_first_activation_does_not_cache_new_client(
 
     lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
 
-    try:
+    with pytest.raises(Exception, match="Failed to activate Memanto session"):
         lifecycle.ensure_ready("agent-a")
-    except Exception:
-        pass
 
     failed_client = FakeSdkClient.instances[-1]
     FakeSdkClient.fail_activate_agents = set()
     recovered_client = lifecycle.ensure_ready("agent-a")
+    cached_client = lifecycle.ensure_ready("agent-a")
 
     assert recovered_client is not failed_client
+    assert cached_client is recovered_client
     assert recovered_client.activated_agents == ["agent-a"]
 
 
@@ -181,3 +183,5 @@ def test_batch_remember_validates_before_lifecycle_side_effects(
     assert result.status == "error"
     # Only the admin client from lifecycle construction should exist.
     assert len(FakeSdkClient.instances) == 1
+    assert FakeSdkClient.instances[0].created_agents == []
+    assert FakeSdkClient.instances[0].activated_agents == []

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-
 from memanto.app.utils.errors import AgentNotFoundError
+
 from memanto_mcp.config import MCPServerSettings
 from memanto_mcp.lifecycle import MemantoLifecycle
 from memanto_mcp.tools import register_tools
@@ -20,7 +20,7 @@ class FakeSdkClient:
     network.
     """
 
-    instances: list["FakeSdkClient"] = []
+    instances: list[FakeSdkClient] = []
     missing_agents: set[str] = set()
     fail_activate_agents: set[str] = set()
 

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -19,6 +19,7 @@ class FakeSdkClient:
     instances: list["FakeSdkClient"] = []
 
     def __init__(self, api_key: str) -> None:
+        """Record constructor calls and initialize mutable session state."""
         self.api_key = api_key
         self.agent_id: str | None = None
         self.session_token: str | None = None
@@ -27,23 +28,27 @@ class FakeSdkClient:
         FakeSdkClient.instances.append(self)
 
     def get_agent(self, agent_id: str) -> dict[str, str]:
+        """Pretend the requested agent already exists."""
         return {"agent_id": agent_id}
 
     def create_agent(
         self, agent_id: str, pattern: str = "tool", description: str | None = None
     ) -> dict[str, str]:
+        """Record auto-created agents for future assertions."""
         self.created_agents.append(agent_id)
         return {"agent_id": agent_id, "pattern": pattern}
 
     def activate_agent(
         self, agent_id: str, duration_hours: int | None = None
     ) -> dict[str, str]:
+        """Mutate instance session state like the real SdkClient does."""
         self.agent_id = agent_id
         self.session_token = f"token-for-{agent_id}"
         self.activated_agents.append(agent_id)
         return {"agent_id": agent_id, "session_token": self.session_token}
 
     def remember(self, *, agent_id: str, **_: Any) -> dict[str, str]:
+        """Fail if a memory call uses a client scoped to another agent."""
         if self.agent_id != agent_id:
             raise AssertionError(
                 f"client for {self.agent_id!r} used for {agent_id!r}"
@@ -54,6 +59,7 @@ class FakeSdkClient:
 def test_ensure_ready_uses_distinct_clients_per_agent(
     fake_api_key: str, monkeypatch
 ) -> None:
+    """Different MCP agents must not share SdkClient session state."""
     monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
     FakeSdkClient.instances = []
 
@@ -70,6 +76,7 @@ def test_ensure_ready_uses_distinct_clients_per_agent(
 
 
 def test_repeated_agent_reuses_its_scoped_client(fake_api_key: str, monkeypatch) -> None:
+    """Repeated calls for one agent should reuse that agent's client."""
     monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
     FakeSdkClient.instances = []
 


### PR DESCRIPTION
/claim #770

## Summary

Fixes an MCP session isolation bug where concurrent tool calls for different `agent_id`s could share and overwrite the same `SdkClient` session state.

`SdkClient` keeps the active `agent_id` and `session_token` on the instance. Before this change, `MemantoLifecycle` had one shared client. `ensure_ready()` was locked only while activating the session, then tool handlers called `lifecycle.client.remember()` / `recall()` outside the lock. If another MCP call activated a different agent in between, the first call could run with the wrong active client state and fail with a session mismatch.

## Fix

- Keep a separate `SdkClient` per agent inside `MemantoLifecycle`.
- Return the ready, agent-scoped client from `ensure_ready()`.
- Cache newly created scoped clients only after agent readiness succeeds.
- Update MCP memory tools to use that scoped client for session-backed operations.
- Validate batch payloads before creating/activating an agent session.
- Keep admin tools on a separate admin client because they are not bound to one active session.
- Add regression coverage proving distinct clients, client reuse, missing-agent auto-create via scoped client, failed activation retry behavior, and side-effect-free invalid batch validation.

## Validation

```text
PYTHONPATH=<repo>;<repo>/integrations/mcp python -m pytest integrations/mcp/tests/test_lifecycle.py integrations/mcp/tests/test_config.py integrations/mcp/tests/test_server.py -q
26 passed

python -m py_compile integrations/mcp/memanto_mcp/lifecycle.py integrations/mcp/memanto_mcp/tools.py integrations/mcp/tests/test_lifecycle.py
```

Refs #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent-specific behavior in MCP by separating agent-management and agent-operations connections.
  * MCP tools now resolve the agent id once and perform remember/recall/answer through a ready, agent-scoped client for more consistent execution.
* **Tests**
  * Added integration-style tests verifying distinct per-agent scoped clients, reuse on subsequent readiness calls, auto-creation/activation for missing agents, correct caching after failed activation, and input validation happening before any lifecycle side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->