### PR TITLE
Keep agent bootstrap stable with invalid confidence

### DIFF
--- a/memanto/cli/commands/agent.py
+++ b/memanto/cli/commands/agent.py
@@ -368,6 +368,15 @@ def agent_bootstrap(
         console.print(f"\n[dim]Completed in {elapsed:.2f}s[/dim]")
         return
 
+    def _confidence_float(value: Any, default: float = 0.0) -> float:
+        """Return a display-safe confidence value for untrusted memory metadata."""
+        if value is None:
+            return default
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return default
+
     # Compute aggregates
     type_counter: Counter = Counter()
     status_counter: Counter = Counter()
@@ -408,7 +417,7 @@ def agent_bootstrap(
 
     key_knowledge = sorted(
         key_knowledge_raw,
-        key=lambda m: float(m.get("confidence") or 0),
+        key=lambda m: _confidence_float(m.get("confidence")),
         reverse=True,
     )
 
@@ -478,7 +487,7 @@ def agent_bootstrap(
                 _snippet(mem.get("title") or "Untitled", 40),
                 _snippet(mem.get("content") or ""),
                 mem.get("type") or "—",
-                f"{float(mem.get('confidence') or 0):.2f}",
+                f"{_confidence_float(mem.get('confidence')):.2f}",
                 format_local_time(mem.get("created_at")) or "—",
             )
 
@@ -509,7 +518,7 @@ def agent_bootstrap(
                 _snippet(mem.get("title") or "Untitled", 40),
                 _snippet(mem.get("content") or ""),
                 mem.get("type") or "—",
-                f"{float(mem.get('confidence') or 0):.2f}",
+                f"{_confidence_float(mem.get('confidence')):.2f}",
                 format_local_time(mem.get("created_at")) or "—",
             )
 
@@ -531,7 +540,7 @@ def agent_bootstrap(
     for mem_type, label in type_labels.items():
         mems = sorted(
             type_samples.get(mem_type, []),
-            key=lambda m: float(m.get("confidence") or 0),
+            key=lambda m: _confidence_float(m.get("confidence")),
             reverse=True,
         )[:5]
 
@@ -549,7 +558,7 @@ def agent_bootstrap(
                 str(i),
                 _snippet(mem.get("title") or "Untitled", 40),
                 _snippet(mem.get("content") or ""),
-                f"{float(mem.get('confidence') or 0):.2f}",
+                f"{_confidence_float(mem.get('confidence')):.2f}",
             )
 
         console.print(Panel(type_table, title=f"{label} (Top 5)", border_style=ACCENT))
@@ -619,7 +628,7 @@ def agent_bootstrap(
                     _mem_to_dict(m)
                     for m in sorted(
                         type_samples.get(t, []),
-                        key=lambda m: float(m.get("confidence") or 0),
+                        key=lambda m: _confidence_float(m.get("confidence")),
                         reverse=True,
                     )[:5]
                 ]

--- a/memanto/cli/commands/agent.py
+++ b/memanto/cli/commands/agent.py
@@ -3,6 +3,7 @@ MEMANTO CLI - Agent commands (create, list, activate, deactivate, delete, bootst
 """
 
 import json
+import math
 import time
 from collections import Counter
 from datetime import datetime
@@ -373,9 +374,12 @@ def agent_bootstrap(
         if value is None:
             return default
         try:
-            return float(value)
-        except (ValueError, TypeError):
+            confidence = float(value)
+        except (OverflowError, ValueError, TypeError):
             return default
+        if not math.isfinite(confidence):
+            return default
+        return confidence
 
     # Compute aggregates
     type_counter: Counter = Counter()
@@ -396,9 +400,12 @@ def agent_bootstrap(
 
         if mem_conf is not None:
             try:
-                confidence_values.append(float(mem_conf))
-            except (ValueError, TypeError):
+                confidence = float(mem_conf)
+            except (OverflowError, ValueError, TypeError):
                 pass
+            else:
+                if math.isfinite(confidence):
+                    confidence_values.append(confidence)
 
         if mem_created:
             dates.append(str(mem_created))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -629,14 +629,23 @@ class TestMEMANTOCLI:
         mock_all_clients.recall.return_value = {
             "memories": [
                 {
-                    "id": "mem-1",
-                    "title": "Malformed confidence",
+                    "id": f"mem-{index}",
+                    "title": memory["title"],
                     "content": "Backend returned a non-numeric confidence.",
                     "type": "fact",
-                    "confidence": "high",
+                    "confidence": memory["confidence"],
                     "status": "active",
                     "created_at": "2026-06-28T00:00:00Z",
                 }
+                for index, memory in enumerate(
+                    (
+                        {"confidence": "high", "title": "Malformed confidence"},
+                        {"confidence": "nan", "title": "NaN confidence"},
+                        {"confidence": "inf", "title": "Infinite confidence"},
+                        {"confidence": "1e10000", "title": "Oversized confidence"},
+                    ),
+                    start=1,
+                )
             ]
         }
         output_path = tmp_path / "bootstrap.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -617,6 +617,39 @@ class TestMEMANTOCLI:
         assert result.exit_code == 0
         assert "Intelligence Snapshot" in result.stdout
 
+    def test_agent_bootstrap_handles_invalid_confidence(
+        self, mock_all_clients, tmp_path
+    ):
+        """Agent bootstrap should not crash on malformed confidence metadata."""
+        mock_all_clients.get_agent.return_value = {
+            "agent_id": "test-agent",
+            "pattern": "support",
+            "namespace": "memanto_agent_test-agent",
+        }
+        mock_all_clients.recall.return_value = {
+            "memories": [
+                {
+                    "id": "mem-1",
+                    "title": "Malformed confidence",
+                    "content": "Backend returned a non-numeric confidence.",
+                    "type": "fact",
+                    "confidence": "high",
+                    "status": "active",
+                    "created_at": "2026-06-28T00:00:00Z",
+                }
+            ]
+        }
+        output_path = tmp_path / "bootstrap.json"
+
+        result = runner.invoke(
+            app, ["agent", "bootstrap", "--output", str(output_path)]
+        )
+
+        assert result.exit_code == 0
+        report = json.loads(output_path.read_text())
+        assert report["key_knowledge"][0]["title"] == "Malformed confidence"
+        assert report["memory_overview"]["avg_confidence"] == 0.0
+
     def test_memory_batch_remember(self, mock_all_clients, tmp_path):
         """Test 'memanto remember --batch'"""
         batch_file = tmp_path / "batch.json"


### PR DESCRIPTION
## Summary

`memanto agent bootstrap` builds an intelligence snapshot from memory metadata and directly coerced `confidence` values with `float(...)` in several sorting and display paths. If a backend/imported memory carries malformed confidence metadata such as `"high"`, the command crashes before the report is rendered or exported.

This PR adds one display-safe confidence coercion helper for the bootstrap report and uses it anywhere the command ranks or formats memory confidence values. Invalid values now render/rank as `0.00` instead of aborting the snapshot. The existing aggregate average behavior still skips malformed values.

## Reproduction

The regression test mocks a memory returned from recall with `confidence: "high"` and runs:

```bash
memanto agent bootstrap --output bootstrap.json
```

Before the fix, the command exits with `ValueError: could not convert string to float: 'high'`. After the fix, the command completes and writes the JSON report.

## Validation

- `uv run --group dev pytest tests\test_cli.py::TestMEMANTOCLI::test_agent_bootstrap_handles_invalid_confidence tests\test_cli.py::TestMEMANTOCLI::test_agent_bootstrap -q`
- `uv run --group dev pytest tests\test_cli.py -q`
- `uv run --group dev ruff check memanto\cli\commands\agent.py tests\test_cli.py`
- `uv run --group dev python -m py_compile memanto\cli\commands\agent.py tests\test_cli.py`
- `git diff --check` (only Windows LF-to-CRLF warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence handling in the agent bootstrap report by safely treating missing or invalid (non-finite) confidence values as `0.0`.
  * Updated confidence-based ordering and confidence display across “Key Knowledge,” “Recent Activity,” and “Memory By Type” to use consistent, finite values.
  * Ensured JSON output remains stable even when confidence data isn’t numeric.

* **Tests**
  * Added an integration test covering malformed confidence inputs to verify successful report generation and correct averaging/display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->