### PR TITLE
Fix update memory on-prem delete response handling

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -23,6 +23,19 @@ class MemoryWriteService:
         self.client = moorcheh_client
         self._parser = MemoryParsingService()
 
+    @staticmethod
+    def _delete_response_succeeded(result: dict[str, Any]) -> bool:
+        """Return whether a Moorcheh delete response removed a document."""
+        raw = result.get("actual_deletions")
+        if isinstance(raw, int):
+            return raw > 0
+        for key in ("deleted_ids", "requested_ids"):
+            ids = result.get(key)
+            if isinstance(ids, list):
+                return len(ids) > 0
+        # Some on-prem builds only return ``{"status": "success"}``.
+        return str(result.get("status", "")).lower() in {"success", "ok"}
+
     def store_memory(
         self, memory: MemoryRecord, context: dict[str, Any] | None = None
     ) -> dict[str, Any]:
@@ -311,7 +324,7 @@ class MemoryWriteService:
                 namespace_name=namespace, ids=[memory_id]
             )
 
-            if delete_result.get("actual_deletions", 0) == 0:
+            if not self._delete_response_succeeded(delete_result):
                 raise MemoryError(f"Failed to delete old version of memory {memory_id}")
 
             validation_result = {"action": "store", "reason": "MVP direct store"}
@@ -349,18 +362,7 @@ class MemoryWriteService:
                 self.client.documents.delete(namespace_name=namespace, ids=[memory_id]),
             )
 
-            # Cloud returns ``actual_deletions``; on-prem's /items/delete only
-            # returns ``deleted_ids`` (and ``status``). Mirror the cloud SDK's
-            # ``_deletion_processed_count`` so both backends report success.
-            raw = result.get("actual_deletions")
-            if isinstance(raw, int):
-                return raw > 0
-            for key in ("deleted_ids", "requested_ids"):
-                ids = result.get(key)
-                if isinstance(ids, list):
-                    return len(ids) > 0
-            # Some on-prem builds only return ``{"status": "success"}``.
-            return str(result.get("status", "")).lower() in {"success", "ok"}
+            return self._delete_response_succeeded(result)
 
         except Exception as e:
             raise MemoryError(f"Failed to delete memory: {e}")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,80 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryWriteServiceUpdate:
+    """``update_memory`` must accept the same delete response shapes."""
+
+    def test_update_memory_accepts_onprem_delete_shape(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": ["mem-abc"],
+        }
+        client.documents.upload.return_value = {"status": "queued"}
+        existing = {
+            "title": "Old title",
+            "content": "Old content",
+            "metadata": {
+                "agent_id": "test-agent",
+                "actor_id": "user",
+                "source": "api",
+                "created_at": "2026-01-01T00:00:00",
+                "type": "fact",
+                "confidence": 0.7,
+                "status": "active",
+                "tags": ["preference"],
+            },
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing,
+        ):
+            result = MemoryWriteService(client).update_memory(
+                "mem-abc",
+                "memanto_agent_test-agent",
+                {"content": "Updated content"},
+            )
+
+        assert result["status"] == "queued"
+        assert result["action"] == "updated"
+        assert result["updated_fields"] == ["content"]
+        client.documents.delete.assert_called_once_with(
+            namespace_name="memanto_agent_test-agent", ids=["mem-abc"]
+        )
+        client.documents.upload.assert_called_once()
+
+    def test_update_memory_rejects_empty_onprem_delete_shape(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        client = MagicMock()
+        client.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": [],
+        }
+        existing = {
+            "title": "Old title",
+            "content": "Old content",
+            "metadata": {"agent_id": "test-agent"},
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing,
+        ):
+            with pytest.raises(MemoryError, match="Failed to delete old version"):
+                MemoryWriteService(client).update_memory(
+                    "mem-abc",
+                    "memanto_agent_test-agent",
+                    {"content": "Updated content"},
+                )
+
+        client.documents.upload.assert_not_called()
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary

- Makes `MemoryWriteService.update_memory()` use the same delete-response success logic as `delete_memory()`.
- Fixes on-prem edit/update flows where the delete endpoint returns `deleted_ids`/`status` instead of cloud-style `actual_deletions`.
- Adds regression tests for successful on-prem `deleted_ids` deletes and genuine empty-delete misses.

## Bug

`update_memory()` implements edits by fetching the existing memory, deleting the old document, and uploading a replacement with the same id. The delete step only checked:

```python
delete_result.get("actual_deletions", 0) == 0
```

That works for cloud responses, but on-prem delete responses may only contain `status` and `deleted_ids`. In that backend shape, editing an existing memory can fail after a successful delete and before upload.

## Validation

```powershell
.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMemoryWriteServiceUpdate -q
.venv\Scripts\python.exe -m pytest tests/test_unit.py::TestMemoryWriteServiceDelete tests/test_unit.py::TestMemoryWriteServiceUpdate tests/test_unit.py::TestForgetEndToEnd -q
.venv\Scripts\python.exe -m pytest tests/test_unit.py -q
.venv\Scripts\python.exe -m ruff check memanto\app\services\memory_write_service.py tests\test_unit.py
.venv\Scripts\python.exe -m ruff format --check memanto\app\services\memory_write_service.py tests\test_unit.py
.venv\Scripts\python.exe -m py_compile memanto\app\services\memory_write_service.py tests\test_unit.py
```

All listed checks pass locally.

## Bounty

For `moorcheh-ai/memanto#770`: this is a reproducible core-package backend compatibility bug affecting memory edit/update integrity on on-prem deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory update/delete flow to reliably detect successful deletions across multiple response formats.
  * Reduced failed updates by accepting additional success signals, including status-based and ID-based delete results.
  * Continued to block inconsistent updates by raising an error when the prior version cannot be deleted.
* **Tests**
  * Added unit tests covering on-prem style delete responses and validation of success vs. failure behavior during `update_memory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->