### PR TITLE
fix auto-renewed session token handoff

### DIFF
--- a/docs/SESSION_ARCHITECTURE.md
+++ b/docs/SESSION_ARCHITECTURE.md
@@ -427,6 +427,14 @@ memanto:
     auto_title: true
 ```
 
+### Automatic Session Renewal
+
+When an authenticated API request reaches the configured renewal threshold,
+Memanto replaces the persisted session and returns the replacement JWT in the
+`X-Session-Token` response header. Raw HTTP clients must store that value for
+their next request because the previous token is no longer active. The web UI
+and TypeScript SDK update their session token automatically.
+
 ---
 
 ## Benefits Summary

--- a/docs/SESSION_ARCHITECTURE.md
+++ b/docs/SESSION_ARCHITECTURE.md
@@ -433,7 +433,10 @@ When an authenticated API request reaches the configured renewal threshold,
 Memanto replaces the persisted session and returns the replacement JWT in the
 `X-Session-Token` response header. Raw HTTP clients must store that value for
 their next request because the previous token is no longer active. The web UI
-and TypeScript SDK update their session token automatically.
+and TypeScript SDK update their session token automatically. Browser clients
+running on a different origin must configure an explicit `ALLOWED_ORIGINS`
+allowlist; Memanto does not expose replacement credentials when that setting
+contains the wildcard origin.
 
 ---
 

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -79,6 +79,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-Session-Token"],
 )
 
 # Include routers

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -76,7 +76,9 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.ALLOWED_ORIGINS,
-    allow_credentials=True,
+    # A wildcard origin must never be combined with credentialed CORS.
+    # Explicit allowlists retain credential support for trusted deployments.
+    allow_credentials="*" not in settings.ALLOWED_ORIGINS,
     allow_methods=["*"],
     allow_headers=["*"],
     # Never expose replacement credentials to arbitrary cross-origin pages.

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -79,7 +79,10 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
-    expose_headers=["X-Session-Token"],
+    # Never expose replacement credentials to arbitrary cross-origin pages.
+    # Same-origin clients can read this header without CORS; cross-origin
+    # deployments must configure an explicit ALLOWED_ORIGINS allowlist.
+    expose_headers=([] if "*" in settings.ALLOWED_ORIGINS else ["X-Session-Token"]),
 )
 
 # Include routers

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,7 +4,7 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
-from fastapi import Header, HTTPException
+from fastapi import Header, HTTPException, Response
 
 from memanto.app.models.session import Session
 from memanto.app.services.session_service import get_session_service
@@ -55,11 +55,15 @@ def verify_moorcheh_api_key() -> str:
     return get_moorcheh_api_key()
 
 
-def get_current_session(x_session_token: str | None = Header(None)) -> Session:
+def get_current_session(
+    response: Response,
+    x_session_token: str | None = Header(None),
+) -> Session:
     """
     Get and validate current session
 
     Args:
+        response: Response used to return a renewed session token
         x_session_token: Session token header
 
     Returns:
@@ -91,6 +95,10 @@ def get_current_session(x_session_token: str | None = Header(None)) -> Session:
         )
         if renewed:
             session = renewed
+            # Renewal replaces the persisted session, which immediately makes the
+            # request token stale. Return the replacement so clients can keep
+            # making authenticated requests without being locked out.
+            response.headers["X-Session-Token"] = renewed.session_token
 
         return session
 

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2652,6 +2652,9 @@
         // State
         const S = { config: null, agentId: null, token: null, apiKey: null, memories: [], charts: {}, connections: [], activeConnection: null, cwd: '' };
 
+        /**
+         * Persist a replacement session token returned after automatic renewal.
+         */
         function captureRenewedSession(res) {
             const token = res.headers.get('X-Session-Token');
             if (!token) return;

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2652,6 +2652,16 @@
         // State
         const S = { config: null, agentId: null, token: null, apiKey: null, memories: [], charts: {}, connections: [], activeConnection: null, cwd: '' };
 
+        function captureRenewedSession(res) {
+            const token = res.headers.get('X-Session-Token');
+            if (!token) return;
+            S.token = token;
+            if (S.config) {
+                S.config.session_token = token;
+                S.config.has_active_session = true;
+            }
+        }
+
         // API helper
         async function api(method, path, body) {
             const headers = { 'Content-Type': 'application/json' };
@@ -2660,6 +2670,7 @@
             const opts = { method, headers };
             if (body) opts.body = JSON.stringify(body);
             const res = await fetch(path, opts);
+            captureRenewedSession(res);
             if (!res.ok) {
                 const err = await res.json().catch(() => ({ detail: res.statusText }));
                 let msg = err.detail || err;
@@ -3222,6 +3233,7 @@
             out.innerHTML = '';
             try {
                 const res = await fetch(`/api/v2/agents/${S.agentId}/upload-file`, { method: 'POST', headers, body: fd });
+                captureRenewedSession(res);
                 const data = await res.json().catch(() => ({ detail: res.statusText }));
                 if (!res.ok) {
                     let msg = data.detail || res.statusText;

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -458,6 +458,7 @@ export class Memanto {
     return (await res.json()) as T;
   }
 
+  /** Persist a replacement session token returned after automatic renewal. */
   private captureRenewedSession(res: Response): void {
     const token = res.headers.get("X-Session-Token");
     if (token) this.sessionToken = token;

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -436,6 +436,7 @@ export class Memanto {
       headers,
       body: body === undefined ? undefined : JSON.stringify(body),
     });
+    this.captureRenewedSession(res);
     if (!res.ok) throw await asError(res, `${method} ${path} failed`);
     if (res.status === 204) return undefined as T;
     return (await res.json()) as T;
@@ -452,8 +453,14 @@ export class Memanto {
       headers: { "X-Session-Token": this.sessionToken ?? "" },
       body: form,
     });
+    this.captureRenewedSession(res);
     if (!res.ok) throw await asError(res, `POST ${path} failed`);
     return (await res.json()) as T;
+  }
+
+  private captureRenewedSession(res: Response): void {
+    const token = res.headers.get("X-Session-Token");
+    if (token) this.sessionToken = token;
   }
 }
 

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server, type IncomingMessage } from "node:http";
 import { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Memanto } from "../src/index.js";
 
 interface Recorded {
@@ -66,7 +69,23 @@ function startFakeApi(): Promise<{
             confidence: 0.9,
             type: "fact",
           });
-        if (url === "/api/v2/agents/test-agent/recall")
+        if (url === "/api/v2/agents/test-agent/upload-file")
+          return reply(
+            200,
+            {
+              agent_id: "test-agent",
+              file_name: "memory.txt",
+              status: "uploaded",
+            },
+            { "X-Session-Token": "multipart-renewed-token" },
+          );
+        if (url === "/api/v2/agents/test-agent/recall") {
+          if ((JSON.parse(body) as { query?: string }).query === "fail")
+            return reply(
+              500,
+              { detail: "intentional failure" },
+              { "X-Session-Token": "error-renewed-token" },
+            );
           return reply(
             200,
             {
@@ -78,6 +97,7 @@ function startFakeApi(): Promise<{
             },
             { "X-Session-Token": "renewed-token" },
           );
+        }
         return reply(404, { detail: "unknown route" });
       });
     });
@@ -149,6 +169,45 @@ describe("Memanto", () => {
     expect(recalls).toHaveLength(2);
     expect(recalls[0]?.headers["x-session-token"]).toBe("fake-token");
     expect(recalls[1]?.headers["x-session-token"]).toBe("renewed-token");
+  });
+
+  it("uses a token renewed by a multipart upload", async () => {
+    const api = await startFakeApi();
+    cleanupFns.push(api.close);
+    const dir = await mkdtemp(join(tmpdir(), "memanto-sdk-"));
+    cleanupFns.push(() => rm(dir, { recursive: true, force: true }));
+    const path = join(dir, "memory.txt");
+    await writeFile(path, "remember this");
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    await m.uploadFile({ path });
+    await m.recall({ query: "after upload" });
+
+    const recall = api.recorded.find((r) => r.url.endsWith("/recall"));
+    expect(recall?.headers["x-session-token"]).toBe(
+      "multipart-renewed-token",
+    );
+  });
+
+  it("keeps a replacement token returned with an error response", async () => {
+    const api = await startFakeApi();
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    await expect(m.recall({ query: "fail" })).rejects.toThrow(
+      /intentional failure/,
+    );
+    await m.recall({ query: "after error" });
+
+    const recalls = api.recorded.filter((r) => r.url.endsWith("/recall"));
+    expect(recalls).toHaveLength(2);
+    expect(recalls[1]?.headers["x-session-token"]).toBe(
+      "error-renewed-token",
+    );
   });
 
   it("rejects empty agentId", () => {

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -27,8 +27,15 @@ function startFakeApi(): Promise<{
         });
 
         const url = req.url ?? "";
-        const reply = (status: number, payload: unknown) => {
-          res.writeHead(status, { "Content-Type": "application/json" });
+        const reply = (
+          status: number,
+          payload: unknown,
+          headers: Record<string, string> = {},
+        ) => {
+          res.writeHead(status, {
+            "Content-Type": "application/json",
+            ...headers,
+          });
           res.end(JSON.stringify(payload));
         };
 
@@ -60,13 +67,17 @@ function startFakeApi(): Promise<{
             type: "fact",
           });
         if (url === "/api/v2/agents/test-agent/recall")
-          return reply(200, {
-            agent_id: "test-agent",
-            session_id: "sess-1",
-            query: "anything",
-            memories: [],
-            count: 0,
-          });
+          return reply(
+            200,
+            {
+              agent_id: "test-agent",
+              session_id: "sess-1",
+              query: "anything",
+              memories: [],
+              count: 0,
+            },
+            { "X-Session-Token": "renewed-token" },
+          );
         return reply(404, { detail: "unknown route" });
       });
     });
@@ -122,6 +133,22 @@ describe("Memanto", () => {
 
     const res = await m.recall({ query: "coffee" });
     expect(res).toMatchObject({ count: 0 });
+  });
+
+  it("uses the replacement token returned after automatic renewal", async () => {
+    const api = await startFakeApi();
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    await m.recall({ query: "first" });
+    await m.recall({ query: "second" });
+
+    const recalls = api.recorded.filter((r) => r.url.endsWith("/recall"));
+    expect(recalls).toHaveLength(2);
+    expect(recalls[0]?.headers["x-session-token"]).toBe("fake-token");
+    expect(recalls[1]?.headers["x-session-token"]).toBe("renewed-token");
   });
 
   it("rejects empty agentId", () => {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -248,9 +248,7 @@ class TestMEMANTOAPI:
         assert first_response.status_code == 200
         replacement_token = first_response.headers["X-Session-Token"]
         assert replacement_token != original_token
-        assert (
-            first_response.headers["Access-Control-Expose-Headers"] == "X-Session-Token"
-        )
+        assert "Access-Control-Expose-Headers" not in first_response.headers
 
         # Renewal replaces the stored session. The old token is invalid, while
         # the token returned in the response keeps the client authenticated.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -248,6 +248,9 @@ class TestMEMANTOAPI:
         assert first_response.status_code == 200
         replacement_token = first_response.headers["X-Session-Token"]
         assert replacement_token != original_token
+        assert "*" in settings.ALLOWED_ORIGINS
+        assert first_response.headers["Access-Control-Allow-Origin"] == "*"
+        assert "Access-Control-Allow-Credentials" not in first_response.headers
         assert "Access-Control-Expose-Headers" not in first_response.headers
 
         # Renewal replaces the stored session. The old token is invalid, while

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -214,6 +214,62 @@ class TestMEMANTOAPI:
         assert data["agent_id"] == self.TEST_AGENT_ID
 
     @pytest.mark.asyncio
+    async def test_auto_renew_returns_replacement_session_token(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """A client can continue after automatic session renewal."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate",
+            headers=auth_headers,
+        )
+        original_token = activate_response.json()["session_token"]
+
+        # Force the newly created session inside the auto-renew threshold.
+        monkeypatch.setattr(settings, "SESSION_EXTEND_THRESHOLD_MINUTES", 10_000)
+        mock_moorcheh.similarity_search.query.return_value = {
+            "results": [],
+            "total_found": 0,
+        }
+        first_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers={
+                **auth_headers,
+                "X-Session-Token": original_token,
+                "Origin": "https://example.test",
+            },
+            json={},
+        )
+
+        assert first_response.status_code == 200
+        replacement_token = first_response.headers["X-Session-Token"]
+        assert replacement_token != original_token
+        assert (
+            first_response.headers["Access-Control-Expose-Headers"] == "X-Session-Token"
+        )
+
+        # Renewal replaces the stored session. The old token is invalid, while
+        # the token returned in the response keeps the client authenticated.
+        monkeypatch.setattr(settings, "SESSION_EXTEND_THRESHOLD_MINUTES", 0)
+        stale_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers={**auth_headers, "X-Session-Token": original_token},
+            json={},
+        )
+        assert stale_response.status_code == 401
+
+        continued_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers={**auth_headers, "X-Session-Token": replacement_token},
+            json={},
+        )
+        assert continued_response.status_code == 200
+
+    @pytest.mark.asyncio
     async def test_remember_with_session(self, client, auth_headers, mock_moorcheh):
         """Test storing memory with session token"""
         # Setup session


### PR DESCRIPTION
## Summary

Fixes a session lockout caused by the HTTP API's automatic renewal path. When a session neared expiry, the server persisted a replacement session and invalidated the request token, but never returned the replacement token to the client. The triggering request succeeded; every later request using the only token the client knew failed with 401.

Bounty submission for #770.

## Reproduction

1. Activate an agent and retain the returned session token.
2. Put the session within `SESSION_EXTEND_THRESHOLD_MINUTES`.
3. Send any authenticated memory request. It succeeds and silently replaces the persisted session.
4. Repeat the request with the original token. It fails with 401 because that session ID is no longer active.

The new API regression test reproduces the full sequence and proves that the returned replacement token can continue making requests while the old token is rejected.

## Fix

- return the replacement JWT in the `X-Session-Token` response header
- expose that header through CORS
- update the web UI for both JSON and multipart requests
- update the TypeScript SDK before handling success or error responses
- document the raw HTTP client contract

## Validation

- `pytest -q` (all non-live tests pass; 24 live E2E tests skipped without a real Moorcheh key)
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- TypeScript: 11 tests pass, typecheck passes, build passes

No credentials or secrets are included in this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic session renewal support, returning replacement session tokens via the `X-Session-Token` response header.
  * Web UI and the TypeScript SDK now automatically capture and use renewed session tokens for subsequent requests, including uploads.

* **Bug Fixes**
  * Improved cross-origin behavior: exposed renewal headers/credentials are now restricted according to configured allowed origins, especially when wildcard origins are enabled.

* **Documentation**
  * Documented how automatic session renewal works for HTTP clients and browser clients across origins.

* **Tests**
  * Added contract and SDK tests covering renewed tokens on both successful and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->