### PR TITLE
fix: fail fast on missing MEMANTO_SECRET_KEY (security)

### DIFF
--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -130,7 +130,7 @@ class Settings(BaseSettings):
     ALLOWED_ORIGINS: list[str] = ["*"]
 
     # Session Configuration
-    MEMANTO_SECRET_KEY: str = "memanto-default-secret-change-in-production"
+    MEMANTO_SECRET_KEY: str = ""
     SESSION_DEFAULT_DURATION_HOURS: int = 6
     SESSION_AUTO_EXTEND: bool = True
     SESSION_EXTEND_THRESHOLD_MINUTES: int = 30

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -63,8 +63,11 @@ class SessionService:
         resolved_secret_key = (
             secret_key
             or os.getenv("MEMANTO_SECRET_KEY")
-            or "memanto-default-secret-change-in-production"
         )
+        if not resolved_secret_key:
+            raise RuntimeError(
+                "MEMANTO_SECRET_KEY is not configured. Set a strong secret before starting MEMANTO."
+            )
         self.secret_key: str = resolved_secret_key
         self.sessions_dir = sessions_dir or get_data_dir() / "sessions"
         self.sessions_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Security Fix

**Severity:** High ( auth bypass via JWT forgery )

**Problem:** `SessionService` fell back to a hardcoded default secret `memanto-default-secret-change-in-production` when `MEMANTO_SECRET_KEY` env var was missing. Any attacker who knows this default can forge valid JWT session tokens for any user/agent.

```
resolved_secret_key = (
    secret_key
    or os.getenv('MEMANTO_SECRET_KEY')
    or 'memanto-default-secret-change-in-production'
)
```

**Fix:** Remove the hardcoded fallback. Sessions service now raises `RuntimeError` at startup if `MEMANTO_SECRET_KEY` is unset.

**Files changed:**
- `memanto/app/config.py` — default to empty string
- `memanto/app/services/session_service.py` — raise if resolved key is empty

**Claim:** /bounty $100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session handling now requires a configured secret key instead of falling back to a built-in default.
  * If the secret key is missing, the app now fails fast with a clear startup error, helping prevent insecure deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->