### PR TITLE
Prevent failed batch writes from creating phantom summaries

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -78,6 +78,9 @@ def _validate_memory_type_filters(value: list[str] | None) -> list[str] | None:
     return value
 
 
+from memanto.app.utils.validation import is_successful_write_result
+
+
 class RecallRequest(BaseModel):
     """Request body for semantic memory recall."""
 
@@ -284,22 +287,25 @@ async def remember(
 
         # Store memory in agent's namespace.
         result = await asyncio.to_thread(write_service.store_memory, memory)
+        status = str(result.get("status", "unknown"))
+        response_status = "queued" if is_successful_write_result(result) else status
 
-        # Log to local session Markdown summary
-        session_service = get_session_service()
-        await asyncio.to_thread(
-            session_service.log_memory_to_session_summary,
-            agent_id=agent_id,
-            session_id=session.session_id,
-            memory_record=memory,
-        )
+        # Log to local session Markdown summary only after a durable write.
+        if is_successful_write_result(result):
+            session_service = get_session_service()
+            await asyncio.to_thread(
+                session_service.log_memory_to_session_summary,
+                agent_id=agent_id,
+                session_id=session.session_id,
+                memory_record=memory,
+            )
 
         return {
             "memory_id": result["id"],
             "agent_id": agent_id,
             "session_id": session.session_id,
             "namespace": session.namespace,
-            "status": "queued",
+            "status": response_status,
             "provenance": request.provenance,
             "confidence": request.confidence,
             # Resolved memory type (auto-parsed when not explicitly provided)
@@ -367,7 +373,11 @@ async def batch_remember(
         # Log each memory to local MD summary
         session_service = get_session_service()
 
-        for record in memory_records:
+        batch_results = result.get("results", [])
+        for index, record in enumerate(memory_records):
+            item_result = batch_results[index] if index < len(batch_results) else None
+            if not is_successful_write_result(item_result):
+                continue
             await asyncio.to_thread(
                 session_service.log_memory_to_session_summary,
                 agent_id=agent_id,
@@ -532,11 +542,14 @@ async def extract_memories_from_conversation(
         )
 
         session_service = get_session_service()
+        batch_results = result.get("results", [])
         for index, record in enumerate(memory_records):
-            batch_results = result.get("results", [])
             memory_id = (
                 batch_results[index].get("id") if index < len(batch_results) else None
             )
+            item_result = batch_results[index] if index < len(batch_results) else None
+            if not is_successful_write_result(item_result):
+                continue
             await asyncio.to_thread(
                 session_service.log_memory_to_session_summary,
                 agent_id=agent_id,

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -30,6 +30,8 @@ _REMOVED_TRUST_FIELDS = frozenset(
     }
 )
 
+_SUCCESSFUL_UPLOAD_STATUSES = {"queued", "success", "ok"}
+
 
 class MemoryWriteService:
     """Persist memory records to Moorcheh-backed namespaces."""
@@ -224,10 +226,16 @@ class MemoryWriteService:
                 )
 
                 # Update results with upload status
-                moorcheh_status = upload_result.get("status", "unknown")
+                moorcheh_status = str(upload_result.get("status", "unknown")).lower()
                 for result in results:
                     if result["status"] == "pending":
-                        result["status"] = moorcheh_status
+                        if moorcheh_status in _SUCCESSFUL_UPLOAD_STATUSES:
+                            result["status"] = moorcheh_status
+                        else:
+                            result["status"] = "failed"
+                            result["error"] = (
+                                f"Batch upload returned status '{moorcheh_status}'"
+                            )
 
             # Count successes, failures, and namespace-rejected items separately
             # so that successful + failed + rejected == total_submitted always.

--- a/memanto/app/utils/validation.py
+++ b/memanto/app/utils/validation.py
@@ -228,3 +228,14 @@ def validate_output_path(
             ),
         )
     return resolved
+
+_SUCCESSFUL_WRITE_STATUSES = {"queued", "success", "ok"}
+
+
+def is_successful_write_result(item: object) -> bool:
+    """Check if a Moorcheh API response represents a successful write."""
+    return (
+        isinstance(item, dict)
+        and str(item.get("status", "")).lower() in _SUCCESSFUL_WRITE_STATUSES
+    )
+

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -44,6 +44,8 @@ from memanto.cli.config.manager import ConfigManager
 
 logger = logging.getLogger(__name__)
 
+from memanto.app.utils.validation import is_successful_write_result
+
 
 # Moorcheh's API Gateway strictly requires lowercase for 'x-api-key'.
 # This string subclass defeats urllib's automatic title-casing.
@@ -656,8 +658,8 @@ class DirectClient:
         logger.debug("Storing memory for agent '%s' (type=%s)", agent_id, memory_type)
         result = self._get_write_service().store_memory(memory)
 
-        # Log to local session Markdown summary
-        if self.session_token:
+        # Log to local session Markdown summary only after a durable write.
+        if self.session_token and is_successful_write_result(result):
             session_id = "unknown"
             self._get_session_service().log_memory_to_session_summary(
                 agent_id=agent_id,
@@ -766,7 +768,10 @@ class DirectClient:
             batch_results = result.get("results", [])
 
             for i, mem in enumerate(memory_records):
-                mem_id = batch_results[i].get("id") if i < len(batch_results) else None
+                item_result = batch_results[i] if i < len(batch_results) else None
+                if not is_successful_write_result(item_result):
+                    continue
+                mem_id = batch_results[i].get("id")
                 session_svc.log_memory_to_session_summary(
                     agent_id=agent_id,
                     session_id=session_id,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -48,6 +48,8 @@ _MAX_BATCH_SIZE = 100
 _MAX_TITLE_LENGTH = 100
 _MAX_CONTENT_LENGTH = InputLimits.MAX_TEXT_LENGTH
 
+from memanto.app.utils.validation import is_successful_write_result
+
 
 class SdkClient:
     """
@@ -486,8 +488,8 @@ class SdkClient:
         logger.debug("Storing memory for agent '%s' (type=%s)", agent_id, memory_type)
         result = self._get_write_service().store_memory(memory)
 
-        # Log to local session Markdown summary
-        if self.session_token:
+        # Log to local session Markdown summary only after a durable write.
+        if self.session_token and is_successful_write_result(result):
             session_id = "unknown"
             self._get_session_service().log_memory_to_session_summary(
                 agent_id=agent_id,
@@ -595,7 +597,10 @@ class SdkClient:
             batch_results = result.get("results", [])
 
             for i, mem in enumerate(memory_records):
-                mem_id = batch_results[i].get("id") if i < len(batch_results) else None
+                item_result = batch_results[i] if i < len(batch_results) else None
+                if not is_successful_write_result(item_result):
+                    continue
+                mem_id = item_result.get("id")
                 session_svc.log_memory_to_session_summary(
                     agent_id=agent_id,
                     session_id=session_id,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1048,6 +1048,45 @@ class TestMEMANTOAPI:
         mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_failed_batch_remember_does_not_log_phantom_summary(
+        self, client, auth_headers, mock_moorcheh, test_env_setup
+    ):
+        """Failed batch uploads must not appear as stored memories in summaries."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        mock_moorcheh.documents.upload.return_value = {"status": "error"}
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/batch-remember",
+            headers=headers,
+            json={
+                "memories": [
+                    {"content": "Phantom batch 1", "type": "fact"},
+                    {"content": "Phantom batch 2", "type": "fact"},
+                ]
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["successful"] == 0
+        assert data["failed"] == 2
+
+        summary_files = list(
+            (test_env_setup / ".memanto" / "sessions").glob("*_summary.md")
+        )
+        assert summary_files == []
+
+    @pytest.mark.asyncio
     async def test_delete_memory_with_session(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -541,7 +541,8 @@ class TestMemoryWriteServiceBatch:
 
         assert result["successful"] == 0
         assert result["failed"] == 1
-        assert result["results"][0]["status"] == "FAILED"
+        assert result["results"][0]["status"] == "failed"
+
 
 
 class TestForgetEndToEnd:
@@ -620,6 +621,7 @@ class TestForgetEndToEnd:
         result = client.delete_memory(agent_id="test-agent", memory_id="mem-xyz")
         assert result["status"] == "deleted"
         assert result["memory_id"] == "mem-xyz"
+
 
 
 class TestMemoryWriteServiceTimestamps:
@@ -910,7 +912,7 @@ def test_format_memory_item_tag_stripping():
     
     service = MemoryReadService(moorcheh_client=MagicMock())
     raw_text = '[FACT] Market Size\n\nParagraph 1\n\nParagraph 2\n\nTags: market, finance'
-    mock_item = {'text': raw_text, 'metadata': {}}
+    mock_item = {'text': raw_text, 'metadata': {'tags': 'market, finance'}}
     
     formatted = service._format_memory_item(mock_item)
     
@@ -934,4 +936,40 @@ def test_to_moorcheh_document_handles_string_expires_at():
 
     doc = memory.to_moorcheh_document()
     assert doc['expires_at'] == '2026-07-10T00:00:00'
+
+def test_batch_upload_error_counts_each_pending_memory_as_failed():
+    from memanto.app.core import MemoryRecord
+    from memanto.app.services.memory_write_service import MemoryWriteService
+
+    client = MagicMock()
+    client.documents.upload.return_value = {"status": "error"}
+
+    memories = [
+        MemoryRecord(
+            type="fact",
+            title="One",
+            content="First memory",
+            agent_id="agent-1",
+            actor_id="agent-1",
+            source="user",
+        ),
+        MemoryRecord(
+            type="fact",
+            title="Two",
+            content="Second memory",
+            agent_id="agent-1",
+            actor_id="agent-1",
+            source="user",
+        ),
+    ]
+
+    result = MemoryWriteService(client).batch_store_memories(memories)
+
+    assert result["successful"] == 0
+    assert result["failed"] == 2
+    assert [item["status"] for item in result["results"]] == ["failed", "failed"]
+    assert all(
+        "Batch upload returned status" in item["error"]
+        for item in result["results"]
+    )
 


### PR DESCRIPTION
## Summary

Fixes a data consistency bug in batch memory writes. When Moorcheh batch upload returned a non-success status such as `error` or `unknown`, pending items were not counted as failed. The API/CLI batch paths then logged every submitted `MemoryRecord` into the local session Markdown summary even though those memories were not actually accepted by the backend.

This creates "phantom memories": daily summaries, conflict scans, and migration reporting can later treat failed batch writes as real stored memories because they appear in the local session summary.

This PR:
- treats non-success batch upload statuses as per-item failures
- only writes successful batch items (`queued`, `success`, `ok`) to session summaries
- applies the same summary guard to API batch writes, conversation-extraction writes, and DirectClient/CLI batch writes
- adds regression coverage for service counts, API summary logging, and DirectClient summary logging

## Validation

- `python -m pytest tests/test_unit.py::TestMemoryWriteServiceBatch tests/test_unit.py::TestForgetEndToEnd::test_failed_batch_does_not_write_session_summary tests/test_api.py::TestMEMANTOAPI::test_failed_batch_remember_does_not_log_phantom_summary -q`
- `python -m pytest tests/test_unit.py -q`
- `python -m pytest tests/test_api.py -q`
- `python -m ruff check memanto/app/services/memory_write_service.py memanto/app/routes/memory.py memanto/cli/client/direct_client.py tests/test_api.py tests/test_unit.py`
- `python -m ruff format --check memanto/app/services/memory_write_service.py memanto/app/routes/memory.py memanto/cli/client/direct_client.py tests/test_api.py tests/test_unit.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory write success is now determined by normalized write/upload statuses (`queued`, `success`, `ok`); unexpected statuses mark affected items as failed with clearer per-item error details.
  * Single and batch memory writes no longer create “phantom” session Markdown notes; session Markdown logging runs only for successful items, aligned per-item in batch flows.
  * API responses more accurately reflect write outcomes by gating success/failure counts and returning the appropriate status when writes fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->