### PR TITLE
Validate UI config inputs before saving

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -17,7 +17,12 @@ from fastapi.staticfiles import StaticFiles
 from memanto.app.clients.backend import Backend
 from memanto.app.config import settings
 from memanto.cli.client.direct_client import DirectClient
-from memanto.cli.config.manager import ConfigManager
+from memanto.cli.config.manager import (
+    ConfigManager,
+    is_valid_schedule_time,
+    parse_recall_limit,
+    parse_session_duration_hours,
+)
 from memanto.cli.connect.agent_registry import AGENT_REGISTRY, list_agents
 from memanto.cli.connect.engine import install_agent, remove_agent
 
@@ -122,13 +127,26 @@ async def update_ui_config(updates: dict):
         )
 
     if "schedule_time" in updates:
+        if not is_valid_schedule_time(updates["schedule_time"]):
+            raise HTTPException(
+                status_code=400,
+                detail="schedule_time must be in 24-hour HH:MM format",
+            )
         _config_manager.set_schedule_time(updates["schedule_time"])
 
     if "session" in updates and isinstance(updates["session"], dict):
+        session_updates = dict(updates["session"])
+        if "default_duration_hours" in session_updates:
+            try:
+                session_updates["default_duration_hours"] = parse_session_duration_hours(
+                    session_updates["default_duration_hours"]
+                )
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
         data = _config_manager.load_yaml()
         if "session" not in data:
             data["session"] = {}
-        data["session"].update(updates["session"])
+        data["session"].update(session_updates)
         _config_manager.save_yaml(data)
 
     if "cli" in updates and isinstance(updates["cli"], dict):
@@ -166,8 +184,12 @@ async def update_ui_config(updates: dict):
 
     if "recall" in updates and isinstance(updates["recall"], dict):
         rec = updates["recall"]
+        try:
+            limit = parse_recall_limit(rec["limit"]) if "limit" in rec else None
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
         _config_manager.set_recall_config(
-            limit=int(rec["limit"]) if "limit" in rec else None,
+            limit=limit,
             min_similarity=float(rec["min_similarity"])
             if "min_similarity" in rec and rec["min_similarity"] is not None
             else None,

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -29,6 +29,49 @@ def _normalize_duplicated_api_key(key: str) -> str:
     return key
 
 
+def is_valid_schedule_time(value: str) -> bool:
+    """Return whether value is a 24-hour HH:MM schedule time."""
+    try:
+        hour_str, minute_str = value.split(":", 1)
+        if len(hour_str) != 2 or len(minute_str) != 2:
+            return False
+        hour = int(hour_str)
+        minute = int(minute_str)
+    except (AttributeError, ValueError):
+        return False
+    return 0 <= hour <= 23 and 0 <= minute <= 59
+
+
+def parse_recall_limit(value: object) -> int:
+    """Parse and validate recall result limits."""
+    if isinstance(value, bool):
+        raise ValueError("recall limit must be an integer between 1 and 100")
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("recall limit must be an integer between 1 and 100") from None
+    if isinstance(value, float) and not value.is_integer():
+        raise ValueError("recall limit must be an integer between 1 and 100")
+    if not 1 <= limit <= 100:
+        raise ValueError("recall limit must be an integer between 1 and 100")
+    return limit
+
+
+def parse_session_duration_hours(value: object) -> int:
+    """Parse and validate positive session duration hours."""
+    if isinstance(value, bool):
+        raise ValueError("default_duration_hours must be a positive integer")
+    try:
+        duration = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("default_duration_hours must be a positive integer") from None
+    if isinstance(value, float) and not value.is_integer():
+        raise ValueError("default_duration_hours must be a positive integer")
+    if duration < 1:
+        raise ValueError("default_duration_hours must be a positive integer")
+    return duration
+
+
 class ConfigManager:
     """Manages MEMANTO CLI configuration.
 
@@ -376,7 +419,7 @@ class ConfigManager:
         data = self.load_yaml()
         recall = data.setdefault("recall", {})
         if limit is not None:
-            recall["limit"] = limit
+            recall["limit"] = parse_recall_limit(limit)
         if min_similarity is not None:
             if (
                 not isinstance(min_similarity, (int, float))
@@ -391,12 +434,14 @@ class ConfigManager:
     def get_schedule_time(self) -> str:
         """Get daily summary + conflict time (HH:MM format)."""
         value = self.load_yaml().get("schedule_time")
-        if isinstance(value, str) and value:
+        if isinstance(value, str) and is_valid_schedule_time(value):
             return value
         return "23:55"
 
     def set_schedule_time(self, time_str: str) -> None:
         """Set daily summary + conflict time."""
+        if not is_valid_schedule_time(time_str):
+            raise ValueError("schedule_time must be in 24-hour HH:MM format")
         self.set("schedule_time", time_str)
 
     # Active session tracking — sourced from SessionService (~/.memanto/sessions/).

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1304,6 +1304,41 @@ class TestCWE200ApiKeyLeak:
         assert data["has_active_session"] is True
 
     @pytest.mark.asyncio
+    async def test_config_endpoint_rejects_invalid_schedule_time(
+        self, client, _mock_ui_config_manager
+    ):
+        """UI config must reject invalid nightly schedule times before saving."""
+        resp = await client.patch("/api/ui/config", json={"schedule_time": "99:99"})
+
+        assert resp.status_code == 400
+        assert "schedule_time" in resp.json()["detail"]
+        _mock_ui_config_manager.set_schedule_time.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_config_update_rejects_invalid_recall_limit(
+        self, client, _mock_ui_config_manager
+    ):
+        """UI config must reject non-positive recall limits before saving."""
+        resp = await client.patch("/api/ui/config", json={"recall": {"limit": 0}})
+
+        assert resp.status_code == 400
+        assert "limit" in resp.json()["detail"]
+        _mock_ui_config_manager.set_recall_config.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_config_update_rejects_invalid_session_duration(
+        self, client, _mock_ui_config_manager
+    ):
+        """UI config must reject non-positive session durations before saving."""
+        resp = await client.patch(
+            "/api/ui/config", json={"session": {"default_duration_hours": 0}}
+        )
+
+        assert resp.status_code == 400
+        assert "default_duration_hours" in resp.json()["detail"]
+        _mock_ui_config_manager.save_yaml.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(
         self, client, auth_headers, mock_moorcheh
     ):


### PR DESCRIPTION
## Summary

Hardens `/api/ui/config` so invalid UI configuration values are rejected before they are persisted into `~/.memanto/config.yaml`.

The endpoint currently accepts malformed or non-positive values for user-editable config fields, returns `200 OK`, and writes them into the CLI config. That can silently break scheduled summary timing, recall quality, or session activation workflows later.

## Reproduction

Each of these requests currently succeeds before this fix:

```bash
PATCH /api/ui/config
{"schedule_time":"99:99"}
```

```bash
PATCH /api/ui/config
{"recall":{"limit":0}}
```

```bash
PATCH /api/ui/config
{"session":{"default_duration_hours":0}}
```

## Fix

- Validate `schedule_time` as strict 24-hour `HH:MM`.
- Validate `recall.limit` as an integer in `1..100`, matching the existing recall client/API limit expectations.
- Validate `session.default_duration_hours` as a positive integer so the UI cannot save a default that creates immediately expired sessions.
- Reject invalid UI config updates with HTTP 400 before saving.
- Keep config-manager-level validation for schedule time and recall limit as a second layer of defense.
- Add API regression tests proving invalid values are rejected and not saved.

## Validation

- `uv run --with pytest pytest tests/test_api.py::TestCWE200ApiKeyLeak::test_config_endpoint_rejects_invalid_schedule_time tests/test_api.py::TestCWE200ApiKeyLeak::test_config_update_rejects_invalid_recall_limit tests/test_api.py::TestCWE200ApiKeyLeak::test_config_update_rejects_invalid_session_duration -q`
- `uv run --with pytest pytest tests/test_api.py::TestCWE200ApiKeyLeak -q`
- `uv run --with pytest pytest tests/test_api.py -q`
- `uv run --with pytest pytest tests -q`
- `uv run --with ruff ruff check memanto/cli/config/manager.py memanto/app/ui/routes/ui_router.py tests/test_api.py`
- `git diff --check origin/main..HEAD`

Refs #770
