### PR TITLE
Keep recall display stable for string numeric fields

### DIFF
--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -28,6 +28,16 @@ from memanto.cli.commands._shared import (
 )
 
 
+def _as_float(value: object, default: float = 0.0) -> float:
+    """Coerce API display fields to float without crashing CLI rendering."""
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 @app.command()
 def remember(
     content: str | None = typer.Argument(None, help="Memory content to store"),
@@ -157,7 +167,7 @@ def remember(
                         f"[bold]{item.get('title', 'Untitled')}[/bold]\n\n"
                         f"{item.get('content', '')}\n\n"
                         f"[dim]Type: {item.get('type', 'fact')} | "
-                        f"Confidence: {item.get('confidence', 0.8):.2f}[/dim]",
+                        f"Confidence: {_as_float(item.get('confidence'), 0.8):.2f}[/dim]",
                         title=f"Candidate {i}",
                         border_style="yellow" if dry_run else SUCCESS,
                     )
@@ -601,10 +611,13 @@ def recall(
         )
 
         for i, memory in enumerate(memories, 1):
-            score = memory.get("score") or 0.0
+            score = _as_float(memory.get("score"))
             mem_type = memory.get("type") or "unknown"
-            conf = memory.get("confidence") or 0.0
-            comp_conf = memory.get("computed_confidence")
+            conf = _as_float(memory.get("confidence"))
+            comp_conf_raw = memory.get("computed_confidence")
+            comp_conf = (
+                _as_float(comp_conf_raw) if comp_conf_raw is not None else None
+            )
             title = memory.get("title") or "Untitled"
             content = memory.get("content") or ""
             created = memory.get("created_at") or ""
@@ -727,7 +740,7 @@ def answer(
             console.print(f"\n[dim]Used {len(context)} memories as context:[/dim]")
             for i, mem in enumerate(context, 1):
                 console.print(
-                    f"  {i}. {mem.get('title', 'Untitled')} (score: {mem.get('score', 0):.3f})"
+                    f"  {i}. {mem.get('title', 'Untitled')} (score: {_as_float(mem.get('score')):.3f})"
                 )
 
         console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,39 @@ class TestMEMANTOCLI:
         mock_all_clients.remember.assert_called_once()
         assert mock_all_clients.remember.call_args.kwargs["title"] == "Custom Title"
 
+    def test_recall_displays_string_numeric_fields(self, mock_all_clients):
+        """Recall output should not crash when API metadata numbers are strings."""
+        mock_all_clients.recall.return_value = {
+            "memories": [
+                {
+                    "id": "mem-123",
+                    "title": "Stored preference",
+                    "content": "Prefers concise reports",
+                    "type": "preference",
+                    "confidence": "0.75",
+                    "computed_confidence": "0.66",
+                    "score": "0.812",
+                    "tags": ["ux"],
+                },
+                {
+                    "id": "mem-456",
+                    "title": "Stored fact",
+                    "content": "Uses UTC timestamps",
+                    "type": "fact",
+                    "confidence": "0.41",
+                    "score": "0.500",
+                },
+            ],
+            "count": 2,
+        }
+
+        result = runner.invoke(app, ["recall", "preference"])
+
+        assert result.exit_code == 0
+        assert "Stored preference" in result.stdout
+        assert "Confidence: 0.66 (computed) | Score: 0.812" in result.stdout
+        assert "Confidence: 0.41 | Score: 0.500" in result.stdout
+
     def test_edit(self, mock_all_clients):
         """Test 'memanto edit' updates selected memory fields."""
         mock_all_clients.update_memory.return_value = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,6 +254,7 @@ class TestMEMANTOCLI:
 
         assert result.exit_code == 0
         assert "Stored preference" in result.stdout
+        assert "Stored fact" in result.stdout
         assert "Confidence: 0.66 (computed) | Score: 0.812" in result.stdout
         assert "Confidence: 0.41 | Score: 0.500" in result.stdout
 


### PR DESCRIPTION
/claim #770

## Summary
- Fix CLI recall rendering so numeric display fields returned as strings do not crash Rich panel formatting.
- Coerce `score`, `confidence`, `computed_confidence`, conversation extraction candidate confidence, and answer context scores through a small display-only helper before applying `:.2f` / `:.3f` formatting.
- Add a regression test covering string `confidence`, `computed_confidence`, and `score` values from the mocked recall client.

## Reproduction
Before this change, `memanto recall ...` could fail while displaying otherwise valid memory results if metadata/API values arrived as numeric strings, for example `{"confidence": "0.75", "computed_confidence": "0.66", "score": "0.812"}`. Python string values do not support the numeric format specifiers used by the CLI, so the command raised a formatting error instead of showing the memory.

## Validation
- `uv run --group dev pytest tests\test_cli.py::TestMEMANTOCLI::test_recall_displays_string_numeric_fields -q`
- `uv run --group dev pytest tests\test_cli.py -q`
- `uv run --group dev ruff check memanto\cli\commands\memory.py tests\test_cli.py`
- `uv run --group dev python -m py_compile memanto\cli\commands\memory.py tests\test_cli.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI rendering for confidence/score fields with safe numeric coercion and graceful handling of missing, null, or non-numeric values.
  * Updated `recall`, `remember`, and `answer` output so computed confidence and scores format reliably even when returned as strings.

* **Tests**
  * Added a CLI integration test ensuring `recall` displays `confidence`, `computed_confidence`, and `score` correctly when the backend returns numeric fields as strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->