### PR TITLE
Fix stale duplicate memory reads in temporal queries

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -471,18 +471,23 @@ class MemoryReadService:
                 if not next_token:
                     break
 
-        seen_ids: set[str] = set()
-        memories: list[dict[str, Any]] = []
-        for item in items:
+        latest_by_id: dict[str, tuple[tuple[datetime, int], dict[str, Any]]] = {}
+        for index, item in enumerate(items):
             # Skip summary chunks — only return real memory documents
             if isinstance(item, dict) and item.get("is_summary"):
                 continue
             formatted = self._format_memory_item(item)
             mid = formatted.get("id")
-            if not mid or mid in seen_ids:
+            if not mid:
                 continue
-            seen_ids.add(cast(str, mid))
 
+            version_key = self._memory_version_key(formatted, index)
+            existing = latest_by_id.get(cast(str, mid))
+            if existing is None or version_key >= existing[0]:
+                latest_by_id[cast(str, mid)] = (version_key, formatted)
+
+        memories: list[dict[str, Any]] = []
+        for _, formatted in latest_by_id.values():
             if type and formatted.get("type") not in type:
                 continue
             if tags:
@@ -493,6 +498,28 @@ class MemoryReadService:
             memories.append(formatted)
 
         return self._filter_expired_memories(memories)
+
+    def _memory_version_key(
+        self, memory: dict[str, Any], fetch_index: int
+    ) -> tuple[datetime, int]:
+        """Order duplicate memory ids by their newest known timestamp.
+
+        Delete-and-recreate updates can briefly expose the old and new document
+        with the same id. Prefer the newest updated_at/created_at value; when
+        timestamps are missing or equal, keep the later fetched item.
+        """
+        from memanto.app.utils.temporal_helpers import parse_iso_timestamp
+
+        fallback = datetime.min.replace(tzinfo=timezone.utc)
+        for field in ("updated_at", "created_at"):
+            raw = memory.get(field)
+            if not raw:
+                continue
+            try:
+                return parse_iso_timestamp(str(raw)), fetch_index
+            except (TypeError, ValueError):
+                continue
+        return fallback, fetch_index
 
     def _build_filtered_query(
         self,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -268,6 +268,58 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceVersionSelection:
+    """Duplicate document ids can appear while a delete-and-recreate update is
+    settling. The read path must keep the newest version so temporal queries do
+    not miss recently updated memories."""
+
+    def test_changed_since_uses_newest_duplicate_memory_version(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "memory-1",
+                    "text": "[FACT] Old title\n\nstale content",
+                    "memory_type": "fact",
+                    "scope_type": "agent",
+                    "scope_id": "agent-1",
+                    "actor_id": "agent-1",
+                    "source": "agent",
+                    "status": "active",
+                    "confidence": 0.8,
+                    "created_at": "2026-06-01T00:00:00+00:00",
+                    "updated_at": "2026-06-01T00:00:00+00:00",
+                },
+                {
+                    "id": "memory-1",
+                    "text": "[FACT] New title\n\nfresh content",
+                    "memory_type": "fact",
+                    "scope_type": "agent",
+                    "scope_id": "agent-1",
+                    "actor_id": "agent-1",
+                    "source": "agent",
+                    "status": "active",
+                    "confidence": 0.9,
+                    "created_at": "2026-06-01T00:00:00+00:00",
+                    "updated_at": "2026-06-15T12:00:00+00:00",
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        result = MemoryReadService(client).search_changed_since(
+            since_date="2026-06-10T00:00:00+00:00",
+            agent_id="agent-1",
+        )
+
+        assert result["total_found"] == 1
+        assert result["results"][0]["title"] == "New title"
+        assert result["results"][0]["content"] == "fresh content"
+        assert result["results"][0]["change_type"] == "updated"
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
/claim #770

## Summary
This PR fixes a memory consistency bug in the read path. When the Moorcheh backend returns duplicate documents with the same memory id during a delete-and-recreate update window, `MemoryReadService._fetch_all_memories` currently keeps the first version it sees. If the stale version is listed before the newly re-uploaded version, temporal reads such as `search_changed_since` can miss a recent update entirely.

## Reproduction
The added regression test mocks `fetch_text_data` returning two documents with id `memory-1`: an old copy updated on 2026-06-01 and a new copy updated on 2026-06-15. Querying `search_changed_since("2026-06-10T00:00:00+00:00")` should return the fresh document, but main returns zero results because it de-duplicates before comparing versions.

## Fix
The read service now groups duplicate ids by id and keeps the newest version using `updated_at`, falling back to `created_at`, and then applies type/tag/TTL filters. If timestamps are missing or tied, the later fetched item wins so eventual-consistency duplicates do not leave stale memory state in agent recall.

## Impact
This prevents timeline amnesia after memory updates: agents relying on recent-change queries will see the latest memory content instead of silently dropping an update because a stale duplicate appeared first.

## Validation
- `uv run pytest tests/test_unit.py::TestMemoryReadServiceVersionSelection tests/test_unit.py::TestMemoryWriteServiceDelete -q`
- `uv run pytest tests/test_unit.py tests/test_api.py tests/test_cli.py -q`
- `uv run ruff check memanto/app/services/memory_read_service.py tests/test_unit.py`
- `uv run pytest -q`

Payment details can be provided privately after maintainer/BountyHub review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory search results to return the latest version when duplicate entries exist for the same item.
  * Preserved correct filtering and expiration handling while skipping summary-only chunks.
  * Fixed changed-since results so updated items are counted once and show the most recent content.

* **Tests**
  * Added coverage for duplicate memory versions to verify the newest item is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->