### PR TITLE
Fix nested summary chunks leaking into memory reads

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -401,7 +401,8 @@ class MemoryReadService:
 
         return self._filter_expired_memories(memories)
 
-    def _is_summary_item(self, item: Any) -> bool:
+    @staticmethod
+    def _is_summary_item(item: Any) -> bool:
         """Return true when a Moorcheh item is a summary/helper chunk."""
         if not isinstance(item, dict):
             return False

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -382,7 +382,7 @@ class MemoryReadService:
         memories: list[dict[str, Any]] = []
         for item in items:
             # Skip summary chunks — only return real memory documents
-            if isinstance(item, dict) and item.get("is_summary"):
+            if self._is_summary_item(item):
                 continue
             formatted = self._format_memory_item(item)
             mid = formatted.get("id")
@@ -400,6 +400,20 @@ class MemoryReadService:
             memories.append(formatted)
 
         return self._filter_expired_memories(memories)
+
+    def _is_summary_item(self, item: Any) -> bool:
+        """Return true when a Moorcheh item is a summary/helper chunk."""
+        if not isinstance(item, dict):
+            return False
+
+        raw = item.get("is_summary")
+        metadata = item.get("metadata")
+        if raw is None and isinstance(metadata, dict):
+            raw = metadata.get("is_summary")
+
+        if isinstance(raw, str):
+            return raw.strip().lower() in {"1", "true", "yes"}
+        return bool(raw)
 
     def _build_filtered_query(
         self,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,50 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceFetchAll:
+    def test_fetch_all_memories_skips_nested_summary_items(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "real-memory",
+                    "text": "[FACT] Useful memory\n\nKeep this in recall.",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2026-07-01T00:00:00Z",
+                    },
+                },
+                {
+                    "id": "nested-summary",
+                    "text": "Batch summary chunk",
+                    "metadata": {
+                        "is_summary": True,
+                        "memory_type": "context",
+                    },
+                },
+                {
+                    "id": "string-summary",
+                    "text": "Uploaded file summary chunk",
+                    "is_summary": "true",
+                    "metadata": {
+                        "memory_type": "context",
+                    },
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        result = MemoryReadService(client).search_recent(
+            agent_id="agent-1",
+            limit=None,
+        )
+
+        assert [memory["id"] for memory in result["results"]] == ["real-memory"]
+        assert result["total_found"] == 1
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary

Fixes a memory-read filtering bug where Moorcheh summary/helper chunks could leak into user-visible recall results when the `is_summary` flag is stored in nested `metadata` instead of as a top-level field.

## Flaw

`MemoryReadService._fetch_all_memories()` already tried to skip summary chunks, but it only checked `item.get(is_summary)`. Several Moorcheh response paths use the nested API shape, where document fields live under `metadata`. In that shape, an item such as `{ metadata: { is_summary: true } }` was treated as a normal memory.

That pollutes `search_recent`, `search_as_of`, and `search_changed_since`, because all three go through `_fetch_all_memories()`. It can make agents recall helper/file-summary chunks as if they were durable memories and inflate memory counts.

## Reproduction

The new regression test mocks `documents.fetch_text_data()` with:

1. one real memory document
2. one summary item with `metadata.is_summary = true`
3. one summary item with top-level `is_summary = true`

Before this fix, the nested summary item was returned by `search_recent()`. After this fix, only the real memory remains.

## Fix

Added a small `_is_summary_item()` helper that checks both top-level and nested `metadata.is_summary`, including common string truthy values. `_fetch_all_memories()` now uses that helper before formatting and returning records.

## Validation

- `.\.venv\Scripts\python -m pytest tests/test_unit.py::TestMemoryReadServiceFetchAll::test_fetch_all_memories_skips_nested_summary_items -q`
- `.\.venv\Scripts\python -m pytest tests/test_unit.py -q`
- `.\.venv\Scripts\python -m pytest tests/test_api.py::TestMEMANTOAPI::test_recall_recent_api -q`
- `.\.venv\Scripts\python -m ruff check memanto\app\services\memory_read_service.py tests\test_unit.py`

Related to #770.

Note: this PR was prepared with Codex assistance for the account owner. No payout details are included publicly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory result filtering to more reliably exclude summary/helper entries, including when the summary flag is stored in nested metadata or provided as a string value.
  * Search totals now align with the number of returned real memory items.

* **Tests**
  * Added unit test coverage for mixed result sets, verifying nested and string-flagged summary items are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->