### PR TITLE
Handle on-prem delete responses during memory updates

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -311,7 +311,7 @@ class MemoryWriteService:
                 namespace_name=namespace, ids=[memory_id]
             )
 
-            if delete_result.get("actual_deletions", 0) == 0:
+            if not self._delete_result_succeeded(delete_result):
                 raise MemoryError(f"Failed to delete old version of memory {memory_id}")
 
             validation_result = {"action": "store", "reason": "MVP direct store"}
@@ -349,18 +349,19 @@ class MemoryWriteService:
                 self.client.documents.delete(namespace_name=namespace, ids=[memory_id]),
             )
 
-            # Cloud returns ``actual_deletions``; on-prem's /items/delete only
-            # returns ``deleted_ids`` (and ``status``). Mirror the cloud SDK's
-            # ``_deletion_processed_count`` so both backends report success.
-            raw = result.get("actual_deletions")
-            if isinstance(raw, int):
-                return raw > 0
-            for key in ("deleted_ids", "requested_ids"):
-                ids = result.get(key)
-                if isinstance(ids, list):
-                    return len(ids) > 0
-            # Some on-prem builds only return ``{"status": "success"}``.
-            return str(result.get("status", "")).lower() in {"success", "ok"}
+            return self._delete_result_succeeded(result)
 
         except Exception as e:
             raise MemoryError(f"Failed to delete memory: {e}")
+
+    def _delete_result_succeeded(self, result: dict[str, Any]) -> bool:
+        # Cloud returns ``actual_deletions``; on-prem may only return
+        # ``deleted_ids`` or ``requested_ids`` for successful deletes.
+        raw = result.get("actual_deletions")
+        if isinstance(raw, int):
+            return raw > 0
+        for key in ("deleted_ids", "requested_ids"):
+            ids = result.get(key)
+            if isinstance(ids, list):
+                return len(ids) > 0
+        return str(result.get("status", "")).lower() in {"success", "ok"}

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -287,6 +287,46 @@ class TestMemoryWriteServiceDelete:
         client.documents.delete.return_value = response
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
+    def test_update_memory_accepts_onprem_delete_response_shape(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.get.return_value = {
+            "items": [
+                {
+                    "id": "m1",
+                    "text": "[FACT] Original title\n\nOriginal content",
+                    "memory_type": "fact",
+                    "agent_id": "agent-a",
+                    "actor_id": "user-a",
+                    "source": "conversation",
+                    "confidence": 0.8,
+                    "status": "active",
+                    "created_at": "2026-07-01T12:00:00",
+                }
+            ]
+        }
+        client.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": ["m1"],
+        }
+        client.documents.upload.return_value = {"status": "success"}
+
+        result = MemoryWriteService(client).update_memory(
+            "m1",
+            "memanto_agent_agent-a",
+            {"content": "Updated content"},
+        )
+
+        assert result["status"] == "success"
+        assert result["action"] == "updated"
+        client.documents.upload.assert_called_once()
+        upload_kwargs = client.documents.upload.call_args.kwargs
+        assert upload_kwargs["namespace_name"] == "memanto_agent_agent-a"
+        uploaded_doc = upload_kwargs["documents"][0]
+        assert uploaded_doc["id"] == "m1"
+        assert "Updated content" in uploaded_doc["text"]
+
 
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →


### PR DESCRIPTION
## Summary

- Reuse the backend delete-result success logic for memory update delete-and-recreate flows.
- Treat on-prem `deleted_ids` / `requested_ids` delete responses as successful before uploading the replacement memory.
- Add regression coverage for updating a memory when on-prem omits `actual_deletions`.

## Flaw / reproduction

`MemoryWriteService.delete_memory()` already understands both cloud and on-prem delete response shapes. The update path did not: after deleting the old memory it only checked `actual_deletions`.

```python
client.documents.get.return_value = {
    "items": [{
        "id": "m1",
        "text": "[FACT] Original title\n\nOriginal content",
        "memory_type": "fact",
        "agent_id": "agent-a",
        "actor_id": "user-a",
        "source": "conversation",
        "confidence": 0.8,
        "status": "active",
    }]
}
client.documents.delete.return_value = {"status": "success", "deleted_ids": ["m1"]}

MemoryWriteService(client).update_memory(
    "m1",
    "memanto_agent_agent-a",
    {"content": "Updated content"},
)
```

Before this change, that successful on-prem delete response was treated as a failure. Because `update_memory()` uses delete-and-recreate, the old memory could be removed and the replacement upload skipped, causing update failures and potential memory loss on on-prem backends.

## Fix

The delete response interpretation is now centralized in `_delete_result_succeeded()` and shared by both `delete_memory()` and `update_memory()`. This keeps cloud `actual_deletions` behavior unchanged while accepting on-prem `deleted_ids` / `requested_ids` responses.

## Validation

- Red test first: `pytest tests/test_unit.py::TestMemoryWriteServiceDelete::test_update_memory_accepts_onprem_delete_response_shape -q` failed on `Failed to delete old version of memory m1` before the fix.
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests/test_unit.py::TestMemoryWriteServiceDelete -q`
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests/test_cli.py tests/test_api.py tests/test_unit.py -k 'update_memory or delete_memory or update_endpoint or delete_memory_with_session' -q`
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests -q` (live Moorcheh E2E skipped because local `MOORCHEH_API_KEY` is missing/placeholder)
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m ruff check .`
- `ruff format --check memanto/app/services/memory_write_service.py tests/test_unit.py`
- `git diff --check`

Bounty: #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory update/delete handling so successful deletions are recognized across different backend response formats.
  * Updates now complete correctly even when the delete response uses alternative success fields.

* **Tests**
  * Added coverage for updating memory with an on-prem-style delete response to verify the updated content is saved and reported as successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->