### PR TITLE
Skip malformed recall result memories

### DIFF
--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -28,6 +28,13 @@ from memanto.cli.commands._shared import (
 )
 
 
+def _memory_records(value):
+    """Return only displayable memory records from a recall response."""
+    if not isinstance(value, list):
+        return []
+    return [memory for memory in value if isinstance(memory, dict)]
+
+
 @app.command()
 def remember(
     content: str | None = typer.Argument(None, help="Memory content to store"),
@@ -580,7 +587,7 @@ def recall(
                 )
         elapsed = time.perf_counter() - start
 
-        memories = results.get("memories", [])
+        memories = _memory_records(results.get("memories", []))
 
         if not memories:
             console.print("[yellow]No memories found matching your query[/yellow]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -456,6 +456,22 @@ class TestMEMANTOCLI:
         assert "Found 2 memories" in result.stdout
         assert "Found memory 1" in result.stdout
 
+    def test_recall_skips_non_object_memory_records(self, mock_all_clients):
+        """Malformed recall results should not crash memory display."""
+        mock_all_clients.recall.return_value = {
+            "memories": [
+                "truncated memory",
+                {"content": "Found memory 1", "score": 0.9, "type": "fact"},
+            ],
+            "count": 2,
+        }
+
+        result = runner.invoke(app, ["recall", "test query"])
+        assert result.exit_code == 0
+        assert "Found 1 memories" in result.stdout
+        assert "Found memory 1" in result.stdout
+        assert "truncated memory" not in result.stdout
+
     def test_recall_recent(self, mock_all_clients):
         """`memanto recall --recent` lists newest memories chronologically."""
         mock_all_clients.recall_recent.return_value = {


### PR DESCRIPTION
Summary: Filter recall response entries so only object-shaped memories are rendered; non-object items no longer crash the CLI display. Added regression coverage for mixed malformed recall results. Tests: uv run --group dev pytest tests\test_cli.py -q -k recall_skips_non_object_memory_records; uv run --group dev pytest tests\test_cli.py -q; uv run --group dev ruff check memanto\cli\commands\memory.py tests\test_cli.py; uv run python -m py_compile memanto\cli\commands\memory.py tests\test_cli.py; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recall results handling so only valid memory entries are shown.
  * Prevented malformed or non-object items from appearing in the CLI output.
  * Added test coverage for mixed valid and invalid memory records to confirm correct display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->