### PR TITLE
Guard direct memory sync cached exports

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1539,27 +1539,40 @@ class DirectClient:
             Dict with ``output_path``, ``total_memories``, ``source``
             (``"cache"`` or ``"fresh"``).
         """
-        self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
+        export_result = self.export_memory_md(
+            agent_id=agent_id, limit_per_type=limit_per_type
+        )
 
         cache_path = Path.home() / ".memanto" / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if cache_path.exists():
-            # Copy the freshly updated cache.
-            shutil.copy2(str(cache_path), str(target_path))
-            content = cache_path.read_text(encoding="utf-8")
-            mem_count = content.count("### ")
-            return {
-                "output_path": str(target_path.resolve()),
-                "total_memories": mem_count,
-                "source": "cache",
-            }
+        source_path = cache_path
+        source_label = "cache"
+        if not source_path.exists():
+            raw_export_path = export_result.get("output_path")
+            if raw_export_path:
+                source_path = Path(str(raw_export_path))
+                source_label = "fresh"
 
+        if not source_path.exists():
+            raise FileNotFoundError(
+                "Fresh memory export did not create a readable MEMORY.md source"
+            )
+
+        # Copy the freshly updated export.
+        if source_path.resolve() != target_path.resolve():
+            shutil.copy2(str(source_path), str(target_path))
+
+        if not target_path.exists():
+            raise FileNotFoundError("Memory sync did not create project MEMORY.md")
+
+        content = target_path.read_text(encoding="utf-8")
+        mem_count = content.count("### ")
         return {
             "output_path": str(target_path.resolve()),
-            "total_memories": 0,
-            "source": "fresh",
+            "total_memories": mem_count,
+            "source": source_label,
         }
 
     # Health Check

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1525,9 +1525,10 @@ class DirectClient:
         """
         Sync agent memories to a project directory's MEMORY.md.
 
-        Uses the cached export at ``~/.memanto/exports/{agent_id}_memory.md``
-        when available. Falls back to a fresh export if
-        the cache file does not exist.
+        Always refreshes the cached export before copying
+        ``~/.memanto/exports/{agent_id}_memory.md``. The fresh export validates
+        the requested agent session, so stale cached files cannot bypass
+        session scope checks.
 
         Args:
             agent_id: Target agent.
@@ -1538,15 +1539,15 @@ class DirectClient:
             Dict with ``output_path``, ``total_memories``, ``source``
             (``"cache"`` or ``"fresh"``).
         """
+        self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
 
         cache_path = Path.home() / ".memanto" / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
         if cache_path.exists():
-            # Fast path: copy cached export
+            # Copy the freshly updated cache.
             shutil.copy2(str(cache_path), str(target_path))
-            # Count memories from the cached file
             content = cache_path.read_text(encoding="utf-8")
             mem_count = content.count("### ")
             return {
@@ -1555,23 +1556,9 @@ class DirectClient:
                 "source": "cache",
             }
 
-        # Fallback: run a fresh export to the default location, then copy
-        logger.debug(
-            "No cached export found, generating fresh export for '%s'", agent_id
-        )
-        export_result = self.export_memory_md(
-            agent_id=agent_id,
-            limit_per_type=limit_per_type,
-        )
-
-        # Now copy the freshly generated export to the project
-        exported_path = Path(export_result["output_path"])
-        if exported_path.exists():
-            shutil.copy2(str(exported_path), str(target_path))
-
         return {
             "output_path": str(target_path.resolve()),
-            "total_memories": export_result.get("total_memories", 0),
+            "total_memories": 0,
             "source": "fresh",
         }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -783,6 +783,42 @@ class TestMEMANTOCLI:
         assert result.exit_code == 0
         assert "Synced 5 memories" in result.stdout
 
+    def test_direct_memory_sync_requires_session_even_with_cached_export(
+        self, tmp_path, monkeypatch
+    ):
+        """A stale cached export must not bypass agent session checks.
+
+        ``sync_memory_to_project`` previously copied
+        ``~/.memanto/exports/{agent}_memory.md`` without first validating the
+        requested agent session, so any local caller that knew another
+        ``agent_id`` could copy that cached MEMORY.md into a project.
+        """
+        from memanto.app.utils.errors import SessionError
+        from memanto.cli.client import direct_client as direct_mod
+        from memanto.cli.client.direct_client import DirectClient
+
+        fake_home = tmp_path / "home"
+        cache_dir = fake_home / ".memanto" / "exports"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "victim_memory.md").write_text(
+            "### Private memory\nsecret\n", encoding="utf-8"
+        )
+        project_dir = tmp_path / "project"
+
+        monkeypatch.setattr(direct_mod.Path, "home", lambda: fake_home)
+
+        client = DirectClient.__new__(DirectClient)
+
+        def reject_victim(agent_id: str):
+            raise SessionError(f"No active session for {agent_id}")
+
+        monkeypatch.setattr(client, "_get_validated_session_for_agent", reject_victim)
+
+        with pytest.raises(SessionError, match="No active session for victim"):
+            client.sync_memory_to_project("victim", str(project_dir))
+
+        assert not (project_dir / "MEMORY.md").exists()
+
     def test_schedule_commands(self, mock_all_clients):
         """Test schedule commands"""
         with patch("memanto.cli.commands.schedule.ScheduleManager") as mock_manager_cls:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -819,6 +819,36 @@ class TestMEMANTOCLI:
 
         assert not (project_dir / "MEMORY.md").exists()
 
+    def test_direct_memory_sync_fails_when_fresh_export_missing(
+        self, tmp_path, monkeypatch
+    ):
+        """Sync must not report success unless a MEMORY.md source exists."""
+        from memanto.cli.client import direct_client as direct_mod
+        from memanto.cli.client.direct_client import DirectClient
+
+        fake_home = tmp_path / "home"
+        cache_dir = fake_home / ".memanto" / "exports"
+        cache_dir.mkdir(parents=True)
+        project_dir = tmp_path / "project"
+
+        monkeypatch.setattr(direct_mod.Path, "home", lambda: fake_home)
+
+        client = DirectClient.__new__(DirectClient)
+        missing_export = cache_dir / "victim_memory.md"
+        monkeypatch.setattr(
+            client,
+            "export_memory_md",
+            lambda **_: {
+                "output_path": str(missing_export),
+                "total_memories": 1,
+            },
+        )
+
+        with pytest.raises(FileNotFoundError, match="did not create"):
+            client.sync_memory_to_project("victim", str(project_dir))
+
+        assert not (project_dir / "MEMORY.md").exists()
+
     def test_schedule_commands(self, mock_all_clients):
         """Test schedule commands"""
         with patch("memanto.cli.commands.schedule.ScheduleManager") as mock_manager_cls:


### PR DESCRIPTION
## Summary
- Make `DirectClient.sync_memory_to_project` refresh the export before copying `MEMORY.md`, matching the SDK path and the CLI docs.
- This forces the normal agent session validation path before any cached export can be copied.
- Add a regression test proving a stale cached export cannot be synced for an agent without an active validated session.

## Reproduction
Before this change, if `~/.memanto/exports/victim_memory.md` existed locally, `sync_memory_to_project("victim", project_dir)` copied that cached file directly into `project_dir/MEMORY.md` without calling `_get_validated_session_for_agent("victim")`. A caller that knew another local `agent_id` could therefore sync stale private memory cache contents without holding that agent session.

## Fix
The direct client now calls `export_memory_md(agent_id=..., limit_per_type=...)` first. That path validates the requested agent session and refreshes the cache before the copy happens.

## Validation
- `uv run --group dev pytest tests/test_cli.py::TestMEMANTOCLI::test_direct_memory_sync_requires_session_even_with_cached_export -q`
- `uv run --group dev pytest tests/test_cli.py::TestMEMANTOCLI::test_memory_export tests/test_cli.py::TestMEMANTOCLI::test_memory_sync tests/test_cli.py::TestMEMANTOCLI::test_direct_memory_sync_requires_session_even_with_cached_export -q`
- `uv run --group dev pytest tests/test_cli.py -q`
- `uv run --group dev ruff check memanto/cli/client/direct_client.py tests/test_cli.py`
- `git diff --check`

Refs #770
BountyHub: https://www.bountyhub.dev/bounty/view/a7d4cc29-f927-4939-bc77-d7b8bb36c3da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory sync behavior by refreshing the cached export before copying it into a project’s `MEMORY.md`.
  * Prevented syncing cached memory when the session scope is invalid, so `MEMORY.md` is not created.
  * When neither a cached export nor a fresh export file is available, sync now raises `FileNotFoundError` (instead of silently returning an empty result).
* **Tests**
  * Added CLI integration coverage for cached-export session validation and missing-fresh-export error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->