### PR TITLE
Recover connect install from malformed JSON state

### DIFF
--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -299,11 +299,13 @@ def _remove_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str |
 
 
 def _read_json_object(path: Path) -> dict[str, Any]:
+    """Read a JSON file and return an object shape, falling back to empty dict."""
     data = json.loads(path.read_text(encoding="utf-8"))
     return data if isinstance(data, dict) else {}
 
 
 def _ensure_dict(container: dict[str, Any], key: str) -> dict[str, Any]:
+    """Return a child dict at ``key``, replacing malformed values in place."""
     value = container.get(key)
     if isinstance(value, dict):
         return value
@@ -313,6 +315,7 @@ def _ensure_dict(container: dict[str, Any], key: str) -> dict[str, Any]:
 
 
 def _ensure_list(container: dict[str, Any], key: str) -> list[Any]:
+    """Return a child list at ``key``, replacing malformed values in place."""
     value = container.get(key)
     if isinstance(value, list):
         return value

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -298,6 +298,29 @@ def _remove_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str |
     return None
 
 
+def _read_json_object(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _ensure_dict(container: dict[str, Any], key: str) -> dict[str, Any]:
+    value = container.get(key)
+    if isinstance(value, dict):
+        return value
+    replacement: dict[str, Any] = {}
+    container[key] = replacement
+    return replacement
+
+
+def _ensure_list(container: dict[str, Any], key: str) -> list[Any]:
+    value = container.get(key)
+    if isinstance(value, list):
+        return value
+    replacement: list[Any] = []
+    container[key] = replacement
+    return replacement
+
+
 # Internal: Hook configuration (Claude Code)
 
 
@@ -320,14 +343,11 @@ def _install_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str 
     config_dir.mkdir(parents=True, exist_ok=True)
     settings_path = config_dir / agent.hook_config.settings_file
 
-    if settings_path.exists():
-        settings = json.loads(settings_path.read_text(encoding="utf-8"))
-    else:
-        settings = {}
+    settings = _read_json_object(settings_path) if settings_path.exists() else {}
 
     # Navigate to hook location
-    hooks = settings.setdefault("hooks", {})
-    session_start = hooks.setdefault("SessionStart", [])
+    hooks = _ensure_dict(settings, "hooks")
+    session_start = _ensure_list(hooks, "SessionStart")
 
     # Check if memanto hook already exists
     memanto_exists = any(
@@ -374,17 +394,14 @@ def _install_permissions(
 
     config_dir.mkdir(parents=True, exist_ok=True)
 
-    if perm_path.exists():
-        existing = json.loads(perm_path.read_text(encoding="utf-8"))
-    else:
-        existing = {}
+    existing = _read_json_object(perm_path) if perm_path.exists() else {}
 
     # Merge permissions
     changed = False
     for key, value in agent.permissions_payload.items():
         if key == "permissions":
-            perms = existing.setdefault("permissions", {})
-            allow_list = perms.setdefault("allow", [])
+            perms = _ensure_dict(existing, "permissions")
+            allow_list = _ensure_list(perms, "allow")
             for perm in value.get("allow", []):
                 if perm not in allow_list:
                     allow_list.append(perm)

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -10,6 +10,7 @@ from memanto.cli.connect.engine import _install_hooks, _install_permissions
 
 
 def _load_json(path: Path) -> dict:
+    """Load a settings file and assert the repair path wrote an object."""
     data = json.loads(path.read_text(encoding="utf-8"))
     assert isinstance(data, dict)
     return data

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -1,0 +1,70 @@
+"""Regression tests for AI-agent connect engine state file handling."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from memanto.cli.connect.agent_registry import AGENT_REGISTRY
+from memanto.cli.connect.engine import _install_hooks, _install_permissions
+
+
+def _load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_install_hooks_recovers_from_non_object_settings(tmp_path: Path) -> None:
+    """A hand-edited Claude settings file must not block hook setup."""
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+
+    result = _install_hooks(AGENT_REGISTRY["claude-code"], tmp_path, False)
+
+    assert result == "Added SessionStart hook"
+    settings = _load_json(settings_path)
+    session_start = settings["hooks"]["SessionStart"]
+    assert isinstance(session_start, list)
+    assert any(
+        "memanto memory sync" in hook["command"]
+        for group in session_start
+        for hook in group["hooks"]
+    )
+
+
+def test_install_hooks_recovers_from_malformed_hook_containers(
+    tmp_path: Path,
+) -> None:
+    """Malformed nested hook containers should be replaced, not crash."""
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps({"hooks": {"SessionStart": "not-a-list"}}),
+        encoding="utf-8",
+    )
+
+    result = _install_hooks(AGENT_REGISTRY["claude-code"], tmp_path, False)
+
+    assert result == "Added SessionStart hook"
+    settings = _load_json(settings_path)
+    assert isinstance(settings["hooks"]["SessionStart"], list)
+
+
+def test_install_permissions_recovers_from_malformed_permission_containers(
+    tmp_path: Path,
+) -> None:
+    """A malformed permissions shape should not prevent MEMANTO permission setup."""
+    permissions_path = tmp_path / ".claude" / "settings.local.json"
+    permissions_path.parent.mkdir(parents=True)
+    permissions_path.write_text(
+        json.dumps({"permissions": {"allow": "not-a-list"}}),
+        encoding="utf-8",
+    )
+
+    result = _install_permissions(AGENT_REGISTRY["claude-code"], tmp_path, False)
+
+    assert result == "Added permissions"
+    settings = _load_json(permissions_path)
+    assert settings["permissions"]["allow"] == ["Bash(memanto:*)"]


### PR DESCRIPTION
## Summary

This fixes a reproducible `memanto connect claude-code` setup failure when a hand-edited Claude Code JSON state file is still valid JSON but has the wrong container shape.

Before this change, these local files could make hook or permission setup fail after instructions/skills had already been written:

- `.claude/settings.json` with a non-object top-level value
- `.claude/settings.json` with `hooks.SessionStart` set to a non-list value
- `.claude/settings.local.json` with `permissions.allow` set to a non-list value

The connect engine now normalizes readable-but-malformed JSON containers back to the object/list shapes it needs before merging MEMANTO-managed hooks and permissions. Invalid JSON syntax still surfaces as an error instead of being silently overwritten.

## Validation

- `uv run --group dev pytest tests\test_connect_engine.py -q`
- `uv run --group dev pytest tests\test_cli.py::TestMEMANTOCLI::test_daily_summary -q`
- `uv run --group dev pytest tests\test_cli.py -q`
- `uv run --group dev ruff check memanto\cli\connect\engine.py tests\test_connect_engine.py`
- `uv run --group dev python -m py_compile memanto\cli\connect\engine.py tests\test_connect_engine.py`
- `git diff --check` (Windows line-ending warning only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of setup when local configuration files contain invalid or unexpected JSON structures; missing or malformed sections are now automatically repaired.
  * Ensured hook and permission settings are correctly preserved and updated even after manual edits or incomplete configuration data.
* **Tests**
  * Added regression coverage to confirm damaged configuration files are repaired and that hook and permission updates apply as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->