### PR TITLE
fix(claudecode): ignore malformed recall profile rows

### DIFF
--- a/integrations/claudecode/claudecode_memanto/profile.py
+++ b/integrations/claudecode/claudecode_memanto/profile.py
@@ -131,7 +131,10 @@ class MemoryProfile:
 
 
 def _render_memory(mem: dict[str, Any]) -> str:
-    content = str(mem.get("content") or mem.get("title") or "").strip()
+    raw_content = mem.get("content")
+    if raw_content is None:
+        raw_content = mem.get("title", "")
+    content = str(raw_content).strip()
     confidence = mem.get("confidence")
     if isinstance(confidence, (int, float)) and confidence < 0.6:
         return f"{content} (tentative)"

--- a/integrations/claudecode/claudecode_memanto/profile.py
+++ b/integrations/claudecode/claudecode_memanto/profile.py
@@ -74,7 +74,14 @@ class MemoryProfile:
         either ``score`` or ``similarity_score`` depending on the endpoint, so
         we coalesce both.
         """
-        memories = list((result or {}).get("memories", []) or [])
+        if not isinstance(result, dict):
+            return cls(memories=[])
+
+        raw_memories = result.get("memories", [])
+        if not isinstance(raw_memories, list):
+            raw_memories = []
+
+        memories = [m for m in raw_memories if isinstance(m, dict)]
         if min_similarity is not None:
             memories = [m for m in memories if _score(m) >= min_similarity]
         return cls(memories=memories)
@@ -90,7 +97,8 @@ class MemoryProfile:
 
         grouped: dict[str, list[dict[str, Any]]] = {}
         for mem in self.memories:
-            grouped.setdefault((mem.get("type") or "context").lower(), []).append(mem)
+            mtype = str(mem.get("type") or "context").lower()
+            grouped.setdefault(mtype, []).append(mem)
 
         # Escape skill_name everywhere it appears in the injected block. The
         # block is fed back into the model as system context, so a crafted
@@ -123,7 +131,7 @@ class MemoryProfile:
 
 
 def _render_memory(mem: dict[str, Any]) -> str:
-    content = (mem.get("content") or mem.get("title") or "").strip()
+    content = str(mem.get("content") or mem.get("title") or "").strip()
     confidence = mem.get("confidence")
     if isinstance(confidence, (int, float)) and confidence < 0.6:
         return f"{content} (tentative)"

--- a/integrations/claudecode/tests/test_profile.py
+++ b/integrations/claudecode/tests/test_profile.py
@@ -76,6 +76,27 @@ class TestFormatContextBlock:
         ).format_context_block()
         assert "456" in block
 
+    def test_falsy_scalar_content_values_are_preserved(self) -> None:
+        block = MemoryProfile(
+            [
+                {"type": "fact", "content": 0, "title": "fallback"},
+                {"type": "fact", "content": False, "title": "fallback"},
+                {"type": "fact", "content": 0.0, "title": "fallback"},
+            ]
+        ).format_context_block()
+
+        assert "  - 0\n" in block
+        assert "  - False\n" in block
+        assert "  - 0.0\n" in block
+        assert "fallback" not in block
+
+    def test_missing_content_falls_back_to_title(self) -> None:
+        block = MemoryProfile(
+            [{"type": "fact", "title": "fallback title"}]
+        ).format_context_block()
+
+        assert "fallback title" in block
+
     def test_content_present(self, sample_memories: list[dict[str, Any]]) -> None:
         block = MemoryProfile(sample_memories).format_context_block()
         assert "Always use Vitest" in block

--- a/integrations/claudecode/tests/test_profile.py
+++ b/integrations/claudecode/tests/test_profile.py
@@ -13,6 +13,24 @@ class TestFromRecall:
         assert not MemoryProfile.from_recall({})
         assert len(MemoryProfile.from_recall({"memories": []})) == 0
 
+    def test_malformed_recall_shape_is_ignored(self) -> None:
+        assert not MemoryProfile.from_recall("backend timeout")  # type: ignore[arg-type]
+        assert not MemoryProfile.from_recall({"memories": "not-a-list"})
+
+    def test_malformed_recall_entries_are_skipped_before_filtering(self) -> None:
+        profile = MemoryProfile.from_recall(
+            {
+                "memories": [
+                    "truncated row",
+                    None,
+                    {"type": "fact", "content": "Keep valid hits", "score": 0.9},
+                ]
+            },
+            min_similarity=0.5,
+        )
+        assert len(profile) == 1
+        assert profile.memories[0]["content"] == "Keep valid hits"
+
     def test_similarity_floor_filters(
         self, sample_memories: list[dict[str, Any]]
     ) -> None:
@@ -51,6 +69,12 @@ class TestFormatContextBlock:
             [{"type": "fact", "content": "maybe true", "confidence": 0.3}]
         ).format_context_block()
         assert "(tentative)" in block
+
+    def test_unusual_scalar_fields_render_without_crashing(self) -> None:
+        block = MemoryProfile(
+            [{"type": 123, "content": 456, "confidence": "high"}]
+        ).format_context_block()
+        assert "456" in block
 
     def test_content_present(self, sample_memories: list[dict[str, Any]]) -> None:
         block = MemoryProfile(sample_memories).format_context_block()


### PR DESCRIPTION
## Summary
Hardens the Claude Code skills memory profile renderer against malformed recall responses from the SDK/backend.

## Reproduction
Before this patch, `MemoryProfile.from_recall()` assumed the recall response was a dict with a list of dict memories. A malformed response such as `"backend timeout"`, `{ "memories": "not-a-list" }`, or a mixed memories list containing strings/`None` could raise while applying a similarity floor or rendering the injected engineering profile, preventing valid recalled memories from reaching Claude Code.

## Fix
- Treat non-dict recall responses and non-list `memories` containers as empty results.
- Skip malformed non-object memory rows before similarity filtering.
- Coerce unusual scalar `type`/`content` fields during rendering so one odd value does not break the whole profile block.
- Add regression coverage for malformed containers, malformed entries, and scalar fields.

Refs #770

## Validation
- `python3 -m pytest tests/test_profile.py -q`
- `python3 -m pytest tests -q`
- `python3 -m ruff check claudecode_memanto tests`
- `python3 -m py_compile claudecode_memanto/profile.py tests/test_profile.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made memory lookup handling more resilient to unexpected or malformed results, returning an empty profile when inputs aren’t in the expected shape.
  * Improved context grouping and rendering to handle unusual value types reliably (including numeric and falsy content), and to safely skip invalid memory entries.
  * Fixed content fallback behavior so titles are only used when content is truly missing.
* **Tests**
  * Added unit tests covering malformed recall outputs, grouping/formatting edge cases, and preservation of scalar content values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->