### PR TITLE
[codex] Stream Claude Code transcript parsing

### DIFF
--- a/integrations/claudecode/hooks/_common.py
+++ b/integrations/claudecode/hooks/_common.py
@@ -17,6 +17,7 @@ Input fields follow the official Claude Code hooks reference: common fields are
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import sys
@@ -28,6 +29,8 @@ from typing import Any
 # Make the sibling ``claudecode_memanto`` package importable whether or not the
 # example has been pip-installed.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+logger = logging.getLogger(__name__)
 
 
 def run(main: Callable[[], int]) -> None:
@@ -191,6 +194,7 @@ def _read_transcript_full(
                         skill = found
                 pieces.append(f"{role}: {text}" if role else text)
     except Exception:
+        logger.debug("Failed to read Claude Code transcript", exc_info=True)
         return None, ""
 
     rendered = "\n".join(pieces)

--- a/integrations/claudecode/hooks/_common.py
+++ b/integrations/claudecode/hooks/_common.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 import sys
+from collections import deque
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -168,33 +169,31 @@ def _read_transcript_full(
     if not path.exists():
         return None, ""
 
+    pieces: deque[str] = deque(maxlen=max(0, int(max_messages)))
+    skill: str | None = None
     try:
         with path.open(encoding="utf-8") as fh:
-            lines = fh.readlines()
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                role, text = _extract_role_text(entry)
+                if not text:
+                    continue
+                # First skill mention wins — typically the opening user prompt.
+                if skill is None:
+                    found = detect_skill(text)
+                    if found:
+                        skill = found
+                pieces.append(f"{role}: {text}" if role else text)
     except Exception:
         return None, ""
 
-    pieces: list[str] = []
-    skill: str | None = None
-    for line in lines:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        role, text = _extract_role_text(entry)
-        if not text:
-            continue
-        # First skill mention wins — typically the opening user prompt.
-        if skill is None:
-            found = detect_skill(text)
-            if found:
-                skill = found
-        pieces.append(f"{role}: {text}" if role else text)
-
-    rendered = "\n".join(pieces[-max_messages:])
+    rendered = "\n".join(pieces)
     return skill, rendered[-max_chars:]
 
 

--- a/integrations/claudecode/tests/test_hooks.py
+++ b/integrations/claudecode/tests/test_hooks.py
@@ -161,6 +161,66 @@ class TestReadTranscriptForDistillation:
         assert "/grill-with-docs" not in text
         assert len(text) <= 2000
 
+    def test_streams_transcript_without_requiring_readlines(self, monkeypatch) -> None:
+        """Transcript reading must work with line-iterable files.
+
+        Stop hooks can see very large JSONL transcripts. The reader only needs
+        the first skill plus the bounded tail, so it should not require
+        ``readlines()`` to materialize the whole file before parsing.
+        """
+        lines = [
+            json.dumps(
+                {"message": {"role": "user", "content": "/tdd pin the parser bug"}}
+            ),
+            json.dumps(
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "We will stream the transcript parser.",
+                    }
+                }
+            ),
+            json.dumps(
+                {
+                    "message": {
+                        "role": "user",
+                        "content": "Final decision: keep only the transcript tail.",
+                    }
+                }
+            ),
+        ]
+
+        class StreamingOnlyFile:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(lines)
+
+            def readlines(self):  # pragma: no cover - old bug path
+                raise AssertionError("readlines() should not be required")
+
+        class FakePath:
+            def __init__(self, raw):
+                self.raw = raw
+
+            def exists(self):
+                return True
+
+            def open(self, encoding=None):
+                return StreamingOnlyFile()
+
+        monkeypatch.setattr(common, "Path", FakePath)
+
+        skill, text = common.read_transcript_for_distillation("stream-only.jsonl")
+
+        assert skill == "tdd"
+        assert "Final decision" in text
+        assert "stream the transcript parser" in text
+
     def test_missing_path_returns_none_and_empty(self) -> None:
         assert common.read_transcript_for_distillation(None) == (None, "")
         assert common.read_transcript_for_distillation("/no/such/file") == (None, "")


### PR DESCRIPTION
## Summary

- Stream Claude Code hook transcripts line by line instead of materializing the whole JSONL file with `readlines()`.
- Preserve the existing behavior: find the first `/skill` across the full transcript while returning only the bounded tail for distillation.
- Add a regression test with a streaming-only file object so the reader does not depend on `readlines()`.

## Bounty

Submission for #770.

## Why

`read_transcript_for_distillation()` only needs the first skill mention plus the last `max_messages`/`max_chars`, but the previous implementation loaded the entire transcript into memory before parsing. Large Claude Code sessions can make the async Stop hook unnecessarily memory-heavy or cause it to skip distillation after a read failure, which hurts memory stability and context continuity.

## Reproduction

The regression test in `integrations/claudecode/tests/test_hooks.py` uses a line-iterable transcript object whose `readlines()` method raises. On the previous implementation, `_read_transcript_full()` caught that failure and returned `(None, "")`, so the Stop hook would silently lose the skill tag and transcript text instead of distilling the session. With this patch, the same stream is parsed line by line and returns the expected skill plus bounded tail text.

## Validation

- `uv run --group dev pytest integrations/claudecode/tests/test_hooks.py -q`
- `uv run --group dev pytest integrations/claudecode/tests -q`
- `uv run --group dev ruff check integrations/claudecode/hooks/_common.py integrations/claudecode/tests/test_hooks.py`
- `git diff --check`

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transcript processing now handles large Claude Code logs more efficiently by reading them incrementally instead of loading everything at once.
  * Improved reliability when parsing transcripts from streaming or iterable file sources.
  * Better error handling ensures transcript rendering fails gracefully and logs useful debugging details when parsing issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->