### PR TITLE
Guard batch summary result rows

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -476,8 +476,9 @@ async def extract_memories_from_conversation(
         session_service = get_session_service()
         for index, record in enumerate(memory_records):
             batch_results = result.get("results", [])
+            batch_item = batch_results[index] if index < len(batch_results) else None
             memory_id = (
-                batch_results[index].get("id") if index < len(batch_results) else None
+                batch_item.get("id") if isinstance(batch_item, dict) else None
             )
             await asyncio.to_thread(
                 session_service.log_memory_to_session_summary,

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -747,7 +747,8 @@ class DirectClient:
             batch_results = result.get("results", [])
 
             for i, mem in enumerate(memory_records):
-                mem_id = batch_results[i].get("id") if i < len(batch_results) else None
+                batch_item = batch_results[i] if i < len(batch_results) else None
+                mem_id = batch_item.get("id") if isinstance(batch_item, dict) else None
                 session_svc.log_memory_to_session_summary(
                     agent_id=agent_id,
                     session_id=session_id,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -576,7 +576,8 @@ class SdkClient:
             batch_results = result.get("results", [])
 
             for i, mem in enumerate(memory_records):
-                mem_id = batch_results[i].get("id") if i < len(batch_results) else None
+                batch_item = batch_results[i] if i < len(batch_results) else None
+                mem_id = batch_item.get("id") if isinstance(batch_item, dict) else None
                 session_svc.log_memory_to_session_summary(
                     agent_id=agent_id,
                     session_id=session_id,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -887,6 +887,75 @@ class TestMEMANTOAPI:
         assert uploaded_doc["provenance"] == "inferred"
 
     @pytest.mark.asyncio
+    async def test_extract_memories_ignores_malformed_batch_result_rows(
+        self, client, auth_headers
+    ):
+        """Malformed per-item batch rows must not hide successful extraction."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        assert activate_resp.status_code == 200, activate_resp.text
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        candidates = [
+            {
+                "type": "fact",
+                "title": "First",
+                "content": "First extracted memory.",
+                "confidence": 0.8,
+                "source": "conversation",
+                "provenance": "inferred",
+            },
+            {
+                "type": "fact",
+                "title": "Second",
+                "content": "Second extracted memory.",
+                "confidence": 0.8,
+                "source": "conversation",
+                "provenance": "inferred",
+            },
+        ]
+        batch_result = {
+            "total_submitted": 2,
+            "successful": 2,
+            "failed": 0,
+            "results": ["truncated row", {"id": "mem-2"}],
+        }
+
+        with (
+            patch(
+                "memanto.app.routes.memory.ConversationMemoryExtractionService"
+            ) as mock_extractor_cls,
+            patch("memanto.app.routes.memory.MemoryWriteService") as mock_write_cls,
+        ):
+            mock_extractor_cls.return_value.extract.return_value = candidates
+            mock_write_cls.return_value.batch_store_memories.return_value = batch_result
+
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/remember/extract",
+                headers=headers,
+                json={
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "The project uses pytest for tests.",
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["successful"] == 2
+        assert data["results"][0] == "truncated row"
+
+    @pytest.mark.asyncio
     async def test_recall_temporal_api(self, client, auth_headers, mock_moorcheh):
         """Test temporal recall modes (POST + JSON body)"""
         await client.post(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -441,6 +441,99 @@ class TestMEMANTOCLI:
         assert forwarded_updates["tags"] == ["a", "b"]
         assert result["status"] == "updated"
 
+    def test_batch_remember_direct_client_ignores_malformed_result_rows(
+        self, mock_all_clients
+    ):
+        from unittest.mock import MagicMock, patch
+
+        from memanto.cli.client.direct_client import DirectClient
+
+        mock_write_service = MagicMock()
+        mock_write_service.batch_store_memories.return_value = {
+            "total_submitted": 2,
+            "successful": 2,
+            "failed": 0,
+            "results": ["truncated row", {"id": "mem-2"}],
+        }
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+        mock_summary = MagicMock()
+
+        with (
+            patch.object(
+                DirectClient, "_get_write_service", return_value=mock_write_service
+            ),
+            patch.object(
+                DirectClient,
+                "_get_validated_session_for_agent",
+                return_value=mock_session,
+            ),
+            patch.object(
+                DirectClient, "_get_session_service", return_value=mock_summary
+            ),
+        ):
+            client = DirectClient.__new__(DirectClient)
+            client.api_key = "test-api-key"
+            client.base_url = "https://api.moorcheh.ai/v1"
+            client.session_token = "test-token"
+
+            result = client.batch_remember(
+                "test-agent",
+                [
+                    {"content": "first"},
+                    {"content": "second"},
+                ],
+            )
+
+        assert result["successful"] == 2
+        first_call, second_call = mock_summary.log_memory_to_session_summary.call_args_list
+        assert first_call.kwargs["memory_id"] is None
+        assert second_call.kwargs["memory_id"] == "mem-2"
+
+    def test_batch_remember_sdk_client_ignores_malformed_result_rows(
+        self, mock_all_clients
+    ):
+        from unittest.mock import MagicMock, patch
+
+        from memanto.cli.client.sdk_client import SdkClient
+
+        mock_write_service = MagicMock()
+        mock_write_service.batch_store_memories.return_value = {
+            "total_submitted": 2,
+            "successful": 2,
+            "failed": 0,
+            "results": ["truncated row", {"id": "mem-2"}],
+        }
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+        mock_summary = MagicMock()
+
+        with (
+            patch.object(
+                SdkClient, "_get_write_service", return_value=mock_write_service
+            ),
+            patch.object(
+                SdkClient, "_get_validated_session_for_agent", return_value=mock_session
+            ),
+            patch.object(SdkClient, "_get_session_service", return_value=mock_summary),
+        ):
+            client = SdkClient.__new__(SdkClient)
+            client.api_key = "test-api-key"
+            client.session_token = "test-token"
+
+            result = client.batch_remember(
+                "test-agent",
+                [
+                    {"content": "first"},
+                    {"content": "second"},
+                ],
+            )
+
+        assert result["successful"] == 2
+        first_call, second_call = mock_summary.log_memory_to_session_summary.call_args_list
+        assert first_call.kwargs["memory_id"] is None
+        assert second_call.kwargs["memory_id"] == "mem-2"
+
     def test_recall(self, mock_all_clients):
         """Test 'memanto recall'"""
         mock_all_clients.recall.return_value = {


### PR DESCRIPTION
Refs #770

## Summary
- guard DirectClient and SdkClient batch summary logging against malformed `results[]` rows
- guard the API extraction route's session-summary logging against the same malformed rows
- preserve successful batch write responses even when a per-item result row is not object-shaped
- add regression coverage for CLI and API paths while session summary logging is enabled

## Reproduction
When `batch_remember()` or conversation extraction succeeds and a session is active, the code logs each stored memory to the local session Markdown summary. That logging path extracts per-memory ids with `batch_results[i].get("id")`. If a backend/client response contains a malformed scalar row such as `"truncated row"`, the write result has already been produced, but summary logging raises `AttributeError` before the caller receives the successful batch response.

The added tests reproduce a successful batch result with `results: ["truncated row", {"id": "mem-2"}]` while session logging is active. Before the fix, DirectClient, SdkClient, and the API extraction route can crash in the summary logging path.

## Fix
Check that each per-item result row is a dict before reading `id`. Malformed rows are logged with `memory_id=None`, while valid rows still keep their ids and the original batch result is returned unchanged.

## Validation
- `uv run pytest tests/test_api.py::TestMEMANTOAPI::test_extract_memories_from_conversation_stores_batch tests/test_api.py::TestMEMANTOAPI::test_extract_memories_ignores_malformed_batch_result_rows tests/test_cli.py::TestMEMANTOCLI::test_batch_remember_direct_client_ignores_malformed_result_rows tests/test_cli.py::TestMEMANTOCLI::test_batch_remember_sdk_client_ignores_malformed_result_rows -q`
- `uv run pytest tests/test_api.py tests/test_cli.py -q`
- `uv run ruff check memanto/app/routes/memory.py memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_api.py tests/test_cli.py`
- `uv run python -m py_compile memanto/app/routes/memory.py memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_api.py tests/test_cli.py`
- `git diff --check`
- `uv run pytest -q`

Live E2E tests were skipped locally because `MOORCHEH_API_KEY` is not configured in this environment.
