### PR TITLE
Reject blank content in batch memory writes

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,7 +5,7 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from memanto.app.constants import MemoryType, SourceType, StatusType
 
@@ -70,6 +70,13 @@ class BatchRememberItem(BaseModel):
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",
     )
+
+    @field_validator("content")
+    @classmethod
+    def content_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Memory content must be a non-empty string")
+        return value
 
 
 class RememberRequest(BatchRememberItem):

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -688,12 +688,18 @@ class DirectClient:
         memory_records = []
         for i, item in enumerate(memories):
             raw_content = item.get("content", "")
-            if not raw_content:
-                raise ValueError(f"Memory at index {i} has no content")
+            if not isinstance(raw_content, str) or not raw_content.strip():
+                raise ValueError(f"Memory at index {i} has no non-empty content")
 
             raw_title = item.get("title")
             title = raw_title or (
                 raw_content[:47] + "..." if len(raw_content) > 50 else raw_content
+            )
+            self._validate_memory_input(
+                item.get("type"),
+                title,
+                raw_content,
+                item.get("confidence", 0.8),
             )
             raw_type = item.get("type")
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -516,12 +516,18 @@ class SdkClient:
         memory_records = []
         for i, item in enumerate(memories):
             raw_content = item.get("content", "")
-            if not raw_content:
-                raise ValueError(f"Memory at index {i} has no content")
+            if not isinstance(raw_content, str) or not raw_content.strip():
+                raise ValueError(f"Memory at index {i} has no non-empty content")
 
             raw_title = item.get("title")
             title = raw_title or (
                 raw_content[:47] + "..." if len(raw_content) > 50 else raw_content
+            )
+            self._validate_memory_input(
+                item.get("type"),
+                title,
+                raw_content,
+                item.get("confidence", 0.8),
             )
             raw_type = item.get("type")
 

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -207,6 +207,12 @@ def remember(
                     f"Item {i} is missing required 'content' field.",
                     hint="Each object must have at least a 'content' field.",
                 )
+            content_value = item["content"]
+            if not isinstance(content_value, str) or not content_value.strip():
+                _error(
+                    f"Item {i} has no non-empty content.",
+                    hint="Each content value must be a non-empty string.",
+                )
 
         try:
             with console.status(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -746,6 +746,31 @@ class TestMEMANTOAPI:
         assert response.json()["successful"] == 2
 
     @pytest.mark.asyncio
+    async def test_batch_remember_rejects_blank_content_api(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Batch API rejects whitespace-only content before storing memories."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/batch-remember",
+            headers=headers,
+            json={"memories": [{"content": "   ", "type": "fact"}]},
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_delete_memory_with_session(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -648,6 +648,19 @@ class TestMEMANTOCLI:
         assert result.exit_code == 0
         assert "Stored 2/2 memories successfully" in result.stdout
 
+    def test_memory_batch_remember_rejects_blank_content(
+        self, mock_all_clients, tmp_path
+    ):
+        """Batch input must reject whitespace-only memories like single writes do."""
+        batch_file = tmp_path / "batch.json"
+        batch_file.write_text(json.dumps([{"content": "   "}]))
+
+        result = runner.invoke(app, ["remember", "--batch", str(batch_file)])
+
+        assert result.exit_code != 0
+        assert "non-empty content" in result.stdout
+        mock_all_clients.batch_remember.assert_not_called()
+
     def test_remember_from_conversation_dry_run(self, mock_all_clients, tmp_path):
         """Test 'memanto remember --from-conversation --dry-run'"""
         conversation_file = tmp_path / "messages.json"


### PR DESCRIPTION
## Summary
- Reject whitespace-only `content` in batch memory writes at the REST model boundary.
- Add the same guard to the CLI batch path and both SDK/direct client batch paths.
- Add regression tests proving blank batch memories are rejected before storage.

## Why
Single-memory writes already reject blank content, but batch writes could accept whitespace-only content. That can add empty/noise memories to an agent namespace, which degrades memory integrity and retrieval quality over time. This patch makes batch writes follow the same non-empty content invariant as single writes.

## Reproduction Before Fix
1. Submit a batch memory payload with `{"content": "   "}`.
2. The request/model layer accepts it because the field is a string under the max length.
3. Downstream code can build a `MemoryRecord` with whitespace content instead of rejecting it consistently with single-memory writes.

## Verification
- `uv run pytest tests/test_cli.py::TestMEMANTOCLI::test_memory_batch_remember tests/test_cli.py::TestMEMANTOCLI::test_memory_batch_remember_rejects_blank_content tests/test_api.py::TestMEMANTOAPI::test_batch_remember_api tests/test_api.py::TestMEMANTOAPI::test_batch_remember_rejects_blank_content_api -q`
- `uv run pytest tests -q`
- `uv run ruff check .`

## Bounty Context
This is a small memory-integrity hardening submission for #770. It prevents an avoidable invalid-memory state and keeps batch ingestion behavior aligned with the single-write validation contract.