### PR TITLE
Skip malformed memories in agent bootstrap

### DIFF
--- a/memanto/cli/commands/agent.py
+++ b/memanto/cli/commands/agent.py
@@ -7,7 +7,7 @@ import time
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import typer
 from rich.panel import Panel
@@ -294,6 +294,12 @@ def agent_bootstrap(
     console.print()
 
     # Helper: fetch memories safely
+    def _memory_records(value: Any) -> list[dict[str, Any]]:
+        """Return only object-shaped memories from a recall response."""
+        if not isinstance(value, list):
+            return []
+        return [item for item in value if isinstance(item, dict)]
+
     def _fetch(
         query: str, type: list[str] | None = None, limit: int = 10
     ) -> list[dict[str, Any]]:
@@ -305,7 +311,7 @@ def agent_bootstrap(
                 limit=limit,
                 type=type,
             )
-            return cast(list[dict[str, Any]], result.get("memories", []))
+            return _memory_records(result.get("memories"))
         except Exception:
             return []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -617,6 +617,33 @@ class TestMEMANTOCLI:
         assert result.exit_code == 0
         assert "Intelligence Snapshot" in result.stdout
 
+    def test_agent_bootstrap_skips_non_object_recall_memories(self, mock_all_clients):
+        """Agent bootstrap ignores malformed recall items and renders valid memories."""
+        mock_all_clients.get_agent.return_value = {
+            "agent_id": "test-agent",
+            "pattern": "support",
+            "namespace": "memanto_agent_test-agent",
+        }
+        mock_all_clients.recall.return_value = {
+            "memories": [
+                "truncated memory",
+                {
+                    "id": "mem-1",
+                    "title": "Support tone",
+                    "content": "Use concise support replies.",
+                    "type": "instruction",
+                    "confidence": 0.9,
+                    "status": "active",
+                    "created_at": "2026-06-01T00:00:00Z",
+                },
+            ]
+        }
+
+        result = runner.invoke(app, ["agent", "bootstrap"])
+
+        assert result.exit_code == 0
+        assert "Support tone" in result.stdout
+
     def test_memory_batch_remember(self, mock_all_clients, tmp_path):
         """Test 'memanto remember --batch'"""
         batch_file = tmp_path / "batch.json"


### PR DESCRIPTION
## Summary

Bounty issue: #770

This PR keeps `memanto agent bootstrap` stable when recall returns malformed memory items inside an otherwise successful response.

The bootstrap command fetches several recall samples, then deduplicates and renders them. It previously cast `result["memories"]` to `list[dict]` without validating the shape, so a non-object item such as a truncated string raised `AttributeError: 'str' object has no attribute 'get'` before any valid memories could be shown.

## Changes

- Normalize recall responses at the bootstrap fetch boundary.
- Skip non-object memory entries instead of letting them reach dedupe/rendering code.
- Add a regression test proving a malformed item does not suppress a valid memory.

This is separate from invalid confidence formatting: this bug is about the memory record itself not being an object.

## Validation

- `uv run --group dev pytest tests\test_cli.py::TestMEMANTOCLI::test_agent_bootstrap_skips_non_object_recall_memories -q`
- `uv run --group dev pytest tests\test_cli.py -q`
- `uv run --group dev ruff check memanto\cli\commands\agent.py tests\test_cli.py`
- `uv run --group dev python -m py_compile memanto\cli\commands\agent.py tests\test_cli.py`
- `git diff --check` (only Windows LF-to-CRLF warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the agent bootstrap command to handle unexpected memory response shapes more safely.
  * Non-object memory entries are now ignored, helping the command continue working when recall results include malformed items.
  * Valid memory items still display normally, and the command remains successful.
* **Tests**
  * Added coverage for agent bootstrap behavior when recall results contain invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->