### PR TITLE
Make Hermes memory mirror writes non-blocking on exit

### DIFF
--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -698,7 +698,7 @@ class MemantoMemoryProvider(MemoryProvider):
         if self._write_thread and self._write_thread.is_alive():
             self._write_thread.join(timeout=2.0)
         self._write_thread = threading.Thread(
-            target=_run, daemon=False, name="memanto-memory-write"
+            target=_run, daemon=True, name="memanto-memory-write"
         )
         self._write_thread.start()
 

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -417,6 +417,13 @@ def test_on_memory_write_mirrors_to_memanto(provider):
     assert provider._client.remember_calls[0]["source"] == "hermes-memory"
 
 
+def test_on_memory_write_uses_daemon_thread(provider):
+    provider.on_memory_write("add", "memory", "The deploy pipeline lives in gh actions")
+    assert provider._write_thread is not None
+    assert provider._write_thread.daemon is True
+    provider._write_thread.join(timeout=1)
+
+
 def test_on_memory_write_user_target_is_preference(provider):
     provider.on_memory_write("add", "user", "Name is Jordan")
     provider._write_thread.join(timeout=1)


### PR DESCRIPTION
## Summary

Fixes a Hermes integration shutdown bug in the built-in memory mirroring path.

`on_memory_write()` mirrors Hermes memory writes into Memanto on a background thread. That thread was created with `daemon=False`, unlike the warmup and turn-capture background threads. If the underlying `remember()` call stalls, `shutdown()` can join with a timeout but the still-running non-daemon thread may keep the Python process alive anyway.

This change makes the memory mirror write thread daemon-backed, preserving the current best-effort behavior while avoiding a stuck process on exit.

## Reproduction / failure mode

Before the fix:

```python
provider.on_memory_write("add", "memory", "The deploy pipeline lives in gh actions")
assert provider._write_thread.daemon is False
```

If that thread is blocked in a network-backed `remember()` call, Python can wait for it even after `shutdown()` times out.

After the fix:

```python
provider.on_memory_write("add", "memory", "The deploy pipeline lives in gh actions")
assert provider._write_thread.daemon is True
```

## Fix

- Set `daemon=True` when creating `memanto-memory-write`.
- Add regression coverage that verifies `on_memory_write()` creates a daemon thread.

## Validation

```bash
uv run --with pytest --with-editable . --with-editable integrations/hermes-agents pytest integrations/hermes-agents/tests/test_provider.py -q
uv run --with ruff --with-editable . --with-editable integrations/hermes-agents ruff check integrations/hermes-agents/hermes_memanto/provider.py integrations/hermes-agents/tests/test_provider.py
git diff --check
```

Results:

- `39 passed`
- `All checks passed`
- `git diff --check` clean

Refs #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory syncing behavior so background work no longer blocks application shutdown.
  * Added coverage to confirm the write process runs as a background task as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->