### PR TITLE
Fix partial ClaudeCode batch memory persistence

### DIFF
--- a/integrations/claudecode/claudecode_memanto/client.py
+++ b/integrations/claudecode/claudecode_memanto/client.py
@@ -205,13 +205,29 @@ class SkillMemory:
             for m in memories
         ]
         try:
-            self._sdk.batch_remember(agent_id=self.config.agent_id, memories=payload)
-            return list(memories)
+            batch_result = self._sdk.batch_remember(
+                agent_id=self.config.agent_id, memories=payload
+            )
+            failed_indices = _failed_batch_indices(batch_result, len(payload))
+            if not failed_indices:
+                return list(memories)
+
+            persisted = [
+                original
+                for i, original in enumerate(memories)
+                if i not in failed_indices
+            ]
+            retry_pairs = [
+                (memories[i], payload[i])
+                for i in failed_indices
+                if i < len(memories) and i < len(payload)
+            ]
         except Exception as exc:
             logger.debug("batch_remember failed, falling back to remember: %s", exc)
+            persisted = []
+            retry_pairs = list(zip(memories, payload, strict=True))
 
-        persisted: list[dict[str, Any]] = []
-        for original, m in zip(memories, payload, strict=True):
+        for original, m in retry_pairs:
             try:
                 self._sdk.remember(
                     agent_id=self.config.agent_id,
@@ -227,3 +243,29 @@ class SkillMemory:
             except Exception as exc:
                 logger.debug("remember failed for %r: %s", m["title"], exc)
         return persisted
+
+
+def _failed_batch_indices(result: dict[str, Any], expected_count: int) -> set[int]:
+    """Return indexes that still need individual retry after a batch write.
+
+    The SDK returns per-item results for mixed batch outcomes. When that shape
+    is missing but the aggregate says something failed, treat the whole batch as
+    uncertain so callers never report unverified memories as persisted.
+    """
+    if int(result.get("failed") or 0) <= 0:
+        return set()
+
+    raw_results = result.get("results")
+    if not isinstance(raw_results, list) or len(raw_results) != expected_count:
+        return set(range(expected_count))
+
+    failed: set[int] = set()
+    for i, item in enumerate(raw_results):
+        if not isinstance(item, dict):
+            failed.add(i)
+            continue
+        status = str(item.get("status", "")).lower()
+        action = str(item.get("action", "")).lower()
+        if status == "failed" or action == "rejected" or item.get("error"):
+            failed.add(i)
+    return failed

--- a/integrations/claudecode/claudecode_memanto/client.py
+++ b/integrations/claudecode/claudecode_memanto/client.py
@@ -252,7 +252,8 @@ def _failed_batch_indices(result: dict[str, Any], expected_count: int) -> set[in
     is missing but the aggregate says something failed, treat the whole batch as
     uncertain so callers never report unverified memories as persisted.
     """
-    if int(result.get("failed") or 0) <= 0:
+    failed_count = int(result.get("failed") or 0)
+    if failed_count <= 0:
         return set()
 
     raw_results = result.get("results")
@@ -268,4 +269,6 @@ def _failed_batch_indices(result: dict[str, Any], expected_count: int) -> set[in
         action = str(item.get("action", "")).lower()
         if status == "failed" or action == "rejected" or item.get("error"):
             failed.add(i)
+    if len(failed) < failed_count:
+        return set(range(expected_count))
     return failed

--- a/integrations/claudecode/tests/test_client.py
+++ b/integrations/claudecode/tests/test_client.py
@@ -102,6 +102,33 @@ class TestDistillAndStore:
         assert len(stored) == 2
         assert len(fake.remembered) == 2  # individual fallback used
 
+    def test_partial_batch_retries_only_failed_items(
+        self, config: SkillsConfig, llm_answer_json: str
+    ) -> None:
+        # batch_remember can return mixed per-item outcomes without raising.
+        # Successful batch items must not be duplicated, and failed items must
+        # not be reported as persisted unless their individual retry works.
+        fake = FakeSdkClient(answer_text=llm_answer_json)
+
+        def partial_batch(agent_id: str, memories: list[dict[str, Any]]) -> dict:
+            fake.batch_calls.append(memories)
+            return {
+                "successful": 1,
+                "failed": 1,
+                "results": [
+                    {"status": "success"},
+                    {"status": "failed", "error": "backend rejected item"},
+                ],
+            }
+
+        fake.batch_remember = partial_batch  # type: ignore[assignment]
+        mem = _mem(config, fake)
+        stored = mem.distill_and_store("tdd", "transcript")
+
+        assert len(stored) == 2
+        assert len(fake.remembered) == 1
+        assert fake.remembered[0]["title"] == "Cart != Order"
+
     def test_llm_failure_falls_back_to_heuristic(self, config: SkillsConfig) -> None:
         fake = FakeSdkClient()
 

--- a/integrations/claudecode/tests/test_client.py
+++ b/integrations/claudecode/tests/test_client.py
@@ -129,6 +129,26 @@ class TestDistillAndStore:
         assert len(fake.remembered) == 1
         assert fake.remembered[0]["title"] == "Cart != Order"
 
+    def test_partial_batch_retries_all_when_failed_count_is_ambiguous(
+        self, config: SkillsConfig, llm_answer_json: str
+    ) -> None:
+        fake = FakeSdkClient(answer_text=llm_answer_json)
+
+        def ambiguous_batch(agent_id: str, memories: list[dict[str, Any]]) -> dict:
+            fake.batch_calls.append(memories)
+            return {
+                "successful": 1,
+                "failed": 1,
+                "results": [{"status": "success"}, {"status": "success"}],
+            }
+
+        fake.batch_remember = ambiguous_batch  # type: ignore[assignment]
+        mem = _mem(config, fake)
+        stored = mem.distill_and_store("tdd", "transcript")
+
+        assert len(stored) == 2
+        assert len(fake.remembered) == 2
+
     def test_llm_failure_falls_back_to_heuristic(self, config: SkillsConfig) -> None:
         fake = FakeSdkClient()
 


### PR DESCRIPTION
/claim #770

## Summary
- Fix the Claude Code SkillMemory persistence path so mixed `batch_remember` outcomes do not get reported as fully persisted.
- When batch results include per-item failures, keep the successful batch items, retry only the failed items with single-memory `remember()`, and return only memories that were actually persisted.
- Treat an aggregate batch failure without aligned per-item results as uncertain and fall back to individual writes instead of returning phantom persisted memories.

## Reproduction
Before this change, `SkillMemory._persist()` returned every extracted memory as stored whenever `batch_remember()` returned without raising, even if the batch response contained `failed > 0` and per-item failed statuses. A Claude Code Stop hook could therefore believe durable engineering decisions had been saved, while failed items were silently absent from future recall.

## Validation
- `uv run --with pytest --with pytest-asyncio --with pytest-timeout --with-editable . --with-editable integrations/claudecode pytest integrations/claudecode/tests/test_client.py::TestDistillAndStore::test_partial_batch_retries_only_failed_items -q`
- `uv run --with pytest --with pytest-asyncio --with pytest-timeout --with-editable . --with-editable integrations/claudecode pytest integrations/claudecode/tests/test_client.py -q`
- `uv run --with ruff --with-editable . --with-editable integrations/claudecode ruff check integrations/claudecode/claudecode_memanto/client.py integrations/claudecode/tests/test_client.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-saving reliability when batch operations return partial success.
  * Only confirmed saved items are now reported back, reducing duplicate or incorrect results.
  * Failed items are retried individually, and mixed batch outcomes are handled more accurately.
* **Tests**
  * Added coverage for mixed and ambiguous batch-result scenarios to ensure the retry behavior matches expected stored results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->