### PR TITLE
Restore memory when update reupload fails

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -306,6 +306,38 @@ class MemoryWriteService:
                 if metadata.get("expires_at"):
                     updated_memory.expires_at = metadata["expires_at"]
 
+            original_memory = MemoryRecord(
+                id=memory_id,
+                type=metadata.get("type", "fact"),
+                title=existing_memory_data.get("title", "Restored Memory"),
+                content=existing_memory_data.get("content", ""),
+                scope_type=metadata.get("scope_type", "agent"),
+                scope_id=metadata.get("scope_id", "unknown"),
+                actor_id=metadata.get("actor_id", "unknown"),
+                source=metadata.get("source", "system"),
+                source_ref=metadata.get("source_ref"),
+                confidence=metadata.get("confidence", 0.8),
+                status=metadata.get("status", "active"),
+                tags=metadata.get("tags", []),
+            )
+            if raw_created:
+                original_memory.created_at = updated_memory.created_at
+            if metadata.get("updated_at"):
+                raw_updated = metadata["updated_at"]
+                if isinstance(raw_updated, str):
+                    try:
+                        original_memory.updated_at = datetime.fromisoformat(
+                            raw_updated.replace("Z", "+00:00")
+                        )
+                    except (ValueError, AttributeError):
+                        pass
+                else:
+                    original_memory.updated_at = raw_updated
+            if metadata.get("ttl_seconds"):
+                original_memory.ttl_seconds = metadata["ttl_seconds"]
+                if metadata.get("expires_at"):
+                    original_memory.expires_at = metadata["expires_at"]
+
             # Step 3: Delete old version
             delete_result = self.client.documents.delete(
                 namespace_name=namespace, ids=[memory_id]
@@ -322,9 +354,25 @@ class MemoryWriteService:
             from moorcheh_sdk.types.document import Document
 
             document = cast(Document, updated_memory.to_moorcheh_document())
-            upload_result = self.client.documents.upload(
-                namespace_name=namespace, documents=[document]
-            )
+            try:
+                upload_result = self.client.documents.upload(
+                    namespace_name=namespace, documents=[document]
+                )
+            except Exception as upload_error:
+                original_document = cast(
+                    Document, original_memory.to_moorcheh_document()
+                )
+                try:
+                    self.client.documents.upload(
+                        namespace_name=namespace, documents=[original_document]
+                    )
+                except Exception as rollback_error:
+                    raise MemoryError(
+                        f"Failed to upload updated memory {memory_id}; rollback also failed"
+                    ) from rollback_error
+                raise MemoryError(
+                    f"Failed to upload updated memory {memory_id}; restored original version"
+                ) from upload_error
 
             return {
                 "id": memory_id,

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -267,10 +267,30 @@ class MemoryWriteService:
                     f"in namespace {namespace}"
                 )
 
+            def parse_datetime(value: Any) -> datetime | None:
+                if isinstance(value, datetime):
+                    return value
+                if isinstance(value, str):
+                    try:
+                        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+                    except (ValueError, AttributeError):
+                        return None
+                return None
+
+            def normalize_tags(value: Any) -> list[str]:
+                if isinstance(value, str):
+                    return [tag.strip() for tag in value.split(",") if tag.strip()]
+                if isinstance(value, list):
+                    return value
+                return []
+
+            memory_type = metadata.get("memory_type", metadata.get("type", "fact"))
+            tags = normalize_tags(metadata.get("tags", []))
+
             # Build updated memory record
             updated_memory = MemoryRecord(
                 id=memory_id,  # Keep same ID
-                type=updates.get("type", metadata.get("type", "fact")),
+                type=updates.get("type", memory_type),
                 title=updates.get(
                     "title", existing_memory_data.get("title", "Updated Memory")
                 ),
@@ -281,21 +301,14 @@ class MemoryWriteService:
                 source_ref=updates.get("source_ref", metadata.get("source_ref")),
                 confidence=updates.get("confidence", metadata.get("confidence", 0.8)),
                 status=updates.get("status", metadata.get("status", "active")),
-                tags=updates.get("tags", metadata.get("tags", [])),
+                tags=updates.get("tags", tags),
             )
 
             # Update timestamps (preserve created_at, set updated_at to now)
             raw_created = metadata.get("created_at")
-            if raw_created:
-                if isinstance(raw_created, str):
-                    try:
-                        updated_memory.created_at = datetime.fromisoformat(
-                            raw_created.replace("Z", "+00:00")
-                        )
-                    except (ValueError, AttributeError):
-                        pass  # Keep default
-                else:
-                    updated_memory.created_at = raw_created
+            parsed_created = parse_datetime(raw_created)
+            if parsed_created:
+                updated_memory.created_at = parsed_created
             updated_memory.updated_at = datetime.utcnow()
 
             # Handle TTL
@@ -303,40 +316,34 @@ class MemoryWriteService:
                 updated_memory.set_ttl(updates["ttl_seconds"])
             elif metadata.get("ttl_seconds"):
                 updated_memory.ttl_seconds = metadata["ttl_seconds"]
-                if metadata.get("expires_at"):
-                    updated_memory.expires_at = metadata["expires_at"]
+                parsed_expires_at = parse_datetime(metadata.get("expires_at"))
+                if parsed_expires_at:
+                    updated_memory.expires_at = parsed_expires_at
 
             original_memory = MemoryRecord(
                 id=memory_id,
-                type=metadata.get("type", "fact"),
+                type=memory_type,
                 title=existing_memory_data.get("title", "Restored Memory"),
                 content=existing_memory_data.get("content", ""),
-                scope_type=metadata.get("scope_type", "agent"),
-                scope_id=metadata.get("scope_id", "unknown"),
+                agent_id=agent_id,
                 actor_id=metadata.get("actor_id", "unknown"),
                 source=metadata.get("source", "system"),
                 source_ref=metadata.get("source_ref"),
                 confidence=metadata.get("confidence", 0.8),
                 status=metadata.get("status", "active"),
-                tags=metadata.get("tags", []),
+                tags=tags,
+                provenance=metadata.get("provenance", "explicit_statement"),
             )
-            if raw_created:
-                original_memory.created_at = updated_memory.created_at
-            if metadata.get("updated_at"):
-                raw_updated = metadata["updated_at"]
-                if isinstance(raw_updated, str):
-                    try:
-                        original_memory.updated_at = datetime.fromisoformat(
-                            raw_updated.replace("Z", "+00:00")
-                        )
-                    except (ValueError, AttributeError):
-                        pass
-                else:
-                    original_memory.updated_at = raw_updated
+            if parsed_created:
+                original_memory.created_at = parsed_created
+            parsed_updated = parse_datetime(metadata.get("updated_at"))
+            if parsed_updated:
+                original_memory.updated_at = parsed_updated
             if metadata.get("ttl_seconds"):
                 original_memory.ttl_seconds = metadata["ttl_seconds"]
-                if metadata.get("expires_at"):
-                    original_memory.expires_at = metadata["expires_at"]
+                parsed_expires_at = parse_datetime(metadata.get("expires_at"))
+                if parsed_expires_at:
+                    original_memory.expires_at = parsed_expires_at
 
             # Step 3: Delete old version
             delete_result = self.client.documents.delete(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -295,17 +295,22 @@ class TestMemoryWriteServiceUpdate:
     def _existing_memory() -> dict[str, object]:
         return {
             "id": "mem-1",
-            "type": "fact",
             "title": "Original title",
             "content": "Original content",
-            "scope_type": "agent",
-            "scope_id": "agent-1",
-            "actor_id": "agent-1",
-            "source": "user",
-            "source_ref": "chat-1",
-            "confidence": 0.9,
-            "status": "active",
-            "tags": ["stable"],
+            "metadata": {
+                "memory_type": "preference",
+                "actor_id": "agent-1",
+                "source": "user",
+                "source_ref": "chat-1",
+                "confidence": 0.9,
+                "status": "active",
+                "tags": "stable,verified",
+                "provenance": "validated",
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-02T00:00:00Z",
+                "ttl_seconds": 3600,
+                "expires_at": "2024-01-04T00:00:00Z",
+            },
         }
 
     def test_update_memory_restores_original_when_reupload_fails(self):
@@ -334,15 +339,29 @@ class TestMemoryWriteServiceUpdate:
                 )
 
         assert client.documents.upload.call_count == 2
+        assert (
+            client.documents.upload.call_args_list[0].kwargs["namespace_name"]
+            == "memanto_agent_agent-1"
+        )
+        assert (
+            client.documents.upload.call_args_list[1].kwargs["namespace_name"]
+            == "memanto_agent_agent-1"
+        )
         restored_document = client.documents.upload.call_args_list[1].kwargs[
             "documents"
         ][0]
         assert restored_document["id"] == "mem-1"
         assert restored_document["text"].startswith(
-            "[FACT] Original title\n\nOriginal content"
+            "[PREFERENCE] Original title\n\nOriginal content"
         )
-        assert restored_document["scope_id"] == "agent-1"
-        assert restored_document["tags"] == "stable"
+        assert restored_document["memory_type"] == "preference"
+        assert restored_document["agent_id"] == "agent-1"
+        assert restored_document["tags"] == "stable,verified"
+        assert restored_document["provenance"] == "validated"
+        assert restored_document["created_at"] == "2024-01-01T00:00:00+00:00"
+        assert restored_document["updated_at"] == "2024-01-02T00:00:00+00:00"
+        assert restored_document["ttl_seconds"] == 3600
+        assert restored_document["expires_at"] == "2024-01-04T00:00:00+00:00"
 
     def test_update_memory_reports_when_restore_also_fails(self):
         """A failed rollback must be reported distinctly from a restored update."""
@@ -371,6 +390,10 @@ class TestMemoryWriteServiceUpdate:
                 )
 
         assert client.documents.upload.call_count == 2
+        assert (
+            client.documents.upload.call_args_list[1].kwargs["namespace_name"]
+            == "memanto_agent_agent-1"
+        )
 
 
 class TestForgetEndToEnd:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,91 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryWriteServiceUpdate:
+    """Regression tests for update_memory's delete-and-recreate flow."""
+
+    @staticmethod
+    def _existing_memory() -> dict[str, object]:
+        return {
+            "id": "mem-1",
+            "type": "fact",
+            "title": "Original title",
+            "content": "Original content",
+            "scope_type": "agent",
+            "scope_id": "agent-1",
+            "actor_id": "agent-1",
+            "source": "user",
+            "source_ref": "chat-1",
+            "confidence": 0.9,
+            "status": "active",
+            "tags": ["stable"],
+        }
+
+    def test_update_memory_restores_original_when_reupload_fails(self):
+        """A failed update upload must not leave the original memory deleted."""
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        existing_memory = self._existing_memory()
+        client = MagicMock()
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.side_effect = [
+            RuntimeError("upload unavailable"),
+            {"status": "restored"},
+        ]
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService"
+        ) as read_service_cls:
+            read_service_cls.return_value.get_memory.return_value = existing_memory
+
+            with pytest.raises(MemoryError, match="Failed to update memory"):
+                MemoryWriteService(client).update_memory(
+                    "mem-1",
+                    "memanto_agent_agent-1",
+                    {"content": "Updated content"},
+                )
+
+        assert client.documents.upload.call_count == 2
+        restored_document = client.documents.upload.call_args_list[1].kwargs[
+            "documents"
+        ][0]
+        assert restored_document["id"] == "mem-1"
+        assert restored_document["text"].startswith(
+            "[FACT] Original title\n\nOriginal content"
+        )
+        assert restored_document["scope_id"] == "agent-1"
+        assert restored_document["tags"] == "stable"
+
+    def test_update_memory_reports_when_restore_also_fails(self):
+        """A failed rollback must be reported distinctly from a restored update."""
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.side_effect = [
+            RuntimeError("upload unavailable"),
+            RuntimeError("rollback unavailable"),
+        ]
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService"
+        ) as read_service_cls:
+            read_service_cls.return_value.get_memory.return_value = (
+                self._existing_memory()
+            )
+
+            with pytest.raises(MemoryError, match="rollback also failed"):
+                MemoryWriteService(client).update_memory(
+                    "mem-1",
+                    "memanto_agent_agent-1",
+                    {"content": "Updated content"},
+                )
+
+        assert client.documents.upload.call_count == 2
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- Preserve the original memory document before `update_memory()` deletes it.
- If the replacement upload fails after deletion, best-effort restore the original document to the same namespace.
- Preserve the current Moorcheh metadata shape during rollback: `agent_id`, `memory_type`, comma-separated `tags`, provenance, TTL, and timestamps.
- If the restore upload also fails, surface that explicitly instead of implying rollback succeeded.
- Add regression coverage for both failed-reupload paths, including restore namespace and metadata payload assertions.

## Why
`update_memory()` uses a delete-and-recreate flow. Before this change, a successful delete followed by a failed replacement upload could leave the original memory missing. The fix keeps the successful path unchanged and adds rollback only for the failed replacement upload path.

The rollback path now restores the original stored record without resetting the metadata fields that are still part of the current core memory model. It also handles older stored records that lack flat `agent_id` metadata by deriving the agent from the namespace.

The rollback failure case is also explicit now: `rollback also failed` is reported when the replacement upload fails and the original document cannot be restored either.

## Validation
```text
.\.venv\Scripts\python.exe -m pytest tests/test_unit.py -q
28 passed

.\.venv\Scripts\python.exe -m ruff check memanto/app/services/memory_write_service.py tests/test_unit.py
All checks passed!

.\.venv\Scripts\python.exe -m ruff format --check memanto/app/services/memory_write_service.py tests/test_unit.py
2 files already formatted

git diff --check
passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory updates to preserve existing timestamps, TTL, type, and tags when editing saved entries.
  * Added a safer recovery path if an updated memory can’t be saved, helping restore the previous version instead of leaving data inconsistent.
  * Made handling of stored date and tag formats more robust, reducing update failures from mixed data formats.

* **Tests**
  * Added regression coverage for successful rollback recovery and for cases where rollback restoration also fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->