### PR TITLE
fix(crewai): harden recall result rendering

### DIFF
--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -37,6 +37,22 @@ VALID_MEMORY_TYPES = (
 )
 
 
+def _normalize_tags(raw_tags: Any) -> list[str]:
+    """Return semantic tag strings from common Memanto tag shapes."""
+    if isinstance(raw_tags, str):
+        return [tag.strip() for tag in raw_tags.split(",") if tag.strip()]
+    if isinstance(raw_tags, list):
+        return [str(tag).strip() for tag in raw_tags if str(tag).strip()]
+    return []
+
+
+def _valid_recall_memories(raw_memories: Any) -> list[dict[str, Any]]:
+    """Filter recall output to object-shaped memories CrewAI can render."""
+    if not isinstance(raw_memories, list):
+        return []
+    return [mem for mem in raw_memories if isinstance(mem, dict)]
+
+
 class MemantoSetup:
     """
     Manages Memanto agent lifecycle for CrewAI integration.
@@ -255,7 +271,7 @@ class MemantoRecallTool(BaseTool):
             min_similarity=min_similarity,
         )
 
-        memories = result.get("memories", [])
+        memories = _valid_recall_memories(result.get("memories", []))
         if not memories:
             return f"No memories found for query: '{query}'"
 
@@ -265,7 +281,7 @@ class MemantoRecallTool(BaseTool):
             content = mem.get("content", "")
             mem_type = mem.get("type", "unknown")
             confidence = mem.get("confidence", "N/A")
-            tags = mem.get("tags", [])
+            tags = _normalize_tags(mem.get("tags", []))
             tag_str = f" [tags: {', '.join(tags)}]" if tags else ""
 
             lines.append(

--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -257,6 +257,7 @@ class MemantoRecallTool(BaseTool):
         memory_types: str = "",
         min_similarity: float | None = None,
     ) -> str:
+        """Recall memories and render only well-formed rows for CrewAI."""
         type_list = (
             [t.strip() for t in memory_types.split(",") if t.strip()]
             if memory_types

--- a/integrations/crewai/tests/test_tools.py
+++ b/integrations/crewai/tests/test_tools.py
@@ -108,6 +108,52 @@ def test_memanto_recall_tool_success():
     )
 
 
+def test_memanto_recall_tool_skips_malformed_memory_rows():
+    client = MagicMock()
+    client.recall.return_value = {
+        "memories": [
+            "truncated row",
+            {
+                "id": "mem-123",
+                "type": "fact",
+                "title": "Fact 1",
+                "content": "Content 1",
+                "confidence": 0.8,
+                "tags": ["test"],
+            },
+        ]
+    }
+
+    tool = MemantoRecallTool(client=client, agent_id="test-agent")
+    result = tool._run(query="test query")
+
+    assert "Found 1 memories for 'test query'" in result
+    assert "Fact 1" in result
+    assert "truncated row" not in result
+
+
+def test_memanto_recall_tool_normalizes_string_tags():
+    client = MagicMock()
+    client.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-123",
+                "type": "fact",
+                "title": "Fact 1",
+                "content": "Content 1",
+                "confidence": 0.8,
+                "tags": "urgent, client",
+            }
+        ]
+    }
+
+    tool = MemantoRecallTool(client=client, agent_id="test-agent")
+    result = tool._run(query="test query")
+
+    assert "[tags: urgent, client]" in result
+    assert "[tags: u, r, g" not in result
+
+
 def test_memanto_recall_tool_empty():
     client = MagicMock()
     client.recall.return_value = {"memories": []}

--- a/integrations/crewai/tests/test_tools.py
+++ b/integrations/crewai/tests/test_tools.py
@@ -109,6 +109,7 @@ def test_memanto_recall_tool_success():
 
 
 def test_memanto_recall_tool_skips_malformed_memory_rows():
+    """Malformed recall rows do not hide valid CrewAI memory results."""
     client = MagicMock()
     client.recall.return_value = {
         "memories": [
@@ -133,6 +134,7 @@ def test_memanto_recall_tool_skips_malformed_memory_rows():
 
 
 def test_memanto_recall_tool_normalizes_string_tags():
+    """String tags render as semantic tags instead of characters."""
     client = MagicMock()
     client.recall.return_value = {
         "memories": [


### PR DESCRIPTION
/claim #770

## Summary

This fixes a CrewAI integration recall rendering bug in `MemantoRecallTool`.

CrewAI recall assumed every item returned from `client.recall()["memories"]` was an object and assumed `tags` was already a list. If a backend/client response contained one malformed non-object row, the tool raised `AttributeError` and hid otherwise valid memories from the CrewAI agent. If tags arrived as a comma-separated string, matching shapes handled elsewhere in Memanto, CrewAI rendered character-level tags like `u, r, g...` instead of semantic tags.

The fix filters recall output to object-shaped memories before rendering and normalizes tags from either a list or comma-separated string.

## Reproduction

Added regression coverage proving:

- a malformed non-object memory row is skipped while valid memories are still returned
- comma-separated string tags render as `urgent, client`, not character-level tags

## Duplicate boundary

This is scoped to `integrations/crewai`. It is separate from the existing MCP, LangGraph, Hermes, CLI recall display, memory export, and bootstrap robustness submissions because CrewAI has its own tool wrapper and rendering path.

## Validation

- `uv run --with pytest --with pytest-asyncio --with pytest-timeout --with-editable . --with-editable integrations/crewai pytest integrations/crewai/tests/test_tools.py::test_memanto_recall_tool_skips_malformed_memory_rows integrations/crewai/tests/test_tools.py::test_memanto_recall_tool_normalizes_string_tags -q`
- `uv run --with pytest --with pytest-asyncio --with pytest-timeout --with-editable . --with-editable integrations/crewai pytest integrations/crewai/tests/test_tools.py -q`
- `uv run ruff check integrations/crewai/crewai_memanto/tools.py integrations/crewai/tests/test_tools.py`
- `uv run python -m py_compile integrations/crewai/crewai_memanto/tools.py integrations/crewai/tests/test_tools.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recall results handling so invalid/non-conforming memory entries are ignored instead of being shown.
  * Standardized how memory tags are rendered, whether tags are provided as a list or as a comma-delimited string.
* **Tests**
  * Added unit test coverage to ensure malformed recall rows are skipped.
  * Added unit test coverage to confirm tags normalize and display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->