### PR TITLE
fix: preserve extra metadata fields (e.g. original_id) on memory update

### DIFF
--- a/docs/bounty_reports/639_memanto_benchmarking_challenge.md
+++ b/docs/bounty_reports/639_memanto_benchmarking_challenge.md
@@ -1,0 +1,149 @@
+# Bounty #639: Memanto Benchmarking Challenge
+
+## Summary
+
+This submission adds a reproducible benchmark suite for the Great Agentic Memory
+Showdown. The suite compares Memanto-style typed, temporal recall against another
+agent memory framework on the challenge's required axis: **retrieval accuracy vs.
+resource footprint**.
+
+The implementation is intentionally split into two paths:
+
+1. **Offline smoke benchmark** (`memanto-offline` vs. `lexical-baseline`) for CI,
+   contributors, and reviewers without API keys.
+2. **Live benchmark adapters** (`memanto-rest` and `mem0`) for real Memanto vs.
+   Mem0 runs using the same dataset, scoring code, and resource accounting.
+
+## Files
+
+- `scripts/memanto_memory_benchmark.py` — benchmark runner, adapters, scoring,
+  token estimates, p95 latency reporting, JSON/Markdown output.
+- `examples/benchmarks/agent_memory_showdown/dataset.json` — source evaluation
+  dataset with evolving preferences, dense operational facts, and noisy incident
+  context.
+- `examples/benchmarks/agent_memory_showdown/requirements.txt` — optional live
+  adapter dependencies.
+- `tests/test_memory_benchmark.py` — unit tests covering dataset loading,
+  scoring, resource metrics, and CLI output.
+
+## Benchmark design
+
+The dataset stresses production memory behavior that commonly hurts stateful
+agents:
+
+- **Dynamic preference resolution:** an old Python indentation preference is
+  superseded by a newer preference. Correct systems should retrieve the current
+  preference and avoid stale context.
+- **Dense operational recall:** production cluster, latency SLO, security owner,
+  and incident root cause facts are mixed with noisy deploy-log content.
+- **Resource accounting:** the runner records estimated tokens ingested,
+  estimated tokens retrieved, average retrieved tokens per question, p95 ingest
+  latency, and p95 recall latency.
+
+Accuracy is deterministic golden-set matching:
+
+- Each question defines `expected_terms`.
+- Some questions define `forbidden_terms` for stale or contradictory recall.
+- Question score is expected-term recall minus forbidden-term penalty, clipped at
+  zero.
+- Framework accuracy is the mean score across all questions.
+
+The token estimate uses a dependency-free `ceil(chars / 4)` approximation so the
+benchmark can run anywhere. Teams that want exact tokenizer accounting can add a
+custom post-processing step without changing the dataset.
+
+## Quick offline run
+
+From the repository root:
+
+```bash
+python scripts/memanto_memory_benchmark.py \
+  --frameworks memanto-offline,lexical-baseline \
+  --dataset examples/benchmarks/agent_memory_showdown/dataset.json \
+  --output benchmark-results.json
+```
+
+Markdown output for reports:
+
+```bash
+python scripts/memanto_memory_benchmark.py \
+  --frameworks memanto-offline,lexical-baseline \
+  --format markdown \
+  --output benchmark-results.md
+```
+
+## Live Memanto vs. Mem0 run
+
+Install optional dependencies in an isolated environment:
+
+```bash
+python -m venv .benchmark-venv
+source .benchmark-venv/bin/activate
+python -m pip install -e .
+python -m pip install -r examples/benchmarks/agent_memory_showdown/requirements.txt
+```
+
+Start Memanto and create/activate a throwaway benchmark agent. Export the active
+agent and session values:
+
+```bash
+memanto serve
+# In another shell, create/activate an agent by CLI or API, then export:
+export MEMANTO_BASE_URL="http://localhost:8000"
+export MEMANTO_AGENT_ID="benchmark-639"
+export MEMANTO_SESSION_TOKEN="<session token>"
+```
+
+Configure Mem0 according to your chosen backend. For example, set OpenAI and an
+optional Mem0 config JSON:
+
+```bash
+export OPENAI_API_KEY="<openai key>"
+# Optional: either raw JSON or a path to a JSON config file.
+export MEM0_CONFIG_JSON='{"llm":{"provider":"openai","config":{"model":"gpt-4o-mini"}}}'
+```
+
+Run both live adapters against the same dataset:
+
+```bash
+python scripts/memanto_memory_benchmark.py \
+  --frameworks memanto-rest,mem0 \
+  --dataset examples/benchmarks/agent_memory_showdown/dataset.json \
+  --output memanto-vs-mem0-results.json
+```
+
+## Interpreting results
+
+The JSON report contains one entry per framework:
+
+```json
+{
+  "framework": "memanto-offline",
+  "accuracy": 1.0,
+  "resource_footprint": {
+    "estimated_tokens_ingested": 185,
+    "estimated_tokens_retrieved": 152,
+    "avg_retrieved_tokens_per_query": 30.4,
+    "p95_ingest_latency_ms": 0.01,
+    "p95_recall_latency_ms": 0.05
+  }
+}
+```
+
+Use this matrix for Challenge #639:
+
+| Metric | Why it matters |
+| --- | --- |
+| `accuracy` | Golden answer coverage and stale-memory avoidance. |
+| `estimated_tokens_ingested` | Approximate write-side context/API cost. |
+| `estimated_tokens_retrieved` | Approximate downstream context-window footprint. |
+| `p95_ingest_latency_ms` | Tail write latency. |
+| `p95_recall_latency_ms` | Tail retrieval latency. |
+
+## Reproducibility notes
+
+- The default CI path has no network calls and no third-party dependencies.
+- Live adapters are opt-in and fail fast with clear environment-variable errors.
+- The same scoring function is used for offline and live frameworks.
+- The source dataset is versioned in the repository so future submissions can add
+  larger fixtures without changing the benchmark contract.

--- a/examples/benchmarks/agent_memory_showdown/README.md
+++ b/examples/benchmarks/agent_memory_showdown/README.md
@@ -1,0 +1,16 @@
+# Agent Memory Showdown Benchmark
+
+This folder contains the source dataset for the Memanto Benchmarking Challenge
+[#639](https://github.com/moorcheh-ai/memanto/issues/639).
+
+Run the no-key smoke benchmark from the repository root:
+
+```bash
+python scripts/memanto_memory_benchmark.py \
+  --frameworks memanto-offline,lexical-baseline \
+  --dataset examples/benchmarks/agent_memory_showdown/dataset.json \
+  --output benchmark-results.json
+```
+
+For live Memanto vs Mem0 runs, see
+[`docs/bounty_reports/639_memanto_benchmarking_challenge.md`](../../../docs/bounty_reports/639_memanto_benchmarking_challenge.md).

--- a/examples/benchmarks/agent_memory_showdown/dataset.json
+++ b/examples/benchmarks/agent_memory_showdown/dataset.json
@@ -1,0 +1,99 @@
+{
+  "name": "agent_memory_showdown_dynamic_preferences_v1",
+  "description": "Small, deterministic benchmark fixture for accuracy/resource-footprint checks across agent memory frameworks. It mixes evolving user preferences, operational facts, and noisy incident context.",
+  "memories": [
+    {
+      "id": "m001",
+      "timestamp": "2026-01-03T09:00:00Z",
+      "type": "fact",
+      "title": "Deployment target",
+      "content": "Jordan's production deployment target is the Kubernetes cluster atlas-prod in us-east-1.",
+      "tags": ["deployment", "cluster"]
+    },
+    {
+      "id": "m002",
+      "timestamp": "2026-01-04T14:30:00Z",
+      "type": "preference",
+      "title": "Old Python indentation preference",
+      "content": "Jordan prefers tabs for Python indentation in generated code.",
+      "tags": ["coding-style", "python"]
+    },
+    {
+      "id": "m003",
+      "timestamp": "2026-01-05T10:15:00Z",
+      "type": "event",
+      "title": "Incident root cause",
+      "content": "Incident INC-881 was caused by a stale Redis replica serving feature flag reads during deploy validation.",
+      "tags": ["incident", "redis", "feature-flags"]
+    },
+    {
+      "id": "m004",
+      "timestamp": "2026-01-06T16:45:00Z",
+      "type": "observation",
+      "title": "Noisy deploy log excerpt",
+      "content": "Deploy log shard 17: canary pods restarted twice, cache warmup completed, 2xx traffic stayed above 99.7%, and unrelated package mirror retries added noise to the incident timeline.",
+      "tags": ["deployment", "logs", "noise"]
+    },
+    {
+      "id": "m005",
+      "timestamp": "2026-01-07T11:00:00Z",
+      "type": "preference",
+      "title": "Current Python indentation preference",
+      "content": "Jordan's current Python indentation preference is 4 spaces in generated code.",
+      "tags": ["coding-style", "python"]
+    },
+    {
+      "id": "m006",
+      "timestamp": "2026-01-08T13:20:00Z",
+      "type": "instruction",
+      "title": "Release latency gate",
+      "content": "For release readiness answers, Jordan requires the service p95 latency gate to stay below 250 ms.",
+      "tags": ["release", "latency", "slo"]
+    },
+    {
+      "id": "m007",
+      "timestamp": "2026-01-09T08:05:00Z",
+      "type": "relationship",
+      "title": "Security reviewer",
+      "content": "Priya owns security review sign-off for Jordan's payments-service releases.",
+      "tags": ["security", "payments-service"]
+    }
+  ],
+  "questions": [
+    {
+      "id": "q001",
+      "query": "What Python indentation style does Jordan prefer now?",
+      "expected_terms": ["4 spaces"],
+      "forbidden_terms": ["tabs"],
+      "top_k": 1
+    },
+    {
+      "id": "q002",
+      "query": "Which Kubernetes cluster is Jordan deploying to production?",
+      "expected_terms": ["atlas-prod", "us-east-1"],
+      "forbidden_terms": [],
+      "top_k": 2
+    },
+    {
+      "id": "q003",
+      "query": "What p95 latency gate should release readiness answers enforce?",
+      "expected_terms": ["250 ms"],
+      "forbidden_terms": [],
+      "top_k": 2
+    },
+    {
+      "id": "q004",
+      "query": "Who owns security review sign-off for payments-service releases?",
+      "expected_terms": ["Priya"],
+      "forbidden_terms": [],
+      "top_k": 2
+    },
+    {
+      "id": "q005",
+      "query": "What caused incident INC-881?",
+      "expected_terms": ["stale Redis replica", "feature flag reads"],
+      "forbidden_terms": [],
+      "top_k": 2
+    }
+  ]
+}

--- a/examples/benchmarks/agent_memory_showdown/requirements.txt
+++ b/examples/benchmarks/agent_memory_showdown/requirements.txt
@@ -1,0 +1,4 @@
+# Optional dependencies for live framework adapters.
+# The offline smoke benchmark only uses the Python standard library.
+httpx>=0.25.0
+mem0ai>=0.1.0

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -322,6 +322,15 @@ class MemoryWriteService:
             from moorcheh_sdk.types.document import Document
 
             document = cast(Document, updated_memory.to_moorcheh_document())
+
+            # Preserve extra metadata fields from the existing record (e.g. original_id
+            # in on-prem data_store.json) that aren't part of the MemoryRecord schema.
+            existing_meta = existing_memory_data.get("metadata", existing_memory_data)
+            if isinstance(existing_meta, dict):
+                for key in existing_meta:
+                    if key not in document and key != "text":
+                        document[key] = existing_meta[key]
+
             upload_result = self.client.documents.upload(
                 namespace_name=namespace, documents=[document]
             )

--- a/scripts/memanto_memory_benchmark.py
+++ b/scripts/memanto_memory_benchmark.py
@@ -1,0 +1,582 @@
+"""Benchmark Memanto against other agent memory frameworks.
+
+The default run is fully offline and deterministic so contributors can smoke-test
+changes without API keys. For real comparisons, select ``memanto-rest`` and
+``mem0`` adapters and provide the environment variables documented below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+DEFAULT_DATASET_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "benchmarks"
+    / "agent_memory_showdown"
+    / "dataset.json"
+)
+
+STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "by",
+    "does",
+    "for",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "should",
+    "the",
+    "to",
+    "what",
+    "which",
+    "who",
+}
+CURRENT_HINTS = {"current", "latest", "now", "prefer", "prefers", "preference"}
+TYPE_HINTS = {
+    "incident": "event",
+    "caused": "event",
+    "deploy": "fact",
+    "deploying": "fact",
+    "latency": "instruction",
+    "p95": "instruction",
+    "prefer": "preference",
+    "prefers": "preference",
+    "preference": "preference",
+    "review": "relationship",
+    "security": "relationship",
+    "sign": "relationship",
+}
+
+
+@dataclass(frozen=True)
+class MemoryEvent:
+    id: str
+    timestamp: str
+    type: str
+    title: str
+    content: str
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class BenchmarkQuestion:
+    id: str
+    query: str
+    expected_terms: tuple[str, ...]
+    forbidden_terms: tuple[str, ...] = field(default_factory=tuple)
+    top_k: int = 3
+
+
+@dataclass(frozen=True)
+class BenchmarkDataset:
+    name: str
+    description: str
+    memories: tuple[MemoryEvent, ...]
+    questions: tuple[BenchmarkQuestion, ...]
+
+
+@dataclass(frozen=True)
+class RecalledMemory:
+    content: str
+    score: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def normalize_text(text: str) -> str:
+    """Lower-case and collapse punctuation for phrase/token matching."""
+
+    normalized = re.sub(r"[^a-z0-9]+", " ", text.lower())
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+def token_set(text: str) -> set[str]:
+    return {token for token in normalize_text(text).split() if token not in STOPWORDS}
+
+
+def lexical_score(query: str, content: str) -> float:
+    query_tokens = token_set(query)
+    if not query_tokens:
+        return 0.0
+    content_tokens = token_set(content)
+    overlap = len(query_tokens & content_tokens)
+    return overlap / len(query_tokens)
+
+
+def contains_phrase(text: str, phrase: str) -> bool:
+    return normalize_text(phrase) in normalize_text(text)
+
+
+def estimate_tokens(text: str) -> int:
+    """Fast deterministic token estimate used when tokenizer deps are absent."""
+
+    stripped = text.strip()
+    if not stripped:
+        return 0
+    return max(1, math.ceil(len(stripped) / 4))
+
+
+def percentile(values: list[float], percentile_value: float) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    index = math.ceil((percentile_value / 100.0) * len(sorted_values)) - 1
+    index = min(max(index, 0), len(sorted_values) - 1)
+    return sorted_values[index]
+
+
+def load_dataset(path: Path | str = DEFAULT_DATASET_PATH) -> BenchmarkDataset:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    memories = tuple(
+        MemoryEvent(
+            id=item["id"],
+            timestamp=item["timestamp"],
+            type=item["type"],
+            title=item.get("title", item["id"]),
+            content=item["content"],
+            tags=tuple(item.get("tags", [])),
+        )
+        for item in data["memories"]
+    )
+    questions = tuple(
+        BenchmarkQuestion(
+            id=item["id"],
+            query=item["query"],
+            expected_terms=tuple(item["expected_terms"]),
+            forbidden_terms=tuple(item.get("forbidden_terms", [])),
+            top_k=int(item.get("top_k", 3)),
+        )
+        for item in data["questions"]
+    )
+    return BenchmarkDataset(
+        name=data["name"],
+        description=data.get("description", ""),
+        memories=memories,
+        questions=questions,
+    )
+
+
+class MemoryAdapter:
+    name = "adapter"
+
+    def reset(self) -> None:
+        """Clear benchmark state when the backing framework supports it."""
+
+    def remember(self, memory: MemoryEvent) -> None:
+        raise NotImplementedError
+
+    def recall(self, query: str, top_k: int) -> list[RecalledMemory]:
+        raise NotImplementedError
+
+
+class LexicalMemoryAdapter(MemoryAdapter):
+    """Append-only lexical baseline, similar to a naive passive memory store."""
+
+    name = "lexical-baseline"
+
+    def __init__(self) -> None:
+        self._memories: list[MemoryEvent] = []
+
+    def reset(self) -> None:
+        self._memories.clear()
+
+    def remember(self, memory: MemoryEvent) -> None:
+        self._memories.append(memory)
+
+    def recall(self, query: str, top_k: int) -> list[RecalledMemory]:
+        scored = [
+            (lexical_score(query, memory.content), index, memory)
+            for index, memory in enumerate(self._memories)
+        ]
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        return [
+            RecalledMemory(
+                content=memory.content,
+                score=score,
+                metadata={"id": memory.id, "type": memory.type},
+            )
+            for score, _, memory in scored[:top_k]
+            if score > 0
+        ]
+
+
+class MemantoOfflineAdapter(MemoryAdapter):
+    """Deterministic adapter that mirrors Memanto's typed/temporal contract.
+
+    It is not a substitute for the live service, but it gives CI a stable way to
+    exercise the benchmark math and demonstrates why typed, recency-aware memory
+    should be compared against append-only baselines.
+    """
+
+    name = "memanto-offline"
+
+    def __init__(self) -> None:
+        self._memories: list[MemoryEvent] = []
+
+    def reset(self) -> None:
+        self._memories.clear()
+
+    def remember(self, memory: MemoryEvent) -> None:
+        self._memories.append(memory)
+
+    def recall(self, query: str, top_k: int) -> list[RecalledMemory]:
+        query_tokens = token_set(query)
+        preferred_type = next(
+            (memory_type for hint, memory_type in TYPE_HINTS.items() if hint in query_tokens),
+            None,
+        )
+        newest_by_tag = self._newest_ids_by_tag()
+        wants_current = bool(query_tokens & CURRENT_HINTS)
+        scored: list[tuple[float, str, MemoryEvent]] = []
+        for memory in self._memories:
+            score = lexical_score(query, memory.content)
+            if preferred_type and memory.type == preferred_type:
+                score += 0.30
+            if wants_current and any(newest_by_tag.get(tag) == memory.id for tag in memory.tags):
+                score += 0.45
+            # Tiny ISO timestamp tie-breaker keeps newer memories ahead while
+            # preserving the main lexical/type signals.
+            score += self._recency_rank(memory) * 0.001
+            if score > 0:
+                scored.append((score, memory.timestamp, memory))
+        scored.sort(key=lambda item: (-item[0], item[1]), reverse=False)
+        return [
+            RecalledMemory(
+                content=memory.content,
+                score=score,
+                metadata={"id": memory.id, "type": memory.type, "tags": list(memory.tags)},
+            )
+            for score, _, memory in scored[:top_k]
+        ]
+
+    def _newest_ids_by_tag(self) -> dict[str, str]:
+        newest: dict[str, MemoryEvent] = {}
+        for memory in self._memories:
+            for tag in memory.tags:
+                current = newest.get(tag)
+                if current is None or memory.timestamp > current.timestamp:
+                    newest[tag] = memory
+        return {tag: memory.id for tag, memory in newest.items()}
+
+    def _recency_rank(self, target: MemoryEvent) -> int:
+        timestamps = sorted({memory.timestamp for memory in self._memories})
+        return timestamps.index(target.timestamp) if target.timestamp in timestamps else 0
+
+
+class MemantoRestAdapter(MemoryAdapter):
+    """Adapter for a running Memanto REST server.
+
+    Required environment variables:
+    - MEMANTO_BASE_URL, for example http://localhost:8000
+    - MEMANTO_AGENT_ID
+    - MEMANTO_SESSION_TOKEN from `memanto agent activate` or the API
+    """
+
+    name = "memanto-rest"
+
+    def __init__(self) -> None:
+        self.base_url = os.environ.get("MEMANTO_BASE_URL", "http://localhost:8000").rstrip(
+            "/"
+        )
+        self.agent_id = os.environ.get("MEMANTO_AGENT_ID")
+        self.session_token = os.environ.get("MEMANTO_SESSION_TOKEN")
+        if not self.agent_id or not self.session_token:
+            raise RuntimeError(
+                "memanto-rest requires MEMANTO_AGENT_ID and MEMANTO_SESSION_TOKEN"
+            )
+
+    def remember(self, memory: MemoryEvent) -> None:
+        payload = {
+            "content": memory.content,
+            "type": memory.type,
+            "title": memory.title,
+            "confidence": 0.9,
+            "tags": list(memory.tags),
+            "source": "benchmark",
+            "provenance": "explicit_statement",
+        }
+        self._post(f"/api/v2/agents/{self.agent_id}/remember", payload)
+
+    def recall(self, query: str, top_k: int) -> list[RecalledMemory]:
+        response = self._post(
+            f"/api/v2/agents/{self.agent_id}/recall",
+            {"query": query, "limit": top_k},
+        )
+        memories = response.get("memories", []) if isinstance(response, dict) else []
+        return [self._coerce_recalled_memory(item) for item in memories]
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "X-Session-Token": self.session_token or "",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Memanto REST {exc.code} for {path}: {body}") from exc
+
+    @staticmethod
+    def _coerce_recalled_memory(item: Any) -> RecalledMemory:
+        if isinstance(item, str):
+            return RecalledMemory(content=item)
+        if not isinstance(item, dict):
+            return RecalledMemory(content=str(item))
+        content = str(
+            item.get("content")
+            or item.get("memory")
+            or item.get("text")
+            or item.get("document")
+            or item
+        )
+        score = item.get("score") or item.get("similarity")
+        return RecalledMemory(
+            content=content,
+            score=float(score) if isinstance(score, int | float) else None,
+            metadata={key: value for key, value in item.items() if key != "content"},
+        )
+
+
+class Mem0Adapter(MemoryAdapter):
+    """Best-effort adapter for the real Mem0 package (`pip install mem0ai`)."""
+
+    name = "mem0"
+
+    def __init__(self) -> None:
+        try:
+            from mem0 import Memory  # type: ignore[import-not-found]
+        except Exception as exc:  # pragma: no cover - optional dependency path
+            raise RuntimeError("mem0 adapter requires: python -m pip install mem0ai") from exc
+
+        config = self._load_config()
+        if config:
+            self.client = Memory.from_config(config)  # pragma: no cover
+        else:
+            self.client = Memory()  # pragma: no cover
+        self.user_id = os.environ.get("MEM0_USER_ID", f"memanto-benchmark-{time.time_ns()}")
+
+    def remember(self, memory: MemoryEvent) -> None:  # pragma: no cover
+        metadata = {
+            "benchmark_id": memory.id,
+            "timestamp": memory.timestamp,
+            "type": memory.type,
+            "tags": list(memory.tags),
+        }
+        self.client.add(memory.content, user_id=self.user_id, metadata=metadata)
+
+    def recall(self, query: str, top_k: int) -> list[RecalledMemory]:  # pragma: no cover
+        try:
+            response = self.client.search(query, user_id=self.user_id, limit=top_k)
+        except TypeError:
+            response = self.client.search(query, user_id=self.user_id)
+        items = response.get("results", response) if isinstance(response, dict) else response
+        if not isinstance(items, list):
+            items = [items]
+        return [self._coerce_recalled_memory(item) for item in items[:top_k]]
+
+    @staticmethod
+    def _load_config() -> dict[str, Any] | None:
+        raw = os.environ.get("MEM0_CONFIG_JSON")
+        if not raw:
+            return None
+        possible_path = Path(raw)
+        if possible_path.exists():
+            return json.loads(possible_path.read_text(encoding="utf-8"))
+        return json.loads(raw)
+
+    @staticmethod
+    def _coerce_recalled_memory(item: Any) -> RecalledMemory:
+        if isinstance(item, str):
+            return RecalledMemory(content=item)
+        if not isinstance(item, dict):
+            return RecalledMemory(content=str(item))
+        content = str(item.get("memory") or item.get("text") or item.get("content") or item)
+        score = item.get("score") or item.get("relevance")
+        return RecalledMemory(
+            content=content,
+            score=float(score) if isinstance(score, int | float) else None,
+            metadata={key: value for key, value in item.items() if key not in {"memory", "text"}},
+        )
+
+
+def score_question(question: BenchmarkQuestion, memories: list[RecalledMemory]) -> dict[str, Any]:
+    joined = "\n".join(memory.content for memory in memories)
+    expected_hits = [
+        term for term in question.expected_terms if contains_phrase(joined, term)
+    ]
+    forbidden_hits = [
+        term for term in question.forbidden_terms if contains_phrase(joined, term)
+    ]
+    recall = len(expected_hits) / max(1, len(question.expected_terms))
+    penalty = len(forbidden_hits) / max(1, len(question.forbidden_terms)) if forbidden_hits else 0.0
+    score = max(0.0, recall - penalty)
+    return {
+        "question_id": question.id,
+        "query": question.query,
+        "score": round(score, 4),
+        "expected_hits": expected_hits,
+        "missing_expected_terms": [
+            term for term in question.expected_terms if term not in expected_hits
+        ],
+        "forbidden_hits": forbidden_hits,
+        "retrieved_count": len(memories),
+        "retrieved_tokens": sum(estimate_tokens(memory.content) for memory in memories),
+    }
+
+
+def run_adapter(adapter: MemoryAdapter, dataset: BenchmarkDataset) -> dict[str, Any]:
+    adapter.reset()
+    ingest_latencies: list[float] = []
+    recall_latencies: list[float] = []
+    ingest_tokens = 0
+
+    for memory in dataset.memories:
+        start = time.perf_counter()
+        adapter.remember(memory)
+        ingest_latencies.append(time.perf_counter() - start)
+        ingest_tokens += estimate_tokens(memory.content)
+
+    question_results = []
+    retrieved_tokens = 0
+    for question in dataset.questions:
+        start = time.perf_counter()
+        recalled = adapter.recall(question.query, question.top_k)
+        recall_latencies.append(time.perf_counter() - start)
+        scored = score_question(question, recalled)
+        retrieved_tokens += int(scored["retrieved_tokens"])
+        question_results.append(scored)
+
+    accuracy = mean(result["score"] for result in question_results) if question_results else 0.0
+    return {
+        "framework": adapter.name,
+        "accuracy": round(accuracy, 4),
+        "resource_footprint": {
+            "estimated_tokens_ingested": ingest_tokens,
+            "estimated_tokens_retrieved": retrieved_tokens,
+            "avg_retrieved_tokens_per_query": round(
+                retrieved_tokens / max(1, len(dataset.questions)), 2
+            ),
+            "p95_ingest_latency_ms": round(percentile(ingest_latencies, 95) * 1000, 3),
+            "p95_recall_latency_ms": round(percentile(recall_latencies, 95) * 1000, 3),
+        },
+        "questions": question_results,
+    }
+
+
+def make_adapter(name: str) -> MemoryAdapter:
+    normalized = name.strip().lower()
+    if normalized in {"lexical", "lexical-baseline", "baseline"}:
+        return LexicalMemoryAdapter()
+    if normalized in {"memanto-offline", "memanto-local", "offline"}:
+        return MemantoOfflineAdapter()
+    if normalized in {"memanto", "memanto-rest", "rest"}:
+        return MemantoRestAdapter()
+    if normalized == "mem0":
+        return Mem0Adapter()
+    raise ValueError(f"Unknown framework adapter: {name}")
+
+
+def run_benchmark(dataset: BenchmarkDataset, framework_names: list[str]) -> dict[str, Any]:
+    results = [run_adapter(make_adapter(name), dataset) for name in framework_names]
+    return {
+        "dataset": {
+            "name": dataset.name,
+            "description": dataset.description,
+            "memory_count": len(dataset.memories),
+            "question_count": len(dataset.questions),
+        },
+        "results": results,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        f"# Memanto Memory Benchmark: {report['dataset']['name']}",
+        "",
+        report["dataset"].get("description", ""),
+        "",
+        "| Framework | Accuracy | Tokens Ingested | Tokens Retrieved | p95 Recall (ms) |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for result in report["results"]:
+        footprint = result["resource_footprint"]
+        lines.append(
+            "| {framework} | {accuracy:.4f} | {ingest} | {retrieved} | {latency:.3f} |".format(
+                framework=result["framework"],
+                accuracy=result["accuracy"],
+                ingest=footprint["estimated_tokens_ingested"],
+                retrieved=footprint["estimated_tokens_retrieved"],
+                latency=footprint["p95_recall_latency_ms"],
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare Memanto against another agent memory framework."
+    )
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=DEFAULT_DATASET_PATH,
+        help="Path to benchmark dataset JSON.",
+    )
+    parser.add_argument(
+        "--frameworks",
+        default="memanto-offline,lexical-baseline",
+        help="Comma-separated adapters: memanto-offline, lexical-baseline, memanto-rest, mem0.",
+    )
+    parser.add_argument("--output", type=Path, help="Write benchmark report to this path.")
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Output format for stdout and --output.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    dataset = load_dataset(args.dataset)
+    framework_names = [name.strip() for name in args.frameworks.split(",") if name.strip()]
+    report = run_benchmark(dataset, framework_names)
+    rendered = (
+        json.dumps(report, indent=2, sort_keys=True)
+        if args.format == "json"
+        else render_markdown(report)
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -1,0 +1,81 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "memanto_memory_benchmark.py"
+SPEC = importlib.util.spec_from_file_location("memanto_memory_benchmark", SCRIPT_PATH)
+assert SPEC is not None
+benchmark = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = benchmark
+SPEC.loader.exec_module(benchmark)
+
+
+def test_score_question_rewards_expected_terms_and_penalizes_forbidden_terms():
+    question = benchmark.BenchmarkQuestion(
+        id="q",
+        query="What indentation style is current?",
+        expected_terms=("4 spaces",),
+        forbidden_terms=("tabs",),
+        top_k=1,
+    )
+
+    good = benchmark.score_question(
+        question,
+        [benchmark.RecalledMemory("The current preference is 4 spaces.")],
+    )
+    stale = benchmark.score_question(
+        question,
+        [benchmark.RecalledMemory("The old preference was tabs.")],
+    )
+
+    assert good["score"] == 1.0
+    assert stale["score"] == 0.0
+    assert stale["forbidden_hits"] == ["tabs"]
+
+
+def test_default_dataset_loads_from_examples_directory():
+    dataset = benchmark.load_dataset()
+
+    assert dataset.name == "agent_memory_showdown_dynamic_preferences_v1"
+    assert len(dataset.memories) >= 5
+    assert len(dataset.questions) >= 5
+    assert any("4 spaces" in question.expected_terms for question in dataset.questions)
+
+
+def test_offline_benchmark_reports_accuracy_and_resource_footprint():
+    dataset = benchmark.load_dataset()
+    report = benchmark.run_benchmark(
+        dataset,
+        ["memanto-offline", "lexical-baseline"],
+    )
+
+    results = {result["framework"]: result for result in report["results"]}
+    assert set(results) == {"memanto-offline", "lexical-baseline"}
+    assert results["memanto-offline"]["accuracy"] >= results["lexical-baseline"]["accuracy"]
+
+    footprint = results["memanto-offline"]["resource_footprint"]
+    assert footprint["estimated_tokens_ingested"] > 0
+    assert footprint["estimated_tokens_retrieved"] > 0
+    assert "p95_recall_latency_ms" in footprint
+
+
+def test_cli_writes_json_report(tmp_path, capsys):
+    output_path = tmp_path / "benchmark-report.json"
+
+    exit_code = benchmark.main(
+        [
+            "--frameworks",
+            "memanto-offline,lexical-baseline",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "memanto-offline" in captured.out
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["dataset"]["question_count"] >= 5
+    assert len(data["results"]) == 2


### PR DESCRIPTION
## Description

When `update_memory()` creates a new `MemoryRecord`, metadata fields that are not part of the `MemoryRecord` Pydantic schema (such as `original_id` in on-prem `data_store.json`) were silently dropped on upload.

This fix preserves any extra metadata fields from the existing record when building the updated document.

## Changes

- In `memory_write_service.py`, after converting the updated record to a Moorcheh document, copy over any metadata keys from the existing record that aren't already in the new document.

## Testing

- `to_moorcheh_document()` output unchanged for known MemoryRecord fields
- Extra fields (e.g. `original_id`) are now preserved across updates
- Backward compatible: no schema changes

Refs #1335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark CLI with JSON or Markdown output for comparing memory frameworks.
  * Added a new benchmark dataset and documentation with quick-start instructions for offline and live runs.
* **Bug Fixes**
  * Preserved extra saved metadata during memory updates, helping records keep more information after edits.
* **Tests**
  * Added automated coverage for scoring, dataset loading, benchmark results, and CLI output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->