### PR TITLE
Guard memory export against malformed result shapes

### DIFF
--- a/memanto/app/services/memory_export_service.py
+++ b/memanto/app/services/memory_export_service.py
@@ -5,6 +5,7 @@ Generates a structured memory.md file with all 13 memory types
 organized into sections, ready for agent consumption.
 """
 
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -89,11 +90,25 @@ class MemoryExportService:
     def __init__(self, exports_dir: Path | None = None):
         self.exports_dir = exports_dir or (Path.home() / ".memanto" / "exports")
 
+    def normalize_memories_by_type(
+        self, memories_by_type: Mapping[str, Any]
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Keep only list-backed memory dictionaries for each memory type."""
+        normalized: dict[str, list[dict[str, Any]]] = {}
+        for mem_type, memories in memories_by_type.items():
+            if not isinstance(memories, list):
+                normalized[mem_type] = []
+                continue
+            normalized[mem_type] = [
+                dict(memory) for memory in memories if isinstance(memory, Mapping)
+            ]
+        return normalized
+
     # Public API
     def format_memory_md(
         self,
         agent_id: str,
-        memories_by_type: dict[str, list[dict[str, Any]]],
+        memories_by_type: Mapping[str, Any],
         generated_at: str | None = None,
     ) -> str:
         """
@@ -108,6 +123,7 @@ class MemoryExportService:
             Formatted Markdown string.
         """
         generated_at = generated_at or datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        memories_by_type = self.normalize_memories_by_type(memories_by_type)
 
         total = sum(len(mems) for mems in memories_by_type.values())
         type_counts = {t: len(mems) for t, mems in memories_by_type.items() if mems}
@@ -145,12 +161,12 @@ class MemoryExportService:
                 continue
 
             for mem in memories:
-                title = mem.get("title") or "Untitled"
-                content = (mem.get("content") or "").strip()
+                title = str(mem.get("title") or "Untitled")
+                content = str(mem.get("content") or "").strip()
                 confidence = mem.get("confidence")
                 tags = mem.get("tags", [])
-                created_at = mem.get("created_at", "")
-                status = mem.get("status", "")
+                created_at = str(mem.get("created_at", ""))
+                status = str(mem.get("status", ""))
 
                 lines.append(f"### {title}")
                 lines.append("")
@@ -190,7 +206,7 @@ class MemoryExportService:
     def write_memory_md(
         self,
         agent_id: str,
-        memories_by_type: dict[str, list[dict[str, Any]]],
+        memories_by_type: Mapping[str, Any],
         output_path: Path | None = None,
     ) -> Path:
         """

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1500,6 +1500,7 @@ class DirectClient:
                 memories_by_type[mem_type] = []
 
         export_svc = self._get_export_service()
+        memories_by_type = export_svc.normalize_memories_by_type(memories_by_type)
         out = output_path if output_path else None
         written_path = export_svc.write_memory_md(
             agent_id=agent_id,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1359,6 +1359,7 @@ class SdkClient:
                 memories_by_type[mem_type] = []
 
         export_svc = self._get_export_service()
+        memories_by_type = export_svc.normalize_memories_by_type(memories_by_type)
         out = output_path if output_path else None
         written_path = export_svc.write_memory_md(
             agent_id=agent_id,

--- a/tests/test_memory_export_service.py
+++ b/tests/test_memory_export_service.py
@@ -1,0 +1,71 @@
+from memanto.app.services.memory_export_service import MemoryExportService
+
+
+class TestMemoryExportService:
+    """Regression coverage for memory export formatting."""
+
+    def test_format_memory_md_skips_malformed_records(self):
+        """Malformed export result shapes do not crash Markdown rendering."""
+        service = MemoryExportService()
+
+        markdown = service.format_memory_md(
+            agent_id="agent-test",
+            memories_by_type={
+                "fact": [
+                    "bad-memory-record",
+                    {"title": "Good Fact", "content": "Remember this"},
+                ],
+                "goal": "not-a-list",
+            },
+            generated_at="2026-06-28 12:00:00",
+        )
+
+        assert "> Total memories: **1**" in markdown
+        assert "> Breakdown: fact: 1" in markdown
+        assert "### Good Fact" in markdown
+        assert "Remember this" in markdown
+        assert "bad-memory-record" not in markdown
+
+    def test_normalize_memories_by_type_counts_only_memory_dicts(self):
+        """Shared normalization keeps client export counts in sync."""
+        service = MemoryExportService()
+
+        normalized = service.normalize_memories_by_type(
+            {
+                "fact": [
+                    {"title": "One"},
+                    ["not", "a", "memory"],
+                    {"title": "Two"},
+                ],
+                "error": {"title": "not-a-list"},
+            }
+        )
+
+        assert normalized == {
+            "fact": [{"title": "One"}, {"title": "Two"}],
+            "error": [],
+        }
+
+    def test_format_memory_md_stringifies_odd_memory_fields(self):
+        """Unexpected scalar field values should render instead of crashing."""
+        service = MemoryExportService()
+
+        markdown = service.format_memory_md(
+            agent_id="agent-test",
+            memories_by_type={
+                "fact": [
+                    {
+                        "title": ["List", "Title"],
+                        "content": 123,
+                        "created_at": 456,
+                        "status": ["kept"],
+                    }
+                ]
+            },
+            generated_at="2026-06-28 12:00:00",
+        )
+
+        assert "### ['List', 'Title']" in markdown
+        assert "123" in markdown
+        assert "Status: ['kept']" in markdown
+        assert "Created: 456" in markdown


### PR DESCRIPTION
## Summary

Bounty issue: #770

This PR keeps `memanto memory export` stable when recall/export result lists contain malformed non-object memory records.

The export path collected per-type recall results and assumed every `memories` entry was a dictionary. A malformed-but-valid client/backend response such as a truncated string inside a memory list could raise `AttributeError: 'str' object has no attribute 'get'` while rendering `memory.md`, even when valid memories were also present.

## Reproduction

Before this fix, the following crashed during Markdown rendering:

```bash
uv run --group dev python -c "from memanto.app.services.memory_export_service import MemoryExportService; svc=MemoryExportService(); print(svc.format_memory_md('agent', {'fact': ['bad-memory-record', {'title': 'Good', 'content': 'ok'}]}))"
```

## Changes

- Add a shared `MemoryExportService.normalize_memories_by_type()` helper.
- Skip malformed non-object records and non-list memory-type buckets before rendering.
- Reuse the same normalized data for `DirectClient` and `SdkClient` export counts.
- Stringify unusual scalar memory fields before Markdown formatting so export does not fail on `.strip()` or slicing assumptions.
- Add regression tests for malformed records, normalized counts, and unusual scalar fields.

## Scope

This is separate from earlier recall display and migration robustness PRs. This PR only hardens the dedicated `memory export` / `memory sync` Markdown export path and its returned per-type counts.

## Validation

- `uv run --group dev pytest tests\\test_memory_export_service.py -q`
- `uv run --group dev pytest tests\\test_memory_export_service.py tests\\test_cli.py::TestMEMANTOCLI::test_memory_export tests\\test_cli.py::TestMEMANTOCLI::test_memory_sync -q`
- `uv run --group dev ruff check memanto\\app\\services\\memory_export_service.py memanto\\cli\\client\\direct_client.py memanto\\cli\\client\\sdk_client.py tests\\test_memory_export_service.py`
- `uv run --group dev python -m py_compile memanto\\app\\services\\memory_export_service.py memanto\\cli\\client\\direct_client.py memanto\\cli\\client\\sdk_client.py tests\\test_memory_export_service.py`
- `uv run --group dev python -c "from memanto.app.services.memory_export_service import MemoryExportService; svc=MemoryExportService(); print(svc.format_memory_md('agent', {'fact': ['bad-memory-record', {'title': 'Good', 'content': 'ok'}]}, generated_at='2026-06-28 12:00:00').splitlines()[3])"`
- `git diff --check` (Windows LF-to-CRLF warnings only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory export handling for mixed or unexpected input, reducing the chance of broken `memory.md` output.
  * Skips malformed memory entries and keeps exports focused on valid items.
  * Makes exported metadata more resilient by safely converting values to readable text.

* **Tests**
  * Added regression coverage for export formatting, input normalization, and handling of unusual field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->