### PR TITLE
Guard answer context memory display

### DIFF
--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -4,6 +4,7 @@ detect-conflicts, conflicts).
 """
 
 import json
+import math
 import sys
 import time
 from datetime import datetime
@@ -26,6 +27,23 @@ from memanto.cli.commands._shared import (
     get_client,
     parse_relative_time,
 )
+
+
+def _answer_context_records(value):
+    """Return only displayable context memory records from answer output."""
+    if not isinstance(value, list):
+        return []
+    return [memory for memory in value if isinstance(memory, dict)]
+
+
+def _context_score(value):
+    try:
+        score = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    if not math.isfinite(score):
+        return 0.0
+    return score
 
 
 @app.command()
@@ -710,7 +728,7 @@ def answer(
         elapsed = time.perf_counter() - start
 
         answer = result.get("answer", "No answer generated")
-        context = result.get("context_memories", [])
+        context = _answer_context_records(result.get("context_memories", []))
 
         # Display answer
         console.print(
@@ -726,8 +744,9 @@ def answer(
         if context:
             console.print(f"\n[dim]Used {len(context)} memories as context:[/dim]")
             for i, mem in enumerate(context, 1):
+                score = _context_score(mem.get("score", 0))
                 console.print(
-                    f"  {i}. {mem.get('title', 'Untitled')} (score: {mem.get('score', 0):.3f})"
+                    f"  {i}. {mem.get('title', 'Untitled')} (score: {score:.3f})"
                 )
 
         console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -531,6 +531,25 @@ class TestMEMANTOCLI:
         assert result.exit_code == 0
         assert "This is the RAG answer" in result.stdout
 
+    def test_answer_skips_malformed_context_memories(self, mock_all_clients):
+        """Malformed answer context should not crash response display."""
+        mock_all_clients.answer.return_value = {
+            "answer": "This is the RAG answer.",
+            "context_memories": [
+                "truncated context",
+                {"title": "Useful context", "score": "0.875"},
+                {"title": "Unscored context", "score": "nan"},
+            ],
+        }
+
+        result = runner.invoke(app, ["answer", "What is the answer?"])
+        assert result.exit_code == 0
+        assert "This is the RAG answer" in result.stdout
+        assert "Used 2 memories as context" in result.stdout
+        assert "Useful context (score: 0.875)" in result.stdout
+        assert "Unscored context (score: 0.000)" in result.stdout
+        assert "truncated context" not in result.stdout
+
     # ========================================================================
     # SESSION COMMANDS
     # ========================================================================


### PR DESCRIPTION
Summary: Harden the user-facing memanto answer context display so malformed non-object context_memories entries are skipped and context scores are rendered from finite numeric values only. This is separate from recall result rendering because it applies to the RAG answer output path. Tests: uv run --group dev pytest tests\test_cli.py -q -k answer_skips_malformed_context_memories; uv run --group dev pytest tests\test_cli.py -q; uv run --group dev ruff check memanto\cli\commands\memory.py tests\test_cli.py; uv run python -m py_compile memanto\cli\commands\memory.py tests\test_cli.py; git diff --check.