### PR TITLE
Fix update memory delete response handling for on-prem backends

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -23,6 +23,18 @@ class MemoryWriteService:
         self.client = moorcheh_client
         self._parser = MemoryParsingService()
 
+    @staticmethod
+    def _deletion_processed(result: dict[str, Any]) -> bool:
+        """Return whether a Moorcheh delete response represents a processed delete."""
+        raw = result.get("actual_deletions")
+        if isinstance(raw, int):
+            return raw > 0
+        for key in ("deleted_ids", "requested_ids"):
+            ids = result.get(key)
+            if isinstance(ids, list):
+                return len(ids) > 0
+        return str(result.get("status", "")).lower() in {"success", "ok"}
+
     def store_memory(
         self, memory: MemoryRecord, context: dict[str, Any] | None = None
     ) -> dict[str, Any]:
@@ -311,7 +323,7 @@ class MemoryWriteService:
                 namespace_name=namespace, ids=[memory_id]
             )
 
-            if delete_result.get("actual_deletions", 0) == 0:
+            if not self._deletion_processed(delete_result):
                 raise MemoryError(f"Failed to delete old version of memory {memory_id}")
 
             validation_result = {"action": "store", "reason": "MVP direct store"}
@@ -342,7 +354,7 @@ class MemoryWriteService:
     def delete_memory(self, memory_id: str, namespace: str) -> bool:
         """Delete memory by ID"""
         try:
-            from typing import Any, cast
+            from typing import cast
 
             result = cast(
                 dict[str, Any],
@@ -352,15 +364,7 @@ class MemoryWriteService:
             # Cloud returns ``actual_deletions``; on-prem's /items/delete only
             # returns ``deleted_ids`` (and ``status``). Mirror the cloud SDK's
             # ``_deletion_processed_count`` so both backends report success.
-            raw = result.get("actual_deletions")
-            if isinstance(raw, int):
-                return raw > 0
-            for key in ("deleted_ids", "requested_ids"):
-                ids = result.get(key)
-                if isinstance(ids, list):
-                    return len(ids) > 0
-            # Some on-prem builds only return ``{"status": "success"}``.
-            return str(result.get("status", "")).lower() in {"success", "ok"}
+            return self._deletion_processed(result)
 
         except Exception as e:
             raise MemoryError(f"Failed to delete memory: {e}")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,51 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryWriteServiceUpdate:
+    def test_update_memory_handles_onprem_delete_response_shape(self):
+        """``update_memory`` also deletes the old document before re-uploading.
+        It must accept the same on-prem delete response shape as forget."""
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.get.return_value = {
+            "items": [
+                {
+                    "id": "mem-abc",
+                    "text": "[fact] Original title\n\nOriginal content",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "agent_id": "test-agent",
+                        "actor_id": "human",
+                        "source": "manual",
+                        "confidence": 0.8,
+                        "status": "active",
+                        "tags": ["onprem"],
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    },
+                }
+            ]
+        }
+        client.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": ["mem-abc"],
+        }
+        client.documents.upload.return_value = {"status": "success"}
+
+        result = MemoryWriteService(client).update_memory(
+            "mem-abc",
+            "memanto_agent_test-agent",
+            {"content": "Updated content"},
+        )
+
+        assert result["status"] == "success"
+        assert result["action"] == "updated"
+        client.documents.delete.assert_called_once_with(
+            namespace_name="memanto_agent_test-agent", ids=["mem-abc"]
+        )
+        client.documents.upload.assert_called_once()
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -331,6 +331,10 @@ class TestMemoryWriteServiceUpdate:
             namespace_name="memanto_agent_test-agent", ids=["mem-abc"]
         )
         client.documents.upload.assert_called_once()
+        document_call_names = [
+            method_call[0] for method_call in client.documents.method_calls
+        ]
+        assert document_call_names.index("delete") < document_call_names.index("upload")
 
 
 class TestForgetEndToEnd:


### PR DESCRIPTION
## Summary

This fixes an edit-path inconsistency between `delete_memory` and `update_memory`.

`delete_memory` already accepts both cloud delete responses (`actual_deletions`) and on-prem delete responses (`deleted_ids` / `status`). However, `update_memory` uses a delete-and-recreate flow and only checked `actual_deletions`, so an on-prem backend could successfully delete the old document but still make the edit fail before the replacement upload.

Changes:
- Extract the delete response handling into `MemoryWriteService._deletion_processed()`.
- Reuse that helper in both `delete_memory` and `update_memory`.
- Add a regression test for the on-prem `deleted_ids` response shape in `update_memory`.

Bounty issue: #770

## Reproduction

1. Mock an existing memory returned from `documents.get`.
2. Mock `documents.delete` to return the on-prem shape:
   ```python
   {"status": "success", "deleted_ids": ["mem-abc"]}
   ```
3. Call `MemoryWriteService.update_memory(...)`.
4. Before this patch, it raises `MemoryError: Failed to delete old version of memory mem-abc` because `actual_deletions` is absent.
5. After this patch, the update proceeds to upload the replacement document and returns `action == "updated"`.

## Tests

- `uv run pytest tests/test_unit.py::TestMemoryWriteServiceUpdate::test_update_memory_handles_onprem_delete_response_shape -q`
- `uv run pytest tests/test_unit.py::TestMemoryWriteServiceDelete -q`
- `uv run pytest tests/test_unit.py tests/test_cli.py tests/test_api.py -q`
- `uv run ruff check memanto/app/services/memory_write_service.py tests/test_unit.py`
- `uv run pytest -q`

Full test run passed locally. Live E2E tests were skipped because no real `MOORCHEH_API_KEY` is configured, matching the repo's skip condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory update/delete success detection to recognize additional backend delete response formats.
  * Fixed cases where certain delete responses were previously misinterpreted, impacting update flows that delete and recreate entries.
  * Added a unit test to verify successful handling of an on-prem delete response shape and ensure the delete occurs before upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->