### PR TITLE
Enforce LangGraph remember input limits

### DIFF
--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -65,7 +65,7 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
             Field(
                 min_length=1,
                 max_length=100,
-                description="Short title for the memory (max 100 characters).",
+                description="Short title for the memory (1-100 characters).",
             ),
         ],
         content: Annotated[
@@ -73,7 +73,7 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
             Field(
                 min_length=1,
                 max_length=10000,
-                description="The memory content to store (max 10000 characters). Be concise and atomic.",
+                description="The memory content to store (1-10000 characters). Be concise and atomic.",
             ),
         ],
         confidence: Annotated[

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -63,12 +63,16 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
         title: Annotated[
             str,
             Field(
+                min_length=1,
+                max_length=100,
                 description="Short title for the memory (max 100 characters).",
             ),
         ],
         content: Annotated[
             str,
             Field(
+                min_length=1,
+                max_length=10000,
                 description="The memory content to store (max 10000 characters). Be concise and atomic.",
             ),
         ],

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
 
+import pytest
 from langgraph_memanto.tools import create_memanto_tools
+from pydantic import ValidationError
 
 
 def test_create_memanto_tools_returns_all_tools():
@@ -68,6 +70,34 @@ def test_memanto_remember_tool_setup_fallback():
     assert client.remember.call_count == 2
     client.create_agent.assert_called_once_with(agent_id="test-agent", pattern="tool")
     client.activate_agent.assert_called_once_with("test-agent", duration_hours=6)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("title", ""),
+        ("title", "t" * 101),
+        ("content", ""),
+        ("content", "c" * 10001),
+    ],
+)
+def test_memanto_remember_tool_enforces_documented_limits(field, value):
+    client = MagicMock()
+    tools = create_memanto_tools(client, "test-agent")
+    remember_tool = next(t for t in tools if t.name == "memanto_remember")
+    payload = {
+        "memory_type": "fact",
+        "title": "Valid title",
+        "content": "Valid content",
+        "confidence": 0.9,
+        "tags": "",
+    }
+    payload[field] = value
+
+    with pytest.raises(ValidationError):
+        remember_tool.invoke(payload)
+
+    client.remember.assert_not_called()
 
 
 def test_memanto_recall_tool_success():


### PR DESCRIPTION
## Summary

Enforces the documented LangGraph remember input limits locally in the tool schema.

`memanto_remember` already documents these constraints:

```text
title max 100 characters
content max 10000 characters
```

But the tool schema did not enforce them, and it accepted empty strings. That allows invalid memory payloads to leave the LangGraph tool layer and fail later in the client/server path.

## Reproduction

Before the fix, the LangGraph remember tool input schema accepted empty and oversized values even though the tool description documents stricter limits:

```python
from pydantic import ValidationError
from langgraph_memanto.tools import RememberInput

# These should raise ValidationError at the tool boundary, but they passed.
RememberInput(memory_type="fact", title="", content="valid")
RememberInput(memory_type="fact", title="x" * 101, content="valid")
RememberInput(memory_type="fact", title="valid", content="")
RememberInput(memory_type="fact", title="valid", content="x" * 10001)
```

The regression tests added in this PR reproduce those invalid inputs and assert they now fail before the client/server path.

## Fix

- Add `min_length=1` and `max_length=100` to `title`.
- Add `min_length=1` and `max_length=10000` to `content`.
- Add regression coverage for empty and oversized title/content values.

## Validation

```bash
uv run --with pytest --with-editable . --with-editable integrations/langgraph pytest integrations/langgraph/tests/test_tools.py -q
uv run --with pytest --with-editable . --with-editable integrations/langgraph pytest integrations/langgraph/tests -q
uv run --with ruff --with-editable . --with-editable integrations/langgraph ruff check integrations/langgraph/langgraph_memanto/tools.py integrations/langgraph/tests/test_tools.py
git diff --check
```

Results:

- 12 focused LangGraph tool tests passed
- 36 LangGraph integration tests passed
- `All checks passed`
- `git diff --check` clean

Refs #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened input validation for memory notes so titles and content must now be non-empty and stay within defined length limits.
  * Invalid entries are rejected before being sent, helping prevent incomplete or oversized submissions.

* **Tests**
  * Added coverage to confirm invalid inputs fail validation and are not processed further.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->