### PR TITLE
Guard analysis metrics against malformed export shapes

### DIFF
--- a/memanto/cli/analyze/_shape.py
+++ b/memanto/cli/analyze/_shape.py
@@ -1,0 +1,30 @@
+"""Shape normalization helpers for provider analysis exports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def dict_or_empty(value: Any) -> dict[str, Any]:
+    """Return a plain dict for mapping values, otherwise an empty dict."""
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def dict_list_or_empty(value: Any) -> list[dict[str, Any]]:
+    """Return only mapping entries from a JSON array-like value."""
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, Mapping)]
+
+
+def int_or_default(value: Any, default: int = 0) -> int:
+    """Coerce provider summary counts to int or fall back safely."""
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/memanto/cli/analyze/letta_compare.py
+++ b/memanto/cli/analyze/letta_compare.py
@@ -40,6 +40,7 @@ ASSUMPTIONS: dict[str, Any] = {
 
 
 def _human_bytes(num: float) -> str:
+    """Format a byte count as a compact human-readable string."""
     for unit in ("B", "KB", "MB", "GB", "TB"):
         if abs(num) < 1024.0:
             return f"{num:.2f} {unit}"
@@ -48,6 +49,7 @@ def _human_bytes(num: float) -> str:
 
 
 def _passage_text(passage: dict[str, Any]) -> str:
+    """Extract the best available text field from a Letta passage record."""
     return (
         passage.get("text")
         or passage.get("content")
@@ -58,6 +60,7 @@ def _passage_text(passage: dict[str, Any]) -> str:
 
 
 def _agent_count(export: dict[str, Any], summary: dict[str, Any]) -> int:
+    """Infer the Letta agent count from summary, agents, or legacy fields."""
     if summary.get("agent_count") is not None:
         return int_or_default(summary["agent_count"])
     agents = dict_list_or_empty(export.get("agents"))
@@ -202,6 +205,7 @@ def build_report_markdown(
     llm_method: str,
     exported_at: str | None,
 ) -> str:
+    """Build the final Letta comparison report markdown."""
     v = metrics["volume"]
     t = metrics["ingestion_tax"]
     s = metrics["storage"]

--- a/memanto/cli/analyze/letta_compare.py
+++ b/memanto/cli/analyze/letta_compare.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from memanto.cli.analyze._shape import (
+    dict_list_or_empty,
+    dict_or_empty,
+    int_or_default,
+)
 from memanto.cli.analyze.ingestion_cost import (
     DEFAULT_INPUT_USD_PER_1M,
     DEFAULT_OUTPUT_USD_PER_1M,
@@ -54,8 +59,8 @@ def _passage_text(passage: dict[str, Any]) -> str:
 
 def _agent_count(export: dict[str, Any], summary: dict[str, Any]) -> int:
     if summary.get("agent_count") is not None:
-        return int(summary["agent_count"])
-    agents = export.get("agents", []) or []
+        return int_or_default(summary["agent_count"])
+    agents = dict_list_or_empty(export.get("agents"))
     if agents:
         return len(agents)
     if export.get("agent_id"):
@@ -65,11 +70,11 @@ def _agent_count(export: dict[str, Any], summary: dict[str, Any]) -> int:
 
 def compute_metrics(export: dict[str, Any]) -> dict[str, Any]:
     """Compute deterministic comparison metrics from a Letta export."""
-    summary = export.get("summary", {}) or {}
-    passages = export.get("passages", []) or []
+    summary = dict_or_empty(export.get("summary"))
+    passages = dict_list_or_empty(export.get("passages"))
 
     agent_count = _agent_count(export, summary)
-    passage_count = int(summary.get("passage_count") or len(passages))
+    passage_count = int_or_default(summary.get("passage_count") or len(passages))
 
     total_chars = sum(len(_passage_text(passage)) for passage in passages)
 

--- a/memanto/cli/analyze/mem0_compare.py
+++ b/memanto/cli/analyze/mem0_compare.py
@@ -45,6 +45,7 @@ ASSUMPTIONS: dict[str, Any] = {
 
 
 def _human_bytes(num: float) -> str:
+    """Format a byte count as a compact human-readable string."""
     for unit in ("B", "KB", "MB", "GB", "TB"):
         if abs(num) < 1024.0:
             return f"{num:.2f} {unit}"
@@ -53,6 +54,7 @@ def _human_bytes(num: float) -> str:
 
 
 def _memory_text(memory: dict[str, Any]) -> str:
+    """Extract the best available text field from a Mem0 memory record."""
     return (
         memory.get("memory")
         or memory.get("content")
@@ -63,6 +65,7 @@ def _memory_text(memory: dict[str, Any]) -> str:
 
 
 def _entity_type_counts(entities: list[dict[str, Any]]) -> dict[str, int]:
+    """Count normalized Mem0 entity types from export records."""
     counts: dict[str, int] = {}
     for entity in entities:
         entity_type = str(entity.get("type") or "unknown").lower()
@@ -215,6 +218,7 @@ def build_report_markdown(
     llm_method: str,
     exported_at: str | None,
 ) -> str:
+    """Build the final Mem0 comparison report markdown."""
     v = metrics["volume"]
     t = metrics["ingestion_tax"]
     s = metrics["storage"]

--- a/memanto/cli/analyze/mem0_compare.py
+++ b/memanto/cli/analyze/mem0_compare.py
@@ -16,6 +16,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from memanto.cli.analyze._shape import (
+    dict_list_or_empty,
+    dict_or_empty,
+    int_or_default,
+)
 from memanto.cli.analyze.ingestion_cost import (
     DEFAULT_INPUT_USD_PER_1M,
     DEFAULT_OUTPUT_USD_PER_1M,
@@ -67,13 +72,13 @@ def _entity_type_counts(entities: list[dict[str, Any]]) -> dict[str, int]:
 
 def compute_metrics(export: dict[str, Any]) -> dict[str, Any]:
     """Compute deterministic comparison metrics from a Mem0 export."""
-    summary = export.get("summary", {}) or {}
-    entities = export.get("entities", []) or []
-    memories = export.get("memories", []) or []
+    summary = dict_or_empty(export.get("summary"))
+    entities = dict_list_or_empty(export.get("entities"))
+    memories = dict_list_or_empty(export.get("memories"))
 
-    entity_count = int(summary.get("entity_count") or len(entities))
-    scope_count = int(summary.get("scope_count") or 0)
-    memory_count = int(summary.get("memory_count") or len(memories))
+    entity_count = int_or_default(summary.get("entity_count") or len(entities))
+    scope_count = int_or_default(summary.get("scope_count"))
+    memory_count = int_or_default(summary.get("memory_count") or len(memories))
     entity_types = _entity_type_counts(entities)
 
     total_chars = sum(len(_memory_text(memory)) for memory in memories)

--- a/memanto/cli/analyze/supermemory_compare.py
+++ b/memanto/cli/analyze/supermemory_compare.py
@@ -48,6 +48,7 @@ ASSUMPTIONS: dict[str, Any] = {
 
 
 def _human_bytes(num: float) -> str:
+    """Format a byte count as a compact human-readable string."""
     for unit in ("B", "KB", "MB", "GB", "TB"):
         if abs(num) < 1024.0:
             return f"{num:.2f} {unit}"
@@ -56,10 +57,12 @@ def _human_bytes(num: float) -> str:
 
 
 def _chunk_text(chunk: dict[str, Any]) -> str:
+    """Extract the best available text field from a Supermemory chunk."""
     return chunk.get("content") or chunk.get("text") or ""
 
 
 def _memory_text(memory: dict[str, Any]) -> str:
+    """Extract the best available text field from a Supermemory memory."""
     return memory.get("content") or memory.get("memory") or memory.get("title") or ""
 
 
@@ -216,6 +219,7 @@ def build_report_markdown(
     llm_method: str,
     exported_at: str | None,
 ) -> str:
+    """Build the final Supermemory comparison report markdown."""
     v = metrics["volume"]
     t = metrics["ingestion_tax"]
     s = metrics["storage"]

--- a/memanto/cli/analyze/supermemory_compare.py
+++ b/memanto/cli/analyze/supermemory_compare.py
@@ -16,6 +16,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from memanto.cli.analyze._shape import (
+    dict_list_or_empty,
+    dict_or_empty,
+    int_or_default,
+)
 from memanto.cli.analyze.ingestion_cost import (
     DEFAULT_INPUT_USD_PER_1M,
     DEFAULT_OUTPUT_USD_PER_1M,
@@ -60,20 +65,25 @@ def _memory_text(memory: dict[str, Any]) -> str:
 
 def compute_metrics(export: dict[str, Any]) -> dict[str, Any]:
     """Compute deterministic comparison metrics from a Supermemory export."""
-    summary = export.get("summary", {}) or {}
-    documents = export.get("documents", []) or []
-    memories = export.get("memories", []) or []
+    summary = dict_or_empty(export.get("summary"))
+    documents = dict_list_or_empty(export.get("documents"))
+    memories = dict_list_or_empty(export.get("memories"))
 
-    doc_count = int(summary.get("document_count") or len(documents))
-    chunk_count = int(summary.get("chunk_count") or 0)
-    memory_count = int(summary.get("memory_entry_count") or len(memories))
-    tag_count = int(summary.get("container_tag_count") or 0)
-    connection_count = int(summary.get("connection_count") or 0)
+    valid_chunks = [
+        chunk
+        for doc in documents
+        for chunk in dict_list_or_empty(doc.get("chunks"))
+    ]
+
+    doc_count = int_or_default(summary.get("document_count") or len(documents))
+    chunk_count = int_or_default(summary.get("chunk_count") or len(valid_chunks))
+    memory_count = int_or_default(summary.get("memory_entry_count") or len(memories))
+    tag_count = int_or_default(summary.get("container_tag_count"))
+    connection_count = int_or_default(summary.get("connection_count"))
 
     input_chars = 0
-    for doc in documents:
-        for chunk in doc.get("chunks", []) or []:
-            input_chars += len(_chunk_text(chunk))
+    for chunk in valid_chunks:
+        input_chars += len(_chunk_text(chunk))
     output_chars = sum(len(_memory_text(memory)) for memory in memories)
     total_chars = input_chars + output_chars
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -124,6 +124,26 @@ class TestSupermemoryCompare:
         assert latency["speedup_x"] == 3.3
         assert latency["ms_saved_per_query"] == 210
 
+    def test_compute_metrics_skips_malformed_export_shapes(self):
+        """Malformed Supermemory report inputs should not crash metrics."""
+        export = {
+            "summary": "not-a-summary-object",
+            "documents": [
+                "not-a-document-object",
+                {"chunks": ["not-a-chunk-object", {"content": "a" * 8}]},
+            ],
+            "memories": ["not-a-memory-object", {"content": "b" * 4}],
+        }
+
+        metrics = compute_supermemory_metrics(export)
+        volume = metrics["volume"]
+
+        assert volume["documents"] == 1
+        assert volume["chunks"] == 1
+        assert volume["memories"] == 1
+        assert volume["estimated_input_tokens"] == 2
+        assert volume["estimated_output_tokens"] == 1
+
     def test_build_llm_prompt_uses_measured_numbers(self):
         metrics = compute_supermemory_metrics(self._sample_export())
         prompt = build_supermemory_llm_prompt(metrics)
@@ -203,6 +223,23 @@ class TestMem0Compare:
         assert latency["mem0_read_ms"] == 499
         assert latency["speedup_x"] == 5.5
         assert latency["ms_saved_per_query"] == 409
+
+    def test_compute_metrics_skips_malformed_export_shapes(self):
+        """Malformed Mem0 report inputs should not crash metrics."""
+        export = {
+            "summary": "not-a-summary-object",
+            "entities": ["not-an-entity-object", {"type": "User"}],
+            "memories": ["not-a-memory-object", {"memory": "a" * 8}],
+        }
+
+        metrics = compute_mem0_metrics(export)
+        volume = metrics["volume"]
+
+        assert volume["entities"] == 1
+        assert volume["memories"] == 1
+        assert volume["entity_types"] == {"user": 1}
+        assert volume["estimated_content_tokens"] == 2
+        assert volume["estimated_input_tokens"] == 5
 
     def test_build_llm_prompt_uses_measured_numbers(self):
         metrics = compute_mem0_metrics(self._sample_export())
@@ -291,6 +328,22 @@ class TestLettaCompare:
         assert latency["letta_read_ms"] == 450
         assert latency["speedup_x"] == 5.0
         assert latency["ms_saved_per_query"] == 360
+
+    def test_compute_metrics_skips_malformed_export_shapes(self):
+        """Malformed Letta report inputs should not crash metrics."""
+        export = {
+            "summary": "not-a-summary-object",
+            "agents": ["not-an-agent-object", {"id": "agent-test-123"}],
+            "passages": ["not-a-passage-object", {"text": "a" * 8}],
+        }
+
+        metrics = compute_letta_metrics(export)
+        volume = metrics["volume"]
+
+        assert volume["agents"] == 1
+        assert volume["passages"] == 1
+        assert volume["estimated_content_tokens"] == 2
+        assert volume["estimated_input_tokens"] == 5
 
     def test_build_llm_prompt_uses_measured_numbers(self):
         metrics = compute_letta_metrics(self._sample_export())

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -45,7 +45,10 @@ ASSUMPTIONS = {
 
 
 class TestIngestionCost:
+    """Validate ingestion token-cost math used by analysis reports."""
+
     def test_estimate_ingestion_cost(self):
+        """Estimate mixed input and output token costs."""
         result = estimate_ingestion_cost(
             input_tokens=1_000_000,
             output_tokens=500_000,
@@ -61,6 +64,7 @@ class TestIngestionCost:
         assert result["tokens_saved"] == 1_500_000
 
     def test_zero_tokens(self):
+        """Return zero cost when no tokens are processed."""
         result = estimate_ingestion_cost(
             input_tokens=0,
             output_tokens=0,
@@ -72,8 +76,11 @@ class TestIngestionCost:
 
 
 class TestSupermemoryCompare:
+    """Validate Supermemory export metrics, prompts, and reports."""
+
     @staticmethod
     def _sample_export() -> dict:
+        """Build a compact Supermemory export fixture."""
         return {
             "exported_at": "2026-06-04T12:00:00Z",
             "summary": {
@@ -95,6 +102,7 @@ class TestSupermemoryCompare:
         }
 
     def test_compute_metrics(self):
+        """Compute deterministic Supermemory metrics from the fixture."""
         metrics = compute_supermemory_metrics(self._sample_export())
         volume = metrics["volume"]
 
@@ -145,6 +153,7 @@ class TestSupermemoryCompare:
         assert volume["estimated_output_tokens"] == 1
 
     def test_build_llm_prompt_uses_measured_numbers(self):
+        """Ground the Supermemory LLM prompt in measured metrics."""
         metrics = compute_supermemory_metrics(self._sample_export())
         prompt = build_supermemory_llm_prompt(metrics)
 
@@ -158,6 +167,7 @@ class TestSupermemoryCompare:
         assert "Do NOT invent benchmark scores" in prompt
 
     def test_build_report_markdown(self):
+        """Render a Supermemory markdown report with measured sections."""
         metrics = compute_supermemory_metrics(self._sample_export())
         report = build_supermemory_report(
             metrics=metrics,
@@ -178,8 +188,11 @@ class TestSupermemoryCompare:
 
 
 class TestMem0Compare:
+    """Validate Mem0 export metrics, prompts, and reports."""
+
     @staticmethod
     def _sample_export() -> dict:
+        """Build a compact Mem0 export fixture."""
         return {
             "exported_at": "2026-06-04T12:00:00Z",
             "summary": {
@@ -198,6 +211,7 @@ class TestMem0Compare:
         }
 
     def test_compute_metrics(self):
+        """Compute deterministic Mem0 metrics from the fixture."""
         metrics = compute_mem0_metrics(self._sample_export())
         volume = metrics["volume"]
 
@@ -242,6 +256,7 @@ class TestMem0Compare:
         assert volume["estimated_input_tokens"] == 5
 
     def test_build_llm_prompt_uses_measured_numbers(self):
+        """Ground the Mem0 LLM prompt in measured metrics."""
         metrics = compute_mem0_metrics(self._sample_export())
         prompt = build_mem0_llm_prompt(metrics)
 
@@ -255,6 +270,7 @@ class TestMem0Compare:
         assert "Migration considerations" in prompt
 
     def test_build_report_markdown(self):
+        """Render a Mem0 markdown report with measured sections."""
         metrics = compute_mem0_metrics(self._sample_export())
         report = build_mem0_report(
             metrics=metrics,
@@ -274,8 +290,11 @@ class TestMem0Compare:
 
 
 class TestLettaCompare:
+    """Validate Letta export metrics, prompts, and reports."""
+
     @staticmethod
     def _sample_export() -> dict:
+        """Build a compact Letta export fixture."""
         return {
             "exported_at": "2026-06-04T12:00:00Z",
             "export_mode": "all_agents",
@@ -305,6 +324,7 @@ class TestLettaCompare:
         }
 
     def test_compute_metrics(self):
+        """Compute deterministic Letta metrics from the fixture."""
         metrics = compute_letta_metrics(self._sample_export())
         volume = metrics["volume"]
 
@@ -346,6 +366,7 @@ class TestLettaCompare:
         assert volume["estimated_input_tokens"] == 5
 
     def test_build_llm_prompt_uses_measured_numbers(self):
+        """Ground the Letta LLM prompt in measured metrics."""
         metrics = compute_letta_metrics(self._sample_export())
         prompt = build_letta_llm_prompt(metrics)
 
@@ -357,6 +378,7 @@ class TestLettaCompare:
         assert "Migration considerations" in prompt
 
     def test_build_report_markdown(self):
+        """Render a Letta markdown report with measured sections."""
         metrics = compute_letta_metrics(self._sample_export())
         report = build_letta_report(
             metrics=metrics,


### PR DESCRIPTION
## Summary

Bounty issue: #770

This PR keeps the `memanto migrate ... --dry-run` analysis/report path stable when provider exports contain malformed-but-valid JSON shapes.

The metrics builders for Supermemory, Mem0, and Letta assumed `summary` was an object and that provider arrays such as `documents`, `chunks`, `memories`, `entities`, `agents`, and `passages` contained only objects. A partially edited or mixed export could therefore raise internal `AttributeError`/`ValueError` while generating the migration report, even when valid records were still present.

## Changes

- Add shared analysis-shape helpers for object maps, object arrays, and safe integer counts.
- Normalize Supermemory, Mem0, and Letta report inputs before computing metrics.
- Skip malformed non-object records while preserving valid reportable records.
- Add regression tests for malformed shapes in all three analysis providers.

## Scope

This is distinct from PR #1235. That PR hardens the migrate mapper/import layer. This PR hardens the analysis/report metrics layer used to produce `migrate-report.md` during dry-run/report generation.

## Validation

- `uv run --group dev pytest tests\\test_analyze.py -q`
- `uv run --group dev pytest tests\\test_cli.py::TestMEMANTOCLI::test_migrate_supermemory_dry_run tests\\test_cli.py::TestMEMANTOCLI::test_migrate_mem0_dry_run tests\\test_cli.py::TestMEMANTOCLI::test_migrate_letta_dry_run -q`
- `uv run --group dev pytest tests\\test_cli.py -q`
- `uv run --group dev pytest tests\\test_analyze.py tests\\test_cli.py -q`
- `uv run --group dev ruff check memanto\\cli\\analyze tests\\test_analyze.py`
- `uv run --group dev python -m py_compile memanto\\cli\\analyze\\_shape.py memanto\\cli\\analyze\\mem0_compare.py memanto\\cli\\analyze\\letta_compare.py memanto\\cli\\analyze\\supermemory_compare.py tests\\test_analyze.py`
- `git diff --check` (Windows LF-to-CRLF warnings only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis robustness when export data is missing, empty, or malformed, so metric counts and token estimates now fall back to safe defaults instead of failing.
  * Standardized interpretation of nested export fields across supported providers for more consistent metric reporting.

* **Tests**
  * Added unit tests covering malformed export shapes for Supermemory, Mem0, and Letta to verify metrics compute reliably and return defaulted volume counts/estimates when inputs are incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->