### PR TITLE
chore: expand ruff rules (BLE blind-except + S security + RUF) to catch logic bugs earlier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@ repos:
   - repo: local
     hooks:
       - id: ruff-check
-        name: ruff lint
-        entry: uv run ruff check .
+        name: ruff lint (BLE blind-except + S security + RUF rules)
+        entry: uv run ruff check --fix .
         language: system
         pass_filenames: false
         always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,18 +127,29 @@ extend-exclude = ["legacy_archive"]
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "UP",   # pyupgrade
+    "BLE",  # blind except — catches bare `except Exception: pass` that swallows errors
+    "S",    # bandit security rules — hardcoded secrets, injection risks
+    "RUF",  # Ruff-specific best-practice rules
 ]
 ignore = [
-    "B904",  # raise exception without from
-    "E501",  # line too long, handled by black
-    "B008",  # do not perform function calls in argument defaults
-    "C901",  # too complex
-    "W191",  # indentation contains tabs
+    "B904",   # raise exception without from
+    "E501",   # line too long, handled by black
+    "B008",   # do not perform function calls in argument defaults
+    "C901",   # too complex
+    "W191",   # indentation contains tabs
+    "S101",   # assert used — pytest uses assert everywhere in tests
+    "S311",   # random for non-crypto — seeded Random(42) is intentional in benchmarks
+    "RUF012", # mutable class variable — conflicts with Pydantic patterns
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101", "BLE001"]
+"integrations/**/tests/**/*.py" = ["S101", "BLE001"]
+"examples/**/*.py" = ["S101", "S311", "BLE001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,12 +144,11 @@ ignore = [
     "B008",   # do not perform function calls in argument defaults
     "C901",   # too complex
     "W191",   # indentation contains tabs
-    "S101",   # assert used — pytest uses assert everywhere in tests
-    "S311",   # random for non-crypto — seeded Random(42) is intentional in benchmarks
     "RUF012", # mutable class variable — conflicts with Pydantic patterns
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# S101: pytest uses assert everywhere; S311: seeded Random(42) is intentional
 "tests/**/*.py" = ["S101", "BLE001"]
 "integrations/**/tests/**/*.py" = ["S101", "BLE001"]
 "examples/**/*.py" = ["S101", "S311", "BLE001"]


### PR DESCRIPTION
## Summary

Expands the project's ruff lint config with three rule groups that catch real bug classes currently invisible to the linter, and enables `--fix` auto-correction in the pre-commit hook.

### New rules

| Group | What it catches | Why it matters |
|---|---|---|
| `BLE` (flake8-blind-except) | Bare `except Exception:` that silently swallows errors | Masked cross-tenant clobber in concurrent LangGraph tests — the bug in #884 was only visible because the node's inner `except Exception` ate the `RuntimeError` and returned empty |
| `S` (bandit) | Hardcoded secrets, `try-except-pass`, injection risks | Already catches `BLE001` + `S110` violations in current source (`backend.py:56`, `moorcheh.py`) |
| `RUF` | Ruff-specific best-practice rules (unsorted `__all__`, etc.) | Catches `moorcheh.py` `__all__` ordering |

### Intentional suppressions

- `S101` — pytest uses `assert` everywhere in tests
- `S311` — seeded `Random(42)` is intentional in benchmarks for reproducibility
- `RUF012` — conflicts with Pydantic class variable patterns
- Per-file ignores for `tests/` and `examples/` where broad exception handling is expected

### Pre-commit change

Added `--fix` to `ruff check` so auto-fixable issues (import sorting, pyupgrade, `__all__` ordering) are corrected on commit rather than just reported.

## Test plan

- [ ] Run `ruff check .` — expect new violations to appear in `backend.py` and `moorcheh.py` (pre-existing, not introduced by this PR)
- [ ] Run `pre-commit run --all-files` — expect ruff to auto-fix import ordering and report remaining manual-fix items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project linting settings to enforce a broader set of code quality and security checks.
  * Enabled automated fixes in pre-commit for lint issues, helping keep contributions more consistent.
  * Applied relaxed linting rules for tests and examples to reduce noise in those areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->