### PR TITLE
Preserve falsey nested metadata fields

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -746,13 +746,17 @@ class MemoryReadService:
 
         # Check if metadata is in nested format (Moorcheh API spec)
         metadata = item.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
 
         # Helper to get field from either nested metadata or flat structure
         def get_field(field_name, flat_field_name=None):
             """Get field from metadata object or fallback to flat field"""
             flat_name = flat_field_name or field_name
             # Try metadata object first (API spec), then flat field (fallback)
-            return metadata.get(field_name) or item.get(flat_name)
+            if field_name in metadata:
+                return metadata[field_name]
+            return item.get(flat_name)
 
         # Parse tags - can be comma-separated string or array
         tags_value = get_field("tags")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,42 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceFormat:
+    """Memory formatting should prefer nested metadata without losing falsey values."""
+
+    def test_format_memory_item_preserves_falsey_metadata_values(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        service = MemoryReadService(MagicMock())
+
+        formatted = service._format_memory_item(
+            {
+                "id": "mem-1",
+                "text": "[FACT] Zero confidence\n\nStored with explicit falsey values.",
+                "metadata": {
+                    "memory_type": "fact",
+                    "confidence": 0.0,
+                    "tags": [],
+                    "validation_count": 0,
+                    "contradiction_detected": False,
+                    "ttl_seconds": 0,
+                },
+                # Flat fields should not replace valid falsey nested metadata.
+                "confidence": 0.95,
+                "tags": "stale",
+                "validation_count": 7,
+                "contradiction_detected": True,
+                "ttl_seconds": 3600,
+            }
+        )
+
+        assert formatted["confidence"] == 0.0
+        assert formatted["tags"] == []
+        assert formatted["validation_count"] == 0
+        assert formatted["contradiction_detected"] is False
+        assert formatted["ttl_seconds"] == 0
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
Summary:
- Preserve explicit falsey values from nested Moorcheh metadata when formatting memory items.
- Only fall back to flat fields when the nested metadata key is absent, not when its value is `0`, `False`, or `[]`.
- Add regression coverage for `confidence: 0.0`, empty tags, zero validation count, false contradiction flags, and zero TTL values.

Reproduction from current service layer:
```py
from unittest.mock import MagicMock
from memanto.app.services.memory_read_service import MemoryReadService

item = {
    "text": "[FACT] Zero confidence\n\nStored with explicit falsey values.",
    "metadata": {"confidence": 0.0, "tags": [], "validation_count": 0, "contradiction_detected": False},
    "confidence": 0.95,
    "tags": "stale",
    "validation_count": 7,
    "contradiction_detected": True,
}
print(MemoryReadService(MagicMock())._format_memory_item(item))
```
Before this fix, nested `0.0` / `[]` / `0` / `False` values are treated as missing and overwritten by the flat fallback fields.

Validation:
- `uv run --group dev pytest tests\\test_unit.py::TestMemoryReadServiceFormat::test_format_memory_item_preserves_falsey_metadata_values -q`
- `uv run --group dev pytest tests\\test_unit.py -q`
- `uv run --group dev ruff check memanto\\app\\services\\memory_read_service.py tests\\test_unit.py`
- `uv run --group dev python -m py_compile memanto\\app\\services\\memory_read_service.py tests\\test_unit.py`
- `git diff --check` (only Windows LF-to-CRLF warnings)

Parent bounty: #770