### PR TITLE
Validate agent IDs before filesystem access

### DIFF
--- a/memanto/app/models/session.py
+++ b/memanto/app/models/session.py
@@ -12,6 +12,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from memanto.app.utils.temporal_helpers import as_utc_naive, utc_now
+from memanto.app.utils.validation import AGENT_ID_PATTERN
 
 
 class SessionStatus(str, Enum):
@@ -33,7 +34,11 @@ class AgentPattern(str, Enum):
 class SessionCreate(BaseModel):
     """Request to create/activate a session"""
 
-    agent_id: str = Field(..., description="Agent identifier")
+    agent_id: str = Field(
+        ...,
+        description="Agent identifier (alphanumeric, hyphens, underscores)",
+        pattern=AGENT_ID_PATTERN,
+    )
     duration_hours: int | None = Field(
         default=None,
         description="Session duration in hours (default: from server config)",
@@ -43,7 +48,7 @@ class SessionCreate(BaseModel):
 class SessionToken(BaseModel):
     """JWT token payload structure"""
 
-    agent_id: str
+    agent_id: str = Field(..., pattern=AGENT_ID_PATTERN)
     namespace: str
     session_id: str
     started_at: datetime
@@ -55,7 +60,7 @@ class Session(BaseModel):
 
     session_id: str
     session_token: str
-    agent_id: str
+    agent_id: str = Field(..., pattern=AGENT_ID_PATTERN)
     namespace: str
     started_at: datetime
     expires_at: datetime
@@ -80,7 +85,7 @@ class SessionInfo(BaseModel):
     """Session information response"""
 
     session_id: str
-    agent_id: str
+    agent_id: str = Field(..., pattern=AGENT_ID_PATTERN)
     namespace: str
     started_at: datetime
     expires_at: datetime
@@ -93,7 +98,7 @@ class SessionSummary(BaseModel):
     """Summary of ended session"""
 
     session_id: str
-    agent_id: str
+    agent_id: str = Field(..., pattern=AGENT_ID_PATTERN)
     started_at: datetime
     ended_at: datetime
     duration_hours: float
@@ -107,7 +112,7 @@ class AgentCreate(BaseModel):
     agent_id: str = Field(
         ...,
         description="Unique agent identifier (alphanumeric, hyphens, underscores)",
-        pattern=r"^[a-zA-Z0-9_-]+$",
+        pattern=AGENT_ID_PATTERN,
     )
     pattern: AgentPattern = Field(
         default=AgentPattern.SUPPORT,
@@ -121,7 +126,7 @@ class AgentCreate(BaseModel):
 class AgentInfo(BaseModel):
     """Agent information"""
 
-    agent_id: str
+    agent_id: str = Field(..., pattern=AGENT_ID_PATTERN)
     namespace: str
     pattern: AgentPattern
     description: str | None = None

--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -15,7 +15,7 @@ from memanto.app.config import get_data_dir
 from memanto.app.core import agent_namespace
 from memanto.app.models.session import AgentCreate, AgentInfo, AgentList
 from memanto.app.utils.errors import AgentAlreadyExistsError, AgentNotFoundError
-from memanto.app.utils.validation import validate_safe_id
+from memanto.app.utils.validation import validate_agent_id
 
 
 class AgentService:
@@ -37,12 +37,11 @@ class AgentService:
 
         Format: memanto_agent_{agent_id}
         """
-        return agent_namespace(agent_id)
+        return agent_namespace(validate_agent_id(agent_id))
 
     def _get_agent_file(self, agent_id: str) -> Path:
         """Get file path for agent metadata"""
-        validate_safe_id(agent_id, "agent_id")
-        return self.agents_dir / f"{agent_id}.json"
+        return self.agents_dir / f"{validate_agent_id(agent_id)}.json"
 
     def create_agent(
         self, agent_create: AgentCreate, moorcheh_api_key: str

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -225,7 +225,7 @@ class SessionService:
                     raise InvalidSessionTokenError(
                         f"Session {token.session_id} is no longer active"
                     )
-            except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            except (OSError, ValueError, json.JSONDecodeError, ValidationError) as exc:
                 raise InvalidSessionTokenError(
                     f"Session {token.session_id} is no longer active"
                 ) from exc
@@ -511,7 +511,7 @@ class SessionService:
 
     def _set_active_session(self, agent_id: str) -> None:
         """Mark session as active"""
-        validate_safe_id(agent_id, "agent_id")
+        agent_id = validate_agent_id(agent_id)
         active_link = self.sessions_dir / "active"
 
         # Remove existing active link
@@ -519,7 +519,6 @@ class SessionService:
             active_link.unlink()
 
         # Create new active marker
-        agent_id = validate_agent_id(agent_id)
         # On Windows, write agent_id to file instead of symlink
         try:
             active_link.symlink_to(f"{agent_id}.json")

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -422,7 +422,6 @@ class SessionService:
             memory_id: The Moorcheh memory ID (if available)
         """
         # Get the timestamp of memory to determine the date string
-        validate_safe_id(agent_id, "agent_id")
         validate_safe_id(session_id, "session_id")
         dt_now = getattr(memory_record, "created_at", utc_now())
         timestamp = dt_now.strftime("%Y-%m-%d %H:%M:%S")
@@ -484,7 +483,6 @@ class SessionService:
             session_id: The current session's identifier
             memory_id: The Moorcheh memory ID that was deleted
         """
-        validate_safe_id(agent_id, "agent_id")
         validate_safe_id(session_id, "session_id")
 
         dt_now = utc_now()

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -32,7 +32,7 @@ from memanto.app.utils.errors import (
 )
 from memanto.app.utils.ids import generate_id
 from memanto.app.utils.temporal_helpers import as_utc_naive, utc_now
-from memanto.app.utils.validation import validate_safe_id
+from memanto.app.utils.validation import validate_agent_id, validate_safe_id
 
 _session_service = None
 logger = logging.getLogger(__name__)
@@ -121,7 +121,7 @@ class SessionService:
 
         Format: memanto_agent_{agent_id}
         """
-        return agent_namespace(agent_id)
+        return agent_namespace(validate_agent_id(agent_id))
 
     def _generate_session_id(self) -> str:
         """Generate unique session ID"""
@@ -145,6 +145,8 @@ class SessionService:
         Returns:
             Session object with JWT token
         """
+        agent_id = validate_agent_id(agent_id)
+
         # Use config default if not explicitly provided
         if duration_hours is None:
             duration_hours = settings.SESSION_DEFAULT_DURATION_HOURS
@@ -245,8 +247,7 @@ class SessionService:
         Returns:
             Session object or None if not found
         """
-        validate_safe_id(agent_id, "agent_id")
-        session_file = self.sessions_dir / f"{agent_id}.json"
+        session_file = self.sessions_dir / f"{validate_agent_id(agent_id)}.json"
         return self._load_session_file(session_file)
 
     def get_active_session(self) -> Session | None:
@@ -268,7 +269,11 @@ class SessionService:
             with open(active_link) as f:
                 agent_id = f.read().strip()
 
-        session = self.get_session(agent_id)
+        try:
+            session = self.get_session(validate_agent_id(agent_id))
+        except ValueError:
+            self._clear_active_session()
+            return None
         if not session:
             return None
 
@@ -292,7 +297,7 @@ class SessionService:
         Raises:
             SessionNotFoundError: If session doesn't exist
         """
-        session = self.get_session(agent_id)
+        session = self.get_session(validate_agent_id(agent_id))
         if not session:
             raise SessionNotFoundError(f"No session found for agent {agent_id}")
 
@@ -365,7 +370,7 @@ class SessionService:
         if not settings.SESSION_AUTO_RENEW_ENABLED:
             return None
 
-        session = self.get_session(agent_id)
+        session = self.get_session(validate_agent_id(agent_id))
         if not session or not session.is_active():
             return None
 
@@ -383,8 +388,7 @@ class SessionService:
 
     def _save_session(self, session: Session) -> None:
         """Save session to file"""
-        validate_safe_id(session.agent_id, "agent_id")
-        session_file = self.sessions_dir / f"{session.agent_id}.json"
+        session_file = self.sessions_dir / f"{validate_agent_id(session.agent_id)}.json"
         with open(session_file, "w") as f:
             json.dump(session.model_dump(mode="json"), f, indent=2)
 
@@ -424,6 +428,7 @@ class SessionService:
         timestamp = dt_now.strftime("%Y-%m-%d %H:%M:%S")
         date_str = dt_now.strftime("%Y-%m-%d")
 
+        agent_id = validate_agent_id(agent_id)
         summary_file = (
             self.sessions_dir / f"{agent_id}_{date_str}_{session_id}_summary.md"
         )
@@ -486,6 +491,7 @@ class SessionService:
         timestamp = dt_now.strftime("%Y-%m-%d %H:%M:%S")
         date_str = dt_now.strftime("%Y-%m-%d")
 
+        agent_id = validate_agent_id(agent_id)
         summary_file = (
             self.sessions_dir / f"{agent_id}_{date_str}_{session_id}_summary.md"
         )
@@ -513,6 +519,7 @@ class SessionService:
             active_link.unlink()
 
         # Create new active marker
+        agent_id = validate_agent_id(agent_id)
         # On Windows, write agent_id to file instead of symlink
         try:
             active_link.symlink_to(f"{agent_id}.json")

--- a/memanto/app/utils/validation.py
+++ b/memanto/app/utils/validation.py
@@ -25,7 +25,8 @@ def validate_agent_id(agent_id: str) -> str:
     """
     if not isinstance(agent_id, str) or not _AGENT_ID_RE.fullmatch(agent_id):
         raise ValueError(
-            "Invalid agent_id. Use only letters, numbers, hyphens, and underscores."
+            "Invalid agent_id contains invalid characters. "
+            "Use only letters, numbers, hyphens, and underscores."
         )
     return agent_id
 

--- a/memanto/app/utils/validation.py
+++ b/memanto/app/utils/validation.py
@@ -10,6 +10,26 @@ from fastapi import HTTPException
 from pydantic import BaseModel, Field, validator
 
 
+AGENT_ID_PATTERN = r"^[a-zA-Z0-9_-]+$"
+_AGENT_ID_RE = re.compile(AGENT_ID_PATTERN)
+
+
+def validate_agent_id(agent_id: str) -> str:
+    """Validate agent IDs before using them in namespaces or local file paths.
+
+    Agent IDs are interpolated into filenames such as
+    ``~/.memanto/agents/{agent_id}.json`` and
+    ``~/.memanto/sessions/{agent_id}.json``. Keep the runtime check in one
+    place so callers that bypass the API/Pydantic request model cannot smuggle
+    path separators (for example ``../``) into those file operations.
+    """
+    if not isinstance(agent_id, str) or not _AGENT_ID_RE.fullmatch(agent_id):
+        raise ValueError(
+            "Invalid agent_id. Use only letters, numbers, hyphens, and underscores."
+        )
+    return agent_id
+
+
 class InputLimits:
     """Input size and cost limits"""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,6 +14,7 @@ from memanto.app.config import settings
 from memanto.app.models.session import AgentCreate, AgentPattern, Session, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
+from memanto.app.utils.errors import InvalidSessionTokenError
 
 
 class TestSessionService:
@@ -175,6 +176,14 @@ class TestSessionService:
             "sess-older",
         ]
 
+    def test_validate_session_translates_invalid_agent_id_lookup(self, session_service):
+        """Invalid persisted/legacy token agent ids should use invalid-token errors."""
+        session = session_service.create_session(agent_id="test-agent", duration_hours=1)
+
+        with patch.object(session_service, "get_session", side_effect=ValueError):
+            with pytest.raises(InvalidSessionTokenError, match="no longer active"):
+                session_service.validate_session(session.session_token)
+
     def test_validate_expired_session(self, session_service):
         """Test session validation fails for expired session"""
         # Create session with very short duration
@@ -252,6 +261,16 @@ class TestSessionService:
         (session_service.sessions_dir / "broken-agent.json").write_text("{")
 
         assert session_service.get_active_session() is None
+
+    def test_set_active_session_validates_before_replacing_marker(self, session_service):
+        """An invalid agent id must not delete the currently active marker."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.write_text("current-agent")
+
+        with pytest.raises(ValueError, match="Invalid agent_id"):
+            session_service._set_active_session("../outside")
+
+        assert active_marker.read_text() == "current-agent"
 
     def test_list_sessions_skips_invalid_session_files(self, session_service):
         """One corrupt session record must not hide all valid sessions."""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -67,6 +67,20 @@ class TestSessionService:
         print(f"   Namespace: {session.namespace}")
         print(f"   Expires in: {time_diff / 3600:.2f} hours")
 
+    def test_create_session_rejects_path_traversal_agent_id(self, session_service, tmp_path):
+        """Session files must stay inside the configured sessions directory."""
+        outside_target = tmp_path / "outside.json"
+
+        with pytest.raises(ValueError, match="Invalid agent_id"):
+            session_service.create_session(agent_id="../outside", duration_hours=1)
+
+        assert not outside_target.exists()
+
+    def test_get_session_rejects_path_traversal_agent_id(self, session_service):
+        """Lookup paths must not be attacker-controlled through agent_id."""
+        with pytest.raises(ValueError, match="Invalid agent_id"):
+            session_service.get_session("../outside")
+
     def test_validate_session(self, session_service):
         """Test session validation"""
         # Create session
@@ -305,6 +319,14 @@ class TestAgentService:
         print("✅ Agent created successfully")
         print(f"   Agent ID: {agent.agent_id}")
         print(f"   Namespace: {agent.namespace}")
+
+    def test_agent_service_rejects_path_traversal_agent_id(self, agent_service):
+        """Agent metadata reads/deletes must not escape the agents directory."""
+        with pytest.raises(ValueError, match="Invalid agent_id"):
+            agent_service.get_agent("../outside")
+
+        with pytest.raises(ValueError, match="Invalid agent_id"):
+            agent_service.delete_agent("../outside")
 
     def test_list_agents(self, agent_service):
         """Test listing agents"""


### PR DESCRIPTION
## Summary
- add a shared agent_id validator for the documented alphanumeric / hyphen / underscore format
- enforce that validation before agent/session metadata paths and summary files are built
- clear invalid active-session markers instead of following attacker-controlled path fragments
- add regression tests for `../` traversal attempts against agent and session services

## Security impact
Direct service/SDK callers could pass path separators in `agent_id`, causing local agent/session metadata operations to resolve outside the configured Memanto data directories. This closes that bypass for the bug challenge.

## Verification
- `pytest -q`

Fixes #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened `agent_id` validation across session and agent models using a shared allowlist pattern.
  * Normalized/validated `agent_id` consistently for namespace generation and on-disk persistence/lookup, preventing invalid IDs from impacting stored files.
  * Hardened session token handling by treating unvalidated `agent_id` states as invalid and clearing active-session markers when validation fails.
* **Tests**
  * Added/extended unit tests to verify invalid `agent_id` handling and path-traversal protection for sessions and agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->