### PR TITLE
Stream uploaded files with enforced size limit

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -47,6 +47,8 @@ from memanto.cli.config.manager import ConfigManager
 router = APIRouter()
 
 _config_manager = ConfigManager()
+MAX_UPLOAD_BYTES = 5 * 1024 * 1024 * 1024
+UPLOAD_CHUNK_BYTES = 1024 * 1024
 
 
 class RecallRequest(BaseModel):
@@ -527,9 +529,8 @@ async def upload_file(
     try:
         namespace = session.namespace
 
-        # Write upload to a temp file so moorcheh SDK can read it
-        # Use original filename so the SDK records it as the source
-        file_bytes = await file.read()
+        # Stream upload to a temp file so moorcheh SDK can read it without
+        # loading untrusted file bodies into memory.
         tmp_dir = tempfile.mkdtemp()
         tmp_path = os.path.join(tmp_dir, original_name)
         # Defense-in-depth: verify resolved path is within tmp_dir
@@ -541,8 +542,18 @@ async def upload_file(
                 detail="Invalid filename",
             )
         try:
+            bytes_written = 0
             with open(tmp_path, "wb") as tmp:
-                tmp.write(file_bytes)
+                while chunk := await file.read(UPLOAD_CHUNK_BYTES):
+                    bytes_written += len(chunk)
+                    if bytes_written > MAX_UPLOAD_BYTES:
+                        raise HTTPException(
+                            status_code=413,
+                            detail=(
+                                f"File exceeds maximum size of {MAX_UPLOAD_BYTES} bytes"
+                            ),
+                        )
+                    tmp.write(chunk)
             result = await asyncio.to_thread(
                 client.documents.upload_file, namespace, tmp_path
             )
@@ -561,6 +572,8 @@ async def upload_file(
             "message": result.get("message", ""),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1201,6 +1201,33 @@ class TestMEMANTOAPI:
         assert data["status"] == "uploaded"
 
     @pytest.mark.asyncio
+    async def test_upload_file_rejects_oversized_body(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """Oversized uploads must fail before calling the Moorcheh client."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        monkeypatch.setattr("memanto.app.routes.memory.MAX_UPLOAD_BYTES", 4)
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+            headers=headers,
+            files={"file": ("notes.txt", b"12345", "text/plain")},
+        )
+
+        assert response.status_code == 413
+        mock_moorcheh.documents.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_upload_file_unsupported_extension(self, client, auth_headers):
         """Test that unsupported file types are rejected"""
         await client.post(


### PR DESCRIPTION
## Summary

Fixes an upload resource-exhaustion bug: `/api/v2/agents/{agent_id}/upload-file` documents a 5GB maximum file size, but the implementation called `await file.read()` before enforcing any size limit. A large request body could be loaded fully into server memory before being rejected or sent to Moorcheh.

This PR:
- streams uploads to the temporary file in 1MB chunks
- enforces the documented 5GB maximum while streaming
- returns HTTP 413 before calling `documents.upload_file` when the limit is exceeded
- adds a regression test that monkeypatches the limit to 4 bytes and verifies oversized uploads are rejected before the Moorcheh client is invoked

## Validation

- `python -m pytest tests/test_api.py::TestMEMANTOAPI::test_upload_file_with_session tests/test_api.py::TestMEMANTOAPI::test_upload_file_rejects_oversized_body tests/test_api.py::TestMEMANTOAPI::test_upload_file_unsupported_extension -q`
- `python -m pytest tests/test_api.py -q`
- `python -m ruff check memanto/app/routes/memory.py tests/test_api.py`
- `python -m ruff format --check memanto/app/routes/memory.py tests/test_api.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large file uploads are now streamed in chunks instead of loading the full file into memory.
  * Uploads that exceed the allowed size are now rejected with a clear “payload too large” response.
  * HTTP errors during upload are now returned consistently without being replaced by a generic error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->