### PR TITLE
Fix session auto-renewal token propagation

### DIFF
--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,7 +4,7 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
-from fastapi import Header, HTTPException
+from fastapi import Header, HTTPException, Response
 
 from memanto.app.models.session import Session
 from memanto.app.services.session_service import get_session_service
@@ -55,7 +55,9 @@ def verify_moorcheh_api_key() -> str:
     return get_moorcheh_api_key()
 
 
-def get_current_session(x_session_token: str | None = Header(None)) -> Session:
+def get_current_session(
+    response: Response, x_session_token: str | None = Header(None)
+) -> Session:
     """
     Get and validate current session
 
@@ -91,6 +93,8 @@ def get_current_session(x_session_token: str | None = Header(None)) -> Session:
         )
         if renewed:
             session = renewed
+            response.headers["X-Session-Token"] = renewed.session_token
+            response.headers["X-Session-Renewed"] = "true"
 
         return session
 

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2660,6 +2660,14 @@
             const opts = { method, headers };
             if (body) opts.body = JSON.stringify(body);
             const res = await fetch(path, opts);
+            const renewedToken = res.headers.get('X-Session-Token');
+            if (renewedToken) {
+                S.token = renewedToken;
+                if (S.config) {
+                    S.config.session_token = renewedToken;
+                    S.config.has_active_session = true;
+                }
+            }
             if (!res.ok) {
                 const err = await res.json().catch(() => ({ detail: res.statusText }));
                 let msg = err.detail || err;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -251,6 +251,48 @@ class TestMEMANTOAPI:
         assert response.json()["status"] == "queued"
 
     @pytest.mark.asyncio
+    async def test_auto_renewed_session_returns_replacement_token(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """A request that auto-renews must expose the fresh token to the client."""
+        from memanto.app.services.session_service import get_session_service
+        from memanto.app.utils.temporal_helpers import utc_now
+
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        old_token = activate_response.json()["session_token"]
+
+        session_service = get_session_service()
+        session = session_service.get_session(self.TEST_AGENT_ID)
+        assert session is not None
+        session.expires_at = utc_now() + timedelta(minutes=1)
+        session_service._save_session(session)
+
+        mock_moorcheh.similarity_search.query.return_value = {"results": []}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall",
+            headers={**auth_headers, "X-Session-Token": old_token},
+            json={"query": "anything"},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["X-Session-Renewed"] == "true"
+        renewed_token = response.headers["X-Session-Token"]
+        assert renewed_token
+        assert renewed_token != old_token
+
+        renewed_payload = session_service.validate_session(renewed_token)
+        stored_session = session_service.get_session(self.TEST_AGENT_ID)
+        assert stored_session is not None
+        assert renewed_payload.session_id == stored_session.session_id
+
+    @pytest.mark.asyncio
     async def test_edit_memory_with_session(self, client, auth_headers):
         """Test updating one memory with session token."""
         app.dependency_overrides[get_current_session] = lambda: Session(


### PR DESCRIPTION
## Summary

Fixes a session auto-renewal reliability bug: `get_current_session()` can create and persist a renewed JWT when the active session is near expiry, but API clients never receive that replacement token. They continue using the old `X-Session-Token` until it expires, so auto-renewal silently fails from the client perspective.

This PR:
- returns the renewed JWT in `X-Session-Token` and marks the response with `X-Session-Renewed: true`
- updates the Web UI fetch helper to adopt renewed tokens automatically
- adds an API regression test that forces a near-expiry session and verifies the replacement token reaches the client

## Validation

- `python -m pytest tests/test_api.py::TestMEMANTOAPI::test_auto_renewed_session_returns_replacement_token -q`
- `python -m pytest tests/test_api.py -q`
- `python -m ruff check memanto/app/routes/auth_deps.py tests/test_api.py`
- `python -m ruff format --check memanto/app/routes/auth_deps.py tests/test_api.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session renewals now return updated session information to the client automatically.
  * The app can refresh an active session token in responses and keep the user’s session state current.

* **Bug Fixes**
  * Improved handling of near-expired sessions so requests can continue seamlessly with a renewed token.
  * The interface now reflects when a session has been renewed, reducing unexpected sign-outs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->