### PR TITLE
Fix LangGraph store tag normalization (#770)

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -239,12 +239,7 @@ class MemantoStore(BaseStore):
         confidence = float(value.pop("confidence", 0.8))
         confidence = max(0.0, min(1.0, confidence))
 
-        raw_tags = value.pop("tags", []) or []
-        if isinstance(raw_tags, str):
-            raw_tags = [t.strip() for t in raw_tags.split(",") if t.strip()]
-        elif not isinstance(raw_tags, (list, tuple, set)):
-            raw_tags = [str(raw_tags)]
-
+        raw_tags = self._normalize_tags(value.pop("tags", None))
         user_tags = [
             str(t) for t in raw_tags if not str(t).startswith(_RESERVED_PREFIX)
         ]

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -177,7 +177,7 @@ class MemantoStore(BaseStore):
             limit=self._MEMANTO_RECALL_CAP,
         )
         for mem in result.get("memories", []):
-            tags = mem.get("tags") or []
+            tags = self._normalize_tags(mem.get("tags"))
             if all(t in tags for t in required_tags):
                 return self._memory_to_item(mem, op.namespace, op.key)
 
@@ -194,7 +194,7 @@ class MemantoStore(BaseStore):
             return None
 
         for mem in result.get("memories", []):
-            tags = mem.get("tags") or []
+            tags = self._normalize_tags(mem.get("tags"))
             if all(t in tags for t in required_tags):
                 return self._memory_to_item(mem, op.namespace, op.key)
         return None
@@ -290,7 +290,7 @@ class MemantoStore(BaseStore):
             type_filter = [type_filter]
         # SearchOp uses "min_confidence"; SdkClient.recall() uses "min_similarity"
         min_similarity = filter_dict.get("min_confidence")
-        extra_tags = list(filter_dict.get("tags", []) or [])
+        extra_tags = self._normalize_tags(filter_dict.get("tags"))
 
         cache_key = (
             op.namespace_prefix,
@@ -346,7 +346,7 @@ class MemantoStore(BaseStore):
 
         out: list[SearchItem] = []
         for mem in result.get("memories", []):
-            tags = mem.get("tags") or []
+            tags = self._normalize_tags(mem.get("tags"))
             if extra_tags and not all(t in tags for t in extra_tags):
                 continue
             key = self._tags_to_key(tags) or mem.get("id", "")
@@ -423,6 +423,16 @@ class MemantoStore(BaseStore):
         return None
 
     @staticmethod
+    def _normalize_tags(raw: Any) -> list[str]:
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            return [tag.strip() for tag in raw.split(",") if tag.strip()]
+        if isinstance(raw, (list, tuple, set)):
+            return [str(tag).strip() for tag in raw if str(tag).strip()]
+        return [str(raw).strip()] if str(raw).strip() else []
+
+    @staticmethod
     def _stringify(value: dict[str, Any]) -> str:
         if not value:
             return "(empty)"
@@ -464,7 +474,7 @@ class MemantoStore(BaseStore):
 
     @staticmethod
     def _memory_to_value(mem: dict[str, Any]) -> dict[str, Any]:
-        tags = mem.get("tags", []) or []
+        tags = MemantoStore._normalize_tags(mem.get("tags"))
         user_tags = [t for t in tags if not t.startswith(_RESERVED_PREFIX)]
         return {
             "kind": mem.get("type", "fact"),

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -235,6 +235,65 @@ def test_do_search_semantic(mock_sdk_client):
     )
 
 
+def test_do_search_accepts_string_tag_filter(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-456",
+                "tags": ["lg:key:key2", "urgent"],
+                "type": "observation",
+                "content": "observed",
+            }
+        ]
+    }
+
+    op = SearchOp(
+        namespace_prefix=("my_ns",), query="test query", filter={"tags": "urgent"}
+    )
+    items = store._do_search(op)
+
+    assert len(items) == 1
+    assert items[0].key == "key2"
+    client_instance.recall.assert_called_once_with(
+        agent_id="langgraph_my_ns",
+        query="test query",
+        limit=10,
+        type=None,
+        tags=["urgent"],
+        min_similarity=None,
+    )
+
+
+def test_do_search_recovers_key_from_comma_separated_tags(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-456",
+                "tags": "lg:key:key2,urgent",
+                "type": "observation",
+                "content": "observed",
+            }
+        ]
+    }
+
+    op = SearchOp(
+        namespace_prefix=("my_ns",), query="test query", filter={"tags": ["urgent"]}
+    )
+    items = store._do_search(op)
+
+    assert len(items) == 1
+    assert items[0].key == "key2"
+    assert items[0].value["tags"] == ["urgent"]
+
+
 def test_batch_execution(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -93,6 +93,34 @@ def test_do_get_recent_success(mock_sdk_client):
     )
 
 
+def test_do_get_recovers_key_from_comma_separated_tags(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall_recent.return_value = {
+        "memories": [
+            {
+                "id": "mem-123",
+                "tags": "lg:key:my_key,urgent",
+                "type": "fact",
+                "title": "my_key",
+                "content": "some content",
+                "confidence": 0.8,
+                "created_at": "2023-01-01T00:00:00Z",
+                "updated_at": "2023-01-01T00:00:00Z",
+            }
+        ]
+    }
+
+    op = GetOp(namespace=("my_ns",), key="my_key")
+    item = store._do_get(op)
+
+    assert item is not None
+    assert item.key == "my_key"
+    assert item.value["tags"] == ["urgent"]
+
+
 def test_do_get_fallback_success(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()


### PR DESCRIPTION
## Summary
- normalize LangGraph store tag inputs before filtering and key extraction
- support both list-shaped tags and comma-separated tag strings returned by backend documents
- preserve user tags in returned LangGraph values while filtering out reserved `lg:*` tags

## Reproduction
`MemantoStore._do_search()` previously used `list(filter_dict.get("tags", []) or [])`. When a caller passed `filter={"tags": "urgent"}`, the filter became `["u", "r", "g", "e", "n", "t"]`, so recall received character tags and local filtering dropped valid memories.

A second failure happened when backend results exposed tags as a comma-separated string such as `"lg:key:key2,urgent"`: `_tags_to_key()` iterated characters instead of tags, losing the LangGraph key and returning the memory id instead.

## Fix
Added a small `_normalize_tags()` helper and reused it for:
- `_do_get()` recent and fallback results
- `_do_search()` filter tags and result tags
- `_memory_to_value()` returned user tags

## Validation
- `python3 -m py_compile integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`
- `git diff --check`
- local stub smoke test for string tag filters and comma-separated backend tags

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag handling for memory retrieval and search, yielding more consistent results across different tag input/output formats.
  * Search filters now correctly interpret single-tag and comma-separated tag strings.
  * Returned items now more reliably preserve user tags while still excluding internal reserved tags.
* **Tests**
  * Added coverage to verify tag normalization and key recovery behavior for retrieval and search flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->