### PR TITLE
Cap temporal recall defaults in API

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -164,6 +164,10 @@ def resolve_recall_limit(request_limit: int | None) -> int:
     except (TypeError, ValueError) as e:
         raise HTTPException(
             status_code=400, detail=f"Invalid recall configuration: {e}"
+        ) from e
+    if limit < 1:
+        raise HTTPException(
+            status_code=400, detail="Invalid recall configuration: limit must be >= 1"
         )
     CostGuard.validate_k_limit(limit)
     return limit

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -152,6 +152,23 @@ def enforce_session_scope(session: Session, agent_id: str) -> None:
         )
 
 
+def resolve_recall_limit(request_limit: int | None) -> int:
+    recall_cfg = _config_manager.get_recall_config()
+    raw_limit = (
+        request_limit
+        if request_limit is not None
+        else recall_cfg.get("limit", settings.RECALL_LIMIT)
+    )
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError) as e:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid recall configuration: {e}"
+        )
+    CostGuard.validate_k_limit(limit)
+    return limit
+
+
 @router.post("/{agent_id}/remember", response_model=RememberResponse)
 async def remember(
     agent_id: str,
@@ -630,18 +647,13 @@ async def recall(
     enforce_session_scope(session, agent_id)
 
     recall_cfg = _config_manager.get_recall_config()
-    raw_limit = (
-        request.limit
-        if request.limit is not None
-        else recall_cfg.get("limit", settings.RECALL_LIMIT)
-    )
     raw_min_similarity = (
         request.min_similarity
         if request.min_similarity is not None
         else recall_cfg.get("min_similarity")
     )
     try:
-        limit = int(raw_limit)
+        limit = resolve_recall_limit(request.limit)
         min_similarity = (
             None if raw_min_similarity is None else float(raw_min_similarity)
         )
@@ -649,8 +661,6 @@ async def recall(
         raise HTTPException(
             status_code=400, detail=f"Invalid recall configuration: {e}"
         )
-    CostGuard.validate_k_limit(limit)
-
     try:
         # Initialize memory read service
         read_service = MemoryReadService(client)
@@ -938,10 +948,7 @@ async def recall_as_of(
     """
     enforce_session_scope(session, agent_id)
 
-    # request.limit is None → fetch all (no cap). Cost guard only applies when capped.
-    limit = request.limit
-    if limit is not None:
-        CostGuard.validate_k_limit(limit)
+    limit = resolve_recall_limit(request.limit)
 
     try:
         read_service = MemoryReadService(client)
@@ -986,10 +993,7 @@ async def recall_changed_since(
     """
     enforce_session_scope(session, agent_id)
 
-    # request.limit is None → fetch all (no cap). Cost guard only applies when capped.
-    limit = request.limit
-    if limit is not None:
-        CostGuard.validate_k_limit(limit)
+    limit = resolve_recall_limit(request.limit)
 
     try:
         read_service = MemoryReadService(client)
@@ -1035,10 +1039,7 @@ async def recall_recent(
     """
     enforce_session_scope(session, agent_id)
 
-    # request.limit is None → fetch all (no cap). Cost guard only applies when capped.
-    limit = request.limit
-    if limit is not None:
-        CostGuard.validate_k_limit(limit)
+    limit = resolve_recall_limit(request.limit)
 
     try:
         read_service = MemoryReadService(client)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -986,6 +986,58 @@ class TestMEMANTOAPI:
         assert response.json()["temporal_mode"] == "changed_since"
 
     @pytest.mark.asyncio
+    async def test_temporal_recall_defaults_to_config_limit(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Temporal HTTP recall should cap omitted limits like CLI/SDK recall."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        items = [
+            {
+                "id": f"m{i}",
+                "metadata": {
+                    "created_at": f"2025-01-{i + 1:02d}T00:00:00Z",
+                    "updated_at": f"2025-01-{i + 1:02d}T01:00:00Z",
+                    "memory_type": "fact",
+                    "status": "active",
+                },
+                "text": f"[FACT] Memory {i}\n\ncontent {i}",
+            }
+            for i in range(12)
+        ]
+        mock_moorcheh.documents.fetch_text_data.return_value = {
+            "status": "ok",
+            "items": items,
+            "pagination": {"has_more": False},
+        }
+
+        requests = [
+            ("recall/as-of", {"as_of": "2025-12-31T00:00:00Z"}),
+            ("recall/changed-since", {"since": "2024-12-31T00:00:00Z"}),
+            ("recall/recent", {}),
+        ]
+
+        for route, payload in requests:
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/{route}",
+                headers=headers,
+                json=payload,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["count"] == 10
+            assert len(data["memories"]) == 10
+
+    @pytest.mark.asyncio
     async def test_recall_recent_api(self, client, auth_headers, mock_moorcheh):
         """Test recall/recent returns newest memories sorted by created_at"""
         await client.post(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1038,6 +1038,37 @@ class TestMEMANTOAPI:
             assert len(data["memories"]) == 10
 
     @pytest.mark.asyncio
+    async def test_temporal_recall_rejects_non_positive_config_limit(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Config-derived temporal limits must enforce the same lower bound."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        with patch("memanto.app.routes.memory._config_manager") as mock_config:
+            mock_config.get_recall_config.return_value = {
+                "limit": 0,
+                "min_similarity": 0.0,
+            }
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                headers=headers,
+                json={},
+            )
+
+        assert response.status_code == 400
+        assert "limit must be >= 1" in str(response.json()["detail"])
+        mock_moorcheh.documents.fetch_text_data.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_recall_recent_api(self, client, auth_headers, mock_moorcheh):
         """Test recall/recent returns newest memories sorted by created_at"""
         await client.post(


### PR DESCRIPTION
## Summary

- Apply the configured recall limit when HTTP temporal recall requests omit `limit`.
- Reuse the same CostGuard-backed limit parsing path as standard recall.
- Add API regression coverage for as-of, changed-since, and recent temporal recall routes.

## Flaw / reproduction

CLI and SDK temporal recall already default `limit=None` to `ConfigManager().get_recall_config()["limit"]`. The FastAPI routes did not: they forwarded `None` into `MemoryReadService`, where `limit=None` means return every fetched memory.

The regression test creates 12 mock memories and calls each HTTP temporal route without a limit:

```python
requests = [
    ("recall/as-of", {"as_of": "2025-12-31T00:00:00Z"}),
    ("recall/changed-since", {"since": "2024-12-31T00:00:00Z"}),
    ("recall/recent", {}),
]
```

Before the fix, the API returned all 12 memories instead of the configured default of 10. This bypassed the intended result cap for temporal recall and made the HTTP API inconsistent with CLI/SDK behavior.

## Fix

`resolve_recall_limit()` centralizes configured default handling, numeric parsing, and `CostGuard.validate_k_limit()`. Standard recall and all temporal recall routes now use that same path, so omitted limits resolve consistently.

## Validation

- Red test first: `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests/test_api.py::TestMEMANTOAPI::test_temporal_recall_defaults_to_config_limit -q` failed with `assert 12 == 10` before the fix.
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests/test_api.py::TestMEMANTOAPI::test_temporal_recall_defaults_to_config_limit -q`
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests/test_api.py tests/test_cli.py -k 'recall or temporal' -q`
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests/test_temporal_helpers.py -q`
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m pytest tests -q` (live Moorcheh E2E skipped because local `MOORCHEH_API_KEY` is missing/placeholder)
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m ruff check .`
- `PYTHONPATH=$PWD /Users/sk/Documents/Codex/2026-06-29/chrome-plugin-chrome-openai-bundled/work/memanto-770-20260701-claim/.venv/bin/python -m ruff format --check memanto/app/routes/memory.py tests/test_api.py`
- `git diff --check`

Bounty: #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporal recall requests now consistently apply the configured result limit, even when no limit is provided in the request.
  * Invalid or non-positive recall limits now return a clear 400-level validation error instead of proceeding with a bad setting.
  * Recall limit handling is now applied more consistently across recall endpoints, helping keep result counts predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->