### PR TITLE
Skip malformed MCP recall hits

### DIFF
--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -491,7 +491,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 limit=limit,
                 type=list(type) if type else None,
             )
-            hits = [_to_memory_hit(m) for m in result.get("memories", [])]
+            hits = _to_memory_hits(result.get("memories", []))
             if min_similarity is not None:
                 hits = [h for h in hits if (h.score or 0.0) >= min_similarity]
             return RecallResult(
@@ -544,7 +544,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 limit=limit,
                 type=list(type) if type else None,
             )
-            hits = [_to_memory_hit(m) for m in result.get("memories", [])]
+            hits = _to_memory_hits(result.get("memories", []))
             return RecallResult(
                 status="ok",
                 agent_id=resolved,
@@ -600,7 +600,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 limit=limit,
                 type=list(type) if type else None,
             )
-            hits = [_to_memory_hit(m) for m in result.get("memories", [])]
+            hits = _to_memory_hits(result.get("memories", []))
             return RecallResult(
                 status="ok",
                 agent_id=resolved,
@@ -656,7 +656,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 limit=limit,
                 type=list(type) if type else None,
             )
-            hits = [_to_memory_hit(m) for m in result.get("memories", [])]
+            hits = _to_memory_hits(result.get("memories", []))
             return RecallResult(
                 status="ok",
                 agent_id=resolved,
@@ -890,13 +890,29 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _to_memory_hit(raw: dict[str, Any]) -> MemoryHit:
+def _to_memory_hits(raw_memories: Any) -> list[MemoryHit]:
+    """Map recall response rows, skipping malformed non-object entries."""
+    if not isinstance(raw_memories, list):
+        return []
+
+    hits: list[MemoryHit] = []
+    for raw in raw_memories:
+        hit = _to_memory_hit(raw)
+        if hit is not None:
+            hits.append(hit)
+    return hits
+
+
+def _to_memory_hit(raw: Any) -> MemoryHit | None:
     """Map a Memanto recall result row into the MCP MemoryHit shape.
 
     Memanto returns slightly different keys across endpoints (e.g. ``score``
     vs ``similarity_score``). We coalesce them here so tool consumers see a
     stable schema.
     """
+    if not isinstance(raw, dict):
+        return None
+
     return MemoryHit(
         id=str(raw.get("id")) if raw.get("id") is not None else None,
         type=raw.get("type"),

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -483,6 +483,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Run semantic recall and return normalized MCP memory hits."""
         try:
             resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
             result = lifecycle.client.recall(
@@ -537,6 +538,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Return recent memories as normalized MCP memory hits."""
         try:
             resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
             result = lifecycle.client.recall_recent(
@@ -592,6 +594,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Return point-in-time memories as normalized MCP memory hits."""
         try:
             resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
             result = lifecycle.client.recall_as_of(
@@ -648,6 +651,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Return changed memories as normalized MCP memory hits."""
         try:
             resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
             result = lifecycle.client.recall_changed_since(

--- a/integrations/mcp/tests/test_tools.py
+++ b/integrations/mcp/tests/test_tools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from memanto_mcp.tools import _to_memory_hit
+from memanto_mcp.tools import _to_memory_hit, _to_memory_hits
 
 
 def test_to_memory_hit_skips_malformed_recall_rows() -> None:
@@ -28,3 +28,25 @@ def test_to_memory_hit_formats_valid_recall_rows() -> None:
     assert hit.content == "Kept"
     assert hit.tags == ["alpha"]
     assert hit.score == 0.91
+
+
+def test_to_memory_hits_filters_payload_shape() -> None:
+    """List-level normalization should keep valid hits and skip malformed payloads."""
+    hits = _to_memory_hits(
+        [
+            {
+                "id": "mem-1",
+                "type": "fact",
+                "title": "Valid",
+                "content": "Kept",
+                "tags": ["alpha"],
+                "similarity_score": 0.91,
+            },
+            "truncated",
+        ]
+    )
+
+    assert len(hits) == 1
+    assert hits[0].id == "mem-1"
+    assert hits[0].content == "Kept"
+    assert _to_memory_hits({"memories": []}) == []

--- a/integrations/mcp/tests/test_tools.py
+++ b/integrations/mcp/tests/test_tools.py
@@ -1,0 +1,30 @@
+"""Focused tests for MCP tool output helpers."""
+
+from __future__ import annotations
+
+from memanto_mcp.tools import _to_memory_hit
+
+
+def test_to_memory_hit_skips_malformed_recall_rows() -> None:
+    """Malformed recall rows should be ignored by MCP recall tools."""
+    assert _to_memory_hit("truncated") is None
+
+
+def test_to_memory_hit_formats_valid_recall_rows() -> None:
+    """Valid recall rows should still map to the stable MemoryHit schema."""
+    hit = _to_memory_hit(
+        {
+            "id": "mem-1",
+            "type": "fact",
+            "title": "Valid",
+            "content": "Kept",
+            "tags": ["alpha"],
+            "similarity_score": 0.91,
+        }
+    )
+
+    assert hit is not None
+    assert hit.id == "mem-1"
+    assert hit.content == "Kept"
+    assert hit.tags == ["alpha"]
+    assert hit.score == 0.91


### PR DESCRIPTION
### Summary
- skip malformed non-object recall rows before converting them into MCP `MemoryHit` objects
- route all MCP recall variants through the same recall-hit normalization helper
- add focused MCP helper regressions while keeping existing valid recall rows unchanged

### Reproduction
The MCP recall tools assume every item in the client response's `memories` list is an object. If a backend/client response contains one malformed entry, such as a truncated string inside an otherwise valid list, `_to_memory_hit()` raises `AttributeError: 'str' object has no attribute 'get'`. That makes the whole MCP recall tool return an error instead of surfacing the valid memories.

### Validation
- Confirmed the new regression failed before the fix with `AttributeError: 'str' object has no attribute 'get'`
- `uv run --group dev --with-editable . --with-editable integrations\\mcp pytest integrations\\mcp\\tests\\test_tools.py -q`
- `uv run --group dev --with-editable . --with-editable integrations\\mcp pytest integrations\\mcp\\tests -q`
- `uv run --group dev ruff check integrations\\mcp\\memanto_mcp\\tools.py integrations\\mcp\\tests\\test_tools.py`
- `uv run --group dev python -m py_compile integrations\\mcp\\memanto_mcp\\tools.py integrations\\mcp\\tests\\test_tools.py`
- `git diff --check` (Windows LF-to-CRLF warning only)

### Distinction from nearby bounty submissions
This is separate from the existing MCP tag normalization work (#1243): this PR does not change string tag semantics. It only prevents malformed non-object recall rows from breaking the MCP recall, recall_recent, recall_as_of, and recall_changed_since tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory recall normalization to handle inconsistent response payload shapes.
  * Malformed recall entries are now safely ignored, while well-formed results are consistently converted into the expected “memory hit” format.
  * Added handling for non-list recall payloads to prevent errors and return an empty result set.

* **Tests**
  * Added coverage to ensure malformed recall rows are skipped.
  * Added coverage to verify valid recall rows are transformed into stable, expected fields.
  * Added coverage to ensure non-list payloads yield an empty list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->