### PR TITLE
Fix changed-since sorting with null updated_at

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -16,12 +16,15 @@ from memanto.app.utils.errors import MemoryError
 
 
 class MemoryReadService:
+    """Read, search, and format memories from the configured Moorcheh backend."""
+
     def __init__(self, moorcheh_client: "MoorchehClient"):
         self.client = moorcheh_client
         self._namespace_service = None
 
     @property
     def namespace_service(self):
+        """Return the namespace service, creating it on first access."""
         if self._namespace_service is None:
             from memanto.app.services.namespace_service import NamespaceService
 
@@ -338,6 +341,7 @@ class MemoryReadService:
 
             # Sort by created_at descending (most recent first)
             def _created_sort_key(m: dict[str, Any]) -> str:
+                """Return a comparable created-at timestamp for recent ordering."""
                 raw = m.get("created_at")
                 if not raw:
                     return ""

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -19,6 +19,7 @@ class MemoryReadService:
     """Read, search, and format memories from the configured Moorcheh backend."""
 
     def __init__(self, moorcheh_client: "MoorchehClient"):
+        """Initialize the reader with an active Moorcheh client."""
         self.client = moorcheh_client
         self._namespace_service = None
 

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -286,10 +286,17 @@ class MemoryReadService:
                     except (ValueError, AttributeError):
                         pass
 
-            # Sort by updated_at descending (most recent first)
-            changed_memories.sort(
-                key=lambda m: m.get("updated_at", m.get("created_at", "")), reverse=True
-            )
+            # Sort by the timestamp that made the memory qualify.
+            def _changed_sort_key(m: dict[str, Any]) -> datetime:
+                raw = m.get("updated_at") or m.get("created_at")
+                if not raw:
+                    return datetime.min.replace(tzinfo=timezone.utc)
+                try:
+                    return parse_iso_timestamp(str(raw))
+                except Exception:
+                    return datetime.min.replace(tzinfo=timezone.utc)
+
+            changed_memories.sort(key=_changed_sort_key, reverse=True)
 
             # Apply limit
             if limit is not None:

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -288,6 +288,7 @@ class MemoryReadService:
 
             # Sort by the timestamp that made the memory qualify.
             def _changed_sort_key(m: dict[str, Any]) -> datetime:
+                """Return a stable aware timestamp for changed-memory ordering."""
                 raw = m.get("updated_at") or m.get("created_at")
                 if not raw:
                     return datetime.min.replace(tzinfo=timezone.utc)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,51 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceChangedSince:
+    """Regression coverage for temporal changed-since result ordering."""
+
+    def test_changed_since_sorts_created_memories_without_updated_at(self):
+        """New memories with ``updated_at=None`` should not crash sorting."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "created-only",
+                    "text": "[fact] Created only",
+                    "metadata": {
+                        "created_at": "2026-01-03T00:00:00Z",
+                        "updated_at": None,
+                        "memory_type": "fact",
+                    },
+                },
+                {
+                    "id": "updated",
+                    "text": "[fact] Updated",
+                    "metadata": {
+                        "created_at": "2025-12-30T00:00:00Z",
+                        "updated_at": "2026-01-04T00:00:00Z",
+                        "memory_type": "fact",
+                    },
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        result = MemoryReadService(client).search_changed_since(
+            since_date="2026-01-01T00:00:00Z",
+            agent_id="agent-1",
+            limit=None,
+        )
+
+        assert [memory["id"] for memory in result["results"]] == [
+            "updated",
+            "created-only",
+        ]
+        assert result["results"][1]["change_type"] == "created"
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- Make `search_changed_since()` sort changed memories by `updated_at` with a `created_at` fallback.
- Parse sort timestamps into comparable datetimes so `updated_at: null` cannot crash mixed result sets.
- Add a regression test for a newly created memory with `updated_at=None` returned alongside an updated memory.

## Root cause / impact
`search_changed_since()` correctly includes newly created memories when `created_at` is after the requested boundary, even when `updated_at` is null. It then sorted results with `m.get("updated_at", m.get("created_at", ""))`, which returns `None` when the `updated_at` key exists with a null value. Mixed `None` and string sort keys raise `TypeError`, so the changed-since recall path can fail instead of returning valid temporal results.

## Validation
- `..\memanto\.venv\Scripts\python.exe -m pytest tests\test_unit.py::TestMemoryReadServiceChangedSince::test_changed_since_sorts_created_memories_without_updated_at -q`
- `..\memanto\.venv\Scripts\python.exe -m pytest tests\test_unit.py -q`
- `..\memanto\.venv\Scripts\python.exe -m pytest tests\test_api.py::TestMEMANTOAPI::test_recall_temporal_api -q`
- `..\memanto\.venv\Scripts\python.exe -m py_compile memanto\app\services\memory_read_service.py tests\test_unit.py`
- `..\memanto\.venv\Scripts\python.exe -m ruff check memanto\app\services\memory_read_service.py tests\test_unit.py`
- `git diff --check`

Bounty: #770
/claim #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “changed since” results ordering to consistently rank memories by the most recent change time, falling back to creation time when an update timestamp is missing or cannot be interpreted.
* **Tests**
  * Added a regression test to confirm correct sorting for memories without an update timestamp and verifies the expected change classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->