### PR TITLE
[codex] Stream uploaded memory files with a size guard

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -48,6 +48,9 @@ router = APIRouter()
 
 _config_manager = ConfigManager()
 
+MAX_UPLOAD_FILE_SIZE = 5 * 1024 * 1024 * 1024
+UPLOAD_CHUNK_SIZE = 1024 * 1024
+
 
 class RecallRequest(BaseModel):
     query: str = Field(..., min_length=1, description="Search query")
@@ -527,9 +530,8 @@ async def upload_file(
     try:
         namespace = session.namespace
 
-        # Write upload to a temp file so moorcheh SDK can read it
-        # Use original filename so the SDK records it as the source
-        file_bytes = await file.read()
+        # Stream upload to a temp file so large files do not have to fit in memory.
+        # Use original filename so the SDK records it as the source.
         tmp_dir = tempfile.mkdtemp()
         tmp_path = os.path.join(tmp_dir, original_name)
         # Defense-in-depth: verify resolved path is within tmp_dir
@@ -541,8 +543,21 @@ async def upload_file(
                 detail="Invalid filename",
             )
         try:
+            total_size = 0
             with open(tmp_path, "wb") as tmp:
-                tmp.write(file_bytes)
+                while chunk := await file.read(UPLOAD_CHUNK_SIZE):
+                    total_size += len(chunk)
+                    if total_size > MAX_UPLOAD_FILE_SIZE:
+                        raise HTTPException(
+                            status_code=413,
+                            detail={
+                                "error": "file_too_large",
+                                "message": "File exceeds maximum upload size of 5GB",
+                                "actual_size": total_size,
+                                "max_size": MAX_UPLOAD_FILE_SIZE,
+                            },
+                        )
+                    tmp.write(chunk)
             result = await asyncio.to_thread(
                 client.documents.upload_file, namespace, tmp_path
             )
@@ -561,6 +576,8 @@ async def upload_file(
             "message": result.get("message", ""),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ from httpx import ASGITransport, AsyncClient
 from memanto.app.config import settings
 from memanto.app.main import app
 from memanto.app.models.session import Session
+from memanto.app.routes import memory as memory_routes
 from memanto.app.routes.auth_deps import get_current_session
 
 # Set test environment
@@ -1199,6 +1200,37 @@ class TestMEMANTOAPI:
         assert data["agent_id"] == self.TEST_AGENT_ID
         assert data["file_name"] == "notes.txt"
         assert data["status"] == "uploaded"
+
+    @pytest.mark.asyncio
+    async def test_upload_file_rejects_oversized_file_before_sdk_upload(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """Oversized uploads should fail before the SDK receives a temp file."""
+        monkeypatch.setattr(memory_routes, "MAX_UPLOAD_FILE_SIZE", 10)
+        monkeypatch.setattr(memory_routes, "UPLOAD_CHUNK_SIZE", 4)
+
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        mock_moorcheh.documents.upload_file.reset_mock()
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+            headers=headers,
+            files={"file": ("large.txt", b"01234567890", "text/plain")},
+        )
+
+        assert response.status_code == 413
+        assert response.json()["detail"]["error"] == "file_too_large"
+        mock_moorcheh.documents.upload_file.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_upload_file_unsupported_extension(self, client, auth_headers):


### PR DESCRIPTION
## Summary
- Stream uploaded memory files to temporary storage instead of loading the full file into memory.
- Enforce the documented 5GB upload limit while reading chunks and return a 413 response before calling the Moorcheh SDK.
- Preserve FastAPI HTTPException responses instead of remapping them to generic 500 errors.

## Why
The upload endpoint documented a 5GB maximum, but it used await file.read(), which loads the entire request body into memory before writing a temp file. Large uploads can exhaust memory or stall the server before the SDK sees the file.

## Validation
- HOME=/private/tmp/memanto-test-home .venv/bin/python -m pytest tests/test_api.py::TestMEMANTOAPI::test_upload_file_with_session tests/test_api.py::TestMEMANTOAPI::test_upload_file_rejects_oversized_file_before_sdk_upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large file uploads are now rejected cleanly with a clear 413 response when they exceed the maximum allowed size.
  * Uploads now stream in smaller chunks instead of loading the entire file into memory, improving reliability for big files.
  * Existing HTTP errors are now passed through unchanged, preserving the original error response.

* **Tests**
  * Added coverage for oversized upload handling to confirm invalid files are blocked before further processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->