### PR TITLE
Filter inactive memories from live recall

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -220,6 +220,9 @@ class MemoryReadService:
 
             # Apply TTL enforcement - filter out expired memories
             all_results = self._filter_expired_memories(all_results)
+            all_results = self._filter_inactive_memories(
+                all_results, status_filter=status_filter
+            )
 
             if min_confidence is not None:
                 all_results = self._filter_by_min_confidence(
@@ -443,6 +446,7 @@ class MemoryReadService:
                 return {"results": [], "total_found": 0}
 
             unique_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            unique_memories = self._filter_inactive_memories(unique_memories)
 
             if created_after or created_before:
                 unique_memories = self._apply_temporal_filter(
@@ -551,6 +555,26 @@ class MemoryReadService:
             except (TypeError, ValueError):
                 continue
         return fallback, fetch_index
+
+    def _filter_inactive_memories(
+        self,
+        results: list[dict[str, Any]],
+        status_filter: list[str] | str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Remove inactive memories unless explicitly requested."""
+        if status_filter is None:
+            requested_statuses: set[str] = set()
+        elif isinstance(status_filter, str):
+            requested_statuses = {status_filter.lower()}
+        else:
+            requested_statuses = {str(status).lower() for status in status_filter}
+
+        hidden_statuses = {"deleted", "superseded"} - requested_statuses
+        return [
+            result
+            for result in results
+            if str(result.get("status") or "active").lower() not in hidden_statuses
+        ]
 
     def _build_filtered_query(
         self,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -836,8 +836,11 @@ class TestMemoryReadServiceRecallStatus:
     """Recall should not surface inactive memory records."""
 
     @staticmethod
-    def _memory_item(memory_id: str, status: str) -> dict[str, object]:
-        return {
+    def _memory_item(
+        memory_id: str,
+        status: str | None = None,
+    ) -> dict[str, object]:
+        item: dict[str, object] = {
             "id": memory_id,
             "text": f"[FACT] {memory_id}\n\nStored fact",
             "memory_type": "fact",
@@ -845,10 +848,14 @@ class TestMemoryReadServiceRecallStatus:
             "actor_id": "agent-1",
             "source": "user",
             "confidence": 0.9,
-            "status": status,
             "created_at": "2026-01-01T00:00:00+00:00",
             "updated_at": "2026-01-01T00:00:00+00:00",
         }
+
+        if status is not None:
+            item["status"] = status
+
+        return item
 
     def test_search_memories_filters_superseded_and_deleted_results(self):
         """Standard recall must not return stale inactive memories."""
@@ -858,6 +865,7 @@ class TestMemoryReadServiceRecallStatus:
         client.similarity_search.query.return_value = {
             "results": [
                 self._memory_item("active", "active"),
+                self._memory_item("legacy"),
                 self._memory_item("superseded", "superseded"),
                 self._memory_item("deleted", "deleted"),
             ],
@@ -866,7 +874,10 @@ class TestMemoryReadServiceRecallStatus:
 
         result = MemoryReadService(client).search_memories("stored", agent_id="agent-1")
 
-        assert [item["id"] for item in result["results"]] == ["active"]
+        assert [item["id"] for item in result["results"]] == [
+            "active",
+            "legacy",
+        ]
 
     def test_search_memories_preserves_explicit_deleted_filter(self):
         """Explicit deleted recall must preserve deleted memories only."""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -832,6 +832,108 @@ class TestClientApiKeyDispatch:
         assert calls == ["mk_instance_specific_key"]
 
 
+class TestMemoryReadServiceRecallStatus:
+    """Recall should not surface inactive memory records."""
+
+    @staticmethod
+    def _memory_item(memory_id: str, status: str) -> dict[str, object]:
+        return {
+            "id": memory_id,
+            "text": f"[FACT] {memory_id}\n\nStored fact",
+            "memory_type": "fact",
+            "agent_id": "agent-1",
+            "actor_id": "agent-1",
+            "source": "user",
+            "confidence": 0.9,
+            "status": status,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }
+
+    def test_search_memories_filters_superseded_and_deleted_results(self):
+        """Standard recall must not return stale inactive memories."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [
+                self._memory_item("active", "active"),
+                self._memory_item("superseded", "superseded"),
+                self._memory_item("deleted", "deleted"),
+            ],
+            "execution_time": 0,
+        }
+
+        result = MemoryReadService(client).search_memories("stored", agent_id="agent-1")
+
+        assert [item["id"] for item in result["results"]] == ["active"]
+
+    def test_search_memories_preserves_explicit_deleted_filter(self):
+        """Explicit deleted recall must preserve deleted memories only."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [
+                self._memory_item("active", "active"),
+                self._memory_item("deleted", "deleted"),
+                self._memory_item("superseded", "superseded"),
+            ],
+            "execution_time": 0,
+        }
+
+        result = MemoryReadService(client).search_memories(
+            "stored",
+            agent_id="agent-1",
+            status_filter=["deleted"],
+        )
+
+        assert [item["id"] for item in result["results"]] == ["active", "deleted"]
+
+    def test_search_memories_preserves_explicit_superseded_filter(self):
+        """Explicit superseded recall must preserve superseded memories only."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [
+                self._memory_item("active", "active"),
+                self._memory_item("deleted", "deleted"),
+                self._memory_item("superseded", "superseded"),
+            ],
+            "execution_time": 0,
+        }
+
+        result = MemoryReadService(client).search_memories(
+            "stored",
+            agent_id="agent-1",
+            status_filter=["superseded"],
+        )
+
+        assert [item["id"] for item in result["results"]] == [
+            "active",
+            "superseded",
+        ]
+
+    def test_search_recent_filters_superseded_and_deleted_results(self):
+        """Recent recall must not return stale inactive memories."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {
+            "items": [
+                self._memory_item("active", "active"),
+                self._memory_item("superseded", "superseded"),
+                self._memory_item("deleted", "deleted"),
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        result = MemoryReadService(client).search_recent("agent-1")
+
+        assert [item["id"] for item in result["results"]] == ["active"]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- Filter `deleted` and `superseded` memory records out of default live similarity recall results.
- Preserve explicitly requested inactive statuses when `search_memories(..., status_filter=...)` asks for them.
- Keep recent-memory recall live-only by always filtering inactive records there.
- Add regression coverage for default recall, explicit deleted recall, explicit superseded recall, and recent recall.

## Root Cause
Live recall only filtered expired memories after fetching search results. It did not exclude memory records whose stored status was already `deleted` or `superseded`, so stale or contradicted records could still be returned as current context.

The initial fix was too broad because it removed inactive records even when the caller explicitly requested them through `status_filter`. The updated fix treats inactive statuses as hidden by default, but allows `deleted` and/or `superseded` through when explicitly requested.

## Reproduction
The regression tests stub stored recall results with records in the same agent scope:
- one `active`
- one `superseded`
- one `deleted`

Before the fix, default `search_memories()` and `search_recent()` returned inactive records as live context. After the fix, default live recall returns only active records.

Additional coverage proves:
- `status_filter=["deleted"]` preserves deleted records while still hiding superseded records
- `status_filter=["superseded"]` preserves superseded records while still hiding deleted records

## Impact
This is a memory integrity and retrieval correctness bug for #770. A deleted or superseded memory can reappear in live recall, causing agents to act on stale facts, contradicted preferences, or intentionally removed context.

## Fix
Add a small live-recall status filter that treats missing status as active for backward compatibility. It removes `deleted` and `superseded` records by default, but honors explicit inactive `status_filter` requests. The filter is applied only to live recall paths, not historical as-of recall.

## Validation
- Full test suite on Python 3.12: `456 passed, 24 skipped` (live E2E tests require `MOORCHEH_API_KEY`)
- Legacy missing-status regression tests: `4 passed`
- `ruff check memanto/app/services/memory_read_service.py tests/test_unit.py`: passed
- `ruff format --check memanto/app/services/memory_read_service.py tests/test_unit.py`: passed
- `git diff --check`: passed
- Rebased onto current `main` (`2b2ae9a`)
- Head commit: `9b8f02e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standard memory searches now hide inactive memories (deleted and superseded) by default.
  * Recent memory results now exclude inactive memories before additional filtering and sorting.
  * When a status filter explicitly requests deleted or superseded, those items remain included.

* **Tests**
  * Added unit tests to verify inactive-memory filtering behavior for both standard and recent search flows, including “missing status” legacy items and explicit status requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
