### PR TITLE
fix(ts): stream SDK file uploads

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,5 +1,8 @@
-import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
 import { basename } from "node:path";
+import { Readable } from "node:stream";
 
 import { ServerLifecycle, type ServerOptions } from "./lifecycle.js";
 
@@ -204,13 +207,10 @@ export class Memanto {
 
   async uploadFile(input: UploadFileInput) {
     await this.ensureReady();
-    const bytes = await readFile(input.path);
-    const form = new FormData();
-    const blob = new Blob([new Uint8Array(bytes)]);
-    form.append("file", blob, input.filename ?? basename(input.path));
-    return this.requestMultipart(
+    return this.requestFileUpload(
       `/api/v2/agents/${this.encodedAgentId}/upload-file`,
-      form,
+      input.path,
+      input.filename ?? basename(input.path),
     );
   }
 
@@ -452,20 +452,50 @@ export class Memanto {
     return (await res.json()) as T;
   }
 
-  private async requestMultipart<T = unknown>(
+  private async requestFileUpload<T = unknown>(
     path: string,
-    form: FormData,
+    filePath: string,
+    filename: string,
   ): Promise<T> {
     await this.ensureReady();
     const baseUrl = this.lifecycle.baseUrl;
+    const fileStats = await stat(filePath);
+    if (!fileStats.isFile()) {
+      throw new Error(`Upload path is not a file: ${filePath}`);
+    }
+    const boundary = `----memanto-${randomUUID()}`;
+    const header = Buffer.from(
+      `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="${escapeMultipartValue(filename)}"\r\n` +
+        "Content-Type: application/octet-stream\r\n\r\n",
+    );
+    const footer = Buffer.from(`\r\n--${boundary}--\r\n`);
+    const body = Readable.from(
+      (async function* streamMultipart() {
+        yield header;
+        for await (const chunk of createReadStream(filePath)) {
+          yield chunk;
+        }
+        yield footer;
+      })(),
+    );
     const res = await fetch(`${baseUrl}${path}`, {
       method: "POST",
-      headers: { "X-Session-Token": this.sessionToken ?? "" },
-      body: form,
-    });
+      headers: {
+        "X-Session-Token": this.sessionToken ?? "",
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+        "Content-Length": String(header.length + fileStats.size + footer.length),
+      },
+      body: body as unknown as BodyInit,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
     if (!res.ok) throw await asError(res, `POST ${path} failed`);
     return (await res.json()) as T;
   }
+}
+
+function escapeMultipartValue(value: string): string {
+  return value.replace(/[\r\n]/g, "_").replace(/[\\"]/g, "\\$&");
 }
 
 async function asError(res: Response, prefix: string): Promise<Error> {

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createServer, type Server, type IncomingMessage } from "node:http";
 import { AddressInfo } from "node:net";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { Memanto } from "../src/index.js";
 
 interface Recorded {
@@ -80,6 +83,16 @@ function startFakeApi(agentId = "test-agent"): Promise<{
             query: "anything",
             memories: [],
             count: 0,
+          });
+        if (
+          url === `/api/v2/agents/${encodedAgentId}/upload-file` &&
+          req.method === "POST"
+        )
+          return reply(200, {
+            agent_id: agentId,
+            session_id: "sess-1",
+            status: "queued",
+            file_name: "notes.txt",
           });
         return reply(404, { detail: "unknown route" });
       });
@@ -175,6 +188,35 @@ describe("Memanto", () => {
       "GET /api/v2/status",
     ]);
     expect(api.recorded[0]?.headers["x-session-token"]).toBeUndefined();
+  });
+
+  it("streams file uploads with session authentication", async () => {
+    const api = await startFakeApi();
+    cleanupFns.push(api.close);
+
+    const dir = await mkdtemp(join(tmpdir(), "memanto-sdk-"));
+    cleanupFns.push(() => rm(dir, { recursive: true, force: true }));
+    const path = join(dir, "notes.txt");
+    await writeFile(path, "hello upload");
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    const res = await m.uploadFile({ path });
+    expect(res).toMatchObject({ status: "queued", file_name: "notes.txt" });
+
+    const upload = api.recorded.find((r) =>
+      r.url.endsWith("/upload-file"),
+    );
+    expect(upload?.headers["x-session-token"]).toBe("fake-token");
+    expect(upload?.headers["content-type"]).toContain(
+      "multipart/form-data; boundary=",
+    );
+    expect(upload?.headers["content-length"]).toBe(
+      String(Buffer.byteLength(upload?.body ?? "")),
+    );
+    expect(upload?.body).toContain('name="file"; filename="notes.txt"');
+    expect(upload?.body).toContain("hello upload");
   });
 
   it("rejects empty agentId", () => {


### PR DESCRIPTION
## Summary

- Change the TypeScript SDK `uploadFile()` path to stream the multipart request from disk instead of preloading the whole file with `readFile()` and wrapping it in a `Blob`.
- Preserve the existing session-authenticated upload API while setting an explicit multipart boundary and `Content-Length`.
- Add regression coverage against the SDK fake API for session headers, multipart headers, payload content, and upload response handling.

## Flaw / Reproduction

Before this change, `sdks/typescript/src/index.ts` did this:

```ts
const bytes = await readFile(input.path);
const form = new FormData();
const blob = new Blob([new Uint8Array(bytes)]);
form.append(file, blob, ...);
```

That means a TypeScript agent uploading a large local file must load the entire file into local Node.js memory before `fetch()` can even start the request. This is a client-side resource-exhaustion and adoption-friction bug: even after the server upload route is streamed, SDK users can still crash or severely degrade their local agent process before the backend receives the upload and can enforce its own limits.

Minimal reproduction before the fix:

1. In `sdks/typescript`, instantiate `new Memanto({ agentId, baseUrl })` against a local or fake Memanto API.
2. Call `await memanto.uploadFile({ path: largeFilePath })` with a large file.
3. Observe that the SDK allocates a `Buffer` and `Blob` for the full file before starting the HTTP request, so peak client memory grows linearly with the file size.

## Fix

The SDK now:

- stats the target path and rejects non-file paths early;
- creates a multipart body with `Readable.from()` and `createReadStream()`;
- streams file bytes between multipart header/footer chunks;
- keeps `X-Session-Token` authentication and returns the existing JSON response shape.

## Validation

```bash
cd sdks/typescript
npm test -- --run
npm run typecheck
npm run build
```

Refs #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file uploads to stream `multipart/form-data` directly from disk, reducing memory usage and improving reliability.
  * Strengthened multipart generation with safer boundary/filename escaping and more accurate `Content-Type`/`Content-Length` handling.
* **Tests**
  * Added an integration-style test that verifies session-authenticated uploads and validates multipart request details (content type, content length, filename, and payload) using a temporary real file and a stub API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->