### PR TITLE
fix(api): stream uploaded files to disk

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field, field_validator
+from starlette.concurrency import run_in_threadpool
 
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.clients.moorcheh import get_moorcheh_client
@@ -55,21 +56,25 @@ UPLOAD_COPY_CHUNK_BYTES = 1024 * 1024
 async def _write_upload_to_path(
     file: UploadFile,
     tmp_path: str,
-    max_bytes: int = MAX_UPLOAD_BYTES,
+    max_bytes: int | None = None,
     chunk_size: int = UPLOAD_COPY_CHUNK_BYTES,
 ) -> int:
     """Stream an UploadFile to disk without materializing the full body in RAM."""
 
     total_size = 0
-    with open(tmp_path, "wb") as tmp:
+    size_limit = MAX_UPLOAD_BYTES if max_bytes is None else max_bytes
+    tmp = await run_in_threadpool(open, tmp_path, "wb")
+    try:
         while chunk := await file.read(chunk_size):
             total_size += len(chunk)
-            if total_size > max_bytes:
+            if total_size > size_limit:
                 raise HTTPException(
                     status_code=413,
                     detail="File exceeds the 5GB upload limit.",
                 )
-            tmp.write(chunk)
+            await run_in_threadpool(tmp.write, chunk)
+    finally:
+        await run_in_threadpool(tmp.close)
     return total_size
 
 
@@ -571,14 +576,18 @@ async def upload_file(
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
+        result_file_size = result.get("fileSize")
+        if result_file_size is None:
+            result_file_size = result.get("file_size")
+        if result_file_size is None:
+            result_file_size = uploaded_size
+
         return {
             "agent_id": agent_id,
             "session_id": session.session_id,
             "namespace": namespace,
             "file_name": original_name,
-            "file_size": result.get("fileSize")
-            or result.get("file_size")
-            or uploaded_size,
+            "file_size": result_file_size,
             "status": "uploaded" if result.get("success") else "failed",
             "message": result.get("message", ""),
         }

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -7,6 +7,7 @@ Replaces legacy agent memory endpoints with session-based auth.
 
 import asyncio
 import os
+import shutil
 import tempfile
 from datetime import date, datetime, time, timezone
 from pathlib import Path
@@ -47,6 +48,29 @@ from memanto.cli.config.manager import ConfigManager
 router = APIRouter()
 
 _config_manager = ConfigManager()
+MAX_UPLOAD_BYTES = 5 * 1024 * 1024 * 1024
+UPLOAD_COPY_CHUNK_BYTES = 1024 * 1024
+
+
+async def _write_upload_to_path(
+    file: UploadFile,
+    tmp_path: str,
+    max_bytes: int = MAX_UPLOAD_BYTES,
+    chunk_size: int = UPLOAD_COPY_CHUNK_BYTES,
+) -> int:
+    """Stream an UploadFile to disk without materializing the full body in RAM."""
+
+    total_size = 0
+    with open(tmp_path, "wb") as tmp:
+        while chunk := await file.read(chunk_size):
+            total_size += len(chunk)
+            if total_size > max_bytes:
+                raise HTTPException(
+                    status_code=413,
+                    detail="File exceeds the 5GB upload limit.",
+                )
+            tmp.write(chunk)
+    return total_size
 
 
 class RecallRequest(BaseModel):
@@ -527,9 +551,6 @@ async def upload_file(
     try:
         namespace = session.namespace
 
-        # Write upload to a temp file so moorcheh SDK can read it
-        # Use original filename so the SDK records it as the source
-        file_bytes = await file.read()
         tmp_dir = tempfile.mkdtemp()
         tmp_path = os.path.join(tmp_dir, original_name)
         # Defense-in-depth: verify resolved path is within tmp_dir
@@ -541,14 +562,13 @@ async def upload_file(
                 detail="Invalid filename",
             )
         try:
-            with open(tmp_path, "wb") as tmp:
-                tmp.write(file_bytes)
+            # Write upload to a temp file so moorcheh SDK can read it.
+            # Use original filename so the SDK records it as the source.
+            uploaded_size = await _write_upload_to_path(file, tmp_path)
             result = await asyncio.to_thread(
                 client.documents.upload_file, namespace, tmp_path
             )
         finally:
-            import shutil
-
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
         return {
@@ -556,11 +576,15 @@ async def upload_file(
             "session_id": session.session_id,
             "namespace": namespace,
             "file_name": original_name,
-            "file_size": result.get("fileSize"),
+            "file_size": result.get("fileSize")
+            or result.get("file_size")
+            or uploaded_size,
             "status": "uploaded" if result.get("success") else "failed",
             "message": result.get("message", ""),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from memanto.app.config import settings
@@ -1201,6 +1202,38 @@ class TestMEMANTOAPI:
         assert data["status"] == "uploaded"
 
     @pytest.mark.asyncio
+    async def test_upload_file_accepts_onprem_file_size_shape(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """The route should preserve on-prem's snake_case file_size response."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        mock_moorcheh.documents.upload_file.return_value = {
+            "success": True,
+            "message": "Upload job submitted",
+            "file_name": "notes.txt",
+            "file_size": 2048,
+        }
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+            headers=headers,
+            files={"file": ("notes.txt", b"chunked test content", "text/plain")},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["file_size"] == 2048
+
+    @pytest.mark.asyncio
     async def test_upload_file_unsupported_extension(self, client, auth_headers):
         """Test that unsupported file types are rejected"""
         await client.post(
@@ -1240,6 +1273,54 @@ class TestMEMANTOAPI:
         )
 
         assert response.status_code in (401, 403, 422)
+
+
+class _ChunkedUpload:
+    """Minimal async UploadFile stand-in for copy-loop regression tests."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+        self.read_sizes: list[int] = []
+
+    async def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            raise AssertionError("upload copy must not perform an unbounded read")
+        self.read_sizes.append(size)
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+class TestUploadFileStreaming:
+    @pytest.mark.asyncio
+    async def test_upload_copy_streams_in_bounded_chunks(self, tmp_path):
+        """Large uploads must be copied without reading the whole body at once."""
+        from memanto.app.routes.memory import _write_upload_to_path
+
+        upload = _ChunkedUpload([b"abcd", b"ef"])
+        tmp_file = tmp_path / "notes.txt"
+
+        written = await _write_upload_to_path(
+            upload, str(tmp_file), max_bytes=10, chunk_size=4
+        )
+
+        assert written == 6
+        assert tmp_file.read_bytes() == b"abcdef"
+        assert upload.read_sizes == [4, 4, 4]
+
+    @pytest.mark.asyncio
+    async def test_upload_copy_rejects_files_over_limit(self, tmp_path):
+        """The backend enforces the advertised upload limit while streaming."""
+        from memanto.app.routes.memory import _write_upload_to_path
+
+        upload = _ChunkedUpload([b"12345", b"67890"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _write_upload_to_path(
+                upload, str(tmp_path / "too-large.txt"), max_bytes=9, chunk_size=5
+            )
+
+        assert exc_info.value.status_code == 413
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1220,7 +1220,7 @@ class TestMEMANTOAPI:
             "success": True,
             "message": "Upload job submitted",
             "file_name": "notes.txt",
-            "file_size": 2048,
+            "file_size": 0,
         }
 
         headers = {**auth_headers, "X-Session-Token": token}
@@ -1231,7 +1231,37 @@ class TestMEMANTOAPI:
         )
 
         assert response.status_code == 200
-        assert response.json()["file_size"] == 2048
+        assert response.json()["file_size"] == 0
+
+    @pytest.mark.asyncio
+    async def test_upload_file_returns_413_when_stream_exceeds_limit(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """The route should preserve the streaming limit's HTTP 413 response."""
+        from memanto.app.routes import memory as memory_route
+
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        monkeypatch.setattr(memory_route, "MAX_UPLOAD_BYTES", 3)
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+            headers=headers,
+            files={"file": ("notes.txt", b"abcd", "text/plain")},
+        )
+
+        assert response.status_code == 413
+        assert response.json()["detail"] == "File exceeds the 5GB upload limit."
+        mock_moorcheh.documents.upload_file.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_upload_file_unsupported_extension(self, client, auth_headers):


### PR DESCRIPTION
## Summary

Bounty submission for #770.

The `/api/v2/agents/{agent_id}/upload-file` endpoint advertised support for uploads up to 5GB, but it copied each multipart upload with `await file.read()` before writing the temp file. That materializes the entire upload body in process memory, so large valid uploads can exhaust RAM before the Moorcheh SDK receives the file.

This PR changes the route to stream the upload into the temporary file in bounded 1MB chunks, while preserving the existing filename sanitization and temp-directory cleanup.

## Reproduction

The old route performed an unbounded `UploadFile.read()` call:

1. Start the API.
2. Activate an agent session.
3. Upload a large supported file, for example a multi-GB `.txt`, `.json`, `.pdf`, or `.csv`.
4. Observe that the server allocates the whole request body in memory before handing the file to `documents.upload_file`.

The new regression test uses a minimal async upload stand-in that raises if the copy path performs an unbounded read.

## Fix

- Added `_write_upload_to_path()` to copy uploads chunk-by-chunk.
- Enforced the documented 5GB backend limit while streaming and return HTTP 413 when exceeded.
- Preserved `fileSize` from cloud SDK responses and `file_size` from the on-prem adapter shape.
- Added upload streaming and on-prem response-shape regression tests.

## Tests

- `uv run pytest`
- `uv run ruff check .`

Result: `179 passed, 24 skipped`; skipped tests are live Moorcheh E2E tests requiring a real `MOORCHEH_API_KEY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large uploads are now streamed to temporary storage in bounded chunks to reduce memory usage.
  * Introduced a default upload size limit (5GB); requests exceeding it are rejected.

* **Bug Fixes**
  * Upload responses now consistently return `file_size` in the expected format, preferring backend metadata when available and falling back to the streamed byte count.

* **Tests**
  * Added regression tests for `file_size` response shape and for HTTP 413 behavior when uploads exceed the configured limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->