### PR TITLE
Skip invalid agent metadata when listing agents

### DIFF
--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -5,16 +5,20 @@ Handles agent creation, listing, and lifecycle management.
 """
 
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 
 from moorcheh_sdk.exceptions import ConflictError
+from pydantic import ValidationError
 
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import get_data_dir
 from memanto.app.core import create_memory_scope
 from memanto.app.models.session import AgentCreate, AgentInfo, AgentList
 from memanto.app.utils.errors import AgentAlreadyExistsError, AgentNotFoundError
+
+logger = logging.getLogger(__name__)
 
 
 class AgentService:
@@ -134,9 +138,13 @@ class AgentService:
         """
         agents = []
         for agent_file in self.agents_dir.glob("*.json"):
-            with open(agent_file) as f:
-                data = json.load(f)
+            try:
+                with open(agent_file) as f:
+                    data = json.load(f)
                 agents.append(AgentInfo(**data))
+            except (OSError, json.JSONDecodeError, TypeError, ValidationError) as exc:
+                logger.warning("Skipping invalid agent metadata %s: %s", agent_file, exc)
+                continue
 
         # Sort by created_at (newest first)
         agents.sort(key=lambda a: a.created_at, reverse=True)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -191,6 +191,19 @@ class TestAgentService:
 
         print(f"✅ Listed {agent_list.count} agents")
 
+    def test_list_agents_skips_invalid_metadata_files(self, agent_service):
+        """Listing agents should ignore corrupt local metadata files."""
+        agent_service.create_agent(
+            AgentCreate(agent_id="valid-agent", pattern=AgentPattern.SUPPORT),
+            settings.MOORCHEH_API_KEY,
+        )
+        (agent_service.agents_dir / "broken.json").write_text("{not-json")
+
+        agent_list = agent_service.list_agents()
+
+        assert agent_list.count == 1
+        assert [agent.agent_id for agent in agent_list.agents] == ["valid-agent"]
+
     def test_get_agent(self, agent_service):
         """Test getting agent info"""
         # Create agent


### PR DESCRIPTION
## Summary
- keep `AgentService.list_agents()` resilient when one local agent metadata file is corrupt, truncated, unreadable, or fails Pydantic validation
- log and skip only the invalid metadata file so healthy agents still appear in `memanto agent list`
- add a regression test covering a valid agent next to a malformed JSON file

## Reproduction
Before the fix, a single bad file under the agents metadata directory made `list_agents()` raise `json.decoder.JSONDecodeError`, so users could not list or switch to otherwise valid local agents.

```python
agent_service.create_agent(AgentCreate(agent_id="valid-agent", pattern=AgentPattern.SUPPORT), key)
(agent_service.agents_dir / "broken.json").write_text("{not-json")
agent_service.list_agents()  # crashed before this PR
```

## Validation
- `uv run --group dev pytest tests\test_unit.py::TestAgentService::test_list_agents_skips_invalid_metadata_files -q`
- `uv run --group dev pytest tests\test_unit.py::TestAgentService -q`
- `uv run --group dev pytest tests\test_unit.py -q`
- `uv run --group dev ruff check memanto\app\services\agent_service.py tests\test_unit.py`
- `uv run --group dev python -m py_compile memanto\app\services\agent_service.py tests\test_unit.py`
- `git diff --check`

Parent bounty: #770