### PR TITLE
fix(cli): honor instance API keys in backend clients (#770)

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -276,10 +276,10 @@ class DirectClient:
         locally.
         """
         if self._moorcheh is None:
-            from memanto.app.clients.moorcheh import get_moorcheh_client
+            from memanto.app.clients.moorcheh import moorcheh_client
 
             logger.debug("Initializing Moorcheh client via backend dispatcher")
-            self._moorcheh = get_moorcheh_client()
+            self._moorcheh = moorcheh_client.get_client(api_key=self.api_key)
         return self._moorcheh
 
     def _get_write_service(self):

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -108,10 +108,10 @@ class SdkClient:
         either way.
         """
         if self._moorcheh is None:
-            from memanto.app.clients.moorcheh import get_moorcheh_client
+            from memanto.app.clients.moorcheh import moorcheh_client
 
             logger.debug("Initializing Moorcheh client via backend dispatcher")
-            self._moorcheh = get_moorcheh_client()
+            self._moorcheh = moorcheh_client.get_client(api_key=self.api_key)
         return self._moorcheh
 
     def _get_write_service(self):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,41 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestClientApiKeyDispatch:
+    """CLI clients must honor the api_key supplied to the client instance."""
+
+    @pytest.mark.parametrize(
+        "client_cls_path",
+        [
+            "memanto.cli.client.direct_client.DirectClient",
+            "memanto.cli.client.sdk_client.SdkClient",
+        ],
+    )
+    def test_clients_pass_instance_api_key_to_backend_dispatcher(
+        self, monkeypatch, client_cls_path
+    ):
+        from memanto.app.clients import moorcheh as moorcheh_mod
+
+        calls = []
+        fake_backend = object()
+
+        class Recorder:
+            def get_client(self, api_key=None):
+                calls.append(api_key)
+                return fake_backend
+
+        module_name, class_name = client_cls_path.rsplit(".", 1)
+        module = __import__(module_name, fromlist=[class_name])
+        client_cls = getattr(module, class_name)
+
+        monkeypatch.setattr(moorcheh_mod, "moorcheh_client", Recorder())
+
+        client = client_cls(api_key="mk_instance_specific_key")
+
+        assert client._get_moorcheh() is fake_backend
+        assert calls == ["mk_instance_specific_key"]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary

- pass each CLI client instance API key into the backend-aware Moorcheh client dispatcher
- cover both `DirectClient` and `SdkClient` with a regression test

## Flaw and impact

`DirectClient(api_key=...)` and `SdkClient(api_key=...)` stored the provided key, but their lazy `_get_moorcheh()` paths called the global backend dispatcher without passing that key. On the cloud backend, the dispatcher then fell back to the module-level `settings.MOORCHEH_API_KEY` or its cached default client. Because settings are loaded at import time, CLI, MCP, migration, or embedded SDK flows can silently read/write through a stale global key instead of the instance key they were constructed with. In multi-key or switched-account setups this can send memory operations to the wrong Moorcheh account/namespace.

## Reproduction

1. Patch `moorcheh_client.get_client` to record the `api_key` argument it receives.
2. Instantiate `DirectClient(api_key="mk_instance_specific_key")` or `SdkClient(api_key="mk_instance_specific_key")`.
3. Call `_get_moorcheh()`.
4. Before this fix, the recorded `api_key` is `None`; after this fix, it is `mk_instance_specific_key`.

## Fix

Both clients now call `moorcheh_client.get_client(api_key=self.api_key)`. The existing backend-aware behavior is preserved: cloud honors the explicit key, while on-prem continues to ignore the placeholder key and use the local backend.

## Validation

- `conda run -n bounty-memanto-770 python -m pytest tests/test_unit.py::TestClientApiKeyDispatch tests/test_unit.py::TestMemoryWriteServiceDelete tests/test_unit.py::TestForgetEndToEnd -q`
- `conda run -n bounty-memanto-770 python -m ruff check memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_unit.py`
- `conda run -n bounty-memanto-770 python -m pytest -q`

Refs #770

Payment details can be provided privately if accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Client connections now consistently use the API key configured on each client instance when initializing the backend.
  * Added coverage to ensure both client modes pass the correct key through during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->