### PR TITLE
Fix Hermes agent id truncation collisions

### DIFF
--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -26,6 +26,7 @@ provider stays inert.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -135,8 +136,15 @@ def _sanitize_agent_id(raw: str) -> str:
     """Coerce to Memanto's id charset (letters, digits, ``-``, ``_``)."""
     cleaned = re.sub(r"[^a-zA-Z0-9_-]", "-", raw or "")
     cleaned = re.sub(r"-+", "-", cleaned).strip("-")
-    cleaned = cleaned[:_MAX_AGENT_ID_LENGTH].strip("-")
-    return cleaned or "hermes"
+    if not cleaned:
+        return "hermes"
+    if len(cleaned) <= _MAX_AGENT_ID_LENGTH:
+        return cleaned
+
+    digest = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:10]
+    prefix_len = _MAX_AGENT_ID_LENGTH - len(digest) - 1
+    prefix = cleaned[:prefix_len].rstrip("-_") or "hermes"
+    return f"{prefix}-{digest}"
 
 
 def _detect_memory_type(text: str) -> str:

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -127,7 +127,18 @@ def test_is_available_false_when_import_missing(monkeypatch):
 def test_sanitize_agent_id_coerces_charset():
     assert _sanitize_agent_id("Hermes Coder!@#") == "Hermes-Coder"
     assert _sanitize_agent_id("") == "hermes"
-    assert _sanitize_agent_id("a" * 100) == "a" * 64
+    long_id = _sanitize_agent_id("a" * 100)
+    assert len(long_id) == 64
+    assert long_id.startswith("a" * 53 + "-")
+
+
+def test_sanitize_agent_id_avoids_truncation_collisions():
+    first = _sanitize_agent_id("hermes-" + "a" * 80)
+    second = _sanitize_agent_id("hermes-" + "a" * 79 + "b")
+
+    assert first != second
+    assert len(first) <= 64
+    assert len(second) <= 64
 
 
 def test_detect_memory_type():


### PR DESCRIPTION
## Summary

Fixes a Hermes Memanto memory-isolation bug where two different long Hermes identities could be sanitized into the same 64-character Memanto `agent_id`.

Before this change, `_sanitize_agent_id()` replaced unsafe characters and then truncated to `_MAX_AGENT_ID_LENGTH`. Distinct identities with the same long prefix therefore collapsed into the same Memanto agent namespace, causing auto-recall, turn capture, mirrored memory writes, and explicit `memanto_*` tool calls to share memory unexpectedly across profiles.

The fix keeps short IDs unchanged and, only for over-length IDs, appends a stable SHA-256 suffix after a readable prefix.

## Reproduction

Before the fix:

```python
from hermes_memanto.provider import _sanitize_agent_id

first = _sanitize_agent_id("hermes-" + "a" * 80)
second = _sanitize_agent_id("hermes-" + "a" * 79 + "b")

assert first == second
```

Both values truncate to the same 64-character `agent_id`.

After the fix, those two identities produce different 64-character-safe IDs:

```text
hermes-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b5d14cd8cf
hermes-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-e56f6493bf
```

## Fix

- Preserve existing behavior for valid short IDs.
- Preserve fallback behavior for empty IDs.
- For over-length IDs, use a readable prefix plus a deterministic hash suffix to avoid collisions while staying within the 64-character Memanto limit.
- Add regression coverage for the long-prefix collision case.

## Validation

```bash
uv run --with pytest --with-editable . --with-editable integrations/hermes-agents pytest integrations/hermes-agents/tests/test_provider.py -q
uv run --with ruff --with-editable . --with-editable integrations/hermes-agents ruff check integrations/hermes-agents/hermes_memanto/provider.py integrations/hermes-agents/tests/test_provider.py
git diff --check
```

Results:

- `39 passed`
- `All checks passed`
- `git diff --check` clean

Refs #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent ID handling for long or unusual inputs so IDs remain valid and more consistent.
  * Reduced the chance of collisions when similar long IDs are processed.
  * Empty or invalid IDs now fall back to a safe default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->