### PR TITLE
Skip malformed MCP agent listings

### DIFF
--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -827,6 +827,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         description="List every Memanto agent visible to the current API key.",
     )
     def list_agents() -> AgentListResult:
+        """List valid agent metadata records visible to the current API key."""
         try:
             agents = _valid_agent_entries(lifecycle.client.list_agents())
             return AgentListResult(status="ok", count=len(agents), agents=agents)

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -172,6 +172,13 @@ class AgentListResult(BaseModel):
     message: str | None = None
 
 
+def _valid_agent_entries(raw_agents: Any) -> list[dict[str, Any]]:
+    """Return only object-shaped agent metadata entries."""
+    if not isinstance(raw_agents, list):
+        return []
+    return [agent for agent in raw_agents if isinstance(agent, dict)]
+
+
 # ---------------------------------------------------------------------------
 # Error shaping
 # ---------------------------------------------------------------------------
@@ -821,7 +828,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
     )
     def list_agents() -> AgentListResult:
         try:
-            agents = lifecycle.client.list_agents()
+            agents = _valid_agent_entries(lifecycle.client.list_agents())
             return AgentListResult(status="ok", count=len(agents), agents=agents)
         except Exception as exc:
             logger.exception("list_agents failed")

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -175,7 +175,7 @@ class AgentListResult(BaseModel):
 def _valid_agent_entries(raw_agents: Any) -> list[dict[str, Any]]:
     """Return only object-shaped agent metadata entries."""
     if not isinstance(raw_agents, list):
-        return []
+        raise TypeError("list_agents() must return a list")
     return [agent for agent in raw_agents if isinstance(agent, dict)]
 
 

--- a/integrations/mcp/tests/test_server.py
+++ b/integrations/mcp/tests/test_server.py
@@ -24,6 +24,14 @@ MAIN_TOOL_NAMES = {
 ADMIN_TOOL_NAMES = {"create_agent", "list_agents", "get_agent", "delete_agent"}
 
 
+class FakeAgentListClient:
+    """Client stub returning one valid agent plus one malformed row."""
+
+    def list_agents(self) -> list[object]:
+        """Return the agent list shape used by the MCP admin tool."""
+        return [{"agent_id": "valid-agent", "pattern": "tool"}, "truncated-row"]
+
+
 @pytest.mark.asyncio
 async def test_build_server_registers_main_tools(fake_api_key: str) -> None:
     mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
@@ -47,6 +55,22 @@ async def test_admin_tools_registered_when_enabled(
     assert ADMIN_TOOL_NAMES.issubset(tools), (
         f"Missing admin tools: {ADMIN_TOOL_NAMES - tools}"
     )
+
+
+@pytest.mark.asyncio
+async def test_list_agents_skips_malformed_agent_entries(
+    fake_api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MCP admin listing keeps valid agents when one backend row is malformed."""
+    monkeypatch.setenv("MEMANTO_EXPOSE_ADMIN", "true")
+    mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
+    mcp._memanto_lifecycle._client = FakeAgentListClient()  # type: ignore[attr-defined]
+
+    _, payload = await mcp.call_tool("list_agents", {})
+
+    assert payload["status"] == "ok"
+    assert payload["count"] == 1
+    assert payload["agents"] == [{"agent_id": "valid-agent", "pattern": "tool"}]
 
 
 @pytest.mark.asyncio

--- a/integrations/mcp/tests/test_server.py
+++ b/integrations/mcp/tests/test_server.py
@@ -34,6 +34,7 @@ class FakeAgentListClient:
 
 @pytest.mark.asyncio
 async def test_build_server_registers_main_tools(fake_api_key: str) -> None:
+    """Default server assembly exposes main tools and hides admin tools."""
     mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
     tools = {t.name for t in await mcp.list_tools()}
     assert MAIN_TOOL_NAMES.issubset(tools), (
@@ -49,6 +50,7 @@ async def test_build_server_registers_main_tools(fake_api_key: str) -> None:
 async def test_admin_tools_registered_when_enabled(
     fake_api_key: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Admin tools are registered only when the opt-in env var is enabled."""
     monkeypatch.setenv("MEMANTO_EXPOSE_ADMIN", "true")
     mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
     tools = {t.name for t in await mcp.list_tools()}
@@ -75,6 +77,7 @@ async def test_list_agents_skips_malformed_agent_entries(
 
 @pytest.mark.asyncio
 async def test_server_name_and_instructions(fake_api_key: str) -> None:
+    """Server metadata includes the expected name and memory guidance."""
     mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
     assert mcp.name == "memanto"
     # Instructions guide the model toward correct memory usage; they must be

--- a/integrations/mcp/tests/test_server.py
+++ b/integrations/mcp/tests/test_server.py
@@ -32,6 +32,14 @@ class FakeAgentListClient:
         return [{"agent_id": "valid-agent", "pattern": "tool"}, "truncated-row"]
 
 
+class FakeBrokenAgentListClient:
+    """Client stub returning a non-list top-level payload."""
+
+    def list_agents(self) -> dict[str, object]:
+        """Return a malformed top-level agent list response."""
+        return {"agents": [{"agent_id": "valid-agent", "pattern": "tool"}]}
+
+
 @pytest.mark.asyncio
 async def test_build_server_registers_main_tools(fake_api_key: str) -> None:
     """Default server assembly exposes main tools and hides admin tools."""
@@ -73,6 +81,23 @@ async def test_list_agents_skips_malformed_agent_entries(
     assert payload["status"] == "ok"
     assert payload["count"] == 1
     assert payload["agents"] == [{"agent_id": "valid-agent", "pattern": "tool"}]
+
+
+@pytest.mark.asyncio
+async def test_list_agents_reports_non_list_agent_payload(
+    fake_api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MCP admin listing surfaces top-level response contract breaks."""
+    monkeypatch.setenv("MEMANTO_EXPOSE_ADMIN", "true")
+    mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
+    mcp._memanto_lifecycle._client = FakeBrokenAgentListClient()  # type: ignore[attr-defined]
+
+    _, payload = await mcp.call_tool("list_agents", {})
+
+    assert payload["status"] == "error"
+    assert payload["count"] == 0
+    assert payload["agents"] == []
+    assert "must return a list" in payload["message"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Filter MCP admin `list_agents` results to object-shaped agent metadata entries before building the typed response.
- Keep valid agent rows visible when a backend/client response includes one malformed row.
- Add an MCP server-level regression that calls the registered admin tool with one valid agent and one truncated row.

## Root cause
The MCP admin `list_agents` tool passed `lifecycle.client.list_agents()` directly into `AgentListResult(agents=...)`. If the client returned a mixed list such as a valid agent dict plus a malformed non-object row, Pydantic validation failed for the whole response and the tool returned `status: error`, hiding valid agents from MCP clients.

This is separate from CLI agent metadata handling: this PR is scoped to the MCP admin tool response layer.

## Validation
- Pre-fix regression: `uv run --group dev --with-editable . --with-editable integrations/mcp pytest integrations/mcp/tests/test_server.py::test_list_agents_skips_malformed_agent_entries -q` returned `status: error` instead of preserving the valid row.
- `uv run --group dev --with-editable . --with-editable integrations/mcp pytest integrations/mcp/tests/test_server.py -q`
- `uv run --group dev --with-editable . --with-editable integrations/mcp pytest integrations/mcp/tests -q`
- `uv run --group dev ruff check integrations/mcp/memanto_mcp/tools.py integrations/mcp/tests/test_server.py`
- `uv run --group dev ruff format --check integrations/mcp/memanto_mcp/tools.py integrations/mcp/tests/test_server.py`
- `uv run --group dev python -m py_compile integrations/mcp/memanto_mcp/tools.py integrations/mcp/tests/test_server.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the agent list view so only valid agent entries are shown.
  * Prevented malformed or incomplete agent records from appearing in the results.
  * Updated agent count reporting to reflect only usable entries.
  * Added clearer error handling when the backend response isn’t a list.
* **Tests**
  * Expanded coverage with client stubs for malformed rows and non-list backend payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->