### PR TITLE
fix: correct import path in search_multi_scope method

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -175,7 +175,7 @@ class MemoryReadService:
             namespaces = []
             from typing import cast
 
-            from memanto.memanto.app.constants import ScopeType
+            from memanto.app.constants import ScopeType
 
             for scope_def in scopes:
                 scope = create_memory_scope(


### PR DESCRIPTION
Bug: The import statement at line 178 of memory_read_service.py referenced 'memanto.memanto.app.constants' (double memanto prefix) instead of 'memanto.app.constants'. This causes an ImportError at runtime when search_multi_scope() is called because there is no module named 'memanto.memanto'.

Impact: Any caller of search_multi_scope() would fail with 'ModuleNotFoundError: No module named memanto.memanto'. This affects multi-scope memory search functionality.

Fix: Changed 'memanto.memanto.app.constants' to 'memanto.app.constants'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search behavior so scope types are resolved correctly across memory search scopes, improving result accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->