### PR TITLE
Skip malformed timestamps in temporal filtering

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -568,14 +568,32 @@ class MemoryReadService:
 
         filtered = results
 
+        def _created_at_matches(
+            result: dict[str, Any],
+            *,
+            after_dt=None,
+            before_dt=None,
+        ) -> bool:
+            created_at = result.get("created_at")
+            if not created_at:
+                return False
+            try:
+                created_dt = parse_iso_timestamp(created_at)
+            except (ValueError, AttributeError):
+                return False
+            if after_dt is not None and created_dt < after_dt:
+                return False
+            if before_dt is not None and created_dt > before_dt:
+                return False
+            return True
+
         if created_after:
             try:
                 after_dt = parse_iso_timestamp(created_after)
                 filtered = [
                     r
                     for r in filtered
-                    if r.get("created_at")
-                    and parse_iso_timestamp(r["created_at"]) >= after_dt
+                    if _created_at_matches(r, after_dt=after_dt)
                 ]
             except (ValueError, AttributeError):
                 pass  # Skip invalid timestamps
@@ -586,8 +604,7 @@ class MemoryReadService:
                 filtered = [
                     r
                     for r in filtered
-                    if r.get("created_at")
-                    and parse_iso_timestamp(r["created_at"]) <= before_dt
+                    if _created_at_matches(r, before_dt=before_dt)
                 ]
             except (ValueError, AttributeError):
                 pass  # Skip invalid timestamps

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -578,8 +578,8 @@ class MemoryReadService:
             if not created_at:
                 return False
             try:
-                created_dt = parse_iso_timestamp(created_at)
-            except (ValueError, AttributeError):
+                created_dt = parse_iso_timestamp(str(created_at))
+            except (ValueError, AttributeError, TypeError):
                 return False
             if after_dt is not None and created_dt < after_dt:
                 return False

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -255,6 +255,7 @@ class TestMemoryReadServiceTemporalFilter:
             {"id": "new", "created_at": "2026-06-28T10:00:00Z"},
             {"id": "old", "created_at": "2026-06-27T10:00:00Z"},
             {"id": "bad", "created_at": "not-a-date"},
+            {"id": "numeric", "created_at": 1782626400},
             {"id": "missing"},
         ]
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -243,6 +243,47 @@ class TestAgentService:
         print("✅ Agent deleted successfully")
 
 
+class TestMemoryReadServiceTemporalFilter:
+    """Temporal post-filtering should isolate malformed result timestamps."""
+
+    def test_created_after_skips_invalid_result_timestamps(self):
+        """One malformed memory timestamp must not disable the whole filter."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        service = MemoryReadService(MagicMock())
+        results = [
+            {"id": "new", "created_at": "2026-06-28T10:00:00Z"},
+            {"id": "old", "created_at": "2026-06-27T10:00:00Z"},
+            {"id": "bad", "created_at": "not-a-date"},
+            {"id": "missing"},
+        ]
+
+        filtered = service._apply_temporal_filter(
+            results,
+            created_after="2026-06-28T00:00:00Z",
+        )
+
+        assert [item["id"] for item in filtered] == ["new"]
+
+    def test_created_before_skips_invalid_result_timestamps(self):
+        """Malformed memory timestamps should be dropped before upper-bound checks."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        service = MemoryReadService(MagicMock())
+        results = [
+            {"id": "old", "created_at": "2026-06-27T10:00:00Z"},
+            {"id": "new", "created_at": "2026-06-28T10:00:00Z"},
+            {"id": "bad", "created_at": "not-a-date"},
+        ]
+
+        filtered = service._apply_temporal_filter(
+            results,
+            created_before="2026-06-28T00:00:00Z",
+        )
+
+        assert [item["id"] for item in filtered] == ["old"]
+
+
 class TestMemoryWriteServiceDelete:
     """``delete_memory`` must report success for both cloud and on-prem
     response shapes. Cloud returns ``actual_deletions``; on-prem's


### PR DESCRIPTION
## Summary

- Fix temporal post-filtering so malformed per-memory `created_at` values are skipped instead of disabling the entire `created_after` / `created_before` filter.
- Keep the existing behavior for invalid caller-supplied temporal bounds: if the bound cannot be parsed, the filter is not applied.
- Add unit coverage for both lower-bound and upper-bound filtering with malformed result timestamps.

## Root cause

`_apply_temporal_filter()` wrapped the whole list comprehension in one `try` block. If any returned memory had an invalid `created_at`, `parse_iso_timestamp()` raised and the method fell through to `pass`, returning the unfiltered result set. That lets stale or future memories leak into temporal searches whenever one bad timestamp is present.

## Validation

- `python -m pytest tests/test_unit.py::TestMemoryReadServiceTemporalFilter -q`
- `python -m pytest tests/test_unit.py -q`
- `python -m ruff check memanto/app/services/memory_read_service.py tests/test_unit.py`
- `python -m py_compile memanto/app/services/memory_read_service.py tests/test_unit.py`
- `git diff --check`

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date filtering for memory results so only records with valid timestamps are included in time-based searches.
  * Records with missing or malformed timestamps are now excluded when applying date range filters, avoiding inconsistent results.

* **Tests**
  * Added coverage for time filtering behavior with invalid or missing timestamps to confirm the filtering rules work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->