### PR TITLE
[codex] Guard repeated pagination tokens

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -363,6 +363,7 @@ class MemoryReadService:
         items: list[Any] = []
         for ns in namespaces:
             next_token: str | None = None
+            seen_tokens: set[str] = set()
             while True:
                 kwargs: dict[str, Any] = {"namespace_name": ns, "limit": 100}
                 if next_token:
@@ -375,8 +376,9 @@ class MemoryReadService:
                 if not pagination.get("has_more"):
                     break
                 next_token = pagination.get("next_token")
-                if not next_token:
+                if not next_token or next_token in seen_tokens:
                     break
+                seen_tokens.add(next_token)
 
         seen_ids: set[str] = set()
         memories: list[dict[str, Any]] = []

--- a/tests/test_pagination_guard.py
+++ b/tests/test_pagination_guard.py
@@ -1,0 +1,30 @@
+"""Regression tests for memory document pagination."""
+
+from unittest.mock import MagicMock
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def test_fetch_all_memories_stops_on_repeated_next_token():
+    """A stuck backend cursor must not keep a read request looping forever."""
+    page = {
+        "items": [
+            {
+                "id": "memory-1",
+                "text": "[FACT] Repeated page",
+                "metadata": {},
+            }
+        ],
+        "pagination": {"has_more": True, "next_token": "stuck-token"},
+    }
+    client = MagicMock()
+    client.documents.fetch_text_data.side_effect = [
+        page,
+        page,
+        AssertionError("repeated cursor triggered another request"),
+    ]
+
+    memories = MemoryReadService(client)._fetch_all_memories(["test-namespace"])
+
+    assert [memory["id"] for memory in memories] == ["memory-1"]
+    assert client.documents.fetch_text_data.call_count == 2


### PR DESCRIPTION
## Summary

- stop document pagination when a namespace returns a continuation token that has already been seen
- add a regression test that reproduces a stuck cursor without network access

## Root cause

`_fetch_all_memories()` trusted `has_more` and `next_token` independently. If the backend returned `has_more: true` with the same non-empty token repeatedly, the loop kept requesting the same page forever. Any endpoint that calls this helper could hang and retain a worker indefinitely.

## Fix

Track continuation tokens per namespace. Pagination stops when the next token is empty or was already observed. Existing memory-ID de-duplication ensures a repeated page does not duplicate the returned memories.

## Validation

- Offline regression harness reproduces the non-terminating behavior and verifies the guard exits after two requests.
- Added `tests/test_pagination_guard.py`; the pre-fix implementation reaches the third mocked call and fails, while the fixed implementation returns one de-duplicated memory after two calls.

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented memory loading from getting stuck in repeated pagination loops by stopping when the same cursor is returned again.
  * Reduced the chance of duplicate results during memory retrieval.

* **Tests**
  * Added a regression test covering repeated pagination tokens to confirm memory loading stops correctly and returns only the expected data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->