### PR TITLE
Guard migrate imports against malformed record arrays

### DIFF
--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -73,8 +73,15 @@ def _coerce_type(raw: str | None) -> str | None:
     return t if t in VALID_MEMORY_TYPES else None
 
 
-def _scope_tag(scope: dict[str, Any] | None) -> str | None:
-    if not scope:
+def _dict_records(value: Any) -> list[dict[str, Any]]:
+    """Return only object records from provider-owned arrays."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _scope_tag(scope: Any) -> str | None:
+    if not isinstance(scope, dict):
         return None
     for k, v in scope.items():
         if v:
@@ -113,7 +120,9 @@ def _parse_dt(value: Any) -> datetime | None:
     return None
 
 
-def _pick_first_dt(record: dict[str, Any], keys: tuple[str, ...]) -> datetime | None:
+def _pick_first_dt(record: Any, keys: tuple[str, ...]) -> datetime | None:
+    if not isinstance(record, dict):
+        return None
     for key in keys:
         dt = _parse_dt(record.get(key))
         if dt is not None:
@@ -182,7 +191,7 @@ def map_mem0(export: dict[str, Any]) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     migrated_at = _now_utc()
 
-    for mem in export.get("memories", []) or []:
+    for mem in _dict_records(export.get("memories")):
         content = (mem.get("memory") or mem.get("content") or "").strip()
         if not content:
             continue
@@ -245,7 +254,7 @@ def map_letta(export: dict[str, Any]) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     migrated_at = _now_utc()
 
-    for passage in export.get("passages", []) or []:
+    for passage in _dict_records(export.get("passages")):
         content = (passage.get("text") or passage.get("content") or "").strip()
         if not content:
             continue
@@ -311,7 +320,7 @@ def map_supermemory(export: dict[str, Any]) -> list[dict[str, Any]]:
     seen: set[str] = set()
     migrated_at = _now_utc()
 
-    for mem in export.get("memories", []) or []:
+    for mem in _dict_records(export.get("memories")):
         content = (
             mem.get("content") or mem.get("memory") or mem.get("text") or ""
         ).strip()
@@ -359,13 +368,13 @@ def map_supermemory(export: dict[str, Any]) -> list[dict[str, Any]]:
         return rows
 
     # Fallback: harvest chunk text when extracted memories are empty.
-    for doc in export.get("documents", []) or []:
+    for doc in _dict_records(export.get("documents")):
         doc_tags = [str(t) for t in (doc.get("container_tags") or []) if t]
         doc_id = doc.get("id")
         doc_created = _pick_first_dt(
             doc.get("detail") or doc, ("createdAt", "created_at")
         )
-        for chunk in doc.get("chunks", []) or []:
+        for chunk in _dict_records(doc.get("chunks")):
             content = (chunk.get("content") or chunk.get("text") or "").strip()
             if not content or content in seen:
                 continue

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -121,6 +121,7 @@ def _parse_dt(value: Any) -> datetime | None:
 
 
 def _pick_first_dt(record: Any, keys: tuple[str, ...]) -> datetime | None:
+    """Pick the first parseable timestamp from a source object."""
     if not isinstance(record, dict):
         return None
     for key in keys:
@@ -178,6 +179,7 @@ def _attach_footer(content: str, footer: str) -> str:
 
 
 def _now_utc() -> datetime:
+    """Return the current UTC timestamp for migrated rows."""
     return datetime.now(timezone.utc)
 
 
@@ -371,9 +373,10 @@ def map_supermemory(export: dict[str, Any]) -> list[dict[str, Any]]:
     for doc in _dict_records(export.get("documents")):
         doc_tags = [str(t) for t in (doc.get("container_tags") or []) if t]
         doc_id = doc.get("id")
+        detail = doc.get("detail")
         doc_created = _pick_first_dt(
-            doc.get("detail") or doc, ("createdAt", "created_at")
-        )
+            detail, ("createdAt", "created_at")
+        ) or _pick_first_dt(doc, ("createdAt", "created_at"))
         for chunk in _dict_records(doc.get("chunks")):
             content = (chunk.get("content") or chunk.get("text") or "").strip()
             if not content or content in seen:

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -86,11 +86,23 @@ def write_preview(rows: list[dict[str, Any]], dest: Path) -> Path:
 
 
 def _source_list(value: Any) -> list[Any]:
+    """Return provider source arrays only when they are actually lists."""
     return value if isinstance(value, list) else []
 
 
 def _source_dicts(value: Any) -> list[dict[str, Any]]:
+    """Return only object entries from a provider source array."""
     return [item for item in _source_list(value) if isinstance(item, dict)]
+
+
+def _supermemory_memory_sources(export: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return Supermemory memory records with text the mapper can import."""
+    records = _source_dicts(export.get("memories"))
+    return [
+        record
+        for record in records
+        if (record.get("content") or record.get("memory") or record.get("text") or "")
+    ]
 
 
 def source_count(provider: str, export: dict[str, Any]) -> int:
@@ -98,7 +110,10 @@ def source_count(provider: str, export: dict[str, Any]) -> int:
     if provider == "letta":
         return len(_source_list(export.get("passages")))
     memories = _source_list(export.get("memories"))
-    if provider == "supermemory" and not memories:
+    if provider == "supermemory":
+        usable_memories = _supermemory_memory_sources(export)
+        if usable_memories:
+            return len(memories)
         # Mirror map_supermemory's fallback: when no extracted memories exist
         # we harvest document chunks, so the summary should reflect that.
         return sum(

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -85,17 +85,25 @@ def write_preview(rows: list[dict[str, Any]], dest: Path) -> Path:
     return dest
 
 
+def _source_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _source_dicts(value: Any) -> list[dict[str, Any]]:
+    return [item for item in _source_list(value) if isinstance(item, dict)]
+
+
 def source_count(provider: str, export: dict[str, Any]) -> int:
     """Best-effort count of source records (for the summary header)."""
     if provider == "letta":
-        return len(export.get("passages", []) or [])
-    memories = export.get("memories", []) or []
+        return len(_source_list(export.get("passages")))
+    memories = _source_list(export.get("memories"))
     if provider == "supermemory" and not memories:
         # Mirror map_supermemory's fallback: when no extracted memories exist
         # we harvest document chunks, so the summary should reflect that.
         return sum(
-            len(doc.get("chunks", []) or [])
-            for doc in (export.get("documents", []) or [])
+            len(_source_list(doc.get("chunks")))
+            for doc in _source_dicts(export.get("documents"))
         )
     return len(memories)
 

--- a/tests/test_migrate_mappers.py
+++ b/tests/test_migrate_mappers.py
@@ -1,7 +1,10 @@
+"""Regression coverage for migration export record-shape resilience."""
+
 from memanto.cli.migrate.runner import map_export, run_migration
 
 
 def test_mem0_mapper_skips_non_object_memory_records():
+    """Mem0 migration skips malformed array items and keeps valid memories."""
     rows = map_export(
         "mem0",
         {
@@ -19,6 +22,7 @@ def test_mem0_mapper_skips_non_object_memory_records():
 
 
 def test_letta_mapper_skips_non_object_passage_records():
+    """Letta migration skips malformed passage entries and maps valid passages."""
     rows = map_export(
         "letta",
         {
@@ -36,6 +40,7 @@ def test_letta_mapper_skips_non_object_passage_records():
 
 
 def test_supermemory_migration_skips_non_object_documents_and_chunks():
+    """Supermemory fallback skips malformed documents/chunks without crashing."""
     summary, rows = run_migration(
         provider="supermemory",
         export={
@@ -63,3 +68,53 @@ def test_supermemory_migration_skips_non_object_documents_and_chunks():
     assert summary.skipped == 1
     assert rows[0]["source"] == "supermemory"
     assert rows[0]["source_ref"] == "doc1:c1"
+
+
+def test_supermemory_migration_falls_back_when_memories_are_malformed():
+    """Malformed Supermemory memories still allow document chunk fallback."""
+    summary, rows = run_migration(
+        provider="supermemory",
+        export={
+            "memories": ["truncated memory"],
+            "documents": [
+                {
+                    "id": "doc1",
+                    "chunks": [
+                        {"id": "c1", "content": "First fallback chunk"},
+                        {"id": "c2", "text": "Second fallback chunk"},
+                    ],
+                },
+            ],
+        },
+        client=object(),
+        agent_id="agent-1",
+        dry_run=True,
+    )
+
+    assert summary.source_count == 2
+    assert summary.mapped_count == 2
+    assert summary.skipped == 0
+    assert [row["source_ref"] for row in rows] == ["doc1:c1", "doc1:c2"]
+
+
+def test_supermemory_migration_uses_doc_timestamp_when_detail_is_malformed():
+    """A malformed detail object does not suppress the document timestamp."""
+    _, rows = run_migration(
+        provider="supermemory",
+        export={
+            "memories": [],
+            "documents": [
+                {
+                    "id": "doc1",
+                    "createdAt": "2026-06-01T12:00:00Z",
+                    "detail": "malformed detail",
+                    "chunks": [{"id": "c1", "content": "Timestamped chunk"}],
+                },
+            ],
+        },
+        client=object(),
+        agent_id="agent-1",
+        dry_run=True,
+    )
+
+    assert rows[0]["created_at"].isoformat() == "2026-06-01T12:00:00+00:00"

--- a/tests/test_migrate_mappers.py
+++ b/tests/test_migrate_mappers.py
@@ -1,0 +1,65 @@
+from memanto.cli.migrate.runner import map_export, run_migration
+
+
+def test_mem0_mapper_skips_non_object_memory_records():
+    rows = map_export(
+        "mem0",
+        {
+            "memories": [
+                "truncated record",
+                {"id": "m1", "memory": "User prefers concise status updates"},
+                42,
+            ]
+        },
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["source"] == "mem0"
+    assert rows[0]["source_ref"] == "m1"
+
+
+def test_letta_mapper_skips_non_object_passage_records():
+    rows = map_export(
+        "letta",
+        {
+            "passages": [
+                None,
+                {"id": "p1", "text": "The support agent should ask for order id"},
+                ["bad", "passage"],
+            ]
+        },
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["source"] == "letta"
+    assert rows[0]["source_ref"] == "p1"
+
+
+def test_supermemory_migration_skips_non_object_documents_and_chunks():
+    summary, rows = run_migration(
+        provider="supermemory",
+        export={
+            "memories": [],
+            "documents": [
+                "truncated document",
+                {
+                    "id": "doc1",
+                    "container_tags": ["team"],
+                    "detail": "malformed detail",
+                    "chunks": [
+                        "truncated chunk",
+                        {"id": "c1", "content": "Team uses Python for automation"},
+                    ],
+                },
+            ],
+        },
+        client=object(),
+        agent_id="agent-1",
+        dry_run=True,
+    )
+
+    assert summary.source_count == 2
+    assert summary.mapped_count == 1
+    assert summary.skipped == 1
+    assert rows[0]["source"] == "supermemory"
+    assert rows[0]["source_ref"] == "doc1:c1"


### PR DESCRIPTION
## Summary

Bounty issue: #770

This PR keeps the migrate flow stable when provider export arrays contain malformed, non-object records.

The current Mem0, Letta, and Supermemory mappers assume every entry in `memories`, `passages`, `documents`, and nested `chunks` is a JSON object. If an export is partially truncated, manually edited, or assembled from mixed provider pages, a string/null/list item can raise an internal `AttributeError` during dry-run or import before valid records are mapped.

## Changes

- Add object-record filtering for provider-owned arrays in the migrate mappers.
- Make timestamp extraction and scope tag handling ignore malformed non-object values.
- Make `source_count()` tolerate malformed Supermemory document containers while still counting source chunk slots for skipped-record reporting.
- Add regression tests for Mem0, Letta, and Supermemory malformed export arrays.

## Validation

- `uv run --group dev pytest tests\test_migrate_mappers.py -q`
- `uv run --group dev pytest tests\test_migrate_mappers.py tests\test_cli.py -q`
- `uv run --group dev ruff check memanto\cli\migrate\mappers.py memanto\cli\migrate\runner.py tests\test_migrate_mappers.py`
- `uv run --group dev python -m py_compile memanto\cli\migrate\mappers.py memanto\cli\migrate\runner.py tests\test_migrate_mappers.py`
- `git diff --check` (only Windows LF-to-CRLF warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import/migration handling for provider exports with unexpected data shapes, reducing crashes during migration.
  * Counts and mapping now ignore malformed entries and non-list fields more consistently, while preserving valid records and references.
  * Added coverage for malformed provider content to ensure migrations continue to work correctly in dry-run and normal mapping flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->