### PR TITLE
Validate agent ids before local file access

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -2,6 +2,7 @@
 MEMANTO Core Architecture - Namespace Strategy & Memory Records
 """
 
+import re
 import uuid
 from datetime import datetime, timedelta
 from typing import Any
@@ -15,9 +16,20 @@ from memanto.app.constants import (
     StatusType,
 )
 
+AGENT_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def validate_agent_id(agent_id: str) -> None:
+    """Ensure an agent id is safe to use in namespaces and local filenames."""
+    if not isinstance(agent_id, str) or not AGENT_ID_PATTERN.fullmatch(agent_id):
+        raise ValueError(
+            "agent_id must contain only letters, numbers, hyphens, and underscores"
+        )
+
 
 def agent_namespace(agent_id: str) -> str:
     """Map an agent_id to its Moorcheh namespace: memanto_agent_{agent_id}."""
+    validate_agent_id(agent_id)
     return f"memanto_agent_{agent_id}"
 
 

--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -12,9 +12,13 @@ from moorcheh_sdk.exceptions import ConflictError
 
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import get_data_dir
-from memanto.app.core import agent_namespace
+from memanto.app.core import agent_namespace, validate_agent_id
 from memanto.app.models.session import AgentCreate, AgentInfo, AgentList
-from memanto.app.utils.errors import AgentAlreadyExistsError, AgentNotFoundError
+from memanto.app.utils.errors import (
+    AgentAlreadyExistsError,
+    AgentNotFoundError,
+    ValidationError,
+)
 
 
 class AgentService:
@@ -40,6 +44,10 @@ class AgentService:
 
     def _get_agent_file(self, agent_id: str) -> Path:
         """Get file path for agent metadata"""
+        try:
+            validate_agent_id(agent_id)
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
         return self.agents_dir / f"{agent_id}.json"
 
     def create_agent(

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -13,10 +13,10 @@ from pathlib import Path
 from typing import Any
 
 import jwt
-from pydantic import ValidationError
+from pydantic import ValidationError as PydanticValidationError
 
 from memanto.app.config import get_data_dir, settings
-from memanto.app.core import agent_namespace
+from memanto.app.core import agent_namespace, validate_agent_id
 from memanto.app.models.session import (
     AgentPattern,
     Session,
@@ -28,6 +28,9 @@ from memanto.app.utils.errors import (
     InvalidSessionTokenError,
     SessionExpiredError,
     SessionNotFoundError,
+)
+from memanto.app.utils.errors import (
+    ValidationError as MemantoValidationError,
 )
 from memanto.app.utils.ids import generate_id
 from memanto.app.utils.temporal_helpers import utc_now
@@ -99,6 +102,8 @@ class SessionService:
         Returns:
             Session object with JWT token
         """
+        self._validate_agent_id(agent_id)
+
         # Use config default if not explicitly provided
         if duration_hours is None:
             duration_hours = settings.SESSION_DEFAULT_DURATION_HOURS
@@ -177,7 +182,12 @@ class SessionService:
                     raise InvalidSessionTokenError(
                         f"Session {token.session_id} is no longer active"
                     )
-            except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            except (
+                OSError,
+                json.JSONDecodeError,
+                PydanticValidationError,
+                MemantoValidationError,
+            ) as exc:
                 raise InvalidSessionTokenError(
                     f"Session {token.session_id} is no longer active"
                 ) from exc
@@ -199,6 +209,7 @@ class SessionService:
         Returns:
             Session object or None if not found
         """
+        self._validate_agent_id(agent_id)
         session_file = self.sessions_dir / f"{agent_id}.json"
         return self._load_session_file(session_file)
 
@@ -221,7 +232,11 @@ class SessionService:
             with open(active_link) as f:
                 agent_id = f.read().strip()
 
-        session = self.get_session(agent_id)
+        try:
+            session = self.get_session(agent_id)
+        except MemantoValidationError:
+            self._clear_active_session()
+            return None
         if not session:
             return None
 
@@ -336,6 +351,7 @@ class SessionService:
 
     def _save_session(self, session: Session) -> None:
         """Save session to file"""
+        self._validate_agent_id(session.agent_id)
         session_file = self.sessions_dir / f"{session.agent_id}.json"
         with open(session_file, "w") as f:
             json.dump(session.model_dump(mode="json"), f, indent=2)
@@ -349,7 +365,12 @@ class SessionService:
             with open(session_file) as f:
                 data = json.load(f)
             return Session(**data)
-        except (OSError, json.JSONDecodeError, TypeError, ValidationError) as exc:
+        except (
+            OSError,
+            json.JSONDecodeError,
+            TypeError,
+            PydanticValidationError,
+        ) as exc:
             logger.warning("Skipping invalid session file %s: %s", session_file, exc)
             return None
 
@@ -452,6 +473,7 @@ class SessionService:
 
     def _set_active_session(self, agent_id: str) -> None:
         """Mark session as active"""
+        self._validate_agent_id(agent_id)
         active_link = self.sessions_dir / "active"
 
         # Remove existing active link
@@ -476,6 +498,13 @@ class SessionService:
     def clear_active_session(self) -> None:
         """Public alias: clear the active-session marker without ending the session."""
         self._clear_active_session()
+
+    def _validate_agent_id(self, agent_id: str) -> None:
+        """Reject unsafe agent ids before they are used as local filenames."""
+        try:
+            validate_agent_id(agent_id)
+        except ValueError as exc:
+            raise MemantoValidationError(str(exc)) from exc
 
     def list_sessions(self) -> list[Session]:
         """

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,6 +14,7 @@ from memanto.app.config import settings
 from memanto.app.models.session import AgentCreate, AgentPattern, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
+from memanto.app.utils.errors import ValidationError as MemantoValidationError
 
 
 class TestSessionService:
@@ -139,6 +140,25 @@ class TestSessionService:
 
         assert [session.agent_id for session in sessions] == [valid_session.agent_id]
 
+    @pytest.mark.parametrize("agent_id", ["../escaped", "..\\escaped", "bad/id"])
+    def test_session_agent_id_cannot_escape_session_dir(
+        self, session_service, agent_id
+    ):
+        """Agent ids used as filenames must not escape the session directory."""
+        with pytest.raises(MemantoValidationError):
+            session_service.create_session(agent_id=agent_id, duration_hours=1)
+
+        assert not (session_service.sessions_dir.parent / "escaped.json").exists()
+
+    def test_active_session_rejects_unsafe_marker(self, session_service):
+        """A tampered active marker must not make get_active_session read outside."""
+        (session_service.sessions_dir / "active").write_text("../escaped")
+        (session_service.sessions_dir.parent / "escaped.json").write_text("{}")
+
+        assert session_service.get_active_session() is None
+
+        assert (session_service.sessions_dir.parent / "escaped.json").exists()
+
 
 class TestAgentService:
     """Unit tests for AgentService"""
@@ -261,6 +281,14 @@ class TestAgentService:
         assert not agent_service.agent_exists("test-agent")
 
         print("✅ Agent deleted successfully")
+
+    @pytest.mark.parametrize("agent_id", ["../escaped", "..\\escaped", "bad/id"])
+    def test_agent_file_access_rejects_path_like_ids(self, agent_service, agent_id):
+        """Agent metadata lookups must stay confined to the agents directory."""
+        with pytest.raises(MemantoValidationError):
+            agent_service.agent_exists(agent_id)
+
+        assert not (agent_service.agents_dir.parent / "escaped.json").exists()
 
 
 class TestMemoryWriteServiceDelete:


### PR DESCRIPTION
## Summary

Fixes a local state isolation bug covered by the #770 bug challenge: service-layer code used raw `agent_id` values to build local JSON filenames. Model validation already protects the create-agent request body, but direct service calls, tampered active-session markers, or other internal paths could still pass path-like IDs such as `../escaped` and make agent/session state resolve outside the intended `agents/` or `sessions/` directories.

This PR:
- adds shared `agent_id` validation for the documented `[A-Za-z0-9_-]+` format
- validates IDs before namespace generation and before file-backed agent/session access
- treats unsafe active-session markers as stale instead of reading outside the session directory
- adds regression tests for POSIX and Windows-style path separators

## Validation

- `python -m pytest -q`
- `ruff check memanto tests`

Live Moorcheh E2E tests were skipped by the suite because no real `MOORCHEH_API_KEY` is configured locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation for agent IDs to prevent unsafe or path-like values from being used in storage paths.
  * Improved handling of invalid session markers so corrupted or tampered active-session references no longer break session lookup.
  * Invalid agent IDs now return consistent validation errors across agent and session operations.

* **Tests**
  * Added coverage for unsafe agent IDs and active-session marker handling to verify files stay within the expected directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->