### PR TITLE
fix(cli): guard conflict operations by active session

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1290,6 +1290,7 @@ class DirectClient:
         Returns:
             List of unresolved conflict dicts.
         """
+        self._get_validated_session_for_agent(agent_id)
 
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
@@ -1331,6 +1332,7 @@ class DirectClient:
         Returns:
             Dict with resolution result.
         """
+        session = self._get_validated_session_for_agent(agent_id)
 
         valid_actions = {"keep_old", "keep_new", "keep_both", "remove_both", "manual"}
         if action not in valid_actions:
@@ -1356,10 +1358,9 @@ class DirectClient:
         old_id = conflict.get("old_memory_id")
         new_id = conflict.get("new_memory_id")
 
-        # Get namespace for memory operations
-        from memanto.app.core import agent_namespace
-
-        namespace = agent_namespace(agent_id)
+        # Use the validated session namespace so conflict resolution cannot
+        # operate on a different agent than the active session.
+        namespace = session.namespace
 
         write_service = self._get_write_service()
         result_details = {"action": action}

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1160,6 +1160,8 @@ class SdkClient:
         Returns:
             List of unresolved conflict dicts.
         """
+        self._get_validated_session_for_agent(agent_id)
+
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
@@ -1200,6 +1202,8 @@ class SdkClient:
         Returns:
             Dict with resolution result.
         """
+        session = self._get_validated_session_for_agent(agent_id)
+
         valid_actions = {"keep_old", "keep_new", "keep_both", "remove_both", "manual"}
         if action not in valid_actions:
             raise ValueError(
@@ -1224,10 +1228,9 @@ class SdkClient:
         old_id = conflict.get("old_memory_id")
         new_id = conflict.get("new_memory_id")
 
-        # Get namespace for memory operations
-        from memanto.app.core import agent_namespace
-
-        namespace = agent_namespace(agent_id)
+        # Use the validated session namespace so conflict resolution cannot
+        # operate on a different agent than the active session.
+        namespace = session.namespace
 
         write_service = self._get_write_service()
         result_details: dict[str, Any] = {"action": action}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -456,6 +456,111 @@ class TestMEMANTOCLI:
         assert forwarded_updates["tags"] == ["a", "b"]
         assert result["status"] == "updated"
 
+    @pytest.mark.parametrize(
+        "client_cls,module_path",
+        [
+            ("memanto.cli.client.direct_client.DirectClient", "memanto.cli.client.direct_client"),
+            ("memanto.cli.client.sdk_client.SdkClient", "memanto.cli.client.sdk_client"),
+        ],
+    )
+    def test_conflict_list_requires_active_agent_session(
+        self, client_cls, module_path, tmp_path
+    ):
+        """Conflict reports are agent-scoped local state and must not be
+        readable unless the requested agent matches the active session."""
+        from importlib import import_module
+
+        from memanto.app.utils.errors import SessionError
+
+        module_name, class_name = client_cls.rsplit(".", 1)
+        client_type = getattr(import_module(module_name), class_name)
+        client = client_type.__new__(client_type)
+
+        conflicts_dir = tmp_path / ".memanto" / "conflicts"
+        conflicts_dir.mkdir(parents=True)
+        (conflicts_dir / "other-agent_2026-07-05_conflicts.json").write_text(
+            json.dumps([{"title": "private conflict", "resolved": False}]),
+            encoding="utf-8",
+        )
+
+        with (
+            patch(f"{module_path}.Path.home", return_value=tmp_path),
+            patch.object(
+                client_type,
+                "_get_validated_session_for_agent",
+                side_effect=SessionError("active session is for a different agent"),
+            ) as validate,
+        ):
+            with pytest.raises(SessionError):
+                client.list_conflicts("other-agent", "2026-07-05")
+
+        validate.assert_called_once_with("other-agent")
+
+    @pytest.mark.parametrize(
+        "client_cls,module_path",
+        [
+            ("memanto.cli.client.direct_client.DirectClient", "memanto.cli.client.direct_client"),
+            ("memanto.cli.client.sdk_client.SdkClient", "memanto.cli.client.sdk_client"),
+        ],
+    )
+    def test_conflict_resolution_uses_validated_session_namespace(
+        self, client_cls, module_path, tmp_path
+    ):
+        """Destructive conflict resolution must run against the namespace
+        returned by the validated session, not just a recomputed user string."""
+        from importlib import import_module
+
+        module_name, class_name = client_cls.rsplit(".", 1)
+        client_type = getattr(import_module(module_name), class_name)
+        client = client_type.__new__(client_type)
+
+        conflicts_dir = tmp_path / ".memanto" / "conflicts"
+        conflicts_dir.mkdir(parents=True)
+        conflict_path = conflicts_dir / "agent-1_2026-07-05_conflicts.json"
+        conflict_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "old_memory_id": "old-memory",
+                        "new_memory_id": "new-memory",
+                        "resolved": False,
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_agent-1"
+        mock_write_service = MagicMock()
+        mock_write_service.delete_memory.return_value = True
+
+        with (
+            patch(f"{module_path}.Path.home", return_value=tmp_path),
+            patch.object(
+                client_type,
+                "_get_validated_session_for_agent",
+                return_value=mock_session,
+            ) as validate,
+            patch.object(
+                client_type, "_get_write_service", return_value=mock_write_service
+            ),
+        ):
+            result = client.resolve_conflict(
+                agent_id="agent-1",
+                date="2026-07-05",
+                conflict_index=0,
+                action="keep_old",
+            )
+
+        validate.assert_called_once_with("agent-1")
+        mock_write_service.delete_memory.assert_called_once_with(
+            "new-memory", "memanto_agent_agent-1"
+        )
+        updated = json.loads(conflict_path.read_text(encoding="utf-8"))
+        assert updated[0]["resolved"] is True
+        assert result["status"] == "resolved"
+
     def test_recall(self, mock_all_clients):
         """Test 'memanto recall'"""
         mock_all_clients.recall.return_value = {


### PR DESCRIPTION
## Summary

Fixes a session-scope bypass in the direct and SDK conflict-management paths.

`remember`, `delete_memory`, `recall`, and `export_memory_md` already validate the active session before touching agent-scoped memory. `list_conflicts` and `resolve_conflict` did not, so a caller with a client object could read unresolved conflict reports or run destructive conflict resolution for an arbitrary `agent_id` string without first proving the active session belongs to that agent.

This matters for issue #770 because conflict reports and resolutions are memory-integrity state:

- conflict reports live under `~/.memanto/conflicts/{agent_id}_{date}_conflicts.json`
- `resolve_conflict` can delete old/new memories or create a manual replacement
- prior behavior recomputed the namespace from the supplied string rather than binding the operation to the validated session object

## Changes

- Validate the requested agent session at the start of `DirectClient.list_conflicts` and `SdkClient.list_conflicts`.
- Validate the requested agent session at the start of `DirectClient.resolve_conflict` and `SdkClient.resolve_conflict`.
- Use `session.namespace` for destructive conflict-resolution writes/deletes instead of recomputing the namespace from `agent_id`.
- Add regression coverage for both clients.

## Verification

- `python -m pytest tests\test_cli.py -q -k "conflict_list_requires_active_agent_session or conflict_resolution_uses_validated_session_namespace"`
- `python -m pytest tests\test_cli.py -q`
- `python -m ruff check memanto\cli\client\direct_client.py memanto\cli\client\sdk_client.py tests\test_cli.py`
- `git diff --check -- memanto\cli\client\direct_client.py memanto\cli\client\sdk_client.py tests\test_cli.py`

Prepared for the Memanto Bug & Exploit Challenge, issue #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conflict listing and resolution now validate the active session for the requested agent before determining the conflict records to use or applying updates.
  * Conflict resolution now scopes all memory operations to the validated session’s namespace to prevent mismatches.
  * Conflict records and the reported resolution outcome are updated consistently.
* **Tests**
  * Added integration tests to verify session-validation requirements for conflict listing and namespace-scoped behavior during conflict resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->