### PR TITLE
Recover malformed connections registry entries

### DIFF
--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -440,6 +440,7 @@ class ConfigManager:
 
     @staticmethod
     def _normalize_connection_entry(entry) -> dict:
+        """Return a canonical connection entry from possibly malformed JSON."""
         if not isinstance(entry, dict):
             return {"projects": [], "installed_global": False}
 

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -438,6 +438,20 @@ class ConfigManager:
     # Connections registry — tracks which agents have memanto installed where.
     # Forward-only: only updated by future install/remove calls, not backfilled.
 
+    @staticmethod
+    def _normalize_connection_entry(entry) -> dict:
+        if not isinstance(entry, dict):
+            return {"projects": [], "installed_global": False}
+
+        raw_projects = entry.get("projects", [])
+        projects = raw_projects if isinstance(raw_projects, list) else []
+        projects = [p for p in projects if isinstance(p, str) and p]
+
+        return {
+            "projects": projects,
+            "installed_global": entry.get("installed_global") is True,
+        }
+
     def load_connections(self) -> dict:
         """Load the connections registry from ~/.memanto/connections.json."""
         if not self.connections_file.exists():
@@ -445,7 +459,13 @@ class ConfigManager:
         try:
             with open(self.connections_file, encoding="utf-8") as f:
                 data = json.load(f)
-            return data if isinstance(data, dict) else {}
+            if not isinstance(data, dict):
+                return {}
+            return {
+                name: self._normalize_connection_entry(entry)
+                for name, entry in data.items()
+                if isinstance(name, str) and name
+            }
         except Exception:
             return {}
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -348,7 +348,10 @@ class TestForgetEndToEnd:
 
 
 class TestConfigManagerConnections:
+    """Tests for repairing malformed AI-agent connection registry entries."""
+
     def test_load_connections_normalizes_malformed_entries(self, tmp_path):
+        """Malformed entries load as canonical project/global connection records."""
         from memanto.cli.config.manager import ConfigManager
 
         manager = ConfigManager(config_dir=tmp_path)
@@ -379,6 +382,7 @@ class TestConfigManagerConnections:
         }
 
     def test_add_connection_replaces_malformed_agent_entry(self, tmp_path):
+        """Adding a project connection replaces a malformed per-agent entry."""
         from memanto.cli.config.manager import ConfigManager
 
         manager = ConfigManager(config_dir=tmp_path)
@@ -399,6 +403,7 @@ class TestConfigManagerConnections:
         }
 
     def test_remove_connection_cleans_malformed_agent_entry(self, tmp_path):
+        """Removing from a malformed per-agent entry leaves a clean registry."""
         from memanto.cli.config.manager import ConfigManager
 
         manager = ConfigManager(config_dir=tmp_path)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,6 +4,7 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
+import json
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -344,6 +345,71 @@ class TestForgetEndToEnd:
         result = client.delete_memory(agent_id="test-agent", memory_id="mem-xyz")
         assert result["status"] == "deleted"
         assert result["memory_id"] == "mem-xyz"
+
+
+class TestConfigManagerConnections:
+    def test_load_connections_normalizes_malformed_entries(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.connections_file.write_text(
+            json.dumps(
+                {
+                    "claude-code": "installed",
+                    "cursor": {
+                        "projects": "not-a-list",
+                        "installed_global": "false",
+                    },
+                    "windsurf": {
+                        "projects": [str(tmp_path / "project"), "", 123],
+                        "installed_global": True,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert manager.load_connections() == {
+            "claude-code": {"projects": [], "installed_global": False},
+            "cursor": {"projects": [], "installed_global": False},
+            "windsurf": {
+                "projects": [str(tmp_path / "project")],
+                "installed_global": True,
+            },
+        }
+
+    def test_add_connection_replaces_malformed_agent_entry(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        project_dir = tmp_path / "project"
+        manager.connections_file.write_text(
+            json.dumps({"claude-code": ["bad entry"]}),
+            encoding="utf-8",
+        )
+
+        manager.add_connection("claude-code", str(project_dir), is_global=False)
+
+        data = json.loads(manager.connections_file.read_text(encoding="utf-8"))
+        assert data == {
+            "claude-code": {
+                "projects": [str(project_dir.resolve())],
+                "installed_global": False,
+            }
+        }
+
+    def test_remove_connection_cleans_malformed_agent_entry(self, tmp_path):
+        from memanto.cli.config.manager import ConfigManager
+
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.connections_file.write_text(
+            json.dumps({"claude-code": "bad entry"}),
+            encoding="utf-8",
+        )
+
+        manager.remove_connection("claude-code", str(tmp_path), is_global=False)
+
+        assert json.loads(manager.connections_file.read_text(encoding="utf-8")) == {}
 
 
 class TestMEMANTOArchitecture:


### PR DESCRIPTION
## Summary
- normalize per-agent entries loaded from `~/.memanto/connections.json`
- recover malformed connection records as empty connection state instead of letting add/remove paths crash
- keep invalid project lists and non-boolean global flags from leaking into UI/CLI connection state

## Root Cause
`ConfigManager.load_connections()` only validated that the registry top level was a JSON object. If one agent entry was valid JSON but had the wrong shape, such as `"claude-code": "installed"` or `"projects": "not-a-list"`, later `add_connection()` / `remove_connection()` treated that value as a dict/list and could raise `TypeError` during connect install or uninstall cleanup.

## Validation
- `uv run --group dev pytest tests\test_unit.py::TestConfigManagerConnections -q`
- `uv run --group dev pytest tests\test_unit.py -q`
- `uv run --group dev pytest tests\test_cli.py::TestMEMANTOCLI::test_connect_list -q`
- `uv run --group dev ruff check memanto\cli\config\manager.py tests\test_unit.py`
- `uv run --group dev python -m py_compile memanto\cli\config\manager.py tests\test_unit.py`
- `git diff --check` (Windows LF-to-CRLF warning only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection settings are now validated and normalized when loaded, preventing malformed saved data from causing issues.
  * Empty or invalid project entries are filtered out, and global install values are consistently handled as true/false.
  * Adding or removing a connection now correctly repairs older malformed entries and can leave the connections list empty when appropriate.
* **Tests**
  * Added coverage for loading, adding, and removing connections with malformed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->