### PR TITLE
fix(cli): refuse to overwrite export/MEMORY.md when backend is unreachable

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1481,6 +1481,7 @@ class DirectClient:
         from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
 
         memories_by_type: dict[str, list] = {}
+        failed_types = 0
 
         for mem_type in MEMORY_TYPE_ORDER:
             try:
@@ -1493,6 +1494,18 @@ class DirectClient:
                 memories_by_type[mem_type] = result.get("memories", [])
             except Exception:
                 memories_by_type[mem_type] = []
+                failed_types += 1
+
+        if failed_types == len(MEMORY_TYPE_ORDER):
+            # Every recall failed (e.g. the backend is unreachable) rather
+            # than each type genuinely having zero memories. Raise instead
+            # of writing an empty export — callers may otherwise overwrite
+            # a good cache/MEMORY.md with nothing. See sync_memory_to_project.
+            raise ConnectionError(
+                f"Failed to recall any memories for agent '{agent_id}' — "
+                "the backend appears unreachable. Refusing to write an "
+                "empty export."
+            )
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1340,6 +1340,7 @@ class SdkClient:
         from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
 
         memories_by_type: dict[str, list] = {}
+        failed_types = 0
 
         for mem_type in MEMORY_TYPE_ORDER:
             try:
@@ -1352,6 +1353,18 @@ class SdkClient:
                 memories_by_type[mem_type] = result.get("memories", [])
             except Exception:
                 memories_by_type[mem_type] = []
+                failed_types += 1
+
+        if failed_types == len(MEMORY_TYPE_ORDER):
+            # Every recall failed (e.g. the backend is unreachable) rather
+            # than each type genuinely having zero memories. Raise instead
+            # of writing an empty export — callers may otherwise overwrite
+            # a good cache/MEMORY.md with nothing. See sync_memory_to_project.
+            raise ConnectionError(
+                f"Failed to recall any memories for agent '{agent_id}' — "
+                "the backend appears unreachable. Refusing to write an "
+                "empty export."
+            )
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None
@@ -1385,15 +1398,30 @@ class SdkClient:
             limit_per_type: Max memories per type for fresh export (default 25).
 
         Returns:
-            Dict with ``output_path``, ``total_memories``, ``source``.
+            Dict with ``output_path``, ``total_memories``, ``source``
+            (``"cache"``, ``"fresh"``, or ``"stale-cache"`` if a refresh
+            failed and a previous export was reused instead).
         """
-        # Run export function first (ensures ~/.memanto/exports/... is fresh)
-        self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
-
-        # Perform sync from cache to project
         cache_path = Path.home() / ".memanto" / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # Run export function first (ensures ~/.memanto/exports/... is fresh)
+            self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
+        except ConnectionError:
+            if cache_path.exists():
+                # Backend unreachable, but we have a previously good export —
+                # serve that instead of wiping the project's MEMORY.md.
+                shutil.copy2(str(cache_path), str(target_path))
+                content = cache_path.read_text(encoding="utf-8")
+                mem_count = content.count("### ")
+                return {
+                    "output_path": str(target_path.resolve()),
+                    "total_memories": mem_count,
+                    "source": "stale-cache",
+                }
+            raise
 
         if cache_path.exists():
             # Copy freshly updated cache to project

--- a/tests/test_export_resilience.py
+++ b/tests/test_export_resilience.py
@@ -1,0 +1,109 @@
+"""Regression coverage: ``export_memory_md`` must not silently write an
+empty export when every ``recall`` call fails (e.g. the on-prem backend is
+unreachable), and ``SdkClient.sync_memory_to_project`` must fall back to a
+previous good export instead of overwriting a project's ``MEMORY.md`` with
+nothing.
+
+Before this fix, a total-outage export produced an all-empty
+``memories_by_type`` (each per-type ``recall`` exception was swallowed) and
+still wrote it out — every call to ``memanto memory sync`` during a brief
+backend outage silently wiped the agent's exported context and the
+project's ``MEMORY.md``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
+from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.client.sdk_client import SdkClient
+
+
+def _build_client(client_cls, monkeypatch, tmp_path):
+    """Construct *client_cls* with session validation stubbed out and
+    ``Path.home()`` redirected to *tmp_path*. ``Path`` is the same class
+    object everywhere it's imported, so this one patch also covers
+    ``MemoryExportService``'s default ``exports_dir`` — export writes and
+    ``sync_memory_to_project``'s cache lookup end up at the same
+    ``tmp_path/.memanto/exports/`` regardless of which module reads
+    ``Path.home()``."""
+    import memanto.cli.client.direct_client as direct_mod
+    import memanto.cli.client.sdk_client as sdk_mod
+
+    module = direct_mod if client_cls is DirectClient else sdk_mod
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+
+    client = client_cls(api_key="test-key")
+    monkeypatch.setattr(
+        client, "_get_validated_session_for_agent", lambda agent_id: None
+    )
+    return client
+
+
+class TestExportMemoryMdRefusesEmptyOnTotalFailure:
+    @pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+    def test_raises_when_every_recall_fails(self, client_cls, monkeypatch, tmp_path):
+        client = _build_client(client_cls, monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            client, "recall", MagicMock(side_effect=ConnectionError("backend down"))
+        )
+
+        with pytest.raises(ConnectionError, match="unreachable"):
+            client.export_memory_md(agent_id="test-agent")
+
+    @pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+    def test_partial_failure_still_exports(self, client_cls, monkeypatch, tmp_path):
+        """One type erroring while others succeed must not raise — only a
+        *total* outage (every type failing) should refuse to write."""
+        client = _build_client(client_cls, monkeypatch, tmp_path)
+
+        def fake_recall(agent_id, query, limit, type):
+            if type == [MEMORY_TYPE_ORDER[0]]:
+                raise ConnectionError("flaky")
+            return {"memories": [{"content": "ok"}]}
+
+        monkeypatch.setattr(client, "recall", MagicMock(side_effect=fake_recall))
+
+        result = client.export_memory_md(agent_id="test-agent")
+        assert result["total_memories"] > 0
+
+
+class TestSyncFallsBackToStaleCacheOnOutage:
+    """``sync_memory_to_project`` (SdkClient) always re-exports before
+    copying its cache. When the backend is briefly unreachable, it must
+    reuse the last good export rather than propagate the now-empty write —
+    or, if there is no prior export at all, surface the outage instead of
+    creating an empty ``MEMORY.md``."""
+
+    def test_stale_cache_used_when_backend_down(self, monkeypatch, tmp_path):
+        client = _build_client(SdkClient, monkeypatch, tmp_path)
+
+        cache_file = tmp_path / ".memanto" / "exports" / "test-agent_memory.md"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text("### Some Memory\n\ngood content\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            client, "recall", MagicMock(side_effect=ConnectionError("backend down"))
+        )
+
+        project_dir = tmp_path / "project"
+        result = client.sync_memory_to_project(
+            agent_id="test-agent", project_dir=str(project_dir)
+        )
+
+        assert result["source"] == "stale-cache"
+        assert result["total_memories"] == 1
+        written = (project_dir / "MEMORY.md").read_text(encoding="utf-8")
+        assert "good content" in written
+
+    def test_raises_when_no_cache_and_backend_down(self, monkeypatch, tmp_path):
+        client = _build_client(SdkClient, monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            client, "recall", MagicMock(side_effect=ConnectionError("backend down"))
+        )
+
+        with pytest.raises(ConnectionError):
+            client.sync_memory_to_project(
+                agent_id="test-agent", project_dir=str(tmp_path / "project")
+            )


### PR DESCRIPTION
## What problem does this solve?

Closes #1340.

`export_memory_md` (both `SdkClient` and `DirectClient`) swallows every per-type `recall` exception into an empty list, then writes the export unconditionally. When the backend is briefly unreachable, *every* type fails, producing an all-empty export that gets written as if it were a genuine "no memories" result.

`SdkClient.sync_memory_to_project` calls `export_memory_md` on every sync before copying its cache, so this silently overwrote a project's `MEMORY.md` (and the cached export) with nothing during a transient outage — no error surfaced, just a misleadingly normal-looking "0 memories" success message.

## What changed

- `export_memory_md` (both clients): now counts failures per type. If *every* type failed, raises `ConnectionError` instead of writing — a genuine "this type has zero memories" (some types fail, others don't) still exports fine, since only a *total* outage is ambiguous with "unreachable."
- `SdkClient.sync_memory_to_project`: catches that `ConnectionError`. If a previous export already exists, it copies that instead (`source: "stale-cache"`) rather than propagating the wipe. If there's no prior export at all, the error surfaces (nothing to reasonably fall back to).
- `DirectClient.sync_memory_to_project` already checks its cache before deciding whether to re-export, so it's only exposed to this on a brand-new agent's very first sync; no change needed there beyond the shared `export_memory_md` fix — the new exception propagates to the CLI's existing `except Exception: _error(...)` handler, which already prints a clean message instead of silently "succeeding" with empty content.

## How did you test it?

Added `tests/test_export_resilience.py` — 6 cases across both clients:
- total recall failure → `ConnectionError` (both clients)
- partial failure (one type errors, others succeed) → still exports normally, unaffected (both clients)
- `sync_memory_to_project` with an existing cache + backend down → falls back to `stale-cache`, project `MEMORY.md` keeps the old content
- `sync_memory_to_project` with no cache + backend down → raises (nothing to fall back to)

```
uv run pytest tests/test_export_resilience.py -v
======================== 6 passed in 0.55s ========================
```

Also ran the full suite (`uv run pytest -q`) and `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy memanto/cli/client/sdk_client.py memanto/cli/client/direct_client.py` — all green, no regressions.

### PR Checklist
- [x] Code follows the project style (`ruff`, `mypy` pass)
- [x] Tests added for changed behavior
- [x] All existing tests pass
- [x] No secrets or credentials in the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty memory exports from overwriting valid local data when the backend is unavailable.
  * Improved sync behavior during outages by reusing the last successful cached export when possible.
  * Now surfaces a clear error if all memory retrievals fail and no cache is available.

* **Tests**
  * Added coverage for full outage, partial failure, and stale-cache fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->