### PR TITLE
Store manual conflict replacement before deletion

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1402,18 +1402,8 @@ class DirectClient:
             if not manual_content:
                 raise ValueError("manual_content is required when action is 'manual'")
 
-            # Delete both, store manual replacement
-            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
-
-            # Store the manual replacement
+            # Store the replacement before deleting originals so a failed write
+            # cannot erase both sides of the conflict.
             mem_type = manual_type or conflict.get("type", "fact")
             if not isinstance(mem_type, str):
                 mem_type = "fact"
@@ -1442,6 +1432,16 @@ class DirectClient:
             )
             store_result = write_service.store_memory(memory)
             result_details["new_memory_id"] = store_result.get("id")
+
+            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
+                if mem_id:
+                    try:
+                        write_service.delete_memory(mem_id, namespace)
+                        result_details[f"deleted_{label}"] = mem_id
+                    except Exception as e:
+                        result_details[f"warning_{label}"] = (
+                            f"Could not delete {label} memory: {e}"
+                        )
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1266,18 +1266,8 @@ class SdkClient:
             if not manual_content:
                 raise ValueError("manual_content is required when action is 'manual'")
 
-            # Delete both, store manual replacement
-            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
-
-            # Store the manual replacement
+            # Store the replacement before deleting originals so a failed write
+            # cannot erase both sides of the conflict.
             mem_type = manual_type or conflict.get("type", "fact")
             if not isinstance(mem_type, str):
                 mem_type = "fact"
@@ -1305,6 +1295,16 @@ class SdkClient:
             )
             store_result = write_service.store_memory(memory)
             result_details["new_memory_id"] = store_result.get("id")
+
+            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
+                if mem_id:
+                    try:
+                        write_service.delete_memory(mem_id, namespace)
+                        result_details[f"deleted_{label}"] = mem_id
+                    except Exception as e:
+                        result_details[f"warning_{label}"] = (
+                            f"Could not delete {label} memory: {e}"
+                        )
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/tests/test_conflict_manual_resolution.py
+++ b/tests/test_conflict_manual_resolution.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.client.sdk_client import SdkClient
+
+
+class FailingStoreService:
+    def __init__(self) -> None:
+        self.deleted: list[tuple[str, str]] = []
+
+    def delete_memory(self, memory_id: str, namespace: str) -> bool:
+        self.deleted.append((memory_id, namespace))
+        return True
+
+    def store_memory(self, memory):
+        raise RuntimeError("store failed")
+
+
+@pytest.mark.parametrize("client_cls", [DirectClient, SdkClient])
+def test_manual_conflict_resolution_does_not_delete_on_store_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client_cls
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    conflicts_dir = tmp_path / ".memanto" / "conflicts"
+    conflicts_dir.mkdir(parents=True)
+    conflict_file = conflicts_dir / "agent-1_2026-07-05_conflicts.json"
+    conflict_file.write_text(
+        json.dumps(
+            [
+                {
+                    "title": "Conflicting preference",
+                    "type": "fact",
+                    "old_memory_id": "old-memory",
+                    "new_memory_id": "new-memory",
+                    "resolved": False,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    service = FailingStoreService()
+    client = client_cls("test-api-key")
+    monkeypatch.setattr(client, "_get_write_service", lambda: service)
+
+    with pytest.raises(RuntimeError, match="store failed"):
+        client.resolve_conflict(
+            agent_id="agent-1",
+            date="2026-07-05",
+            conflict_index=0,
+            action="manual",
+            manual_content="Keep the corrected memory.",
+        )
+
+    assert service.deleted == []
+    persisted_conflicts = json.loads(conflict_file.read_text(encoding="utf-8"))
+    assert persisted_conflicts[0]["resolved"] is False


### PR DESCRIPTION
## Summary
- Store manual conflict-resolution replacements before deleting the conflicting originals.
- Prevents permanent loss of both memories if the replacement write fails.
- Covers both DirectClient and SdkClient conflict resolution paths.

## Bug / reproduction
Manual conflict resolution currently deletes the old and new memories before calling store_memory() for the user-provided replacement. If that write raises after the deletes succeed, both originals are gone and the conflict remains unresolved.

## Fix
Create the replacement memory first. Only after store_memory() succeeds does the client delete the original conflicting memories and mark the conflict resolved.

## Tests
- python -m pytest tests/test_conflict_manual_resolution.py -q
- python -m pytest tests/test_api.py::TestMEMANTOAPI::test_conflicts_resolve_api tests/test_api.py::TestMEMANTOAPI::test_conflicts_resolve_rejects_invalid_action tests/test_api.py::TestMEMANTOAPI::test_conflicts_resolve_requires_manual_content tests/test_cli.py::TestMEMANTOCLI::test_conflicts_list -q
- python -m pytest tests/test_conflict_manual_resolution.py tests/test_api.py tests/test_cli.py -q
- python -m ruff check memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_conflict_manual_resolution.py
- git diff --check

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manual conflict resolution so the replacement entry is saved before any conflicting entries are removed, reducing the risk of losing data if saving fails.
  * Preserved existing delete error reporting while making the cleanup step happen only after a successful save.
  * Added coverage for failure scenarios to ensure conflicting entries are not deleted when saving the replacement does not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->