### PR TITLE
Keep session info stable with timezone-aware expiry

### DIFF
--- a/memanto/cli/commands/session.py
+++ b/memanto/cli/commands/session.py
@@ -2,7 +2,7 @@
 MEMANTO CLI - Legacy session aliases for agent activation commands.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import jwt
 from rich.table import Table
@@ -38,10 +38,12 @@ def session_info():
         payload = jwt.decode(active_session_token, options={"verify_signature": False})
         expires_at_str = payload.get("expires_at")
         if expires_at_str:
-            # Handle fromisoformat replacing Z if needed
+            # Normalize JWT UTC offsets to the CLI's existing naive UTC clock.
             if expires_at_str.endswith("Z"):
-                expires_at_str = expires_at_str[:-1]
+                expires_at_str = expires_at_str[:-1] + "+00:00"
             expires_at = datetime.fromisoformat(expires_at_str)
+            if expires_at.tzinfo is not None:
+                expires_at = expires_at.astimezone(timezone.utc).replace(tzinfo=None)
             now = datetime.utcnow()
 
             if now > expires_at:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,10 @@ Uses extensive mocking to intercept API calls across all command modules.
 """
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import jwt
 import pytest
 from typer.testing import CliRunner
 
@@ -567,6 +569,24 @@ class TestMEMANTOCLI:
         assert result.exit_code == 0
         assert "Active Agent" in result.stdout
         assert "Session Token" in result.stdout
+
+    def test_session_info_handles_timezone_aware_token(self, mock_all_clients):
+        """Test 'memanto session info' displays aware JWT expirations."""
+        from memanto.cli.commands import session as session_commands
+
+        expires_at = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        token = jwt.encode({"expires_at": expires_at}, key="", algorithm="none")
+        session_commands.config_manager.get_active_session.return_value = (
+            "test-agent",
+            token,
+        )
+
+        result = runner.invoke(app, ["session", "info"])
+
+        assert result.exit_code == 0
+        assert "Active" in result.stdout
+        assert "Time Remaining" in result.stdout
+        assert "Unknown" not in result.stdout
 
     def test_agent_deactivate(self, mock_all_clients):
         """Test 'memanto agent deactivate'"""


### PR DESCRIPTION
## Summary

Fixes a narrow legacy CLI session-status bug in `memanto session info`: JWT payloads can contain ISO expirations with a UTC offset such as `2026-03-19T20:00:00+00:00`, but the command compared that aware datetime against the existing naive UTC `datetime.utcnow()` clock. That raised `TypeError` internally and the command showed `Unknown (Token unreadable)` even though the token decoded correctly.

This normalizes aware JWT expiry values to naive UTC before computing status and time remaining. The change is scoped to the legacy CLI command and does not alter session validation or persistence.

## Why

The broader session datetime fix in #853 covers model/service comparisons, but `memanto/cli/commands/session.py` performs its own JWT decode and time comparison. Users can still see an unreadable/unknown active session in the legacy CLI alias when the token expiry includes `+00:00`.

## Validation

- `uv run --group dev pytest tests\test_cli.py::TestMEMANTOCLI::test_session_info tests\test_cli.py::TestMEMANTOCLI::test_session_info_handles_timezone_aware_token -q`
- `uv run --group dev pytest tests\test_cli.py -q`
- `uv run --group dev ruff check memanto\cli\commands\session.py tests\test_cli.py`
- `uv run --group dev python -m py_compile memanto\cli\commands\session.py tests\test_cli.py`
- `git diff --check` (only Windows LF-to-CRLF warnings)

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session expiration handling so time remaining is calculated correctly for tokens with timezone-aware expiry timestamps.
  * Session details now display more reliably for active sessions instead of showing an unknown status in this case.

* **Tests**
  * Added coverage for viewing session info when the active token includes a timezone-aware expiration time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->