### PR TITLE
Skip malformed namespace list entries

### DIFF
--- a/memanto/app/services/namespace_service.py
+++ b/memanto/app/services/namespace_service.py
@@ -44,20 +44,32 @@ class NamespaceService:
         try:
             all_namespaces = self.client.namespaces.list()
 
-            # Extract namespace names from response
-            if isinstance(all_namespaces, dict) and "namespaces" in all_namespaces:
-                namespace_list = [
-                    ns["namespace_name"] for ns in all_namespaces["namespaces"]
-                ]
-            else:
-                namespace_list = all_namespaces
+            entries = (
+                all_namespaces.get("namespaces", [])
+                if isinstance(all_namespaces, dict)
+                else all_namespaces
+            )
+            if isinstance(entries, str):
+                entries = [entries]
+            if not isinstance(entries, (list, tuple)):
+                entries = []
 
-            # Filter MEMANTO namespaces
-            memanto_namespaces = [
-                ns for ns in namespace_list if ns.startswith("memanto_")
-            ]
+            namespace_list: list[str] = []
+            for entry in entries:
+                if isinstance(entry, str):
+                    namespace_name = entry
+                elif isinstance(entry, dict):
+                    raw_name = entry.get("namespace_name") or entry.get("name")
+                    if not isinstance(raw_name, str):
+                        continue
+                    namespace_name = raw_name
+                else:
+                    continue
 
-            return memanto_namespaces
+                if namespace_name.startswith("memanto_"):
+                    namespace_list.append(namespace_name)
+
+            return namespace_list
 
         except Exception as e:
             raise NamespaceError(f"Failed to list namespaces: {e}")

--- a/memanto/app/services/namespace_service.py
+++ b/memanto/app/services/namespace_service.py
@@ -59,8 +59,10 @@ class NamespaceService:
                 if isinstance(entry, str):
                     namespace_name = entry
                 elif isinstance(entry, dict):
-                    raw_name = entry.get("namespace_name") or entry.get("name")
-                    if not isinstance(raw_name, str):
+                    raw_name = entry.get("namespace_name")
+                    if not isinstance(raw_name, str) or not raw_name:
+                        raw_name = entry.get("name")
+                    if not isinstance(raw_name, str) or not raw_name:
                         continue
                     namespace_name = raw_name
                 else:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -404,6 +404,7 @@ class TestNamespaceService:
                 {"namespace_name": "memanto_agent_alpha"},
                 {"namespace_name": "other_product"},
                 {"namespace_name": 123},
+                {"namespace_name": 123, "name": "memanto_agent_delta"},
                 {"name": "memanto_agent_beta"},
                 "memanto_agent_gamma",
                 None,
@@ -412,6 +413,7 @@ class TestNamespaceService:
 
         assert NamespaceService(client).list_namespaces() == [
             "memanto_agent_alpha",
+            "memanto_agent_delta",
             "memanto_agent_beta",
             "memanto_agent_gamma",
         ]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -391,5 +391,40 @@ class TestMEMANTOArchitecture:
         print("   ✅ NO tenant_id in token!")
 
 
+class TestNamespaceService:
+    """Namespace listing should tolerate malformed backend entries."""
+
+    def test_list_namespaces_skips_malformed_entries(self):
+        """One malformed namespace record should not hide valid MEMANTO namespaces."""
+        from memanto.app.services.namespace_service import NamespaceService
+
+        client = MagicMock()
+        client.namespaces.list.return_value = {
+            "namespaces": [
+                {"namespace_name": "memanto_agent_alpha"},
+                {"namespace_name": "other_product"},
+                {"namespace_name": 123},
+                {"name": "memanto_agent_beta"},
+                "memanto_agent_gamma",
+                None,
+            ]
+        }
+
+        assert NamespaceService(client).list_namespaces() == [
+            "memanto_agent_alpha",
+            "memanto_agent_beta",
+            "memanto_agent_gamma",
+        ]
+
+    def test_list_namespaces_ignores_non_iterable_namespace_container(self):
+        """Malformed namespace containers should return an empty list."""
+        from memanto.app.services.namespace_service import NamespaceService
+
+        client = MagicMock()
+        client.namespaces.list.return_value = {"namespaces": {"not": "a list"}}
+
+        assert NamespaceService(client).list_namespaces() == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
### Summary
- normalize namespace listing responses before filtering MEMANTO namespaces
- skip malformed namespace entries instead of raising on the first bad record
- keep support for SDK shapes that return either string namespace names or objects with `namespace_name`

### Reproduction
A valid `namespaces.list()` response can still contain one malformed entry, for example an object without `namespace_name`, a non-string namespace value, or a non-list `namespaces` container. The previous implementation indexed every entry as `ns["namespace_name"]`, so one malformed record raised `KeyError`/`TypeError` and hid all valid MEMANTO namespaces from status/search flows.

### Validation
- Confirmed the new regression failed before the fix with `NamespaceError: Failed to list namespaces: 'namespace_name'`
- `uv run --group dev pytest tests\\test_unit.py::TestNamespaceService -q`
- `uv run --group dev pytest tests\\test_unit.py -q`
- `uv run --group dev pytest tests\\test_cli.py -q`
- `uv run --group dev ruff check memanto\\app\\services\\namespace_service.py tests\\test_unit.py`
- `uv run --group dev python -m py_compile memanto\\app\\services\\namespace_service.py tests\\test_unit.py`
- `git diff --check` (Windows LF-to-CRLF warning only)

### Distinction from nearby bounty submissions
This is separate from namespace parsing fixes for underscored scope IDs and from multi-scope search import-path fixes. This PR only hardens `NamespaceService.list_namespaces()` against malformed namespace-list response shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace listing reliability by defensively handling malformed or inconsistent backend responses.
  * Invalid namespace entries are now ignored, while valid namespaces with the expected `memanto_` prefix are preserved.
  * If the backend returns a non-iterable container for namespaces, the list now safely returns empty.
* **Tests**
  * Added unit tests covering malformed entries and non-iterable namespace containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->