### PR TITLE
fix(langgraph): avoid namespace collisions in MemantoStore

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -418,58 +418,26 @@ class MemantoStore(BaseStore):
             return f"{self._agent_prefix}default"
 
         parts = tuple(str(part) for part in namespace)
-        legacy_suffix = "_".join(parts)
-        if self._can_use_legacy_namespace_suffix(legacy_suffix, parts):
-            return f"{self._agent_prefix}{legacy_suffix}"
-
         encoded = "_".join(self._encode_namespace_part(part) for part in parts)
         return f"{self._encoded_namespace_prefix}{encoded}"
-
-    def _can_use_legacy_namespace_suffix(
-        self, legacy_suffix: str, parts: tuple[str, ...]
-    ) -> bool:
-        if any(not part or "_" in part for part in parts):
-            return False
-        if legacy_suffix == "default":
-            return False
-
-        encoded_suffix_prefix = self._encoded_namespace_prefix[
-            len(self._agent_prefix) :
-        ]
-        if legacy_suffix.startswith(encoded_suffix_prefix):
-            encoded = legacy_suffix[len(encoded_suffix_prefix) :]
-            try:
-                decoded = tuple(
-                    self._decode_namespace_part(part) for part in encoded.split("_")
-                )
-            except (UnicodeDecodeError, ValueError):
-                return True
-            return decoded == parts
-
-        return True
 
     def _agent_id_to_namespace(self, agent_id: str) -> tuple[str, ...] | None:
         if not agent_id.startswith(self._agent_prefix):
             return None
 
-        ns_str = agent_id[len(self._agent_prefix) :]
-        if ns_str == "default":
+        if agent_id == f"{self._agent_prefix}default":
             return ()
 
         if agent_id.startswith(self._encoded_namespace_prefix):
             encoded = agent_id[len(self._encoded_namespace_prefix) :]
             try:
-                decoded = tuple(
+                return tuple(
                     self._decode_namespace_part(part) for part in encoded.split("_")
                 )
             except (UnicodeDecodeError, ValueError):
-                pass
-            else:
-                if self._namespace_to_agent_id(decoded) == agent_id:
-                    return decoded
+                return None
 
-        # Backward compatibility for agents created before namespace encoding.
-        return tuple(ns_str.split("_"))
+        return None
 
     @staticmethod
     def _encode_namespace_part(part: str) -> str:

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -418,11 +418,35 @@ class MemantoStore(BaseStore):
             return f"{self._agent_prefix}default"
 
         parts = tuple(str(part) for part in namespace)
-        if all(part and "_" not in part for part in parts):
-            return f"{self._agent_prefix}{'_'.join(parts)}"
+        legacy_suffix = "_".join(parts)
+        if self._can_use_legacy_namespace_suffix(legacy_suffix, parts):
+            return f"{self._agent_prefix}{legacy_suffix}"
 
         encoded = "_".join(self._encode_namespace_part(part) for part in parts)
         return f"{self._encoded_namespace_prefix}{encoded}"
+
+    def _can_use_legacy_namespace_suffix(
+        self, legacy_suffix: str, parts: tuple[str, ...]
+    ) -> bool:
+        if any(not part or "_" in part for part in parts):
+            return False
+        if legacy_suffix == "default":
+            return False
+
+        encoded_suffix_prefix = self._encoded_namespace_prefix[
+            len(self._agent_prefix) :
+        ]
+        if legacy_suffix.startswith(encoded_suffix_prefix):
+            encoded = legacy_suffix[len(encoded_suffix_prefix) :]
+            try:
+                decoded = tuple(
+                    self._decode_namespace_part(part) for part in encoded.split("_")
+                )
+            except (UnicodeDecodeError, ValueError):
+                return True
+            return decoded == parts
+
+        return True
 
     def _agent_id_to_namespace(self, agent_id: str) -> tuple[str, ...] | None:
         if not agent_id.startswith(self._agent_prefix):
@@ -435,14 +459,14 @@ class MemantoStore(BaseStore):
         if agent_id.startswith(self._encoded_namespace_prefix):
             encoded = agent_id[len(self._encoded_namespace_prefix) :]
             try:
-                return tuple(
+                decoded = tuple(
                     self._decode_namespace_part(part) for part in encoded.split("_")
                 )
             except (UnicodeDecodeError, ValueError):
-                logger.warning(
-                    "MemantoStore: failed to decode encoded LangGraph namespace %r",
-                    agent_id,
-                )
+                pass
+            else:
+                if self._namespace_to_agent_id(decoded) == agent_id:
+                    return decoded
 
         # Backward compatibility for agents created before namespace encoding.
         return tuple(ns_str.split("_"))

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -8,7 +8,8 @@ Mapping between abstractions
 ----------------------------
 
     BaseStore                         ->  Memanto
-    namespace (tuple[str, ...])       ->  agent_id       (``langgraph_<p0>_<p1>...``)
+    namespace (tuple[str, ...])       ->  agent_id       (legacy ``langgraph_<p0>_<p1>...``
+                                               or encoded when needed)
     key (str)                         ->  reserved tag   ``lg:key:<key>``
     value["kind"] / value["type"]     ->  memory_type    (auto-parsed if absent)
     value["title"]                    ->  title          (auto-derived if absent)
@@ -103,14 +104,14 @@ class MemantoStore(BaseStore):
         self._lock = threading.RLock()
         self._client_pool: dict[str, SdkClient] = {}
         self._agent_prefix = "langgraph_"
+        self._encoded_namespace_prefix = f"{self._agent_prefix}ns_"
         # (namespace, query, limit, type, min_sim) -> (timestamp, list[SearchItem])
         self._search_cache: dict[tuple, tuple[float, list[SearchItem]]] = {}
         # Survives 429s without flashing the UI panel to zero.
         self._last_good: dict[tuple[str, ...], list[SearchItem]] = {}
 
     def _ensure_client(self, namespace: tuple[str, ...]) -> tuple[SdkClient, str]:
-        ns_str = "_".join(namespace) or "default"
-        agent_id = f"{self._agent_prefix}{ns_str}"
+        agent_id = self._namespace_to_agent_id(namespace)
         with self._lock:
             if agent_id in self._client_pool:
                 return self._client_pool[agent_id], agent_id
@@ -384,12 +385,9 @@ class MemantoStore(BaseStore):
         namespaces = []
         for agent in agents:
             agent_id = agent.get("agent_id") or agent.get("id") or ""
-            if agent_id.startswith(self._agent_prefix):
-                ns_str = agent_id[len(self._agent_prefix) :]
-                if ns_str == "default":
-                    namespaces.append(())
-                else:
-                    namespaces.append(tuple(ns_str.split("_")))
+            namespace = self._agent_id_to_namespace(agent_id)
+            if namespace is not None:
+                namespaces.append(namespace)
 
         if op.match_conditions:
             for cond in op.match_conditions:
@@ -414,6 +412,54 @@ class MemantoStore(BaseStore):
     @staticmethod
     def _key_to_tag(key: str) -> str:
         return f"{_KEY_TAG_PREFIX}{key}"
+
+    def _namespace_to_agent_id(self, namespace: tuple[str, ...]) -> str:
+        if not namespace:
+            return f"{self._agent_prefix}default"
+
+        parts = tuple(str(part) for part in namespace)
+        if all(part and "_" not in part for part in parts):
+            return f"{self._agent_prefix}{'_'.join(parts)}"
+
+        encoded = "_".join(self._encode_namespace_part(part) for part in parts)
+        return f"{self._encoded_namespace_prefix}{encoded}"
+
+    def _agent_id_to_namespace(self, agent_id: str) -> tuple[str, ...] | None:
+        if not agent_id.startswith(self._agent_prefix):
+            return None
+
+        ns_str = agent_id[len(self._agent_prefix) :]
+        if ns_str == "default":
+            return ()
+
+        if agent_id.startswith(self._encoded_namespace_prefix):
+            encoded = agent_id[len(self._encoded_namespace_prefix) :]
+            try:
+                return tuple(
+                    self._decode_namespace_part(part) for part in encoded.split("_")
+                )
+            except (UnicodeDecodeError, ValueError):
+                logger.warning(
+                    "MemantoStore: failed to decode encoded LangGraph namespace %r",
+                    agent_id,
+                )
+
+        # Backward compatibility for agents created before namespace encoding.
+        return tuple(ns_str.split("_"))
+
+    @staticmethod
+    def _encode_namespace_part(part: str) -> str:
+        raw = part.encode("utf-8")
+        return f"{len(raw):x}x{raw.hex()}"
+
+    @staticmethod
+    def _decode_namespace_part(part: str) -> str:
+        length_hex, encoded = part.split("x", 1)
+        raw = bytes.fromhex(encoded)
+        expected_length = int(length_hex, 16)
+        if len(raw) != expected_length:
+            raise ValueError("encoded namespace component length mismatch")
+        return raw.decode("utf-8")
 
     @staticmethod
     def _tags_to_key(tags: list[str]) -> str | None:

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -32,14 +32,14 @@ def test_ensure_client_creates_and_activates(mock_sdk_client):
     namespace = ("test", "ns")
     client, agent_id = store._ensure_client(namespace)
 
-    assert agent_id == "langgraph_test_ns"
+    assert agent_id == "langgraph_ns_4x74657374_2x6e73"
     assert client == client_instance
 
     mock_sdk_client.assert_called_once_with(api_key="test_key")
     client_instance.create_agent.assert_called_once_with(
-        agent_id="langgraph_test_ns", pattern="tool"
+        agent_id="langgraph_ns_4x74657374_2x6e73", pattern="tool"
     )
-    client_instance.activate_agent.assert_called_once_with(agent_id="langgraph_test_ns")
+    client_instance.activate_agent.assert_called_once_with(agent_id="langgraph_ns_4x74657374_2x6e73")
 
     # Second call should return cached client
     client2, agent_id2 = store._ensure_client(namespace)
@@ -65,14 +65,14 @@ def test_ensure_client_encodes_underscore_namespace_without_collision(mock_sdk_c
     _, split_agent_id = store._ensure_client(("team", "a"))
 
     assert underscored_agent_id == "langgraph_ns_6x7465616d5f61"
-    assert split_agent_id == "langgraph_team_a"
+    assert split_agent_id == "langgraph_ns_4x7465616d_1x61"
     assert underscored_agent_id != split_agent_id
 
     client_instance.create_agent.assert_any_call(
         agent_id="langgraph_ns_6x7465616d5f61", pattern="tool"
     )
     client_instance.create_agent.assert_any_call(
-        agent_id="langgraph_team_a", pattern="tool"
+        agent_id="langgraph_ns_4x7465616d_1x61", pattern="tool"
     )
 
 
@@ -477,8 +477,8 @@ def test_do_list_namespaces(mock_sdk_client):
     # Mock list_agents returning various agents
     client_instance.list_agents.return_value = [
         {"agent_id": "langgraph_default"},
-        {"agent_id": "langgraph_my_ns"},
-        {"agent_id": "langgraph_other_ns_sub"},
+        {"agent_id": "langgraph_ns_2x6d79_2x6e73"},
+        {"agent_id": "langgraph_ns_5x6f74686572_2x6e73_3x737562"},
         {"agent_id": "unrelated_agent"},
     ]
 
@@ -499,7 +499,7 @@ def test_do_list_namespaces_decodes_encoded_underscore_namespaces(mock_sdk_clien
 
     client_instance.list_agents.return_value = [
         {"agent_id": "langgraph_default"},
-        {"agent_id": "langgraph_team_a"},
+        {"agent_id": "langgraph_ns_4x7465616d_1x61"},
         {"agent_id": "langgraph_ns_6x7465616d5f61"},
         {"agent_id": "langgraph_ns_foo"},
         {"agent_id": "langgraph_ns_1x61"},
@@ -511,8 +511,7 @@ def test_do_list_namespaces_decodes_encoded_underscore_namespaces(mock_sdk_clien
 
     assert namespaces == [
         (),
-        ("ns", "1x61"),
-        ("ns", "foo"),
+        ("a",),
         ("team", "a"),
         ("team_a",),
     ]
@@ -524,9 +523,9 @@ def test_do_list_namespaces_match_conditions(mock_sdk_client):
     mock_sdk_client.return_value = client_instance
 
     client_instance.list_agents.return_value = [
-        {"agent_id": "langgraph_my_ns"},
-        {"agent_id": "langgraph_my_other"},
-        {"agent_id": "langgraph_not_my"},
+        {"agent_id": "langgraph_ns_2x6d79_2x6e73"},
+        {"agent_id": "langgraph_ns_2x6d79_5x6f74686572"},
+        {"agent_id": "langgraph_ns_3x6e6f74_2x6d79"},
     ]
 
     from langgraph.store.base import MatchCondition

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -76,6 +76,32 @@ def test_ensure_client_encodes_underscore_namespace_without_collision(mock_sdk_c
     )
 
 
+def test_ensure_client_encodes_legacy_reserved_namespace_suffixes(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    _, empty_agent_id = store._ensure_client(())
+    _, default_agent_id = store._ensure_client(("default",))
+    _, encoded_agent_id = store._ensure_client(("team_a",))
+    _, encoded_looking_agent_id = store._ensure_client(("ns", "6x7465616d5f61"))
+
+    assert empty_agent_id == "langgraph_default"
+    assert default_agent_id == "langgraph_ns_7x64656661756c74"
+    assert encoded_agent_id == "langgraph_ns_6x7465616d5f61"
+    assert encoded_looking_agent_id == (
+        "langgraph_ns_2x6e73_ex3678373436353631366435663631"
+    )
+    assert len(
+        {
+            empty_agent_id,
+            default_agent_id,
+            encoded_agent_id,
+            encoded_looking_agent_id,
+        }
+    ) == 4
+
+
 def test_do_get_recent_success(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()
@@ -310,13 +336,21 @@ def test_do_list_namespaces_decodes_encoded_underscore_namespaces(mock_sdk_clien
         {"agent_id": "langgraph_default"},
         {"agent_id": "langgraph_team_a"},
         {"agent_id": "langgraph_ns_6x7465616d5f61"},
+        {"agent_id": "langgraph_ns_foo"},
+        {"agent_id": "langgraph_ns_1x61"},
         {"agent_id": "unrelated_agent"},
     ]
 
     op = ListNamespacesOp()
     namespaces = store._do_list_namespaces(op)
 
-    assert namespaces == [(), ("team", "a"), ("team_a",)]
+    assert namespaces == [
+        (),
+        ("ns", "1x61"),
+        ("ns", "foo"),
+        ("team", "a"),
+        ("team_a",),
+    ]
 
 
 def test_do_list_namespaces_match_conditions(mock_sdk_client):

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -272,7 +272,7 @@ def test_do_put_stringifies_non_string_content(mock_sdk_client):
     store._do_put(op)
 
     client_instance.remember.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id="langgraph_ns_5x6d795f6e73",
         memory_type=None,
         title="42",
         content="42",
@@ -348,7 +348,7 @@ def test_do_search_wildcard_with_tags_uses_backend_tag_filter(mock_sdk_client):
     assert items[0].key == "key3"
     client_instance.recall_recent.assert_not_called()
     client_instance.recall.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id="langgraph_ns_5x6d795f6e73",
         query="*",
         limit=10,
         type=None,
@@ -414,7 +414,7 @@ def test_do_search_accepts_string_tag_filter(mock_sdk_client):
     assert len(items) == 1
     assert items[0].key == "key2"
     client_instance.recall.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id="langgraph_ns_5x6d795f6e73",
         query="test query",
         limit=10,
         type=None,

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -56,6 +56,26 @@ def test_ensure_client_empty_namespace(mock_sdk_client):
     assert agent_id == "langgraph_default"
 
 
+def test_ensure_client_encodes_underscore_namespace_without_collision(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    _, underscored_agent_id = store._ensure_client(("team_a",))
+    _, split_agent_id = store._ensure_client(("team", "a"))
+
+    assert underscored_agent_id == "langgraph_ns_6x7465616d5f61"
+    assert split_agent_id == "langgraph_team_a"
+    assert underscored_agent_id != split_agent_id
+
+    client_instance.create_agent.assert_any_call(
+        agent_id="langgraph_ns_6x7465616d5f61", pattern="tool"
+    )
+    client_instance.create_agent.assert_any_call(
+        agent_id="langgraph_team_a", pattern="tool"
+    )
+
+
 def test_do_get_recent_success(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()
@@ -89,7 +109,7 @@ def test_do_get_recent_success(mock_sdk_client):
     assert item.value["kind"] == "fact"
 
     client_instance.recall_recent.assert_called_once_with(
-        agent_id="langgraph_my_ns", limit=100
+        agent_id="langgraph_ns_5x6d795f6e73", limit=100
     )
 
 
@@ -123,7 +143,10 @@ def test_do_get_fallback_success(mock_sdk_client):
     assert item is not None
     assert item.value["content"] == "fallback content"
     client_instance.recall.assert_called_once_with(
-        agent_id="langgraph_my_ns", query="my_key", limit=100, tags=["lg:key:my_key"]
+        agent_id="langgraph_ns_5x6d795f6e73",
+        query="my_key",
+        limit=100,
+        tags=["lg:key:my_key"],
     )
 
 
@@ -154,7 +177,7 @@ def test_do_put_success(mock_sdk_client):
     store._do_put(op)
 
     client_instance.remember.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id="langgraph_ns_5x6d795f6e73",
         memory_type="fact",
         title="fact title",
         content="my new fact",
@@ -198,7 +221,7 @@ def test_do_search_recent(mock_sdk_client):
     assert len(items) == 1
     assert items[0].key == "key1"
     client_instance.recall_recent.assert_called_once_with(
-        agent_id="langgraph_my_ns", limit=100, type=None
+        agent_id="langgraph_ns_5x6d795f6e73", limit=100, type=None
     )
 
 
@@ -226,7 +249,7 @@ def test_do_search_semantic(mock_sdk_client):
     assert len(items) == 1
     assert items[0].key == "key2"
     client_instance.recall.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id="langgraph_ns_5x6d795f6e73",
         query="test query",
         limit=10,
         type=["observation"],
@@ -276,6 +299,24 @@ def test_do_list_namespaces(mock_sdk_client):
     assert ("my", "ns") in namespaces
     assert ("other", "ns", "sub") in namespaces
     assert len(namespaces) == 3
+
+
+def test_do_list_namespaces_decodes_encoded_underscore_namespaces(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.list_agents.return_value = [
+        {"agent_id": "langgraph_default"},
+        {"agent_id": "langgraph_team_a"},
+        {"agent_id": "langgraph_ns_6x7465616d5f61"},
+        {"agent_id": "unrelated_agent"},
+    ]
+
+    op = ListNamespacesOp()
+    namespaces = store._do_list_namespaces(op)
+
+    assert namespaces == [(), ("team", "a"), ("team_a",)]
 
 
 def test_do_list_namespaces_match_conditions(mock_sdk_client):


### PR DESCRIPTION
Refs #770

I found this in the LangGraph `MemantoStore` namespace mapping. The store maps a namespace tuple to a Memanto `agent_id`, but it currently joins tuple parts with `_` and later splits on `_` when listing namespaces. That makes these two different namespaces collapse to the same agent:

```python
("team_a",)     -> langgraph_team_a
("team", "a") -> langgraph_team_a
```

If a LangGraph app uses namespace parts for users, teams, threads, or tenants, that collision can put logically separate memories behind the same Memanto agent. Reads and writes can then cross namespace boundaries.

## Reproduction

The regression tests in this PR exercise two namespaces that should remain distinct:

```python
("team_a",)
("team", "a")
```

Before the fix, both resolve to `langgraph_team_a`. I also added coverage for reserved legacy suffixes like `("default",)` and `("ns", "6x7465616d5f61")`, because those can collide with the encoded namespace prefix if they are not handled explicitly.

## What changed

- Added a reversible encoded agent ID format for namespace components that cannot be represented safely in the legacy underscore-joined format.
- Kept the legacy `langgraph_<p0>_<p1>` format for namespaces that are already unambiguous.
- Made encoded namespace decoding require an exact round trip, so older `langgraph_ns_*` legacy agents still list through the legacy path unless they were produced by the new encoder.
- Added regression tests for namespace collision cases and namespace-listing round trip behavior.

## Validation

- `.venv/bin/python -m pytest integrations/langgraph/tests/test_store.py -q` -> 16 passed
- `.venv/bin/python -m pytest integrations/langgraph/tests -q` -> 35 passed
- `.venv/bin/python -m py_compile integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace handling so names with underscores or empty parts map correctly and no longer collide.
  * Namespace listings now round-trip back to the expected values more reliably, including encoded names and legacy formats.

* **Tests**
  * Updated coverage for client selection, namespace encoding, and namespace listing behavior.
  * Added checks for underscore-containing, empty, and legacy-style namespace cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->