### PR TITLE
Filter secret-like conversation memory candidates

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -430,6 +430,18 @@ async def extract_memories_from_conversation(
                 "count": len(candidates),
             }
 
+        if not candidates:
+            return {
+                "agent_id": agent_id,
+                "session_id": session.session_id,
+                "dry_run": False,
+                "candidates": [],
+                "total_submitted": 0,
+                "successful": 0,
+                "failed": 0,
+                "results": [],
+            }
+
         write_service = MemoryWriteService(client)
 
         from typing import cast

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -23,7 +23,7 @@ class ConversationMemoryExtractionService:
     SENSITIVE_VALUE_PATTERNS: ClassVar[tuple[re.Pattern[str], ...]] = (
         re.compile(
             r"\b(?:api[_\s-]?key|secret|password|passwd|token|credential|authorization|bearer)\b"
-            r"\s*(?:[:=]|is|was)\s*\S+",
+            r"\s*[:=]\s*\S+",
             re.IGNORECASE,
         ),
         re.compile(r"\b(?:sk|mch)-[A-Za-z0-9][A-Za-z0-9_-]{10,}\b"),
@@ -140,6 +140,7 @@ class ConversationMemoryExtractionService:
 
         normalized: list[dict[str, Any]] = []
         seen: set[tuple[str | None, str]] = set()
+        skipped_sensitive = 0
 
         for item in parsed:
             if not isinstance(item, dict):
@@ -161,6 +162,7 @@ class ConversationMemoryExtractionService:
             title = title[:100]
 
             if self._contains_sensitive_value(title, content):
+                skipped_sensitive += 1
                 continue
 
             try:
@@ -188,6 +190,8 @@ class ConversationMemoryExtractionService:
                 break
 
         if not normalized:
+            if skipped_sensitive:
+                return []
             raise ValueError("Memory extraction produced no usable candidates")
 
         return normalized

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import Any, ClassVar
 
 from memanto.app.constants import VALID_MEMORY_TYPES
 
@@ -20,6 +20,20 @@ class ConversationMemoryExtractionService:
     MAX_MESSAGES = 200
     MAX_MEMORIES = 100
     MAX_CONTENT_CHARS = 12_000
+    SENSITIVE_VALUE_PATTERNS: ClassVar[tuple[re.Pattern[str], ...]] = (
+        re.compile(
+            r"\b(?:api[_\s-]?key|secret|password|passwd|token|credential|authorization|bearer)\b"
+            r"\s*(?:[:=]|is|was)\s*\S+",
+            re.IGNORECASE,
+        ),
+        re.compile(r"\b(?:sk|mch)-[A-Za-z0-9][A-Za-z0-9_-]{10,}\b"),
+        re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+        re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+        re.compile(
+            r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"
+        ),
+        re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    )
 
     def __init__(self, client: Any) -> None:
         self.client = client
@@ -146,6 +160,9 @@ class ConversationMemoryExtractionService:
             title = str(item.get("title") or content[:80]).strip()
             title = title[:100]
 
+            if self._contains_sensitive_value(title, content):
+                continue
+
             try:
                 confidence = float(item.get("confidence", 0.8))
             except (TypeError, ValueError):
@@ -174,3 +191,7 @@ class ConversationMemoryExtractionService:
             raise ValueError("Memory extraction produced no usable candidates")
 
         return normalized
+
+    def _contains_sensitive_value(self, *values: str) -> bool:
+        text = "\n".join(value for value in values if value)
+        return any(pattern.search(text) for pattern in self.SENSITIVE_VALUE_PATTERNS)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -923,6 +923,57 @@ class TestMEMANTOAPI:
         assert uploaded_doc["provenance"] == "inferred"
 
     @pytest.mark.asyncio
+    async def test_extract_memories_from_conversation_sensitive_only_noops(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Sensitive-only extraction returns a clean no-op response."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        assert activate_resp.status_code == 200, activate_resp.text
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        mock_moorcheh.answer.generate.return_value = {
+            "answer": json.dumps(
+                [
+                    {
+                        "type": "fact",
+                        "title": "Deployment token",
+                        "content": "Use token: ghp_1234567890abcdef1234567890abcdef1234",
+                        "confidence": 0.99,
+                    }
+                ]
+            ),
+            "sources": [],
+        }
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember/extract",
+            headers=headers,
+            json={
+                "messages": [
+                    {"role": "user", "content": "Never persist this token."}
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["dry_run"] is False
+        assert data["candidates"] == []
+        assert data["total_submitted"] == 0
+        assert data["successful"] == 0
+        assert data["failed"] == 0
+        assert data["results"] == []
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_recall_temporal_api(self, client, auth_headers, mock_moorcheh):
         """Test temporal recall modes (POST + JSON body)"""
         await client.post(

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -80,6 +80,44 @@ def test_extract_conversation_memories_normalizes_candidates():
     assert "user:" in client.answer.call_kwargs["query"]
 
 
+def test_extract_drops_secret_like_candidates():
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "fact",
+            "title": "Deployment token",
+            "content": "The production API key is sk-test-1234567890abcdef.",
+            "confidence": 0.99
+          },
+          {
+            "type": "preference",
+            "title": "Review style",
+            "content": "The user prefers short pull request summaries.",
+            "confidence": 0.9
+          }
+        ]
+        """
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Keep summaries short."}],
+    )
+
+    assert candidates == [
+        {
+            "type": "preference",
+            "title": "Review style",
+            "content": "The user prefers short pull request summaries.",
+            "confidence": 0.9,
+            "source": "conversation",
+            "provenance": "inferred",
+        }
+    ]
+
+
 def test_extract_rejects_non_json_answers():
     service = ConversationMemoryExtractionService(FakeClient("not json"))
 

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -118,6 +118,56 @@ def test_extract_drops_secret_like_candidates():
     ]
 
 
+def test_extract_keeps_non_secret_token_prose():
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "fact",
+            "title": "Token budget",
+            "content": "The parser token budget should stay under 1000 characters.",
+            "confidence": 0.8
+          }
+        ]
+        """
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Keep parser output small."}],
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["title"] == "Token budget"
+    assert candidates[0]["content"] == (
+        "The parser token budget should stay under 1000 characters."
+    )
+
+
+def test_extract_returns_empty_when_only_secret_like_candidates():
+    client = FakeClient(
+        """
+        [
+          {
+            "type": "fact",
+            "title": "Deployment token",
+            "content": "Use token: ghp_1234567890abcdef1234567890abcdef1234",
+            "confidence": 0.99
+          }
+        ]
+        """
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Never store this token."}],
+    )
+
+    assert candidates == []
+
+
 def test_extract_rejects_non_json_answers():
     service = ConversationMemoryExtractionService(FakeClient("not json"))
 


### PR DESCRIPTION
Linked bounty: moorcheh-ai/memanto#770

## Summary
- add a local sensitive-value filter to conversation memory extraction normalization
- skip LLM-generated candidates that contain credential-like values before they can become stored memories
- add a regression test proving that a secret-like extracted candidate is dropped while a safe candidate from the same response is retained

## Why
The extraction prompt already tells the model not to include secrets, API keys, passwords, or tokens. The normalizer still accepted those candidates if the model returned them anyway. This creates a memory-integrity/security hardening gap: secret-like values can be persisted even though the prompt explicitly forbids them.

This patch does not rely on the LLM obeying the prompt. It adds a deterministic local guard for common sensitive-value shapes such as API-key assignments, `sk-`/`mch-` tokens, GitHub tokens, AWS access key IDs, JWTs, and private-key blocks.

## Reproduction / before-state
I added `test_extract_drops_secret_like_candidates` first and ran it against the unpatched code. It failed because this candidate was accepted:

```text
The production API key is sk-test-1234567890abcdef.
```

The value is fake and used only as a deterministic regression marker.

## Verification

```bash
.venv/bin/python -m pytest tests/test_conversation_memory_extraction.py tests/test_memory_parsing.py -q
# 19 passed

.venv/bin/python -m ruff check memanto/app/services/conversation_memory_extraction_service.py tests/test_conversation_memory_extraction.py
# All checks passed
```

## Boundary
- no live credentials used
- no attack against Moorcheh infrastructure
- no backend probing
- this is a local package hardening fix with reproducible tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory extraction now ignores entries that appear to contain secret-like values, such as API keys, tokens, credentials, or private keys.
  * Improved candidate filtering so sensitive text is less likely to be stored as a conversation memory.

* **Tests**
  * Added coverage to verify that secret-like candidates are dropped while normal memory candidates are still retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->