### PR TITLE
Reject blank remember content

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,7 +5,7 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from memanto.app.constants import MemoryType, SourceType, StatusType
 
@@ -55,7 +55,9 @@ class MemoryBatchWriteRequest(BaseModel):
 class BatchRememberItem(BaseModel):
     """Single memory item in a batch-remember request"""
 
-    content: str = Field(..., max_length=10000, description="Memory content")
+    content: str = Field(
+        ..., min_length=1, max_length=10000, description="Memory content"
+    )
     type: MemoryType | None = Field(
         None,
         description="Memory type. Omit to auto-parse.",
@@ -70,6 +72,13 @@ class BatchRememberItem(BaseModel):
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",
     )
+
+    @field_validator("content")
+    @classmethod
+    def validate_content_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Memory content must be a non-empty string")
+        return value
 
 
 class RememberRequest(BatchRememberItem):

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -687,9 +687,11 @@ class DirectClient:
 
         memory_records = []
         for i, item in enumerate(memories):
-            raw_content = item.get("content", "")
-            if not raw_content:
-                raise ValueError(f"Memory at index {i} has no content")
+            raw_content = item.get("content")
+            if not isinstance(raw_content, str) or not raw_content.strip():
+                raise ValueError(
+                    f"Memory at index {i} must have non-empty string content"
+                )
 
             raw_title = item.get("title")
             title = raw_title or (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -709,6 +709,32 @@ class TestMEMANTOAPI:
         assert uploaded_doc["memory_type"] == "preference"
 
     @pytest.mark.asyncio
+    async def test_remember_rejects_blank_content(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Single-memory writes should reject content with only whitespace."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=headers,
+            json={"content": "   "},
+        )
+
+        assert response.status_code == 422
+        assert "non-empty" in response.text
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_global_status_no_active_session(self, client):
         """Test GET /api/v2/status returns 404 when no session is active"""
         response = await client.get("/api/v2/status")
@@ -744,6 +770,38 @@ class TestMEMANTOAPI:
         )
         assert response.status_code == 200
         assert response.json()["successful"] == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_remember_rejects_blank_content(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Batch writes should reject blank content before uploading anything."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        payload = {
+            "memories": [
+                {"content": "A real memory", "type": "fact"},
+                {"content": "   ", "type": "fact"},
+            ]
+        }
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/batch-remember",
+            headers=headers,
+            json=payload,
+        )
+
+        assert response.status_code == 422
+        assert "non-empty" in response.text
+        mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_memory_with_session(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -365,6 +365,18 @@ class TestForgetEndToEnd:
         assert result["status"] == "deleted"
         assert result["memory_id"] == "mem-xyz"
 
+    def test_batch_remember_rejects_blank_content(self, direct_client):
+        """Direct batch writes should reject whitespace-only memory content."""
+        client, moorcheh = direct_client
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            client.batch_remember(
+                agent_id="test-agent",
+                memories=[{"content": "   ", "type": "fact"}],
+            )
+
+        moorcheh.documents.upload.assert_not_called()
+
 
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory submissions now reject blank or whitespace-only content, preventing empty entries from being accepted.
  * Validation errors are returned earlier for both single and batch memory writes, before any upload action occurs.

* **Tests**
  * Added coverage for rejecting whitespace-only content in both API and unit-level memory write flows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->