### PR TITLE
Skip malformed memory read items

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -42,14 +42,17 @@ class MemoryReadService:
 
             items: list[Any] = cast(list[Any], result.get("items", []))
             if items and isinstance(items, list) and len(items) > 0:
-                memory = self._format_memory_item(items[0])
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    memory = self._format_memory_item(item)
 
-                # Apply TTL enforcement
-                filtered = self._filter_expired_memories([memory])
-                if filtered:
-                    return filtered[0]
-                else:
-                    return None  # Memory has expired
+                    # Apply TTL enforcement
+                    filtered = self._filter_expired_memories([memory])
+                    if filtered:
+                        return filtered[0]
+
+                return None
 
             return None
 
@@ -120,7 +123,11 @@ class MemoryReadService:
             search_items = search_result.get("results", [])
 
             # Format results
-            all_results = [self._format_memory_item(item) for item in search_items]
+            all_results = [
+                self._format_memory_item(item)
+                for item in search_items
+                if isinstance(item, dict)
+            ]
 
             # Apply temporal filtering (post-processing since Moorcheh metadata filters are string-based)
             if created_after or created_before:
@@ -474,8 +481,10 @@ class MemoryReadService:
         seen_ids: set[str] = set()
         memories: list[dict[str, Any]] = []
         for item in items:
+            if not isinstance(item, dict):
+                continue
             # Skip summary chunks — only return real memory documents
-            if isinstance(item, dict) and item.get("is_summary"):
+            if item.get("is_summary"):
                 continue
             formatted = self._format_memory_item(item)
             mid = formatted.get("id")
@@ -746,6 +755,8 @@ class MemoryReadService:
 
         # Check if metadata is in nested format (Moorcheh API spec)
         metadata = item.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
 
         # Helper to get field from either nested metadata or flat structure
         def get_field(field_name, flat_field_name=None):

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -182,7 +182,7 @@ class MemoryReadService:
             namespaces = []
             from typing import cast
 
-            from memanto.memanto.app.constants import ScopeType
+            from memanto.app.constants import ScopeType
 
             for scope_def in scopes:
                 scope = create_memory_scope(
@@ -224,6 +224,7 @@ class MemoryReadService:
             formatted_results = [
                 self._format_memory_item(item)
                 for item in search_result.get("results", [])
+                if isinstance(item, dict)
             ]
 
             return {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -346,6 +346,105 @@ class TestForgetEndToEnd:
         assert result["memory_id"] == "mem-xyz"
 
 
+class TestMemoryReadServiceMalformedItems:
+    def test_get_memory_skips_non_object_document_items(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.get.return_value = {
+            "items": [
+                "truncated row",
+                {
+                    "id": "memory-1",
+                    "text": "[FACT] Valid memory\n\nbody",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    },
+                },
+            ]
+        }
+
+        result = MemoryReadService(client).get_memory("memory-1", "memanto_agent_a")
+
+        assert result is not None
+        assert result["id"] == "memory-1"
+
+    def test_recent_search_skips_non_object_document_items(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {
+            "items": [
+                "truncated row",
+                {
+                    "id": "memory-1",
+                    "text": "[FACT] Valid memory\n\nbody",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    },
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        result = MemoryReadService(client).search_recent("agent-1")
+
+        assert result["total_found"] == 1
+        assert result["results"][0]["id"] == "memory-1"
+
+    def test_recent_search_treats_non_object_metadata_as_empty(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "memory-1",
+                    "text": "[FACT] Valid memory\n\nbody",
+                    "metadata": "truncated metadata",
+                    "memory_type": "fact",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        result = MemoryReadService(client).search_recent("agent-1")
+
+        assert result["total_found"] == 1
+        assert result["results"][0]["id"] == "memory-1"
+        assert result["results"][0]["type"] == "fact"
+
+    def test_similarity_search_skips_non_object_result_items(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [
+                "truncated row",
+                {
+                    "id": "memory-1",
+                    "text": "[FACT] Valid memory\n\nbody",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    },
+                },
+            ],
+            "execution_time": 0.1,
+        }
+
+        service = MemoryReadService(client)
+        service._get_search_namespaces = lambda *_, **__: ["memanto_agent_agent-1"]
+
+        result = service.search_memories("valid")
+
+        assert result["total_found"] == 1
+        assert result["results"][0]["id"] == "memory-1"
+
+
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -444,6 +444,34 @@ class TestMemoryReadServiceMalformedItems:
         assert result["total_found"] == 1
         assert result["results"][0]["id"] == "memory-1"
 
+    def test_multi_scope_search_skips_non_object_result_items(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [
+                "truncated row",
+                {
+                    "id": "memory-1",
+                    "text": "[FACT] Valid memory\n\nbody",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    },
+                },
+            ],
+            "execution_time": 0.1,
+        }
+
+        result = MemoryReadService(client).search_multi_scope(
+            "valid",
+            scopes=[{"scope_type": "agent", "scope_id": "agent-1"}],
+        )
+
+        assert result["total_found"] == 1
+        assert result["results"][0]["id"] == "memory-1"
+        assert result["searched_namespaces"] == ["memanto_agent_agent-1"]
+
 
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""


### PR DESCRIPTION
Refs #770

## Summary
- skip non-object items returned from core memory read paths before formatting them
- make `get_memory()` continue past malformed rows and return the first valid non-expired memory
- treat non-object `metadata` payloads as empty metadata so flat fields can still be used
- add regression coverage for `get_memory`, paginated document reads, similarity-search result formatting, and malformed metadata

## Reproduction
`MemoryReadService` assumed every document/search item and nested `metadata` value had object shape. If a backend/client response included a truncated scalar row such as `"truncated row"`, `_format_memory_item()` called `.get()` on that scalar and the whole read failed before valid memories were returned. If a row had `metadata` as a scalar, flat fallback fields like `memory_type` were never reached.

The added tests reproduce mixed responses containing malformed rows plus valid memory documents. Before the fix, `get_memory()`, `search_recent()`, and `search_memories()` raise `MemoryError` or drop the valid flat-field fallback path.

## Fix
Filter core read-path items to object-shaped rows before formatting them, have `get_memory()` scan for the first valid non-expired item, and normalize scalar `metadata` to `{}` before flat-field fallback. Summary chunks and existing type/tag/TTL filters continue to behave as before.

## Validation
- `uv run pytest tests/test_unit.py::TestMemoryReadServiceMalformedItems -q`
- `uv run pytest tests/test_unit.py -q`
- `uv run ruff check memanto/app/services/memory_read_service.py tests/test_unit.py`
- `uv run python -m py_compile memanto/app/services/memory_read_service.py tests/test_unit.py`
- `git diff --check`
- `uv run pytest -q`

Live E2E tests were skipped locally because `MOORCHEH_API_KEY` is not configured in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory read and search to safely skip malformed/non-standard upstream entries and return the first valid non-expired memory.
  * Search results now ignore non-dictionary items and handle multi-scope result formatting more defensively.
  * Memory formatting is more resilient when metadata is missing or not in the expected format.
* **Tests**
  * Added unit tests covering malformed “truncated row” payloads for memory retrieval and search, ensuring only valid results are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->