### PR TITLE
Fix multi-scope memory search import

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -175,7 +175,7 @@ class MemoryReadService:
             namespaces = []
             from typing import cast
 
-            from memanto.memanto.app.constants import ScopeType
+            from memanto.app.constants import ScopeType
 
             for scope_def in scopes:
                 scope = create_memory_scope(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,59 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceMultiScope:
+    """Multi-scope search is the cross-agent retrieval path. It should build
+    each scope namespace and delegate to Moorcheh without importing a
+    non-existent nested package."""
+
+    def test_search_multi_scope_builds_namespaces(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [
+                {
+                    "id": "mem-1",
+                    "text": "[FACT] Deployment target\n\nProd runs in us-east-1.",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "status": "active",
+                        "created_at": "2026-06-29T00:00:00Z",
+                        "updated_at": "2026-06-29T00:00:00Z",
+                    },
+                    "score": 0.91,
+                }
+            ],
+            "execution_time": 0.01,
+        }
+
+        result = MemoryReadService(client).search_multi_scope(
+            query="deployment",
+            scopes=[
+                {"scope_type": "agent", "scope_id": "support-agent"},
+                {"scope_type": "workspace", "scope_id": "launch-room"},
+            ],
+            limit=5,
+        )
+
+        client.similarity_search.query.assert_called_once_with(
+            query="deployment",
+            namespaces=[
+                "memanto_agent_support-agent",
+                "memanto_workspace_launch-room",
+            ],
+            top_k=5,
+            threshold=None,
+            kiosk_mode=False,
+        )
+        assert result["total_found"] == 1
+        assert result["searched_namespaces"] == [
+            "memanto_agent_support-agent",
+            "memanto_workspace_launch-room",
+        ]
+        assert result["results"][0]["title"] == "Deployment target"
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
# Fix multi-scope memory search import

## Summary

- Fixes `MemoryReadService.search_multi_scope()` importing `ScopeType` from `memanto.memanto.app.constants`, a non-existent package path.
- Adds a regression test covering multi-scope namespace construction and the Moorcheh query call.

## Bug

Calling `search_multi_scope()` currently fails before it can query memory because the method tries to import:

```python
from memanto.memanto.app.constants import ScopeType
```

That path does not exist in the package. This breaks the cross-agent / multi-workspace retrieval path, which is directly relevant to complex workflows and multi-agent use cases.

## Validation

```powershell
.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMemoryReadServiceMultiScope -q
.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMemoryWriteServiceDelete tests/test_unit.py::TestForgetEndToEnd -q
.venv\Scripts\python.exe -m pytest tests/test_unit.py -q
.venv\Scripts\python.exe -m ruff check memanto\app\services\memory_read_service.py tests\test_unit.py
.venv\Scripts\python.exe -m ruff format --check memanto\app\services\memory_read_service.py tests\test_unit.py
.venv\Scripts\python.exe -m py_compile memanto\app\services\memory_read_service.py tests\test_unit.py
```

All listed checks pass locally.

## Bounty

For `moorcheh-ai/memanto#770`: this is a reproducible core-package logic bug affecting multi-scope memory retrieval. The PR includes the fix and a focused regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected multi-scope search namespace handling so searches use the proper scope constants and build the expected namespace list.

- **Tests**
  - Added coverage for multi-scope memory search, verifying namespace construction, search parameters, and returned results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->