### PR TITLE
Validate migrate export JSON shape

### DIFF
--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -23,7 +23,7 @@ import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from memanto.cli.migrate.mappers import MAPPERS, type_breakdown
 
@@ -60,7 +60,10 @@ def load_export(file_path: Path) -> dict[str, Any]:
     """Load a previously-produced provider export JSON from disk."""
     if not file_path.exists():
         raise FileNotFoundError(f"Export file not found: {file_path}")
-    return cast(dict[str, Any], json.loads(file_path.read_text(encoding="utf-8")))
+    data = json.loads(file_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Export file must be a JSON object: {file_path}")
+    return data
 
 
 def map_export(provider: str, export: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/test_migrate_runner.py
+++ b/tests/test_migrate_runner.py
@@ -1,0 +1,13 @@
+import pytest
+
+from memanto.cli.migrate.runner import load_export
+
+
+class TestMigrateLoadExport:
+    @pytest.mark.parametrize("payload", ["[]", '"not an export"', "null"])
+    def test_load_export_rejects_non_object_json(self, tmp_path, payload):
+        export_path = tmp_path / "mem0_export.json"
+        export_path.write_text(payload, encoding="utf-8")
+
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            load_export(export_path)

--- a/tests/test_migrate_runner.py
+++ b/tests/test_migrate_runner.py
@@ -1,11 +1,16 @@
+"""Focused regression tests for migration runner helpers."""
+
 import pytest
 
 from memanto.cli.migrate.runner import load_export
 
 
 class TestMigrateLoadExport:
+    """Validate loading migration export files from disk."""
+
     @pytest.mark.parametrize("payload", ["[]", '"not an export"', "null"])
     def test_load_export_rejects_non_object_json(self, tmp_path, payload):
+        """Non-object JSON roots fail before provider-specific mapping starts."""
         export_path = tmp_path / "mem0_export.json"
         export_path.write_text(payload, encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- reject migration export files whose parsed JSON root is not an object
- add focused regression coverage for array, string, and null JSON roots
- preserve existing valid supermemory/mem0/letta dry-run behavior

## Root Cause
`load_export()` parsed JSON and cast the result to `dict[str, Any]` without checking the runtime type. A valid JSON file with an array, string, or `null` root could pass the loader and then fail later in `source_count()` or provider mappers when they call `.get(...)`, producing an internal `AttributeError` in migration preview/import flows instead of a clear export validation error.

## Validation
- Confirmed the new regression failed before the fix with `Failed: DID NOT RAISE <class 'ValueError'>`
- `uv run --group dev pytest tests\test_migrate_runner.py::TestMigrateLoadExport::test_load_export_rejects_non_object_json -q`
- `uv run --group dev pytest tests\test_cli.py::TestMEMANTOCLI::test_migrate_supermemory_dry_run tests\test_cli.py::TestMEMANTOCLI::test_migrate_mem0_dry_run tests\test_cli.py::TestMEMANTOCLI::test_migrate_letta_dry_run -q`
- `uv run --group dev pytest tests\test_cli.py -q`
- `uv run --group dev ruff check memanto\cli\migrate\runner.py tests\test_migrate_runner.py`
- `uv run --group dev python -m py_compile memanto\cli\migrate\runner.py tests\test_migrate_runner.py`
- `git diff --check` (Windows LF-to-CRLF warning only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export loading to validate the JSON structure before processing.
  * Non-object JSON values now return a clear error instead of being accepted silently.
* **Tests**
  * Added coverage for invalid export files, including arrays, strings, and null values, to confirm the new validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->