### PR TITLE
Fix TypeScript lifecycle stop after child exit

### DIFF
--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -96,7 +96,13 @@ export class ServerLifecycle {
     const child = this.process;
     this.process = null;
     this.url = null;
-    if (!child || child.killed) return;
+    if (
+      !child ||
+      child.killed ||
+      child.exitCode !== null ||
+      child.signalCode !== null
+    )
+      return;
 
     let exited = false;
     await new Promise<void>((resolve, reject) => {

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { AddressInfo } from "node:net";
+import { setTimeout as sleep } from "node:timers/promises";
 import { ServerLifecycle } from "../src/lifecycle.js";
 
 function startFakeHealthyServer(): Promise<{ url: string; close: () => void }> {
@@ -64,5 +66,27 @@ describe("ServerLifecycle", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
+  });
+
+  it("stop resolves when the spawned process has already exited", async () => {
+    const child = spawn(process.execPath, ["-e", "process.exit(0)"], {
+      stdio: "ignore",
+    });
+    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+
+    const life = new ServerLifecycle();
+    const internals = life as unknown as {
+      process: ChildProcess | null;
+      url: string | null;
+    };
+    internals.process = child;
+    internals.url = "http://127.0.0.1:1";
+
+    const result = await Promise.race([
+      life.stop().then(() => "stopped"),
+      sleep(200).then(() => "timed-out"),
+    ]);
+
+    expect(result).toBe("stopped");
   });
 });


### PR DESCRIPTION
## Summary

Fixes a TypeScript SDK lifecycle edge case where `ServerLifecycle.stop()` can hang if the spawned `uvx memanto serve` process has already exited before `stop()` is called.

## Problem

`stop()` currently skips only missing or `child.killed` processes. A child process that exits on its own can have:

- `killed === false`
- a non-null `exitCode` or `signalCode`
- an already-emitted `exit` event

In that state, `stop()` registers a new `once("exit")` listener after the event has already happened, then waits forever. This can make `Memanto.close()` hang in cleanup paths after a server crash or early server exit.

## Fix

Return immediately when the child process has already exited by checking `exitCode` and `signalCode` before attaching a new `exit` listener.

## Test

Added a regression test that:

1. Spawns a Node child process that exits immediately.
2. Waits until the process has already emitted `exit`.
3. Injects it into a `ServerLifecycle` instance.
4. Calls `stop()` and asserts it resolves instead of timing out.

## Verification

From `sdks/typescript`:

```bash
npm test -- test/lifecycle.test.ts
npm run typecheck
npm test
npm run build
```

All commands pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling so stopping a server no longer tries to act on processes that have already exited or been signaled.
  * `stop()` now returns promptly in these cases, reducing the chance of unnecessary delays during cleanup.
* **Tests**
  * Added coverage to confirm shutdown completes quickly when the tracked process has already ended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->