### PR TITLE
Skip malformed timestamps during temporal filtering

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -473,31 +473,41 @@ class MemoryReadService:
         """
         from memanto.app.utils.temporal_helpers import parse_iso_timestamp
 
-        filtered = results
+        after_dt = None
+        before_dt = None
 
         if created_after:
             try:
                 after_dt = parse_iso_timestamp(created_after)
-                filtered = [
-                    r
-                    for r in filtered
-                    if r.get("created_at")
-                    and parse_iso_timestamp(r["created_at"]) >= after_dt
-                ]
-            except (ValueError, AttributeError):
-                pass  # Skip invalid timestamps
+            except (ValueError, AttributeError, TypeError):
+                pass  # Keep existing fail-open behavior for invalid caller input.
 
         if created_before:
             try:
                 before_dt = parse_iso_timestamp(created_before)
-                filtered = [
-                    r
-                    for r in filtered
-                    if r.get("created_at")
-                    and parse_iso_timestamp(r["created_at"]) <= before_dt
-                ]
-            except (ValueError, AttributeError):
-                pass  # Skip invalid timestamps
+            except (ValueError, AttributeError, TypeError):
+                pass  # Keep existing fail-open behavior for invalid caller input.
+
+        if after_dt is None and before_dt is None:
+            return results
+
+        filtered = []
+        for result in results:
+            raw_created = result.get("created_at")
+            if not raw_created:
+                continue
+
+            try:
+                created_dt = parse_iso_timestamp(raw_created)
+            except (ValueError, AttributeError, TypeError):
+                continue
+
+            if after_dt is not None and created_dt < after_dt:
+                continue
+            if before_dt is not None and created_dt > before_dt:
+                continue
+
+            filtered.append(result)
 
         return filtered
 

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -1,5 +1,6 @@
 from datetime import timezone
 
+from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.utils.temporal_helpers import parse_iso_timestamp
 
 
@@ -15,3 +16,19 @@ def test_parse_iso_timestamp_assumes_naive_values_are_utc():
 
     assert parsed.tzinfo == timezone.utc
     assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"
+
+
+def test_temporal_filter_skips_malformed_memory_timestamps_per_record():
+    service = MemoryReadService(object())
+
+    results = [
+        {"id": "old", "created_at": "2025-01-01T00:00:00Z"},
+        {"id": "new", "created_at": "2025-02-01T00:00:00Z"},
+        {"id": "bad", "created_at": "not-a-timestamp"},
+    ]
+
+    filtered = service._apply_temporal_filter(
+        results, created_after="2025-01-15T00:00:00Z"
+    )
+
+    assert [memory["id"] for memory in filtered] == ["new"]


### PR DESCRIPTION
Fixes a temporal filtering bug where one malformed memory `created_at` value could make the whole temporal filter fail open and return out-of-range memories.

The patch parses filter bounds once, skips only malformed records, and preserves existing fail-open behavior for invalid caller-provided filter inputs.

Why this matters:
- Temporal recall should not return memories outside the requested range just because one stored record has corrupt or migrated timestamp metadata.
- The bug affects memory integrity and timeline accuracy, which are explicitly in scope for the bounty.

Reproduction before the fix:
```python
from memanto.app.services.memory_read_service import MemoryReadService

service = MemoryReadService(object())
rows = [
    {"id": "old", "created_at": "2025-01-01T00:00:00Z"},
    {"id": "new", "created_at": "2025-02-01T00:00:00Z"},
    {"id": "bad", "created_at": "not-a-timestamp"},
]
print([r["id"] for r in service._apply_temporal_filter(rows, created_after="2025-01-15T00:00:00Z")])
# Before: ['old', 'new', 'bad']
# After:  ['new']
```

Tests:
```bash
python -m pytest tests/test_api.py tests/test_unit.py tests/test_backend.py tests/test_memory_parsing.py tests/test_temporal_helpers.py -q
# 117 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-based filtering for memory results so invalid input timestamps are handled more reliably.
  * Records with missing or malformed timestamps are now skipped, while valid results still respect the selected date range.

* **Tests**
  * Added coverage to confirm malformed record timestamps are ignored during temporal filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->