### PR TITLE
Skip malformed Hermes recall hits

### DIFF
--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -222,7 +222,7 @@ def _is_trivial_message(text: str) -> bool:
     return bool(_TRIVIAL_RE.match((text or "").strip()))
 
 
-def _memory_score(raw: dict) -> float | None:
+def _memory_score(raw: dict[str, Any]) -> float | None:
     """Coalesce the score key Memanto uses across endpoints."""
     score = raw.get("score")
     if score is None:
@@ -233,10 +233,17 @@ def _memory_score(raw: dict) -> float | None:
         return None
 
 
+def _valid_memory_entries(raw_memories: Any) -> list[dict[str, Any]]:
+    """Return only object-shaped memory records from a recall response."""
+    if not isinstance(raw_memories, list):
+        return []
+    return [item for item in raw_memories if isinstance(item, dict)]
+
+
 def _format_recall_block(memories: list[dict], max_results: int) -> str:
     """Render recall hits into a context block for prefetch injection."""
     lines = []
-    for item in (memories or [])[:max_results]:
+    for item in _valid_memory_entries(memories)[:max_results]:
         content = (item.get("content") or item.get("title") or "").strip()
         content = _RECALL_TAG_RE.sub("", content).strip()
         if not content:
@@ -783,7 +790,7 @@ class MemantoMemoryProvider(MemoryProvider):
                 min_confidence=self._min_confidence,
             )
             formatted = []
-            for item in memories:
+            for item in _valid_memory_entries(memories):
                 entry: dict[str, Any] = {
                     "id": item.get("id"),
                     "type": item.get("type"),

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -183,6 +183,18 @@ def test_format_recall_block_renders_types_and_scores():
     assert "[fact] Lives in Berlin" in block
 
 
+def test_format_recall_block_skips_malformed_entries():
+    block = _format_recall_block(
+        [
+            "truncated-row",
+            {"type": "fact", "content": "Lives in Berlin", "score": 0.91},
+        ],
+        max_results=10,
+    )
+    assert "Lives in Berlin" in block
+    assert "truncated-row" not in block
+
+
 def test_format_recall_block_empty():
     assert _format_recall_block([], max_results=10) == ""
 
@@ -477,6 +489,21 @@ def test_recall_tool_formats_results(provider):
     assert result["count"] == 1
     assert result["results"][0]["score"] == 77
     assert result["results"][0]["type"] == "fact"
+
+
+def test_recall_tool_skips_malformed_results(provider):
+    provider._client.recall_results = [
+        "truncated-row",
+        {
+            "id": "m1",
+            "type": "fact",
+            "content": "Lives in Berlin",
+            "similarity_score": 0.77,
+        },
+    ]
+    result = json.loads(provider.handle_tool_call("memanto_recall", {"query": "where"}))
+    assert result["count"] == 1
+    assert result["results"][0]["content"] == "Lives in Berlin"
 
 
 def test_answer_tool(provider):


### PR DESCRIPTION
## Summary
- Filter Hermes recall results to object-shaped memory entries before formatting them into prefetch context.
- Apply the same guard to the Hermes `memanto_recall` tool response formatting.
- Add regression coverage for malformed recall rows in both Hermes consumption paths.

## Root cause
The Hermes provider assumed every recall hit returned by Memanto was a dict-like memory record. If the backend/client response contained one malformed non-object row, such as a truncated string, the prefetch formatter raised `AttributeError`, and the explicit `memanto_recall` tool returned an error instead of preserving valid memories.

This is separate from the existing Hermes prompt-boundary/tag delimiter fix: this PR handles malformed recall response item shapes, not memory text containing wrapper tags.

## Validation
- Pre-fix regression: `uv run --group dev pytest integrations/hermes-agents/tests/test_provider.py::test_format_recall_block_skips_malformed_entries integrations/hermes-agents/tests/test_provider.py::test_recall_tool_skips_malformed_results -q` failed with the prefetch `AttributeError` and a recall-tool error response.
- `uv run --group dev pytest integrations/hermes-agents/tests/test_provider.py -q`
- `uv run --group dev ruff check integrations/hermes-agents/hermes_memanto/provider.py integrations/hermes-agents/tests/test_provider.py`
- `uv run --group dev ruff format --check integrations/hermes-agents/hermes_memanto/provider.py integrations/hermes-agents/tests/test_provider.py`
- `uv run --group dev python -m py_compile integrations/hermes-agents/hermes_memanto/provider.py integrations/hermes-agents/tests/test_provider.py`
- `git diff --check`