### PR TITLE
Skip invalid session files

### DIFF
--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -6,12 +6,14 @@ Uses JWT tokens for stateless authentication.
 """
 
 import json
+import logging
 import os
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
 import jwt
+from pydantic import ValidationError
 
 from memanto.app.config import get_data_dir, settings
 from memanto.app.core import create_memory_scope
@@ -31,6 +33,7 @@ from memanto.app.utils.ids import generate_id
 from memanto.app.utils.temporal_helpers import utc_now
 
 _session_service = None
+logger = logging.getLogger(__name__)
 
 
 def get_session_service() -> "SessionService":
@@ -184,12 +187,7 @@ class SessionService:
             Session object or None if not found
         """
         session_file = self.sessions_dir / f"{agent_id}.json"
-        if not session_file.exists():
-            return None
-
-        with open(session_file) as f:
-            data = json.load(f)
-            return Session(**data)
+        return self._load_session_file(session_file)
 
     def get_active_session(self) -> Session | None:
         """
@@ -329,6 +327,19 @@ class SessionService:
         with open(session_file, "w") as f:
             json.dump(session.model_dump(mode="json"), f, indent=2)
 
+    def _load_session_file(self, session_file: Path) -> Session | None:
+        """Load one session file, treating corrupt local state as absent."""
+        if not session_file.exists():
+            return None
+
+        try:
+            with open(session_file) as f:
+                data = json.load(f)
+            return Session(**data)
+        except (OSError, json.JSONDecodeError, TypeError, ValidationError) as exc:
+            logger.warning("Skipping invalid session file %s: %s", session_file, exc)
+            return None
+
     def log_memory_to_session_summary(
         self,
         agent_id: str,
@@ -462,8 +473,8 @@ class SessionService:
         """
         sessions = []
         for session_file in self.sessions_dir.glob("*.json"):
-            with open(session_file) as f:
-                data = json.load(f)
-                sessions.append(Session(**data))
+            session = self._load_session_file(session_file)
+            if session is not None:
+                sessions.append(session)
 
         return sorted(sessions, key=lambda s: s.started_at, reverse=True)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -119,6 +119,26 @@ class TestSessionService:
         print("✅ Session ended successfully")
         print(f"   Duration: {summary.duration_hours} hours")
 
+    def test_get_active_session_ignores_invalid_session_file(self, session_service):
+        """A corrupt active session file should not crash status checks."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.write_text("broken-agent")
+        (session_service.sessions_dir / "broken-agent.json").write_text("{")
+
+        assert session_service.get_active_session() is None
+
+    def test_list_sessions_skips_invalid_session_files(self, session_service):
+        """One corrupt session record must not hide all valid sessions."""
+        valid_session = session_service.create_session(
+            agent_id="valid-agent",
+            duration_hours=1,
+        )
+        (session_service.sessions_dir / "broken-agent.json").write_text("{")
+
+        sessions = session_service.list_sessions()
+
+        assert [session.agent_id for session in sessions] == [valid_session.agent_id]
+
 
 class TestAgentService:
     """Unit tests for AgentService"""


### PR DESCRIPTION
Summary:
- Treat corrupt or invalid local session JSON files as absent instead of letting them crash session status/listing flows.
- Reuse one `_load_session_file()` helper from both `get_session()` and `list_sessions()`.
- Add regression coverage for a corrupt active session file and for `list_sessions()` skipping one bad record while preserving valid sessions.

Root cause:
`SessionService.get_session()` and `list_sessions()` loaded local `~/.memanto/sessions/*.json` records directly with `json.load()` and `Session(**data)`. A truncated file such as `{` raised `JSONDecodeError`, so `get_active_session()` / `/status` and session listing paths could fail entirely because of one damaged local state file.

Reproduction from the current service layer:
```py
service = SessionService(secret_key="test-secret-key-min-32-bytes-1234", sessions_dir=sessions_dir)
(sessions_dir / "active").write_text("broken-agent")
(sessions_dir / "broken-agent.json").write_text("{")
service.get_active_session()  # currently raises JSONDecodeError
```

Validation:
- `uv run --group dev pytest tests\\test_unit.py::TestSessionService::test_get_active_session_ignores_invalid_session_file tests\\test_unit.py::TestSessionService::test_list_sessions_skips_invalid_session_files -q`
- `uv run --group dev pytest tests\\test_unit.py -q`
- `uv run --group dev ruff check memanto\\app\\services\\session_service.py tests\\test_unit.py`
- `uv run --group dev python -m py_compile memanto\\app\\services\\session_service.py tests\\test_unit.py`
- `git diff --check` (only Windows LF-to-CRLF warnings)

Duplicate check:
- This is separate from #1225, which handles corrupt agent metadata files.
- This is separate from #853, which handles timezone-aware session datetime comparisons.

Parent bounty: #770