### PR TITLE
Parse conversation extraction JSON arrays robustly

### DIFF
--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -122,6 +122,7 @@ class ConversationMemoryExtractionService:
             return json.loads(text)
         except json.JSONDecodeError:
             decoder = json.JSONDecoder()
+            fallback_array: Any | None = None
             for match in re.finditer(r"[\[{]", text):
                 try:
                     parsed, end = decoder.raw_decode(text[match.start() :])
@@ -130,7 +131,9 @@ class ConversationMemoryExtractionService:
                 if not text[match.start() + end :].strip():
                     return parsed
                 if isinstance(parsed, list):
-                    return parsed
+                    fallback_array = parsed
+            if fallback_array is not None:
+                return fallback_array
             raise ValueError("Memory extraction did not return valid JSON")
 
     def _normalize_candidates(

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -121,10 +121,16 @@ class ConversationMemoryExtractionService:
         try:
             return json.loads(text)
         except json.JSONDecodeError:
-            start = text.find("[")
-            end = text.rfind("]")
-            if start != -1 and end != -1 and end > start:
-                return json.loads(text[start : end + 1])
+            decoder = json.JSONDecoder()
+            for match in re.finditer(r"[\[{]", text):
+                try:
+                    parsed, end = decoder.raw_decode(text[match.start() :])
+                except json.JSONDecodeError:
+                    continue
+                if not text[match.start() + end :].strip():
+                    return parsed
+                if isinstance(parsed, list):
+                    return parsed
             raise ValueError("Memory extraction did not return valid JSON")
 
     def _normalize_candidates(

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -131,6 +131,39 @@ def test_extract_skips_bracketed_prose_before_json_array():
     ]
 
 
+def test_extract_keeps_scanning_after_array_with_trailing_prose():
+    client = FakeClient(
+        """
+        Notes: [] means no durable facts in a segment.
+        [
+          {
+            "type": "fact",
+            "title": "Timezone",
+            "content": "The user schedules maintenance in UTC.",
+            "confidence": 0.82
+          }
+        ]
+        """
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Schedule maintenance in UTC."}],
+    )
+
+    assert candidates == [
+        {
+            "type": "fact",
+            "title": "Timezone",
+            "content": "The user schedules maintenance in UTC.",
+            "confidence": 0.82,
+            "source": "conversation",
+            "provenance": "inferred",
+        }
+    ]
+
+
 def test_extract_rejects_non_json_answers():
     service = ConversationMemoryExtractionService(FakeClient("not json"))
 

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -98,6 +98,39 @@ def test_extract_omits_unset_active_ai_model(monkeypatch):
     assert "ai_model" not in client.answer.call_kwargs
 
 
+def test_extract_skips_bracketed_prose_before_json_array():
+    client = FakeClient(
+        """
+        Extraction notes [draft]: scanned transcript for durable facts.
+        [
+          {
+            "type": "fact",
+            "title": "Deployment window",
+            "content": "The user deploys production services after 18:00 UTC.",
+            "confidence": 0.88
+          }
+        ]
+        """
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "I deploy production after 18:00 UTC."}],
+    )
+
+    assert candidates == [
+        {
+            "type": "fact",
+            "title": "Deployment window",
+            "content": "The user deploys production services after 18:00 UTC.",
+            "confidence": 0.88,
+            "source": "conversation",
+            "provenance": "inferred",
+        }
+    ]
+
+
 def test_extract_rejects_non_json_answers():
     service = ConversationMemoryExtractionService(FakeClient("not json"))
 


### PR DESCRIPTION
## Summary

Fixes conversation memory extraction JSON parsing when the backend LLM includes bracketed prose before the actual JSON array.

The current fallback slices from the first `[` to the last `]`. If an otherwise-valid answer starts with a note such as `Extraction notes [draft]: ...` followed by the real memory array, parsing starts at `[draft]`, raises `JSONDecodeError`, and drops all extracted memories.

## Fix

- Scan candidate JSON starts with `JSONDecoder.raw_decode` instead of using first-bracket/last-bracket slicing.
- Return the first valid JSON array even when earlier bracketed prose is present.
- Add regression coverage for conversation extraction with bracketed prose before the memory array.

## Validation

```bash
python3 -m pytest tests/test_conversation_memory_extraction.py -q
python3 -m pytest tests -q
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when extracting JSON from model responses that include extra bracketed prose or non-JSON text before the payload.
  * Enhanced handling to correctly parse the first valid JSON segment even when additional trailing prose follows.
* **Tests**
  * Added unit tests covering extraction behavior with pre-payload bracketed prose and continued scanning after a JSON array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->