### PR TITLE
Preserve long first messages in conversation extraction

### DIFF
--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -77,10 +77,14 @@ class ConversationMemoryExtractionService:
         total = 0
         for message in messages:
             line = f"{message['role'].strip()}: {message['content'].strip()}"
-            total += len(line)
-            if total > self.MAX_CONTENT_CHARS:
+            remaining = self.MAX_CONTENT_CHARS - total
+            if remaining <= 0:
+                break
+            if len(line) > remaining:
+                lines.append(line[:remaining])
                 break
             lines.append(line)
+            total += len(line)
         return "\n".join(lines)
 
     def _header_prompt(self, max_memories: int) -> str:

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -77,14 +77,15 @@ class ConversationMemoryExtractionService:
         total = 0
         for message in messages:
             line = f"{message['role'].strip()}: {message['content'].strip()}"
-            remaining = self.MAX_CONTENT_CHARS - total
+            separator_len = 1 if lines else 0
+            remaining = self.MAX_CONTENT_CHARS - total - separator_len
             if remaining <= 0:
                 break
             if len(line) > remaining:
                 lines.append(line[:remaining])
                 break
             lines.append(line)
-            total += len(line)
+            total += separator_len + len(line)
         return "\n".join(lines)
 
     def _header_prompt(self, max_memories: int) -> str:

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -95,3 +95,24 @@ def test_extract_requires_messages():
 
     with pytest.raises(ValueError, match="at least one message"):
         service.extract(namespace="memanto_agent_test", messages=[])
+
+
+def test_extract_truncates_overlong_first_message_instead_of_dropping_query():
+    client = FakeClient(
+        '[{"type": "fact", "title": "Long note", "content": "The user shared a long deployment note.", "confidence": 0.8}]'
+    )
+    service = ConversationMemoryExtractionService(client)
+
+    service.extract(
+        namespace="memanto_agent_test",
+        messages=[
+            {
+                "role": "user",
+                "content": "Deployment note: " + ("A" * service.MAX_CONTENT_CHARS),
+            }
+        ],
+    )
+
+    query = client.answer.call_kwargs["query"]
+    assert query.startswith("user: Deployment note: ")
+    assert len(query) == service.MAX_CONTENT_CHARS

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -116,3 +116,23 @@ def test_extract_truncates_overlong_first_message_instead_of_dropping_query():
     query = client.answer.call_kwargs["query"]
     assert query.startswith("user: Deployment note: ")
     assert len(query) == service.MAX_CONTENT_CHARS
+
+
+def test_extract_counts_newline_separators_toward_query_budget():
+    client = FakeClient(
+        '[{"type": "fact", "title": "Budget", "content": "The query stayed within budget.", "confidence": 0.8}]'
+    )
+    service = ConversationMemoryExtractionService(client)
+    first_content = "A" * (service.MAX_CONTENT_CHARS - len("user: ") - 2)
+
+    service.extract(
+        namespace="memanto_agent_test",
+        messages=[
+            {"role": "user", "content": first_content},
+            {"role": "assistant", "content": "ok"},
+        ],
+    )
+
+    query = client.answer.call_kwargs["query"]
+    assert len(query) == service.MAX_CONTENT_CHARS
+    assert query.endswith("\na")


### PR DESCRIPTION
## Summary

- Keep conversation extraction queries non-empty when the first message alone exceeds the 12k character budget.
- Truncate the overlong line to the remaining budget instead of dropping it entirely.
- Add regression coverage for an overlong first user message.

## Flaw / reproduction

```python
from memanto.app.services.conversation_memory_extraction_service import ConversationMemoryExtractionService

service = ConversationMemoryExtractionService(client)
service.extract(
    namespace="memanto_agent_test",
    messages=[{"role": "user", "content": "Deployment note: " + ("A" * service.MAX_CONTENT_CHARS)}],
)
```

Before this change, `_conversation_text()` added the line length to `total`, saw the budget was exceeded, and broke before appending anything. The extraction model then received an empty `query`, so a valid but long first message produced no usable conversation context.

## Fix

The query builder now tracks remaining budget before appending each line. If a line exceeds the remaining budget, it appends a truncated slice and stops, preserving as much of the conversation as allowed by `MAX_CONTENT_CHARS`.

## Validation

- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests/test_conversation_memory_extraction.py -q`
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests/test_api.py tests/test_conversation_memory_extraction.py -q`
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests -q` (live Moorcheh E2E skipped because local `MOORCHEH_API_KEY` is missing/placeholder)
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m ruff check .`
- `ruff format --check` on changed files
- `git diff --check`

Bounty: #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved truncation when conversation text reaches the maximum size: the app now retains the part of the next formatted line that fits instead of omitting it.
  * Refined budgeting for long messages to ensure the extracted text preserves the expected prefix and fits exactly within the limit, including newline separators.

* **Tests**
  * Added new test coverage for query truncation and exact-length behavior at the content limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->