### PR TITLE
fix: restrict CORS wildcard to known origins (security)

### DIFF
--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -127,7 +127,7 @@ class Settings(BaseSettings):
     DEBUG: bool = False
 
     # CORS Configuration
-    ALLOWED_ORIGINS: list[str] = ["*"]
+    ALLOWED_ORIGINS: list[str] = ["http://localhost:3000", "http://localhost:4000"]
 
     # Session Configuration
     MEMANTO_SECRET_KEY: str = "memanto-default-secret-change-in-production"


### PR DESCRIPTION
CORS middleware had `allow_origins=['*']` with `allow_credentials=True`, allowing any website to make authenticated cross-origin requests.

Locked to expected local frontend origins.

Closes #770 /bounty $100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated app access settings to allow requests only from local development frontends by default, improving protection against unintended cross-origin access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->