### PR TITLE
Fix LangGraph store writes for non-string content values

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -230,11 +230,12 @@ class MemantoStore(BaseStore):
         raw_content = value.pop("content", None)
         if raw_content is None:
             raw_content = self._stringify(value)
+        content = str(raw_content)
 
         title = value.pop("title", None)
         if not title:
-            title = raw_content if len(raw_content) <= 80 else raw_content[:77] + "..."
-        title = title[:100]
+            title = content if len(content) <= 80 else content[:77] + "..."
+        title = str(title)[:100]
 
         confidence = float(value.pop("confidence", 0.8))
         confidence = max(0.0, min(1.0, confidence))
@@ -255,7 +256,7 @@ class MemantoStore(BaseStore):
             agent_id=agent_id,
             memory_type=memory_type,
             title=title,
-            content=str(raw_content),
+            content=content,
             confidence=confidence,
             tags=all_tags,
             source="langgraph-store",

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -165,6 +165,26 @@ def test_do_put_success(mock_sdk_client):
     )
 
 
+def test_do_put_stringifies_non_string_content(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    op = PutOp(namespace=("my_ns",), key="answer", value={"content": 42})
+    store._do_put(op)
+
+    client_instance.remember.assert_called_once_with(
+        agent_id="langgraph_my_ns",
+        memory_type=None,
+        title="42",
+        content="42",
+        confidence=0.8,
+        tags=["lg:key:answer"],
+        source="langgraph-store",
+        provenance="explicit_statement",
+    )
+
+
 def test_do_put_delete_not_supported(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     op = PutOp(namespace=("my_ns",), key="my_key", value=None)


### PR DESCRIPTION
/claim #770

## Summary

- Normalize `MemantoStore._do_put()` content to a string before deriving the default title.
- Preserve existing behavior for missing `content`, explicit titles, memory type inference, confidence, and tags.
- Add regression coverage for `PutOp.value["content"]` carrying a non-string JSON value.

## Bug / impact

LangGraph `PutOp.value` is a generic mapping, so callers can persist JSON-like values such as numbers or booleans. `MemantoStore._do_put()` already stringifies the value when the `content` field is absent, and it stringifies `raw_content` at the final `client.remember()` call. However, when `content` is present but not a string, the default title path calls `len(raw_content)` before that final conversion.

Example:

```python
PutOp(namespace=("my_ns",), key="answer", value={"content": 42})
```

Before this fix, `_do_put()` raised:

```text
TypeError: object of type 'int' has no len()
```

That prevents LangGraph store writes for otherwise representable values, even though the downstream memory content can safely be stored as `"42"`.

## Fix

Convert `raw_content` to `content = str(raw_content)` immediately after resolving the fallback content. The default title and stored content now share the same normalized value. Explicit titles are also coerced to string before truncation so non-string title values cannot fail slicing.

## Validation

- `uv run --project integrations/langgraph --with pytest --with pytest-asyncio --with pytest-timeout pytest integrations/langgraph/tests -q`
  - `33 passed`
- `uv run ruff check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`
  - `All checks passed!`
- `git diff --check`
  - passed with no output

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of saved content so non-text values are consistently converted to strings before being stored.
  * Auto-generated titles now use the stringified content, helping ensure titles are created reliably and truncated correctly.
  * Added coverage for saving non-string content to confirm the stored values and metadata are passed through as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->