### PR TITLE
Protect UI helper APIs from remote unauthenticated access

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -47,6 +47,7 @@ from memanto.cli.config.manager import ConfigManager
 router = APIRouter()
 
 _config_manager = ConfigManager()
+MAX_UPLOAD_BYTES = 5 * 1024 * 1024 * 1024
 
 
 class RecallRequest(BaseModel):
@@ -530,6 +531,8 @@ async def upload_file(
         # Write upload to a temp file so moorcheh SDK can read it
         # Use original filename so the SDK records it as the source
         file_bytes = await file.read()
+        if len(file_bytes) > MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="Uploaded file is too large")
         tmp_dir = tempfile.mkdtemp()
         tmp_path = os.path.join(tmp_dir, original_name)
         # Defense-in-depth: verify resolved path is within tmp_dir
@@ -561,6 +564,8 @@ async def upload_file(
             "message": result.get("message", ""),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -7,10 +7,12 @@ Serves the Web UI static files and provides UI-specific API endpoints.
 import os
 import signal
 import time
+from ipaddress import ip_address
 from pathlib import Path
+from secrets import compare_digest
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -21,10 +23,36 @@ from memanto.cli.config.manager import ConfigManager
 from memanto.cli.connect.agent_registry import AGENT_REGISTRY, list_agents
 from memanto.cli.connect.engine import install_agent, remove_agent
 
-router = APIRouter()
-
 # Shared ConfigManager instance (reads from ~/.memanto/)
 _config_manager = ConfigManager()
+
+
+def _require_trusted_ui_request(
+    request: Request, authorization: str | None = Header(None)
+) -> None:
+    """Protect UI helper APIs from remote unauthenticated callers."""
+
+    client_host = request.client.host if request.client else ""
+    try:
+        if client_host and ip_address(client_host).is_loopback:
+            return
+    except ValueError:
+        if client_host in {"localhost", "testclient"}:
+            return
+
+    api_key = _config_manager.get_api_key()
+    if api_key and authorization:
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and compare_digest(token, api_key):
+            return
+
+    raise HTTPException(
+        status_code=403,
+        detail="UI API requests must originate from localhost or use the configured API key.",
+    )
+
+
+router = APIRouter(dependencies=[Depends(_require_trusted_ui_request)])
 
 # Path to the static directory
 STATIC_DIR = Path(__file__).parent.parent / "static"

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -26,6 +26,19 @@ from memanto.cli.connect.engine import install_agent, remove_agent
 # Shared ConfigManager instance (reads from ~/.memanto/)
 _config_manager = ConfigManager()
 
+_PROXY_HEADER_NAMES = {
+    "forwarded",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-real-ip",
+}
+
+
+def _has_proxy_headers(request: Request) -> bool:
+    """Return true when a request carries common reverse-proxy headers."""
+    return any(name in request.headers for name in _PROXY_HEADER_NAMES)
+
 
 def _require_trusted_ui_request(
     request: Request, authorization: str | None = Header(None)
@@ -33,11 +46,16 @@ def _require_trusted_ui_request(
     """Protect UI helper APIs from remote unauthenticated callers."""
 
     client_host = request.client.host if request.client else ""
+    has_proxy_headers = _has_proxy_headers(request)
     try:
-        if client_host and ip_address(client_host).is_loopback:
+        if (
+            client_host
+            and ip_address(client_host).is_loopback
+            and not has_proxy_headers
+        ):
             return
     except ValueError:
-        if client_host in {"localhost", "testclient"}:
+        if client_host in {"localhost", "testclient"} and not has_proxy_headers:
             return
 
     api_key = _config_manager.get_api_key()
@@ -48,7 +66,7 @@ def _require_trusted_ui_request(
 
     raise HTTPException(
         status_code=403,
-        detail="UI API requests must originate from localhost or use the configured API key.",
+        detail="UI API requests must come from direct localhost access or use the configured API key.",
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1341,6 +1341,19 @@ class TestCWE200ApiKeyLeak:
         assert resp.status_code == 403
 
     @pytest.mark.asyncio
+    async def test_ui_config_rejects_proxied_loopback_without_api_key(
+        self, _mock_ui_config_manager
+    ):
+        transport = ASGITransport(app=app, client=("127.0.0.1", 4242))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            resp = await remote.get(
+                "/api/ui/config",
+                headers={"X-Forwarded-For": "203.0.113.10"},
+            )
+
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
     async def test_ui_config_allows_remote_configured_api_key(
         self, _mock_ui_config_manager
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1201,6 +1201,33 @@ class TestMEMANTOAPI:
         assert data["status"] == "uploaded"
 
     @pytest.mark.asyncio
+    async def test_upload_file_rejects_oversized_body(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """Oversized uploads must fail before calling the Moorcheh client."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        monkeypatch.setattr("memanto.app.routes.memory.MAX_UPLOAD_BYTES", 4)
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+            headers=headers,
+            files={"file": ("notes.txt", b"12345", "text/plain")},
+        )
+
+        assert response.status_code == 413
+        mock_moorcheh.documents.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_upload_file_unsupported_extension(self, client, auth_headers):
         """Test that unsupported file types are rejected"""
         await client.post(
@@ -1302,6 +1329,31 @@ class TestCWE200ApiKeyLeak:
         # Session status field should be present (replaces sensitive session_token)
         assert "has_active_session" in data
         assert data["has_active_session"] is True
+
+    @pytest.mark.asyncio
+    async def test_ui_config_rejects_remote_unauthenticated_requests(
+        self, _mock_ui_config_manager
+    ):
+        transport = ASGITransport(app=app, client=("203.0.113.10", 4242))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            resp = await remote.get("/api/ui/config")
+
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_ui_config_allows_remote_configured_api_key(
+        self, _mock_ui_config_manager
+    ):
+        transport = ASGITransport(app=app, client=("203.0.113.10", 4242))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            resp = await remote.get(
+                "/api/ui/config",
+                headers={
+                    "Authorization": "Bearer mk_test_secret_api_key_12345678",
+                },
+            )
+
+        assert resp.status_code == 200
 
     @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(


### PR DESCRIPTION
## Summary

Fixes an exposed UI API trust-boundary bug. The `/api/ui/*` helper routes are mounted on the FastAPI app and include sensitive or mutating operations such as reading UI config/session status, changing config/API key, browsing server directories, installing integrations, running migrations, restarting on-prem, resolving conflicts, and shutting down UI-mode servers. These routes previously accepted unauthenticated requests from any client.

This PR adds a shared UI API trust gate:
- loopback/local browser requests continue to work without extra headers
- non-local requests must provide `Authorization: Bearer <configured Memanto API key>`
- unauthenticated remote requests receive HTTP 403 before reaching any UI helper handler

## Why this matters

The Web UI is intended for local operational control, but the helper routes are mounted with the app. When the service is exposed beyond localhost, remote callers should not be able to read local UI/session metadata or trigger privileged local actions without authentication.

## Validation

- `python -m pytest tests/test_api.py::TestCWE200ApiKeyLeak::test_config_endpoint_does_not_return_api_key tests/test_api.py::TestCWE200ApiKeyLeak::test_config_endpoint_still_has_api_key_status_fields tests/test_api.py::TestCWE200ApiKeyLeak::test_ui_config_rejects_remote_unauthenticated_requests tests/test_api.py::TestCWE200ApiKeyLeak::test_ui_config_allows_remote_configured_api_key -q`
- `python -m pytest tests/test_api.py -q`
- `python -m ruff check memanto/app/ui/routes/ui_router.py tests/test_api.py`
- `python -m ruff format --check memanto/app/ui/routes/ui_router.py tests/test_api.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened access controls for UI-related API requests, permitting only trusted local requests or requests presenting the configured bearer token.
  * Added an upload size limit; oversized `/upload-file` requests are rejected with HTTP 413 and the upload is not processed.

* **Tests**
  * Added coverage for rejecting oversized uploads (HTTP 413).
  * Added coverage for `/api/ui/config` remote access rules: rejecting unauthenticated and proxied loopback requests, while allowing requests with the correct bearer token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->