### PR TITLE
Skip malformed LangGraph recall hits

### DIFF
--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from langchain_core.tools import tool
 from pydantic import Field
@@ -23,6 +23,12 @@ VALID_MEMORY_TYPES = (
     "commitment (promises/next steps), "
     "error (failures/mistakes)"
 )
+
+
+def _valid_memory_entries(raw_memories: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_memories, list):
+        return []
+    return [mem for mem in raw_memories if isinstance(mem, dict)]
 
 
 def create_memanto_tools(client: SdkClient, agent_id: str):
@@ -174,7 +180,7 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
                 type=type_list,
             )
 
-        memories = result.get("memories", [])
+        memories = _valid_memory_entries(result.get("memories", []))
         if not memories:
             return f"No memories found for query: '{query}'"
 

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -99,6 +99,32 @@ def test_memanto_recall_tool_success():
     )
 
 
+def test_memanto_recall_tool_skips_malformed_memory_entries():
+    client = MagicMock()
+    client.recall.return_value = {
+        "memories": [
+            "truncated-row",
+            {
+                "title": "Valid Fact",
+                "content": "This memory should still be shown.",
+                "type": "fact",
+                "confidence": 0.9,
+                "tags": ["valid"],
+            },
+        ]
+    }
+
+    tools = create_memanto_tools(client, "test-agent")
+    recall_tool = next(t for t in tools if t.name == "memanto_recall")
+
+    result = recall_tool.invoke({"query": "test query", "limit": 5, "memory_types": ""})
+
+    assert "Found 1 memories for 'test query'" in result
+    assert "Valid Fact" in result
+    assert "This memory should still be shown." in result
+    assert "truncated-row" not in result
+
+
 def test_memanto_recall_tool_no_results():
     client = MagicMock()
     client.recall.return_value = {"memories": []}


### PR DESCRIPTION
## Summary
- Filter LangGraph recall results to object-shaped memory entries before formatting.
- Keep valid recalled memories visible when a backend/client response includes a malformed non-object row.
- Add regression coverage for a truncated recall row followed by a valid memory.

## Root cause
`memanto_recall` assumed every item in `result["memories"]` was a dict-like memory and called `.get()` on each entry. A single malformed entry such as a truncated string could raise `AttributeError` and prevent LangGraph agents from seeing otherwise valid recall results.

## Validation
- Pre-fix regression: `uv run --project integrations/langgraph --with pytest --with pytest-asyncio --with pytest-timeout --with-editable . pytest integrations/langgraph/tests/test_tools.py::test_memanto_recall_tool_skips_malformed_memory_entries -q` failed with `AttributeError: 'str' object has no attribute 'get'`.
- `uv run --project integrations/langgraph --with pytest --with pytest-asyncio --with pytest-timeout --with-editable . pytest integrations/langgraph/tests/test_tools.py -q`
- `uv run --project integrations/langgraph --with pytest --with pytest-asyncio --with pytest-timeout --with-editable . pytest integrations/langgraph/tests -q`
- `uv run --group dev ruff check integrations/langgraph/langgraph_memanto/tools.py integrations/langgraph/tests/test_tools.py`
- `uv run --group dev ruff format --check integrations/langgraph/langgraph_memanto/tools.py integrations/langgraph/tests/test_tools.py`
- `uv run --group dev python -m py_compile integrations/langgraph/langgraph_memanto/tools.py integrations/langgraph/tests/test_tools.py`
- `git diff --check`