### PR TITLE
Parse Claude Code extraction JSON arrays robustly

### DIFF
--- a/integrations/claudecode/claudecode_memanto/extractor.py
+++ b/integrations/claudecode/claudecode_memanto/extractor.py
@@ -148,11 +148,11 @@ def _extract_json_array(text: str) -> str | None:
         if char != "[":
             continue
         try:
-            parsed, end = decoder.raw_decode(cleaned[start:])
+            parsed, end = decoder.raw_decode(cleaned, start)
         except json.JSONDecodeError:
             continue
         if isinstance(parsed, list):
-            return cleaned[start : start + end]
+            return cleaned[start:end]
     return None
 
 

--- a/integrations/claudecode/claudecode_memanto/extractor.py
+++ b/integrations/claudecode/claudecode_memanto/extractor.py
@@ -143,11 +143,17 @@ _FENCE_RE = re.compile(r"```(?:json)?", re.IGNORECASE)
 
 def _extract_json_array(text: str) -> str | None:
     cleaned = _FENCE_RE.sub("", text).strip()
-    start = cleaned.find("[")
-    end = cleaned.rfind("]")
-    if start == -1 or end == -1 or end <= start:
-        return None
-    return cleaned[start : end + 1]
+    decoder = json.JSONDecoder()
+    for start, char in enumerate(cleaned):
+        if char != "[":
+            continue
+        try:
+            parsed, end = decoder.raw_decode(cleaned[start:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, list):
+            return cleaned[start : start + end]
+    return None
 
 
 def _coerce_memory(item: Any) -> dict[str, Any] | None:

--- a/integrations/claudecode/tests/test_extractor.py
+++ b/integrations/claudecode/tests/test_extractor.py
@@ -22,6 +22,15 @@ class TestParseLlmMemories:
         assert len(mems) == 1
         assert mems[0]["type"] == "fact"
 
+    def test_ignores_bracketed_prose_before_json_array(self) -> None:
+        text = (
+            "Extraction notes [draft]: checked the transcript.\n"
+            '[{"type":"decision","title":"Queue","content":"Use a durable queue."}]'
+        )
+        mems = extractor.parse_llm_memories(text)
+        assert len(mems) == 1
+        assert mems[0]["title"] == "Queue"
+
     def test_invalid_type_coerced_to_learning(self) -> None:
         mems = extractor.parse_llm_memories(
             '[{"type":"nonsense","content":"something durable"}]'


### PR DESCRIPTION
## Summary

Fixes Claude Code memory extraction when the backend LLM returns bracketed prose before the actual JSON array.

The parser currently slices from the first `[` to the last `]`. If the answer starts with harmless text like:

```text
Extraction notes [draft]: checked the transcript.
[{"type":"decision","title":"Queue","content":"Use a durable queue."}]
```

the parser starts at `[draft]`, fails JSON parsing, and drops the valid memories that follow.

## Reproduction

Before the fix, this response shape returns no memories because parsing starts at `[draft]` instead of scanning for the first valid JSON array:

```python
from claudecode_memanto.extractor import parse_llm_memories

text = """Extraction notes [draft]: checked the transcript.
[{"type":"decision","title":"Queue","content":"Use a durable queue."}]
"""

assert parse_llm_memories(text) == []
```

After the fix, the same input returns the valid `decision` memory from the second line. The added test covers that exact bracketed-prose failure mode.

## Fix

- Replace first-bracket/last-bracket slicing with `JSONDecoder.raw_decode` scanning.
- Return the first syntactically valid JSON array in the response.
- Add regression coverage for bracketed prose before the real array.

## Validation

```bash
uv run --with pytest --with-editable . --with-editable integrations/claudecode pytest integrations/claudecode/tests/test_extractor.py -q
uv run --with pytest --with-editable . --with-editable integrations/claudecode pytest integrations/claudecode/tests -q
uv run --with ruff --with-editable . --with-editable integrations/claudecode ruff check integrations/claudecode/claudecode_memanto integrations/claudecode/hooks integrations/claudecode/tests
git diff --check
```

Results:

- 15 focused extractor tests passed
- 69 Claude Code integration tests passed
- `All checks passed`
- `git diff --check` clean

Refs #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON array extraction by locating and decoding the first valid JSON array within the LLM response, even if bracketed text appears beforehand.
  * Reduced parsing failures by returning only the exact detected JSON array.
* **Tests**
  * Added a unit test to verify bracketed prose preceding the JSON array is ignored and that parsing still succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->