### PR TITLE
fix(memory): timeline amnesia in search_as_of - add superseded_at field (#770)

### DIFF
--- a/docs/bounty_reports/poc_timeline_amnesia.py
+++ b/docs/bounty_reports/poc_timeline_amnesia.py
@@ -1,0 +1,277 @@
+"""
+独立 PoC：验证 search_as_of 的 Timeline Amnesia bug (issue #770)
+
+不依赖 pytest，可直接 `python docs/bounty_reports/poc_timeline_amnesia.py` 运行。
+
+bug 描述：
+    MemoryReadService.search_as_of 用 memory['updated_at'] 判断 supersession
+    发生的时间。但 updated_at 会被 validate() / detect_contradiction() /
+    update_memory() 等多种操作刷新，导致 supersession 时间被错误判定为更晚，
+    进而让 point-in-time 查询返回已经被 supersede 的记忆。
+
+正确行为：
+    as_of_date 之前已被 supersede 的记忆不应出现在 search_as_of 结果中。
+
+运行方式：
+    cd <memanto repo root>
+    python docs/bounty_reports/poc_timeline_amnesia.py
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+# 确保 memanto 包可被导入
+sys.path.insert(0, ".")
+
+from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def iso(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def make_memory(
+    memory_id: str,
+    created_at: datetime,
+    updated_at: datetime,
+    *,
+    superseded_by: str | None = None,
+    status: str = "active",
+    title: str = "memory",
+    content: str = "content",
+) -> dict:
+    """构造 _format_memory_item 格式的 memory dict。"""
+    return {
+        "id": memory_id,
+        "title": title,
+        "content": content,
+        "text": f"[FACT] {title}\n\n{content}",
+        "type": "fact",
+        "memory_type": "fact",
+        "confidence": 0.9,
+        "status": status,
+        "tags": [],
+        "created_at": iso(created_at),
+        "updated_at": iso(updated_at),
+        "expires_at": None,
+        "ttl_seconds": None,
+        "actor_id": "user-1",
+        "source": "user",
+        "source_ref": None,
+        "scope_type": "agent",
+        "scope_id": "agent-1",
+        "score": 0.95,
+        "provenance": "explicit_statement",
+        "validation_count": 0,
+        "contradiction_detected": False,
+        "superseded_by": superseded_by,
+    }
+
+
+def main() -> int:
+    print("=" * 70)
+    print("PoC: Timeline Amnesia in search_as_of (issue #770)")
+    print("=" * 70)
+
+    # ── 场景 1：BUG 复现（无 superseded_at 字段，fallback 到被污染的 updated_at）──
+    #
+    # 时间线：
+    #   2026-01-01  A 创建（"用户喜欢咖啡"）
+    #   2026-02-01  A 被 B supersede（mark_superseded 刷新 updated_at=2026-02-01）
+    #   2026-03-01  A 被错误地 validate()，updated_at 被刷新为 2026-03-01
+    #   查询 as_of = 2026-02-15
+    #
+    # 期望：A 不应出现（2026-02-15 时 A 已被 supersede）
+    # 旧数据（无 superseded_at）：fallback 到 updated_at，A 错误出现
+
+    memory_a_legacy = make_memory(
+        "mem-A-legacy",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 3, 1, tzinfo=timezone.utc),  # 被 validate 污染
+        superseded_by="mem-B-legacy",
+        status="superseded",
+        title="用户喜欢咖啡(旧数据)",
+        content="用户偏好：咖啡",
+    )
+    memory_b_legacy = make_memory(
+        "mem-B-legacy",
+        created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        status="active",
+        title="用户喜欢茶(旧数据)",
+        content="用户偏好：茶",
+    )
+
+    client = MagicMock()
+    read_service = MemoryReadService(client)
+    read_service._fetch_all_memories = lambda namespaces, **kw: [
+        memory_a_legacy,
+        memory_b_legacy,
+    ]
+
+    result = read_service.search_as_of(
+        as_of_date="2026-02-15T00:00:00Z",
+        agent_id="agent-1",
+    )
+    result_ids = [m["id"] for m in result["results"]]
+
+    print(f"\n[场景 1] 旧数据（无 superseded_at 字段）—— 验证向后兼容 fallback")
+    print(f"  时间线：2026-01-01 A创建 → 2026-02-01 A被supersede → 2026-03-01 updated_at被污染")
+    print(f"  查询 as_of = 2026-02-15")
+    print(f"  search_as_of 返回: {result_ids}")
+    print(f"  说明：旧数据没有 superseded_at，fallback 到 updated_at（被污染），A 仍错误出现。")
+    print(f"  这是已知限制 —— 修复是 forward-looking 的，新 supersede 的 memory 会有 superseded_at。")
+
+    # ── 场景 2：修复后行为（有 superseded_at，正确排除）──
+    #
+    # 同样时间线，但 A 有 superseded_at=2026-02-01（mark_superseded 设置）
+    # 即使 updated_at=2026-03-01（被污染），search_as_of 用 superseded_at 判断
+
+    memory_a_fixed = make_memory(
+        "mem-A-fixed",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 3, 1, tzinfo=timezone.utc),  # 被 validate 污染
+        superseded_by="mem-B-fixed",
+        status="superseded",
+        title="用户喜欢咖啡(修复后)",
+        content="用户偏好：咖啡",
+    )
+    # 关键：superseded_at 记录真正的 supersession 时间
+    memory_a_fixed["superseded_at"] = iso(datetime(2026, 2, 1, tzinfo=timezone.utc))
+
+    memory_b_fixed = make_memory(
+        "mem-B-fixed",
+        created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        status="active",
+        title="用户喜欢茶(修复后)",
+        content="用户偏好：茶",
+    )
+
+    read_service._fetch_all_memories = lambda namespaces, **kw: [
+        memory_a_fixed,
+        memory_b_fixed,
+    ]
+
+    result_fixed = read_service.search_as_of(
+        as_of_date="2026-02-15T00:00:00Z",
+        agent_id="agent-1",
+    )
+    result_ids_fixed = [m["id"] for m in result_fixed["results"]]
+
+    print(f"\n[场景 2] 修复后（有 superseded_at=2026-02-01）—— 验证 bug 已修复")
+    print(f"  时间线同上，但 A.superseded_at = 2026-02-01（mark_superseded 设置）")
+    print(f"  查询 as_of = 2026-02-15")
+    print(f"  search_as_of 返回: {result_ids_fixed}")
+
+    bug_fixed = "mem-A-fixed" not in result_ids_fixed
+    if bug_fixed:
+        print(f"  [OK] 记忆 A 被正确排除！superseded_at=2026-02-01 <= as_of=2026-02-15")
+        print(f"  即使 updated_at=2026-03-01 被污染，search_as_of 仍用 superseded_at 判断。")
+    else:
+        print(f"  [FAIL] 记忆 A 仍错误出现，修复未生效！")
+        return 1
+
+    # ── 场景 3：mark_superseded 正确设置 superseded_at ──
+    print(f"\n[场景 3] 验证 MemoryRecord.mark_superseded 正确设置 superseded_at")
+    memory = MemoryRecord(
+        id="mem-X",
+        type="preference",
+        title="测试",
+        content="测试内容",
+        scope_type="agent",
+        scope_id="agent-1",
+        actor_id="user-1",
+        source="user",
+    )
+    memory.mark_superseded("mem-Y")
+    has_field = hasattr(memory, "superseded_at") and memory.superseded_at is not None
+    print(f"  mark_superseded 后：superseded_at = {memory.superseded_at}")
+    if has_field:
+        print(f"  [OK] superseded_at 字段已正确设置")
+    else:
+        print(f"  [FAIL] superseded_at 字段未设置")
+        return 1
+
+    # ── 场景 4：validate/detect_contradiction 不污染 superseded memory ──
+    print(f"\n[场景 4] 验证 validate/detect_contradiction 不操作 superseded memory")
+    memory2 = MemoryRecord(
+        id="mem-X2",
+        type="preference",
+        title="测试2",
+        content="测试内容2",
+        scope_type="agent",
+        scope_id="agent-1",
+        actor_id="user-1",
+        source="user",
+    )
+    memory2.mark_superseded("mem-Y2")
+    updated_at_before = memory2.updated_at
+    memory2.validate()  # 应该被跳过
+    memory2.detect_contradiction()  # 应该被跳过
+    no_pollution = memory2.updated_at == updated_at_before
+    print(f"  supersede 后 updated_at = {updated_at_before}")
+    print(f"  调用 validate() + detect_contradiction() 后 updated_at = {memory2.updated_at}")
+    if no_pollution:
+        print(f"  [OK] updated_at 未被污染（validate/detect_contradiction 被正确跳过）")
+    else:
+        print(f"  [FAIL] updated_at 被污染")
+        return 1
+
+    print(f"\n{'=' * 70}")
+    print(f"总结：所有修复场景验证通过")
+    print(f"  - 场景 2: search_as_of 用 superseded_at 正确排除已 supersede 的记忆")
+    print(f"  - 场景 3: mark_superseded 正确设置 superseded_at")
+    print(f"  - 场景 4: validate/detect_contradiction 不再污染 superseded memory 的 updated_at")
+    print(f"{'=' * 70}")
+    return 0
+
+
+def demo_root_cause_on_memory_record() -> None:
+    """直接在 MemoryRecord 上演示 updated_at 被污染。"""
+    print("\n" + "=" * 70)
+    print("根因演示：MemoryRecord.updated_at 被多种操作污染")
+    print("=" * 70)
+
+    memory = MemoryRecord(
+        id="mem-A",
+        type="preference",
+        title="用户喜欢咖啡",
+        content="用户偏好：咖啡",
+        scope_type="agent",
+        scope_id="agent-1",
+        actor_id="user-1",
+        source="user",
+    )
+
+    # 模拟 supersede
+    memory.mark_superseded("mem-B")
+    supersede_time = memory.updated_at
+    print(f"\nmark_superseded 后：")
+    print(f"  status        = {memory.status}")
+    print(f"  superseded_by = {memory.superseded_by}")
+    print(f"  updated_at    = {supersede_time}")
+    print(f"  superseded_at = {getattr(memory, 'superseded_at', '<字段不存在>')}")
+
+    # 模拟 30 天后调用 validate()（错误操作，但没有被阻止）
+    later = supersede_time + timedelta(days=30)
+    memory.validated_at = later
+    memory.updated_at = later
+    memory.validation_count += 1
+    print(f"\n30 天后调用 validate() 后：")
+    print(f"  status        = {memory.status}")
+    print(f"  updated_at    = {memory.updated_at}  (被污染！远晚于 supersede 时间)")
+    print(f"  supersede 时间信息已丢失 — search_as_of 无法判断真正的 supersession 时间")
+
+
+if __name__ == "__main__":
+    exit_code = main()
+    demo_root_cause_on_memory_record()
+    print(f"\nPoC 退出码: {exit_code} (1=bug存在, 0=bug已修复)")
+    sys.exit(exit_code)

--- a/docs/bounty_reports/timeline_amnesia_supersession.md
+++ b/docs/bounty_reports/timeline_amnesia_supersession.md
@@ -1,0 +1,205 @@
+# Timeline Amnesia in `search_as_of` — Bug Report for Bounty #770
+
+> **Severity**: Critical / High
+> **Category**: Retrieval Quality & Accuracy · Architectural & Logic Flaws
+> **Bounty**: [Memanto Bug & Exploit Challenge #770](https://github.com/moorcheh-ai/memanto/issues/770) ($100 USD)
+
+## 1. Summary
+
+`MemoryReadService.search_as_of` is a **point-in-time query** whose stated
+purpose is *"What was true at this point in time?"*. To decide whether a
+memory was already superseded at the requested `as_of_date`, it inspects the
+memory's `updated_at` field.
+
+The problem: `updated_at` is **shared by every mutating operation** on a
+`MemoryRecord` — `validate()`, `detect_contradiction()`, `update_memory()`,
+etc. — not just `mark_superseded()`. Any later call to those operations
+"refreshes" `updated_at` to a much later timestamp, so `search_as_of` cannot
+tell when the supersession actually happened.
+
+The net effect is **timeline amnesia**: a memory that was superseded *before*
+`as_of_date` can silently reappear in the result set, causing the agent to
+recall a stale, already-replaced preference or fact as if it were still true
+at that point in time.
+
+This directly violates three of the bounty's in-scope targets:
+
+- *Retrieval Quality & Accuracy* — fails to recall the correct version
+- *Losing track of when an event occurred (timeline amnesia)*
+- *Deeply flawed contradiction handling* — supersession is the system's
+  primary contradiction-resolution mechanism
+
+## 2. Root Cause
+
+### 2.1 `search_as_of` uses `updated_at` to time supersession
+
+`memanto/app/services/memory_read_service.py` (original code, lines 289-299):
+
+```python
+# Skip if superseded before as_of_date
+if memory.get("superseded_by"):
+    # Memory was superseded - check if supersession happened before as_of_date
+    updated_at = memory.get("updated_at")
+    if updated_at:
+        try:
+            updated_dt = parse_iso_timestamp(updated_at)
+            if updated_dt <= as_of_dt:
+                continue  # Already superseded at as_of_date
+        except (ValueError, AttributeError):
+            pass
+```
+
+### 2.2 `updated_at` is mutated by many unrelated operations
+
+`memanto/app/core.py` — `MemoryRecord`:
+
+| Method | Mutates `updated_at`? |
+|--------|------------------------|
+| `mark_superseded(id)` | ✅ |
+| `validate()` | ✅ |
+| `detect_contradiction()` | ✅ |
+| `MemoryWriteService.update_memory()` | ✅ (sets `updated_at = datetime.utcnow()`) |
+
+There is **no dedicated field** recording *when* the supersession happened —
+the legacy `MemorySupersedeResponse` model has a `supersede_timestamp`, but
+the core `MemoryRecord` does not, and `_mark_memory_superseded` in
+`app/legacy/universal_services.py` is a no-op stub that only logs.
+
+So the moment any of the four operations above runs *after* a supersession,
+`updated_at` no longer reflects the supersession time, and `search_as_of`
+becomes unreliable.
+
+### 2.3 `validate()` / `detect_contradiction()` don't check `status`
+
+Even worse, neither `validate()` nor `detect_contradiction()` guards against
+operating on a memory whose `status == "superseded"`. A superseded memory is
+already replaced by a newer version — validating it or flagging a
+contradiction on it is semantically meaningless, yet both methods happily
+bump `updated_at`, which is exactly what poisons `search_as_of`.
+
+## 3. Reproducibility
+
+A self-contained PoC is included at
+[`docs/bounty_reports/poc_timeline_amnesia.py`](./poc_timeline_amnesia.py).
+It requires only the `memanto` package importable (no Moorcheh API key, no
+network) — the Moorcheh client is mocked.
+
+### 3.1 Reproduction steps
+
+```bash
+cd <memanto repo root>
+python docs/bounty_reports/poc_timeline_amnesia.py
+```
+
+### 3.2 Timeline used by the PoC
+
+| Time | Event |
+|------|-------|
+| 2026-01-01 | Memory A created ("用户喜欢咖啡") |
+| 2026-02-01 | Memory B created; A is superseded by B |
+| 2026-03-01 | A is (mistakenly) `validate()`-d → `updated_at` refreshed to 2026-03-01 |
+| Query | `search_as_of(as_of_date="2026-02-15")` |
+
+### 3.3 Expected vs actual (pre-fix)
+
+| | Expected | Actual (buggy) |
+|---|----------|----------------|
+| Result IDs | `["mem-B"]` | `["mem-A", "mem-B"]` |
+| A present? | ❌ No (already superseded) | ✅ Yes (wrongly recalled) |
+
+`search_as_of` returns the *already-replaced* preference A as if it were
+still true at 2026-02-15 — even though A was superseded on 2026-02-01.
+
+## 4. Impact
+
+- **Incorrect point-in-time retrieval.** Agents consuming `search_as_of`
+  will see superseded memories as if they were active, producing
+  self-contradictory context ("the user likes coffee" and "the user likes
+  tea" both returned for the same point in time).
+- **Silent regression.** The bug only manifests when *any* post-supersession
+  mutation happens — exactly the kind of long-tail edge case that survives
+  testing and bites in production.
+- **Contradiction-handling defeat.** Supersession is Memanto's primary
+  contradiction-resolution primitive; if superseded memories leak back into
+  point-in-time queries, the contradiction effectively re-appears.
+- **Backwards compatibility.** The legacy `MemorySupersedeResponse` model
+  already exposes `supersede_timestamp`, so the concept exists in the code
+  base — it just never made it to the core `MemoryRecord`.
+
+## 5. Fix
+
+The fix is split across three files. The central idea: introduce a dedicated
+`superseded_at` field that is set *only* by `mark_superseded()` and never
+touched by `validate()` / `detect_contradiction()` / `update_memory()`.
+
+### 5.1 `memanto/app/core.py`
+
+1. New field on `MemoryRecord`:
+   ```python
+   superseded_at: datetime | None = None
+   ```
+2. `mark_superseded()` now sets `superseded_at = now` alongside `updated_at`.
+3. `validate()` and `detect_contradiction()` early-return when
+   `self.status == "superseded"` — no state change, no `updated_at` bump.
+4. `to_moorcheh_document()` emits `superseded_at` so the field round-trips
+   through Moorcheh storage.
+
+### 5.2 `memanto/app/services/memory_read_service.py`
+
+1. `search_as_of` now reads `superseded_at` first, falling back to
+   `updated_at` only for legacy data that predates the field:
+   ```python
+   supersede_ts = memory.get("superseded_at") or memory.get("updated_at")
+   ```
+   This keeps existing stored memories working unchanged.
+2. `_format_memory_item` extracts `superseded_at` into the formatted dict so
+   downstream consumers (including `search_as_of`) can see it.
+
+### 5.3 `memanto/app/services/memory_write_service.py`
+
+`update_memory()` now preserves `superseded_by`, `supersedes`, and
+`superseded_at` from the existing memory (unless explicitly overridden in
+`updates`). Previously the reconstructed `MemoryRecord` dropped these fields,
+which would have made a superseded memory look active again after an edit.
+
+### 5.4 Verification
+
+`python docs/bounty_reports/poc_timeline_amnesia.py` now exits 0:
+
+```
+[场景 2] 修复后（有 superseded_at=2026-02-01）—— 验证 bug 已修复
+  search_as_of 返回: ['mem-B-fixed']
+  [OK] 记忆 A 被正确排除！superseded_at=2026-02-01 <= as_of=2026-02-15
+  即使 updated_at=2026-03-01 被污染，search_as_of 仍用 superseded_at 判断。
+
+[场景 3] 验证 MemoryRecord.mark_superseded 正确设置 superseded_at
+  [OK] superseded_at 字段已正确设置
+
+[场景 4] 验证 validate/detect_contradiction 不操作 superseded memory
+  [OK] updated_at 未被污染（validate/detect_contradiction 被正确跳过）
+```
+
+A pytest-based regression test is also included at
+`tests/failing_tests/test_timeline_amnesia.py`.
+
+## 6. Backwards Compatibility
+
+- **Old stored memories** (no `superseded_at` field): `search_as_of` falls
+  back to `updated_at`, so behavior is unchanged from before this fix —
+  these memories continue to work, they just don't get the new protection
+  until they are re-superseded.
+- **No schema migration required**: `superseded_at` is an optional field;
+  existing Moorcheh documents are not touched.
+- **No API change**: no endpoint signature is modified; `superseded_at` is
+  surfaced in response payloads only when present.
+
+## 7. Files Changed
+
+| File | Change |
+|------|--------|
+| `memanto/app/core.py` | New `superseded_at` field; `mark_superseded` sets it; `validate` / `detect_contradiction` skip superseded memories; `to_moorcheh_document` emits it |
+| `memanto/app/services/memory_read_service.py` | `search_as_of` prefers `superseded_at`; `_format_memory_item` extracts it |
+| `memanto/app/services/memory_write_service.py` | `update_memory` preserves `superseded_at` / `superseded_by` / `supersedes` |
+| `tests/failing_tests/test_timeline_amnesia.py` | Regression test (was failing pre-fix, passes post-fix) |
+| `docs/bounty_reports/poc_timeline_amnesia.py` | Self-contained PoC |
+| `docs/bounty_reports/timeline_amnesia_supersession.md` | This report |

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -63,6 +63,10 @@ class MemoryRecord(BaseModel):
     provenance: ProvenanceType = "explicit_statement"
     superseded_by: str | None = None  # Memory ID that supersedes this one
     supersedes: str | None = None  # Memory ID that this supersedes
+    # 独立的 supersession 时间戳 —— mark_superseded 时设置。
+    # 不能复用 updated_at，因为 validate()/detect_contradiction()/update_memory()
+    # 等操作也会刷新 updated_at，会导致 search_as_of 误判 supersession 时间。
+    superseded_at: datetime | None = None
     validated_at: datetime | None = None  # Last validation timestamp
     validation_count: int = 0  # Number of times validated/confirmed
     contradiction_detected: bool = False  # Flag for contradictions
@@ -121,6 +125,8 @@ class MemoryRecord(BaseModel):
             document["superseded_by"] = self.superseded_by
         if self.supersedes:
             document["supersedes"] = self.supersedes
+        if self.superseded_at:
+            document["superseded_at"] = self.superseded_at.isoformat()
         if self.validated_at:
             document["validated_at"] = self.validated_at.isoformat()
 
@@ -184,7 +190,14 @@ class MemoryRecord(BaseModel):
         return round(final, 2)
 
     def validate(self):
-        """Mark memory as validated (increases trust)"""
+        """Mark memory as validated (increases trust).
+
+        对已 superseded 的记忆调用 validate() 是无意义的（它已被更新版本取代），
+        且会污染 updated_at，导致 search_as_of 误判 supersession 时间。
+        因此对 superseded 记忆直接跳过，不修改任何字段。
+        """
+        if self.status == "superseded":
+            return
         self.validation_count += 1
         self.validated_at = datetime.utcnow()
         self.updated_at = datetime.utcnow()
@@ -194,13 +207,25 @@ class MemoryRecord(BaseModel):
             self.provenance = "validated"
 
     def mark_superseded(self, superseded_by_id: str):
-        """Mark this memory as superseded by a newer one"""
+        """Mark this memory as superseded by a newer one.
+
+        同时记录 superseded_at —— 独立于 updated_at 的时间戳，
+        供 search_as_of 准确判断 supersession 发生的时间点。
+        """
         self.superseded_by = superseded_by_id
         self.status = "superseded"
-        self.updated_at = datetime.utcnow()
+        now = datetime.utcnow()
+        self.updated_at = now
+        self.superseded_at = now
 
     def detect_contradiction(self):
-        """Flag memory as contradicted (lowers trust)"""
+        """Flag memory as contradicted (lowers trust).
+
+        对已 superseded 的记忆跳过，避免污染 updated_at 导致
+        search_as_of 时间线失忆。
+        """
+        if self.status == "superseded":
+            return
         self.contradiction_detected = True
         self.updated_at = datetime.utcnow()
 

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -288,12 +288,16 @@ class MemoryReadService:
 
                 # Skip if superseded before as_of_date
                 if memory.get("superseded_by"):
-                    # Memory was superseded - check if supersession happened before as_of_date
-                    updated_at = memory.get("updated_at")
-                    if updated_at:
+                    # 优先用 superseded_at（独立的 supersession 时间戳），
+                    # fallback 到 updated_at（向后兼容旧数据）。
+                    # 不能只用 updated_at，因为它会被 validate()/
+                    # detect_contradiction()/update_memory() 等操作刷新，
+                    # 导致 supersession 时间被误判为更晚。
+                    supersede_ts = memory.get("superseded_at") or memory.get("updated_at")
+                    if supersede_ts:
                         try:
-                            updated_dt = parse_iso_timestamp(updated_at)
-                            if updated_dt <= as_of_dt:
+                            supersede_dt = parse_iso_timestamp(supersede_ts)
+                            if supersede_dt <= as_of_dt:
                                 continue  # Already superseded at as_of_date
                         except (ValueError, AttributeError):
                             pass
@@ -769,6 +773,7 @@ class MemoryReadService:
         contradiction_detected = get_field("contradiction_detected") or False
         superseded_by = get_field("superseded_by")
         supersedes = get_field("supersedes")
+        superseded_at_str = get_field("superseded_at")
         validated_at_str = get_field("validated_at")
 
         # Parse validated_at timestamp
@@ -845,6 +850,8 @@ class MemoryReadService:
             formatted["superseded_by"] = superseded_by
         if supersedes:
             formatted["supersedes"] = supersedes
+        if superseded_at_str:
+            formatted["superseded_at"] = superseded_at_str
         if validated_at:
             formatted["validated_at"] = validated_at.isoformat()
 

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -298,6 +298,38 @@ class MemoryWriteService:
                     updated_memory.created_at = raw_created
             updated_memory.updated_at = datetime.utcnow()
 
+            # 保留 supersession 相关字段 —— 这些字段记录了 memory 的历史
+            # supersession 状态，update（修改 content/title 等）不应丢失它们。
+            # 特别是 superseded_at：search_as_of 依赖它判断 supersession 时间，
+            # 丢失会导致时间线失忆（详见 docs/bounty_reports/timeline_amnesia_supersession.md）。
+            raw_superseded_by = (
+                updates.get("superseded_by")
+                if "superseded_by" in updates
+                else metadata.get("superseded_by")
+            )
+            if raw_superseded_by:
+                updated_memory.superseded_by = raw_superseded_by
+
+            raw_supersedes = (
+                updates.get("supersedes")
+                if "supersedes" in updates
+                else metadata.get("supersedes")
+            )
+            if raw_supersedes:
+                updated_memory.supersedes = raw_supersedes
+
+            raw_superseded_at = metadata.get("superseded_at")
+            if raw_superseded_at:
+                if isinstance(raw_superseded_at, str):
+                    try:
+                        updated_memory.superseded_at = datetime.fromisoformat(
+                            raw_superseded_at.replace("Z", "+00:00")
+                        )
+                    except (ValueError, AttributeError):
+                        pass
+                elif isinstance(raw_superseded_at, datetime):
+                    updated_memory.superseded_at = raw_superseded_at
+
             # Handle TTL
             if "ttl_seconds" in updates:
                 updated_memory.set_ttl(updates["ttl_seconds"])

--- a/tests/failing_tests/test_timeline_amnesia.py
+++ b/tests/failing_tests/test_timeline_amnesia.py
@@ -1,0 +1,303 @@
+"""
+Regression test: Timeline Amnesia in search_as_of (issue #770)
+
+验证 search_as_of 的 supersession 时间判断已修复：
+  - 优先用 superseded_at（独立时间戳）判断
+  - fallback 到 updated_at（向后兼容旧数据）
+  - validate()/detect_contradiction() 不再污染 superseded memory 的 updated_at
+
+运行方式：
+    uv run --group dev python -m pytest tests/failing_tests/test_timeline_amnesia.py -v
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _iso(dt: datetime) -> str:
+    """转成 ISO 字符串（带 Z 后缀，模拟 Moorcheh 存储格式）。"""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _make_memory(
+    memory_id: str,
+    created_at: datetime,
+    updated_at: datetime,
+    *,
+    superseded_by: str | None = None,
+    superseded_at: str | None = None,
+    status: str = "active",
+    title: str = "memory",
+    content: str = "content",
+) -> dict:
+    """构造一个 _format_memory_item 格式的 memory dict。"""
+    return {
+        "id": memory_id,
+        "title": title,
+        "content": content,
+        "text": f"[FACT] {title}\n\n{content}",
+        "type": "fact",
+        "memory_type": "fact",
+        "confidence": 0.9,
+        "status": status,
+        "tags": [],
+        "created_at": _iso(created_at),
+        "updated_at": _iso(updated_at),
+        "superseded_at": superseded_at,
+        "expires_at": None,
+        "ttl_seconds": None,
+        "actor_id": "user-1",
+        "source": "user",
+        "source_ref": None,
+        "scope_type": "agent",
+        "scope_id": "agent-1",
+        "score": 0.95,
+        "provenance": "explicit_statement",
+        "validation_count": 0,
+        "contradiction_detected": False,
+        "superseded_by": superseded_by,
+    }
+
+
+class TestTimelineAmnesiaAsOf:
+    """验证 search_as_of 的 supersession 时间判断。"""
+
+    @pytest.fixture
+    def read_service(self) -> MemoryReadService:
+        """构造一个 MemoryReadService，client 全 mock。"""
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {"items": []}
+        return MemoryReadService(client)
+
+    def test_superseded_memory_excluded_when_superseded_at_before_as_of(
+        self, read_service, monkeypatch
+    ):
+        """
+        场景：A 在 2026-02-01 被 supersede（superseded_at=2026-02-01），
+              但 updated_at 被 validate() 污染到 2026-03-01。
+              查询 as_of=2026-02-15。
+        期望：A 不应出现（superseded_at=2026-02-01 <= as_of=2026-02-15）。
+        """
+        memory_a = _make_memory(
+            "mem-A",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 3, 1, tzinfo=timezone.utc),  # 被 validate 污染
+            superseded_by="mem-B",
+            superseded_at=_iso(datetime(2026, 2, 1, tzinfo=timezone.utc)),
+            status="superseded",
+            title="用户喜欢咖啡",
+            content="用户偏好：咖啡",
+        )
+        memory_b = _make_memory(
+            "mem-B",
+            created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+            status="active",
+            title="用户喜欢茶",
+            content="用户偏好：茶",
+        )
+
+        monkeypatch.setattr(
+            read_service,
+            "_fetch_all_memories",
+            lambda namespaces, **kw: [memory_a, memory_b],
+        )
+
+        result = read_service.search_as_of(
+            as_of_date="2026-02-15T00:00:00Z",
+            agent_id="agent-1",
+        )
+        result_ids = [m["id"] for m in result["results"]]
+
+        assert "mem-A" not in result_ids, (
+            "superseded_at=2026-02-01 <= as_of=2026-02-15，A 应被排除。"
+        )
+        assert "mem-B" in result_ids
+
+    def test_superseded_memory_included_when_superseded_at_after_as_of(
+        self, read_service, monkeypatch
+    ):
+        """
+        场景：A 在 2026-03-01 被 supersede（superseded_at=2026-03-01）。
+              查询 as_of=2026-02-15。
+        期望：A 应出现（supersession 发生在 as_of 之后，A 当时仍有效）。
+        """
+        memory_a = _make_memory(
+            "mem-A",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
+            superseded_by="mem-B",
+            superseded_at=_iso(datetime(2026, 3, 1, tzinfo=timezone.utc)),
+            status="superseded",
+            title="用户喜欢咖啡",
+            content="用户偏好：咖啡",
+        )
+
+        monkeypatch.setattr(
+            read_service,
+            "_fetch_all_memories",
+            lambda namespaces, **kw: [memory_a],
+        )
+
+        result = read_service.search_as_of(
+            as_of_date="2026-02-15T00:00:00Z",
+            agent_id="agent-1",
+        )
+        result_ids = [m["id"] for m in result["results"]]
+
+        assert "mem-A" in result_ids, (
+            "superseded_at=2026-03-01 > as_of=2026-02-15，A 在 as_of 时仍有效，应出现。"
+        )
+
+    def test_legacy_data_falls_back_to_updated_at(self, read_service, monkeypatch):
+        """
+        向后兼容：旧数据没有 superseded_at，fallback 到 updated_at。
+        A.updated_at=2026-02-01 <= as_of=2026-02-15 → A 被排除。
+        """
+        memory_a = _make_memory(
+            "mem-A",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 2, 1, tzinfo=timezone.utc),  # 没有 superseded_at
+            superseded_by="mem-B",
+            superseded_at=None,
+            status="superseded",
+        )
+
+        monkeypatch.setattr(
+            read_service,
+            "_fetch_all_memories",
+            lambda namespaces, **kw: [memory_a],
+        )
+
+        result = read_service.search_as_of(
+            as_of_date="2026-02-15T00:00:00Z",
+            agent_id="agent-1",
+        )
+        result_ids = [m["id"] for m in result["results"]]
+
+        assert "mem-A" not in result_ids, (
+            "旧数据 fallback 到 updated_at=2026-02-01 <= as_of=2026-02-15，A 应被排除。"
+        )
+
+
+class TestMemoryRecordSupersession:
+    """验证 MemoryRecord 的 supersession 行为。"""
+
+    def test_mark_superseded_sets_superseded_at(self):
+        """mark_superseded 应设置独立的 superseded_at 字段。"""
+        memory = MemoryRecord(
+            id="mem-A",
+            type="preference",
+            title="测试",
+            content="内容",
+            scope_type="agent",
+            scope_id="agent-1",
+            actor_id="user-1",
+            source="user",
+        )
+        assert memory.superseded_at is None
+
+        memory.mark_superseded("mem-B")
+
+        assert memory.superseded_at is not None
+        assert memory.superseded_by == "mem-B"
+        assert memory.status == "superseded"
+        assert memory.updated_at == memory.superseded_at
+
+    def test_validate_skips_superseded_memory(self):
+        """validate() 不应操作 superseded memory，避免污染 updated_at。"""
+        memory = MemoryRecord(
+            id="mem-A",
+            type="preference",
+            title="测试",
+            content="内容",
+            scope_type="agent",
+            scope_id="agent-1",
+            actor_id="user-1",
+            source="user",
+        )
+        memory.mark_superseded("mem-B")
+        updated_at_before = memory.updated_at
+        validation_count_before = memory.validation_count
+
+        memory.validate()  # 应该被跳过
+
+        assert memory.updated_at == updated_at_before, "updated_at 不应被污染"
+        assert memory.validation_count == validation_count_before, "validation_count 不应增加"
+
+    def test_detect_contradiction_skips_superseded_memory(self):
+        """detect_contradiction() 不应操作 superseded memory。"""
+        memory = MemoryRecord(
+            id="mem-A",
+            type="fact",
+            title="测试",
+            content="内容",
+            scope_type="agent",
+            scope_id="agent-1",
+            actor_id="user-1",
+            source="user",
+        )
+        memory.mark_superseded("mem-B")
+        updated_at_before = memory.updated_at
+
+        memory.detect_contradiction()  # 应该被跳过
+
+        assert memory.updated_at == updated_at_before, "updated_at 不应被污染"
+
+    def test_validate_works_on_active_memory(self):
+        """validate() 仍正常作用于 active memory。"""
+        memory = MemoryRecord(
+            id="mem-A",
+            type="preference",
+            title="测试",
+            content="内容",
+            scope_type="agent",
+            scope_id="agent-1",
+            actor_id="user-1",
+            source="user",
+        )
+        memory.validate()
+
+        assert memory.validation_count == 1
+        assert memory.validated_at is not None
+
+    def test_to_moorcheh_document_includes_superseded_at(self):
+        """to_moorcheh_document 应包含 superseded_at 字段。"""
+        memory = MemoryRecord(
+            id="mem-A",
+            type="preference",
+            title="测试",
+            content="内容",
+            scope_type="agent",
+            scope_id="agent-1",
+            actor_id="user-1",
+            source="user",
+        )
+        memory.mark_superseded("mem-B")
+
+        doc = memory.to_moorcheh_document()
+
+        assert "superseded_at" in doc
+        assert doc["superseded_by"] == "mem-B"
+
+    def test_to_moorcheh_document_omits_superseded_at_when_none(self):
+        """active memory 的 document 不应包含 superseded_at。"""
+        memory = MemoryRecord(
+            id="mem-A",
+            type="preference",
+            title="测试",
+            content="内容",
+            scope_type="agent",
+            scope_id="agent-1",
+            actor_id="user-1",
+            source="user",
+        )
+        doc = memory.to_moorcheh_document()
+        assert "superseded_at" not in doc


### PR DESCRIPTION
# Fix: Timeline Amnesia in `search_as_of` — introduce dedicated `superseded_at` field

> Submitted for [Bounty #770 — Bug & Exploit Challenge](https://github.com/moorcheh-ai/memanto/issues/770) ($100 USD)

## Summary of the flaw

`MemoryReadService.search_as_of` is a **point-in-time query** ("What was true at this point in time?"). To decide whether a memory was already superseded at the requested `as_of_date`, it inspects the memory's `updated_at` field.

The problem: `updated_at` is **shared by every mutating operation** on a `MemoryRecord` — `validate()`, `detect_contradiction()`, `update_memory()`, etc. — not just `mark_superseded()`. Any later call to those operations "refreshes" `updated_at` to a much later timestamp, so `search_as_of` cannot tell when the supersession actually happened.

**Net effect — timeline amnesia**: a memory that was superseded *before* `as_of_date` silently reappears in the result set, causing the agent to recall a stale, already-replaced preference as if it were still true at that point in time.

This directly violates three of the bounty's in-scope targets:
- *Retrieval Quality & Accuracy* — fails to recall the correct version
- *Losing track of when an event occurred (timeline amnesia)*
- *Deeply flawed contradiction handling* — supersession is the system's primary contradiction-resolution mechanism

### Root cause (3 sub-causes)

1. **`search_as_of` uses `updated_at` to time supersession** — but `updated_at` is mutated by `mark_superseded`, `validate`, `detect_contradiction`, and `update_memory` alike.
2. **No dedicated field records *when* supersession happened.** The legacy `MemorySupersedeResponse` model has `supersede_timestamp`, but the core `MemoryRecord` does not, and `_mark_memory_superseded` in `app/legacy/universal_services.py` is a no-op stub.
3. **`validate()` / `detect_contradiction()` don't guard against `status == "superseded"`** — they happily bump `updated_at` on an already-replaced memory, which is exactly what poisons `search_as_of`.

## Reproduction steps

A self-contained PoC is included at [`docs/bounty_reports/poc_timeline_amnesia.py`](docs/bounty_reports/poc_timeline_amnesia.py). It requires only the `memanto` package importable — **no Moorcheh API key, no network** (the Moorcheh client is mocked).

```bash
cd <memanto repo root>
python docs/bounty_reports/poc_timeline_amnesia.py
```

### Timeline used by the PoC

| Time | Event |
|------|-------|
| 2026-01-01 | Memory A created ("user likes coffee") |
| 2026-02-01 | Memory B created; A is superseded by B |
| 2026-03-01 | A is (mistakenly) `validate()`-d → `updated_at` refreshed to 2026-03-01 |
| Query | `search_as_of(as_of_date="2026-02-15")` |

### Expected vs actual (pre-fix)

| | Expected | Actual (buggy) |
|---|----------|----------------|
| Result IDs | `["mem-B"]` | `["mem-A", "mem-B"]` |
| A present? | No (already superseded) | **Yes (wrongly recalled)** |

`search_as_of` returns the *already-replaced* preference A as if it were still true at 2026-02-15 — even though A was superseded on 2026-02-01.

Run the PoC on the pre-fix code → exit code `1` (bug reproduced). Run it on this branch → exit code `0` (bug fixed).

A pytest-based regression test is also included at `tests/failing_tests/test_timeline_amnesia.py` (9 tests, all passing on this branch).

## Fix / architectural proposal

**Central idea**: introduce a dedicated `superseded_at` field that is set *only* by `mark_superseded()` and never touched by `validate()` / `detect_contradiction()` / `update_memory()`.

### `memanto/app/core.py`
1. New field on `MemoryRecord`: `superseded_at: datetime | None = None`
2. `mark_superseded()` now sets `superseded_at = now` alongside `updated_at`.
3. `validate()` and `detect_contradiction()` early-return when `self.status == "superseded"` — no state change, no `updated_at` bump.
4. `to_moorcheh_document()` emits `superseded_at` so the field round-trips through Moorcheh storage.

### `memanto/app/services/memory_read_service.py`
1. `search_as_of` now reads `superseded_at` first, falling back to `updated_at` only for legacy data:
   ```python
   supersede_ts = memory.get("superseded_at") or memory.get("updated_at")
   ```
2. `_format_memory_item` extracts `superseded_at` so downstream consumers can see it.

### `memanto/app/services/memory_write_service.py`
`update_memory()` now preserves `superseded_by`, `supersedes`, and `superseded_at` from the existing memory (unless explicitly overridden in `updates`). Previously the delete-and-recreate pattern dropped these fields, which would have made a superseded memory look active again after an edit.

## Backwards compatibility

- **Old stored memories** (no `superseded_at` field): `search_as_of` falls back to `updated_at`, so behavior is unchanged — these memories continue to work, they just don't get the new protection until they are re-superseded.
- **No schema migration required**: `superseded_at` is an optional field; existing Moorcheh documents are not touched.
- **No API change**: no endpoint signature is modified; `superseded_at` is surfaced in response payloads only when present.

## Files changed

| File | Change |
|------|--------|
| `memanto/app/core.py` | New `superseded_at` field; `mark_superseded` sets it; `validate` / `detect_contradiction` skip superseded memories; `to_moorcheh_document` emits it |
| `memanto/app/services/memory_read_service.py` | `search_as_of` prefers `superseded_at`; `_format_memory_item` extracts it |
| `memanto/app/services/memory_write_service.py` | `update_memory` preserves `superseded_at` / `superseded_by` / `supersedes` |
| `tests/failing_tests/test_timeline_amnesia.py` | Regression test (was failing pre-fix, passes post-fix) |
| `docs/bounty_reports/poc_timeline_amnesia.py` | Self-contained PoC |
| `docs/bounty_reports/timeline_amnesia_supersession.md` | Detailed bug report |

## Verification

```bash
# PoC (pre-fix: exit 1, post-fix: exit 0)
python docs/bounty_reports/poc_timeline_amnesia.py

# Regression tests (9 tests, all pass on this branch)
python -m pytest tests/failing_tests/test_timeline_amnesia.py -v
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where older superseded memories could reappear in time-based search results after later updates.
  * Improved handling of supersession history so previously replaced items are filtered more reliably.

* **New Features**
  * Added support for preserving and displaying supersession timestamps in memory records and search output.

* **Tests**
  * Added regression coverage for supersession behavior, legacy data fallback, and timestamp preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->