### PR TITLE
fix: only strip Tags: suffix from content when metadata tags exist

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -657,30 +657,35 @@ class MemoryReadService:
         content = raw_text
 
         if raw_text:
-            lines = raw_text.split("\n\n", 2)  # Split into at most 3 parts
+            # Split into all \n\n-delimited segments so that the Tags: suffix
+            # can be reliably identified as the *last* segment, even when the
+            # content itself contains multiple paragraphs (multiple \n\n).
+            lines = raw_text.split("\n\n")
             first_line = lines[0] if lines else ""
 
             # Extract title: strip the "[TYPE] " prefix from first line
-
             title_match = re.match(r"^\[.*?\]\s*(.*)$", first_line)
             if title_match:
                 title = title_match.group(1).strip()
-                # Content is the rest after the first line (skip tags section)
+                # Content is everything between the title and the Tags suffix
                 if len(lines) > 1:
-                    # Check if last part is tags
-                    remaining = lines[1:]
-                    content_parts = []
-                    for part in remaining:
-                        if part.startswith("Tags: "):
-                            continue
-                        content_parts.append(part)
-                    content = "\n\n".join(content_parts) if content_parts else ""
+                    content_lines = lines[1:]
+                    # The Tags suffix (if any) is always the last segment.
+                    # Only strip it when the document actually has tags in
+                    # its flat metadata — otherwise a "Tags: ..." paragraph
+                    # in the content itself would be silently eaten.
+                    if content_lines and tags and content_lines[-1].startswith("Tags: "):
+                        content_lines = content_lines[:-1]
+                    content = "\n\n".join(content_lines) if content_lines else ""
                 else:
                     content = ""
             else:
                 # No [TYPE] prefix — use first line as title, rest as content
                 title = first_line.strip()
-                content = "\n\n".join(lines[1:]) if len(lines) > 1 else ""
+                content_parts = lines[1:]
+                if content_parts and tags and content_parts[-1].startswith("Tags: "):
+                    content_parts = content_parts[:-1]
+                content = "\n\n".join(content_parts) if content_parts else ""
 
         # Build basic formatted item
         formatted = {

--- a/tests/test_memory_format.py
+++ b/tests/test_memory_format.py
@@ -1,0 +1,216 @@
+"""Test memory format round-trip integrity: content/tag parsing in _format_memory_item."""
+
+from unittest.mock import MagicMock
+
+from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _make_read_service():
+    return MemoryReadService(MagicMock())
+
+
+def test_content_with_newlines_and_tags_preserves_content_integrity():
+    """
+    When memory content contains \\n\\n (multiple paragraphs), the Tags: suffix
+    must NOT leak into the content field after round-tripping through
+    to_moorcheh_document → _format_memory_item.
+
+    Regression test for the bug where split("\\n\\n", 2) in _format_memory_item
+    fails to separate the Tags line when content has multiple paragraphs.
+    """
+    memory = MemoryRecord(
+        type="fact",
+        title="Test Memory",
+        content="This is paragraph one.\n\nThis is paragraph two.",
+        agent_id="test-agent",
+        actor_id="user",
+        source="test",
+        tags=["important", "test"],
+    )
+
+    document = memory.to_moorcheh_document()
+
+    formatted = MemoryReadService._format_memory_item(
+        MemoryReadService(MagicMock()), document
+    )
+
+    assert "Tags:" not in formatted["content"], (
+        f"Tags suffix leaked into content field: {formatted['content']!r}"
+    )
+    assert formatted["content"] == "This is paragraph one.\n\nThis is paragraph two.", (
+        f"Content was corrupted: expected paragraphs, got {formatted['content']!r}"
+    )
+    assert formatted["tags"] == ["important", "test"], (
+        f"Tags were corrupted: {formatted['tags']}"
+    )
+
+
+def test_content_without_newlines_is_unchanged():
+    """Memories without newlines in content should round-trip unchanged."""
+    memory = MemoryRecord(
+        type="fact",
+        title="Simple",
+        content="Single line content.",
+        agent_id="test-agent",
+        actor_id="user",
+        source="test",
+        tags=["tag1"],
+    )
+
+    document = memory.to_moorcheh_document()
+    formatted = MemoryReadService._format_memory_item(
+        MemoryReadService(MagicMock()), document
+    )
+
+    assert formatted["content"] == "Single line content."
+    assert formatted["tags"] == ["tag1"]
+
+
+def test_content_with_multiple_newlines_and_no_tags():
+    """Content with \\n\\n but no tags should still work."""
+    memory = MemoryRecord(
+        type="fact",
+        title="Multi Para",
+        content="Para one.\n\nPara two.\n\nPara three.",
+        agent_id="test-agent",
+        actor_id="user",
+        source="test",
+    )
+
+    document = memory.to_moorcheh_document()
+    formatted = MemoryReadService._format_memory_item(
+        MemoryReadService(MagicMock()), document
+    )
+
+    assert "Tags:" not in formatted["content"]
+    assert formatted["content"] == "Para one.\n\nPara two.\n\nPara three."
+    assert formatted["tags"] == []
+
+
+def test_memory_without_type_prefix_round_trips_tags():
+    """Documents without [TYPE] prefix should also strip tags correctly."""
+    document = {
+        "id": "test-id",
+        "text": "My Title\n\nContent here\n\nTags: tag1, tag2",
+        "memory_type": "fact",
+        "tags": "tag1,tag2",
+    }
+
+    formatted = MemoryReadService._format_memory_item(
+        MemoryReadService(MagicMock()), document
+    )
+
+    assert "Tags:" not in formatted["content"]
+    assert formatted["content"] == "Content here"
+    assert formatted["tags"] == ["tag1", "tag2"]
+
+
+def test_memory_with_tags_in_middle_paragraph_does_not_leak():
+    """
+    Content where the 'Tags:' substring appears naturally in the text
+    should not be stripped.  Only an exact "Tags: " at the start of a
+    \\n\\n-delimited segment is the tag suffix.
+    """
+    memory = MemoryRecord(
+        type="fact",
+        title="Tags in Content",
+        content="Use the #Tags: feature for organization.\n\nThis is fine.",
+        agent_id="test-agent",
+        actor_id="user",
+        source="test",
+        tags=["label"],
+    )
+
+    document = memory.to_moorcheh_document()
+    formatted = MemoryReadService._format_memory_item(
+        MemoryReadService(MagicMock()), document
+    )
+
+    assert "#Tags: feature" in formatted["content"]
+    assert formatted["tags"] == ["label"]
+
+
+def test_content_only_tag_line_not_confused_with_tags_suffix():
+    """A line that starts with 'Tags: ' but is actual content should be kept when
+    it is NOT the last \\n\\n-delimited segment that starts with 'Tags: '."""
+    memory = MemoryRecord(
+        type="fact",
+        title="Strange",
+        content="Tags: this is not a tag line\n\nActual second paragraph.",
+        agent_id="test-agent",
+        actor_id="user",
+        source="test",
+        tags=["foo"],
+    )
+
+    document = memory.to_moorcheh_document()
+    formatted = MemoryReadService._format_memory_item(
+        MemoryReadService(MagicMock()), document
+    )
+
+    assert "Tags: this is not a tag line" in formatted["content"]
+
+
+def test_content_with_tags_line_but_no_metadata_tags_is_not_stripped():
+    """
+    When the content itself ends with a line that starts with 'Tags: ' (e.g.
+    'Tags: my custom notes') but no tags are stored in the flat metadata
+    field, the content must NOT be stripped.
+
+    The Tags-suffix heuristic should only fire when the document actually
+    has tags in its metadata.  Without this guard, legitimate content
+    is silently truncated.
+    """
+    memory = MemoryRecord(
+        type="fact",
+        title="Formatting Note",
+        content="First paragraph.\n\nTags: this is not actually tag metadata",
+        agent_id="test-agent",
+        actor_id="user",
+        source="test",
+        tags=[],  # No tags stored — "Tags: ..." is content, not metadata
+    )
+
+    document = memory.to_moorcheh_document()
+    formatted = MemoryReadService._format_memory_item(
+        MemoryReadService(MagicMock()), document
+    )
+
+    # The content must contain the "Tags: ..." line since it was never
+    # a real metadata suffix.
+    assert "Tags: this is not actually tag metadata" in formatted["content"], (
+        f"Content was incorrectly stripped: {formatted['content']!r}"
+    )
+    assert formatted["content"] == "First paragraph.\n\nTags: this is not actually tag metadata", (
+        f"Content was corrupted: {formatted['content']!r}"
+    )
+    assert formatted["tags"] == [], f"Tags should be empty: {formatted['tags']}"
+
+
+def test_content_with_tags_line_and_real_tags_keeps_content_intact():
+    """
+    When the document has both real tags AND content that contains a
+    'Tags: ...' line in a non-final paragraph, everything should survive.
+    """
+    memory = MemoryRecord(
+        type="fact",
+        title="Mixed Content",
+        content="Tags: this is inline in the content\n\nMore content here.",
+        agent_id="test-agent",
+        actor_id="user",
+        source="test",
+        tags=["real-tag"],
+    )
+
+    document = memory.to_moorcheh_document()
+    formatted = MemoryReadService._format_memory_item(
+        MemoryReadService(MagicMock()), document
+    )
+
+    # The internal line "Tags: this is inline in the content" must stay
+    # (only the final "Tags: real-tag" segment is the metadata suffix).
+    assert "Tags: this is inline in the content" in formatted["content"], (
+        f"Inline Tags: line was incorrectly stripped: {formatted['content']!r}"
+    )
+    assert formatted["tags"] == ["real-tag"]


### PR DESCRIPTION
Description
This PR fixes a bug where content containing a line starting with "Tags: " was being silently truncated during read-back in memory_read_service.py.

The Problem
The previous logic incorrectly assumed that any line starting with "Tags: " at the end of a memory item was an automatically appended metadata suffix. This caused legitimate user-generated content to be stripped whenever the flat tags field was empty.

The Fix
Updated the conditional logic in _format_memory_item to ensure the content-stripping behavior only triggers when the tags field is actually populated. This prevents legitimate text from being removed.

Testing & Verification

Added two new tests in tests/test_memory_format.py to verify that content is preserved when tags are empty and that existing metadata suffixes are still correctly handled.

Confirmed all 8/8 tests in test_memory_format.py pass, alongside full unit, integration, and API test suites.

Verified clean ruff linting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory formatting so titles and content are extracted more reliably from multi-paragraph text.
  * Prevented paragraphs that begin with “Tags:” from being incorrectly removed when no tag metadata is present.
  * Preserved proper handling of entries with and without a type prefix.

* **Tests**
  * Added regression coverage for memory formatting to verify content integrity and tag parsing across several edge cases.

issue #770 