### PR TITLE
Normalize Mem0 category strings during migration

### DIFF
--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -73,6 +73,19 @@ def _coerce_type(raw: str | None) -> str | None:
     return t if t in VALID_MEMORY_TYPES else None
 
 
+def _normalize_mem0_categories(raw: Any) -> list[str]:
+    """Normalize Mem0 category payloads into lower-case category labels."""
+    if raw in (None, "", [], {}):
+        return []
+    if isinstance(raw, str):
+        values: list[Any] = [raw]
+    elif isinstance(raw, (list, tuple, set)):
+        values = list(raw)
+    else:
+        values = [raw]
+    return [text for item in values if (text := str(item).strip().lower())]
+
+
 def _scope_tag(scope: dict[str, Any] | None) -> str | None:
     if not scope:
         return None
@@ -187,7 +200,7 @@ def map_mem0(export: dict[str, Any]) -> list[dict[str, Any]]:
         if not content:
             continue
 
-        categories = [str(c).lower() for c in (mem.get("categories") or []) if c]
+        categories = _normalize_mem0_categories(mem.get("categories"))
         memory_type: str | None = None
         for cat in categories:
             memory_type = _MEM0_CATEGORY_TO_TYPE.get(cat) or _coerce_type(cat)

--- a/tests/test_migrate_mappers.py
+++ b/tests/test_migrate_mappers.py
@@ -1,0 +1,19 @@
+from memanto.cli.migrate.mappers import map_mem0
+
+
+def test_map_mem0_accepts_single_category_string():
+    rows = map_mem0(
+        {
+            "memories": [
+                {
+                    "id": "mem-1",
+                    "memory": "The user prefers concise PR summaries.",
+                    "categories": "personal_preferences",
+                }
+            ]
+        }
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["type"] == "preference"
+    assert rows[0]["tags"] == ["personal_preferences"]


### PR DESCRIPTION
Summary
- Normalize Mem0 category payloads before mapping migrated memories.
- Treat a single category string as one category instead of iterating over individual characters.
- Add a regression test for `personal_preferences` mapping to `preference` with a single tag.

Flaw reproduction
- Before this change, `map_mem0({"memories": [{"memory": "...", "categories": "personal_preferences"}]})` processed the category string character-by-character.
- The migrated memory lost its semantic type (`None`) and received character tags instead of `personal_preferences`.
- That degrades migration quality because imported preferences no longer land in the preference bucket and tags become noisy.

Fix
- Add a small Mem0 category normalizer that preserves existing list/tuple/set behavior while accepting single strings and other scalar payloads.
- Use the normalizer in `map_mem0` before type/tag mapping.

Validation
- Red test first: `pytest tests/test_migrate_mappers.py -q` failed with `None == "preference"` before the fix.
- Green focused tests: `pytest tests/test_migrate_mappers.py tests/test_cli.py::TestMEMANTOCLI::test_migrate_mem0_dry_run tests/test_cli.py::TestMEMANTOCLI::test_migrate_letta_dry_run tests/test_cli.py::TestMEMANTOCLI::test_migrate_supermemory_dry_run -q`.
- Full tests: `pytest tests -q` passed; live Moorcheh E2E skipped because no real `MOORCHEH_API_KEY` is configured.
- Lint/format: `ruff check memanto tests`; `ruff format --check memanto/cli/migrate/mappers.py tests/test_migrate_mappers.py`.

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category handling during migration so single values, lists, and other formats are cleaned consistently.
  * Category text is now normalized more reliably, helping mapped items produce the expected type and tags.
  * Added test coverage for migrations that include a single category string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->