### PR TITLE
Preserve unmanaged agent rule files on disconnect

### DIFF
--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -233,7 +233,10 @@ def _remove_instructions(
 
     # For dedicated files (cline, roo, continue, augment, cursor)
     if agent.instruction_is_dir or agent.instruction_format == "mdc":
-        existing = instr_path.read_text(encoding="utf-8")
+        try:
+            existing = instr_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return None
         if MEMANTO_SENTINEL not in existing:
             return None
         instr_path.unlink()

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -233,6 +233,9 @@ def _remove_instructions(
 
     # For dedicated files (cline, roo, continue, augment, cursor)
     if agent.instruction_is_dir or agent.instruction_format == "mdc":
+        existing = instr_path.read_text(encoding="utf-8")
+        if MEMANTO_SENTINEL not in existing:
+            return None
         instr_path.unlink()
         # Clean up empty parent dirs
         parent = instr_path.parent

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -15,6 +15,18 @@ def test_remove_dedicated_instruction_preserves_unmanaged_file(tmp_path):
     assert rules_path.read_text(encoding="utf-8") == "User-owned Cursor rules\n"
 
 
+def test_remove_dedicated_instruction_preserves_non_utf8_unmanaged_file(tmp_path):
+    agent = AGENT_REGISTRY["cursor"]
+    rules_path = tmp_path / ".cursor" / "rules" / "memanto.mdc"
+    rules_path.parent.mkdir(parents=True)
+    rules_path.write_bytes(b"\xff\xfeuser-owned rules")
+
+    result = _remove_instructions(agent, tmp_path, is_global=False)
+
+    assert result is None
+    assert rules_path.read_bytes() == b"\xff\xfeuser-owned rules"
+
+
 def test_remove_dedicated_instruction_deletes_memanto_managed_file(tmp_path):
     agent = AGENT_REGISTRY["cursor"]
     rules_path = tmp_path / ".cursor" / "rules" / "memanto.mdc"

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -1,0 +1,27 @@
+from memanto.cli.connect.agent_registry import AGENT_REGISTRY
+from memanto.cli.connect.engine import _remove_instructions
+from memanto.cli.connect.templates import get_instruction_content
+
+
+def test_remove_dedicated_instruction_preserves_unmanaged_file(tmp_path):
+    agent = AGENT_REGISTRY["cursor"]
+    rules_path = tmp_path / ".cursor" / "rules" / "memanto.mdc"
+    rules_path.parent.mkdir(parents=True)
+    rules_path.write_text("User-owned Cursor rules\n", encoding="utf-8")
+
+    result = _remove_instructions(agent, tmp_path, is_global=False)
+
+    assert result is None
+    assert rules_path.read_text(encoding="utf-8") == "User-owned Cursor rules\n"
+
+
+def test_remove_dedicated_instruction_deletes_memanto_managed_file(tmp_path):
+    agent = AGENT_REGISTRY["cursor"]
+    rules_path = tmp_path / ".cursor" / "rules" / "memanto.mdc"
+    rules_path.parent.mkdir(parents=True)
+    rules_path.write_text(get_instruction_content("cursor"), encoding="utf-8")
+
+    result = _remove_instructions(agent, tmp_path, is_global=False)
+
+    assert result == "Removed memanto.mdc"
+    assert not rules_path.exists()


### PR DESCRIPTION
## Summary
- keep dedicated agent rule files when they do not contain Memanto's managed sentinel
- continue removing Memanto-managed dedicated rule files as before
- add regression coverage for unmanaged and managed Cursor rule files

## Why
Disconnecting Cursor/Cline/Continue/Roo/Augment currently unlinks the dedicated rule file path whenever it exists. If a user already has their own file at that path without Memanto's managed section, `memanto connect remove` can delete user-owned configuration.

## Validation
- `.venv/bin/python -m pytest tests/test_connect_engine.py -q`
- `.venv/bin/python -m pytest tests/test_cli.py tests/test_connect_engine.py -q`
- `.venv/bin/python -m pytest tests -q` (live E2E skipped locally because no real `MOORCHEH_API_KEY` is configured)
- `.venv/bin/python -m ruff check memanto/cli/connect/engine.py tests/test_connect_engine.py`
- `.venv/bin/python -m ruff format --check memanto/cli/connect/engine.py tests/test_connect_engine.py`
- `git diff --check`

Bounty lane: #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instruction-file removal to avoid deleting user-owned files when the managed content can’t be safely verified.
  * If the instruction file can’t be decoded as text, removal is skipped and no cleanup is performed.
  * If the expected sentinel isn’t present, the file is left unchanged.

* **Tests**
  * Added pytest coverage for preserving unmanaged UTF-8 and non-UTF-8 instruction files.
  * Added coverage confirming managed instruction files are removed as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->