### PR TITLE
Fix on-prem answer fallback when no active model is configured

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -709,7 +709,7 @@ async def answer(
         if request.temperature is not None
         else settings.ANSWER_TEMPERATURE
     )
-    ai_model = (
+    resolved_ai_model = (
         request.ai_model
         if request.ai_model is not None
         else get_active_llm_model(settings.ANSWER_MODEL)
@@ -740,11 +740,12 @@ async def answer(
             "query": request.question,
             "top_k": limit,
             "temperature": temperature,
-            "ai_model": ai_model,
             "kiosk_mode": request.kiosk_mode,
             "header_prompt": header_prompt,
             "footer_prompt": footer_prompt,
         }
+        if resolved_ai_model is not None:
+            generate_kwargs["ai_model"] = resolved_ai_model
         if request.kiosk_mode:
             generate_kwargs["threshold"] = (
                 request.threshold if request.threshold is not None else 0.15

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -11,6 +11,7 @@ import json
 import re
 from typing import Any
 
+from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.constants import VALID_MEMORY_TYPES
 
 
@@ -39,16 +40,24 @@ class ConversationMemoryExtractionService:
         self._validate_messages(messages)
         max_memories = max(1, min(max_memories, self.MAX_MEMORIES))
 
-        response = self.client.answer.generate(
-            namespace=namespace,
-            query=self._conversation_text(messages),
-            top_k=1,
-            temperature=0,
-            ai_model=ai_model or settings.ANSWER_MODEL,
-            kiosk_mode=False,
-            header_prompt=self._header_prompt(max_memories),
-            footer_prompt=self._footer_prompt(),
+        generate_kwargs: dict[str, Any] = {
+            "namespace": namespace,
+            "query": self._conversation_text(messages),
+            "top_k": 1,
+            "temperature": 0,
+            "kiosk_mode": False,
+            "header_prompt": self._header_prompt(max_memories),
+            "footer_prompt": self._footer_prompt(),
+        }
+        resolved_ai_model = (
+            ai_model
+            if ai_model is not None
+            else get_active_llm_model(settings.ANSWER_MODEL)
         )
+        if resolved_ai_model is not None:
+            generate_kwargs["ai_model"] = resolved_ai_model
+
+        response = self.client.answer.generate(**generate_kwargs)
 
         raw_answer = response.get("answer", "")
         parsed = self._parse_json_answer(raw_answer)

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -89,12 +89,15 @@ Format the output as a Markdown report:
 ...
 """
         try:
-            result = client.answer.generate(
-                namespace=namespace,
-                query=summary_prompt,
-                ai_model=get_active_llm_model(settings.SUMMARY_MODEL),
-                top_k=50,
-            )
+            generate_kwargs: dict[str, Any] = {
+                "namespace": namespace,
+                "query": summary_prompt,
+                "top_k": 50,
+            }
+            ai_model = get_active_llm_model(settings.SUMMARY_MODEL)
+            if ai_model is not None:
+                generate_kwargs["ai_model"] = ai_model
+            result = client.answer.generate(**generate_kwargs)
             summary_text = result.get("answer", "Failed to generate summary.")
         except Exception as e:
             raise MemoryError(f"AI summarization failed: {str(e)}")
@@ -191,12 +194,15 @@ Example response format:
 [{{"type": "contradiction", "title": "Database preference changed", "old_memory_id": "abc-123", "old_content": "We use PostgreSQL", "new_memory_id": "def-456", "new_content": "We migrated to MongoDB", "description": "New memory contradicts old database preference", "recommendation": "keep_new"}}]
 """
         try:
-            result = client.answer.generate(
-                namespace=namespace,
-                query=conflict_prompt,
-                ai_model=get_active_llm_model(settings.SUMMARY_MODEL),
-                top_k=50,
-            )
+            generate_kwargs = {
+                "namespace": namespace,
+                "query": conflict_prompt,
+                "top_k": 50,
+            }
+            ai_model = get_active_llm_model(settings.SUMMARY_MODEL)
+            if ai_model is not None:
+                generate_kwargs["ai_model"] = ai_model
+            result = client.answer.generate(**generate_kwargs)
             conflict_text = result.get("answer", "[]")
         except Exception as e:
             raise MemoryError(f"Conflict detection failed: {str(e)}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -383,6 +383,38 @@ class TestMEMANTOAPI:
         assert "threshold" not in call_kwargs
 
     @pytest.mark.asyncio
+    async def test_answer_omits_unset_active_ai_model(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """On-prem fallback should omit ai_model instead of sending None."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        mock_moorcheh.answer.generate.return_value = {
+            "answer": "This is a mocked answer",
+            "sources": [],
+        }
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        with patch("memanto.app.routes.memory.get_active_llm_model", return_value=None):
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/answer",
+                headers=headers,
+                json={"question": "What is being tested?"},
+            )
+
+        assert response.status_code == 200
+        call_kwargs = mock_moorcheh.answer.generate.call_args.kwargs
+        assert "ai_model" not in call_kwargs
+
+    @pytest.mark.asyncio
     async def test_answer_with_kiosk_mode_uses_default_threshold(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -84,7 +84,7 @@ def test_extract_omits_unset_active_ai_model(monkeypatch):
     """On-prem fallback should let answer.generate use its configured model."""
     from memanto.app.services import conversation_memory_extraction_service as module
 
-    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None, raising=False)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None)
     client = FakeClient(
         '[{"type":"fact","title":"Test","content":"Use pytest.","confidence":0.9}]'
     )

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -80,6 +80,24 @@ def test_extract_conversation_memories_normalizes_candidates():
     assert "user:" in client.answer.call_kwargs["query"]
 
 
+def test_extract_omits_unset_active_ai_model(monkeypatch):
+    """On-prem fallback should let answer.generate use its configured model."""
+    from memanto.app.services import conversation_memory_extraction_service as module
+
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None, raising=False)
+    client = FakeClient(
+        '[{"type":"fact","title":"Test","content":"Use pytest.","confidence":0.9}]'
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "The project uses pytest."}],
+    )
+
+    assert "ai_model" not in client.answer.call_kwargs
+
+
 def test_extract_rejects_non_json_answers():
     service = ConversationMemoryExtractionService(FakeClient("not json"))
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -450,5 +450,66 @@ def test_conflict_report_handles_non_object_json_items(tmp_path, monkeypatch):
     assert conflicts[0]["description"] == '["not an object", 1]'
 
 
+def test_daily_summary_omits_unset_active_ai_model(tmp_path, monkeypatch):
+    """On-prem summary generation should omit ai_model when no active model is set."""
+    from unittest.mock import MagicMock
+
+    from memanto.app.services import daily_analysis_service as module
+
+    sessions_dir = tmp_path / "sessions"
+    summaries_dir = tmp_path / "summaries"
+    sessions_dir.mkdir()
+    (sessions_dir / "agent-1_2026-06-28_001_summary.md").write_text(
+        "# Session\n\nRemembered a project milestone.",
+        encoding="utf-8",
+    )
+
+    client = MagicMock()
+    client.answer.generate.return_value = {"answer": "# Daily Summary"}
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None)
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=summaries_dir,
+    )
+    result = service.generate_summary("agent-1", "2026-06-28")
+
+    assert result["status"] == "success"
+    call_kwargs = client.answer.generate.call_args.kwargs
+    assert "ai_model" not in call_kwargs
+
+
+def test_conflict_report_omits_unset_active_ai_model(tmp_path, monkeypatch):
+    """On-prem conflict detection should omit ai_model when no active model is set."""
+    from unittest.mock import MagicMock
+
+    from memanto.app.services import daily_analysis_service as module
+
+    sessions_dir = tmp_path / "sessions"
+    summaries_dir = tmp_path / "summaries"
+    sessions_dir.mkdir()
+    (sessions_dir / "agent-1_2026-06-28_001_summary.md").write_text(
+        "# Session\n\nRemembered a project milestone.",
+        encoding="utf-8",
+    )
+
+    client = MagicMock()
+    client.answer.generate.return_value = {"answer": "[]"}
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None)
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=summaries_dir,
+    )
+    result = service.generate_conflict_report("agent-1", "2026-06-28")
+
+    assert result["status"] == "success"
+    call_kwargs = client.answer.generate.call_args.kwargs
+    assert "ai_model" not in call_kwargs
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary
- Fix on-prem answer generation paths so they omit `ai_model` when `get_active_llm_model(...)` has no active model.
- Covers REST answers, conversation memory extraction, daily summary, and conflict report generation.
- Adds regression tests for each affected path.

## Bug / Reproduction
For on-prem Moorcheh, `get_active_llm_model(...)` can return `None`. Several answer-generation paths still passed `ai_model=None` or fell back to the cloud default, preventing Moorcheh from using its configured on-prem default LLM.

## Fix
Build `answer.generate` kwargs and add `ai_model` only when an active model is present.

## Validation
- `uv run --with pytest pytest tests -q`
- `uv run --with ruff ruff check .`
- `uv run --with ruff ruff format --check memanto/app/routes/memory.py memanto/app/services/conversation_memory_extraction_service.py memanto/app/services/daily_analysis_service.py tests/test_api.py tests/test_conversation_memory_extraction.py tests/test_unit.py`
- `git diff --check`

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI request handling so the app only includes the model setting when an active model is available.
  * Updated memory extraction, daily summaries, and conflict report generation to omit the model parameter when it’s unset.
* **Tests**
  * Added API and unit tests to verify requests do not pass an `ai_model` argument when the active model is `None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->