### PR TITLE
Skip malformed persisted conflict entries

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -423,6 +423,7 @@ async def list_conflict_scans(agent_id: str | None = None):
                 continue
             if not isinstance(conflicts, list):
                 conflicts = []
+            conflicts = [c for c in conflicts if isinstance(c, dict)]
             # astimezone() stamps the local offset so the browser compares it
             # as an absolute instant against memory created_at (no TZ skew).
             scanned_at = dt.fromtimestamp(path.stat().st_mtime).astimezone().isoformat()

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1308,7 +1308,13 @@ class DirectClient:
             all_conflicts = json.load(f)
 
         # Return only unresolved conflicts
-        return [c for c in all_conflicts if not c.get("resolved", False)]
+        if not isinstance(all_conflicts, list):
+            return []
+        return [
+            c
+            for c in all_conflicts
+            if isinstance(c, dict) and not c.get("resolved", False)
+        ]
 
     def resolve_conflict(
         self,
@@ -1350,12 +1356,17 @@ class DirectClient:
         with open(json_path, encoding="utf-8") as f:
             all_conflicts = json.load(f)
 
+        if not isinstance(all_conflicts, list):
+            raise ValueError("Conflict report is malformed: expected a JSON array")
+
         if conflict_index < 0 or conflict_index >= len(all_conflicts):
             raise ValueError(
                 f"Conflict index {conflict_index} out of range (0-{len(all_conflicts) - 1})"
             )
 
         conflict = all_conflicts[conflict_index]
+        if not isinstance(conflict, dict):
+            raise ValueError(f"Conflict entry {conflict_index} is malformed")
         old_id = conflict.get("old_memory_id")
         new_id = conflict.get("new_memory_id")
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1177,7 +1177,13 @@ class SdkClient:
             all_conflicts = json.load(f)
 
         # Return only unresolved conflicts
-        return [c for c in all_conflicts if not c.get("resolved", False)]
+        if not isinstance(all_conflicts, list):
+            return []
+        return [
+            c
+            for c in all_conflicts
+            if isinstance(c, dict) and not c.get("resolved", False)
+        ]
 
     def resolve_conflict(
         self,
@@ -1218,12 +1224,17 @@ class SdkClient:
         with open(json_path, encoding="utf-8") as f:
             all_conflicts = json.load(f)
 
+        if not isinstance(all_conflicts, list):
+            raise ValueError("Conflict report is malformed: expected a JSON array")
+
         if conflict_index < 0 or conflict_index >= len(all_conflicts):
             raise ValueError(
                 f"Conflict index {conflict_index} out of range (0-{len(all_conflicts) - 1})"
             )
 
         conflict = all_conflicts[conflict_index]
+        if not isinstance(conflict, dict):
+            raise ValueError(f"Conflict entry {conflict_index} is malformed")
         old_id = conflict.get("old_memory_id")
         new_id = conflict.get("new_memory_id")
 

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -976,10 +976,14 @@ def conflicts(
     )
     with open(json_path, encoding="utf-8") as f:
         all_conflicts = json.load(f)
+    if not isinstance(all_conflicts, list):
+        all_conflicts = []
 
     # Map unresolved conflicts to their original indices
     unresolved_indices = [
-        idx for idx, c in enumerate(all_conflicts) if not c.get("resolved", False)
+        idx
+        for idx, c in enumerate(all_conflicts)
+        if isinstance(c, dict) and not c.get("resolved", False)
     ]
 
     resolved_count = 0

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,6 +4,7 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
+import json
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -344,6 +345,62 @@ class TestForgetEndToEnd:
         result = client.delete_memory(agent_id="test-agent", memory_id="mem-xyz")
         assert result["status"] == "deleted"
         assert result["memory_id"] == "mem-xyz"
+
+
+class TestConflictFileResilience:
+    """Conflict list/resolve should tolerate malformed persisted JSON entries."""
+
+    def _write_conflicts(self, tmp_path, agent_id, date, payload):
+        """Write a conflict report under the temporary Memanto home."""
+        conflicts_dir = tmp_path / ".memanto" / "conflicts"
+        conflicts_dir.mkdir(parents=True)
+        path = conflicts_dir / f"{agent_id}_{date}_conflicts.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_list_conflicts_skips_malformed_entries(self, tmp_path, monkeypatch):
+        """Non-object entries in the conflict file must not crash listing."""
+        from pathlib import Path
+
+        from memanto.cli.client.direct_client import DirectClient
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        self._write_conflicts(
+            tmp_path,
+            "agent-a",
+            "2026-06-28",
+            [
+                "truncated",
+                {"title": "resolved", "resolved": True},
+                {"title": "real conflict", "resolved": False},
+                7,
+            ],
+        )
+
+        conflicts = DirectClient(api_key="test-key").list_conflicts(
+            "agent-a", "2026-06-28"
+        )
+
+        assert conflicts == [{"title": "real conflict", "resolved": False}]
+
+    def test_resolve_conflict_rejects_malformed_entry(self, tmp_path, monkeypatch):
+        """Resolving a malformed conflict entry should fail with a clear error."""
+        from pathlib import Path
+
+        from memanto.cli.client.direct_client import DirectClient
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        self._write_conflicts(
+            tmp_path,
+            "agent-a",
+            "2026-06-28",
+            ["truncated", {"title": "real conflict", "resolved": False}],
+        )
+
+        with pytest.raises(ValueError, match="Conflict entry 0 is malformed"):
+            DirectClient(api_key="test-key").resolve_conflict(
+                "agent-a", "2026-06-28", 0, "keep_both"
+            )
 
 
 class TestMEMANTOArchitecture:


### PR DESCRIPTION
## Summary
- skip non-object entries when listing unresolved persisted conflict reports
- reject malformed conflict entries with a clear ValueError during direct resolve
- keep the interactive CLI and UI conflict-scan paths from crashing on malformed saved entries

## Scope
This is distinct from the AI conflict-report parsing guard: it handles already-written ~/.memanto/conflicts/*.json files that are malformed or manually edited after generation.

## Validation
- uv run --group dev pytest tests\\test_unit.py::TestConflictFileResilience -q
- uv run --group dev pytest tests\\test_cli.py::TestMEMANTOCLI::test_conflicts_list -q
- uv run --group dev pytest tests\\test_unit.py -q
- uv run --group dev pytest tests\\test_cli.py -q
- uv run --group dev ruff check memanto\\cli\\client\\direct_client.py memanto\\cli\\client\\sdk_client.py memanto\\cli\\commands\\memory.py memanto\\app\\ui\\routes\\ui_router.py tests\\test_unit.py
- uv run python -m py_compile memanto\\cli\\client\\direct_client.py memanto\\cli\\client\\sdk_client.py memanto\\cli\\commands\\memory.py memanto\\app\\ui\\routes\\ui_router.py tests\\test_unit.py
- git diff --check (Windows LF-to-CRLF warnings only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conflict handling so malformed or unexpected entries in saved conflict data no longer break conflict lists or counts.
  * Conflict resolution now validates the loaded data more safely and shows a clear error when an item can’t be resolved.
  * Interactive conflict selection is more resilient when conflict records contain invalid or non-standard values.
* **Tests**
  * Added coverage for malformed conflict-file scenarios to confirm valid conflicts still appear and invalid entries are rejected gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->