### PR TITLE
fix(core): broaden commitment parser to support reminding third parties (Fixes #770)

### DIFF
--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -129,7 +129,7 @@ class MemoryParsingService:
                     r"\b(?:assign|assigned|responsible for|owner is|by tomorrow|by eod|by end of day)\b",
                     4,
                 ),
-                (r"\b(?:remind me to|don't forget to|need a reminder)\b", 6),
+                (r"\b(?:remind\s+(?:\w+|the\s+\w+)\s+to|don't forget to|need a reminder)\b", 6),
             ]
         ],
         "event": [

--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -129,7 +129,7 @@ class MemoryParsingService:
                     r"\b(?:assign|assigned|responsible for|owner is|by tomorrow|by eod|by end of day)\b",
                     4,
                 ),
-                (r"\b(?:remind\s+(?:\w+|the\s+\w+)\s+to|don't forget to|need a reminder)\b", 6),
+                (r"\b(?:remind\s+(?:the\s+)?(?:\w+(?:\s+\w+){0,4})\s+to|don't forget to|need a reminder)\b", 6),
             ]
         ],
         "event": [

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -190,3 +190,14 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
     parser.parse_memory(memory)
 
     assert memory.type == "fact"
+
+
+def test_remind_other_people_than_me():
+    parser = MemoryParsingService()
+
+    memory = make_memory("remind the team to email the report tomorrow")
+
+    parser.parse_memory(memory)
+
+    assert memory.type == "commitment"
+

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -195,9 +195,24 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
 def test_remind_other_people_than_me():
     parser = MemoryParsingService()
 
-    memory = make_memory("remind the team to email the report tomorrow")
+    # Single-word after remind/remind the
+    m1 = make_memory("remind the team to email the report tomorrow")
+    parser.parse_memory(m1)
+    assert m1.type == "commitment"
 
-    parser.parse_memory(memory)
+    # Multi-word after remind the
+    m2 = make_memory("remind the product team to email the report tomorrow")
+    parser.parse_memory(m2)
+    assert m2.type == "commitment"
 
-    assert memory.type == "commitment"
+    # Multi-word after remind (without the)
+    m3 = make_memory("remind my direct reports to join the sync tomorrow")
+    parser.parse_memory(m3)
+    assert m3.type == "commitment"
+
+    # Long multi-word after remind the
+    m4 = make_memory("remind the entire frontend engineering team to deploy next week")
+    parser.parse_memory(m4)
+    assert m4.type == "commitment"
+
 


### PR DESCRIPTION
# Bug Fix: Broaden Commitment parsing to support reminding third parties

This PR addresses an issue in `MemoryParsingService` where commitments were incorrectly classified as default facts/relationships when they involved reminding anyone other than the current user (e.g., "remind the team", "remind Alex").

## Changes
- **Core Regex**: Updated the commitment regex rule from strictly matching `remind me to` to matching `remind <someone/group> to` (e.g., `remind the team to`, `remind us to`).
- **Tests**: Added a test case `test_remind_other_people_than_me` in `tests/test_memory_parsing.py` to assert correct classification of third-party reminders.

Payment Info: PayPal: https://paypal.me/sureshc26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded reminder/commitment detection to recognize additional phrasing, including “remind <word> to…” and “remind the <word> to…”, alongside existing “don’t forget to” and “need a reminder.”

* **Tests**
  * Added new test coverage to ensure reminders directed at others (e.g., team members) are correctly classified as commitments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->