### PR TITLE
fix: sanitize configured schedule times (#770)

### DIFF
--- a/memanto/cli/schedule_manager.py
+++ b/memanto/cli/schedule_manager.py
@@ -55,6 +55,30 @@ class ScheduleManager:
     def _command(self) -> str:
         return f'"{self.python_exe}" "{self.cli_main.absolute()}" schedule _run'
 
+    def _parse_schedule_time(self, time_str: str) -> tuple[int, int, str]:
+        """Return a cron/schtasks-safe hour, minute, and normalized HH:MM.
+
+        Configuration values are user-editable, so they can drift outside the
+        scheduler's accepted range (for example ``99:99``). Previously Unix
+        installs wrote those invalid values directly to crontab and Windows
+        installs handed them to ``schtasks``, which either disabled the nightly
+        memory-maintenance job or made setup fail with a platform-specific
+        error. Fall back to the documented default when the configured time is
+        malformed or out of range.
+        """
+
+        try:
+            parts = time_str.split(":")
+            if len(parts) != 2:
+                raise ValueError
+            hour, minute = int(parts[0]), int(parts[1])
+            if not (0 <= hour <= 23 and 0 <= minute <= 59):
+                raise ValueError
+        except (AttributeError, ValueError):
+            hour, minute = 23, 55
+
+        return hour, minute, f"{hour:02d}:{minute:02d}"
+
     def enable(self, time_str: str = "23:55") -> dict[str, Any]:
         self._remove_legacy_tasks()
         if self.os_type == "Windows":
@@ -75,6 +99,7 @@ class ScheduleManager:
     # Windows (schtasks)
 
     def _enable_windows(self, time_str: str = "23:55") -> dict[str, Any]:
+        _hour, _minute, normalized_time = self._parse_schedule_time(time_str)
         command = [
             "schtasks",
             "/create",
@@ -85,14 +110,14 @@ class ScheduleManager:
             "/sc",
             "daily",
             "/st",
-            time_str,
+            normalized_time,
             "/f",
         ]
         try:
             subprocess.run(command, capture_output=True, text=True, check=True)
             return {
                 "status": "success",
-                "message": f"Scheduled task created for {time_str} daily.",
+                "message": f"Scheduled task created for {normalized_time} daily.",
             }
         except subprocess.CalledProcessError as e:
             return {
@@ -131,11 +156,7 @@ class ScheduleManager:
     # Unix/OSX (crontab)
 
     def _enable_unix(self, time_str: str = "23:55") -> dict[str, Any]:
-        try:
-            parts = time_str.split(":")
-            hour, minute = int(parts[0]), int(parts[1])
-        except (ValueError, IndexError):
-            hour, minute = 23, 55
+        hour, minute, normalized_time = self._parse_schedule_time(time_str)
 
         marker = f"# {self.TASK_NAME}"
         cron_entry = f"{minute} {hour} * * * {self._command()}  {marker}"
@@ -149,7 +170,7 @@ class ScheduleManager:
             subprocess.run(["crontab", "-"], input=new_cron, text=True, check=True)
             return {
                 "status": "success",
-                "message": f"Crontab entry added for {time_str} daily.",
+                "message": f"Crontab entry added for {normalized_time} daily.",
             }
         except Exception as e:
             return {"status": "error", "message": f"Failed to update crontab: {str(e)}"}

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,6 +14,7 @@ from memanto.app.config import settings
 from memanto.app.models.session import AgentCreate, AgentPattern, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
+from memanto.cli.schedule_manager import ScheduleManager
 
 
 class TestSessionService:
@@ -448,6 +449,45 @@ def test_conflict_report_handles_non_object_json_items(tmp_path, monkeypatch):
     conflicts = json.loads(conflicts_path.read_text(encoding="utf-8"))
     assert conflicts[0]["title"] == "Unparsed conflict report"
     assert conflicts[0]["description"] == '["not an object", 1]'
+
+
+def test_schedule_time_parser_rejects_out_of_range_values():
+    """User-edited schedule config cannot write invalid cron/schtasks times."""
+    manager = ScheduleManager()
+
+    assert manager._parse_schedule_time("05:07") == (5, 7, "05:07")
+    assert manager._parse_schedule_time("24:00") == (23, 55, "23:55")
+    assert manager._parse_schedule_time("23:60") == (23, 55, "23:55")
+    assert manager._parse_schedule_time("not-a-time") == (23, 55, "23:55")
+
+
+def test_enable_unix_sanitizes_invalid_schedule_time():
+    manager = ScheduleManager()
+    manager.os_type = "Linux"
+
+    with patch("memanto.cli.schedule_manager.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="")
+        result = manager._enable_unix("99:99")
+
+    assert result["status"] == "success"
+    assert "23:55" in result["message"]
+    crontab_write = mock_run.call_args_list[1]
+    assert crontab_write.args[0] == ["crontab", "-"]
+    assert "55 23 * * *" in crontab_write.kwargs["input"]
+    assert "99 99 * * *" not in crontab_write.kwargs["input"]
+
+
+def test_enable_windows_sanitizes_invalid_schedule_time():
+    manager = ScheduleManager()
+    manager.os_type = "Windows"
+
+    with patch("memanto.cli.schedule_manager.subprocess.run") as mock_run:
+        result = manager._enable_windows("99:99")
+
+    assert result["status"] == "success"
+    assert "23:55" in result["message"]
+    command = mock_run.call_args.args[0]
+    assert command[command.index("/st") + 1] == "23:55"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes a scheduler setup robustness bug for #770: user-editable schedule configuration could contain out-of-range times such as `99:99` or malformed values. Unix setup wrote those values directly into crontab, creating an invalid nightly memory-maintenance job, while Windows setup passed them to `schtasks` and failed with a platform-specific error.

## Reproduction
1. Set or mock the configured schedule time to `99:99`.
2. Run the scheduler enable path.
3. Before this change, Unix generated a crontab line beginning `99 99 * * * ...`; Windows passed `/st 99:99` to `schtasks`.

## Fix
- Add a shared schedule-time parser that accepts only `00:00` through `23:59`.
- Normalize valid times to `HH:MM`.
- Fall back to the documented default `23:55` for malformed or out-of-range values on both Unix and Windows.
- Add regression coverage for parser behavior and both OS-specific enable paths.

## Validation
- `uv run --group dev pytest tests/test_unit.py::test_schedule_time_parser_rejects_out_of_range_values tests/test_unit.py::test_enable_unix_sanitizes_invalid_schedule_time tests/test_unit.py::test_enable_windows_sanitizes_invalid_schedule_time -q`
- `uv run --group dev pytest tests/test_unit.py -q`
- `uv run --group dev ruff check memanto/cli/schedule_manager.py tests/test_unit.py`
- `uv run --group dev python -m py_compile memanto/cli/schedule_manager.py tests/test_unit.py`
- `git diff --check`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule times are now validated and normalized before being used, preventing invalid times from breaking scheduled tasks.
  * If a time is malformed or out of range, the app now falls back to a safe default time of **23:55**.
  * Success messages now reflect the actual scheduled time that will be used on both Windows and Unix/macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->