### PR TITLE
Fix tag filters for comma-separated metadata

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -381,7 +381,7 @@ class MemoryReadService:
         seen_ids: set[str] = set()
         memories: list[dict[str, Any]] = []
         for item in items:
-            # Skip summary chunks — only return real memory documents
+            # Skip summary chunks ? only return real memory documents
             if isinstance(item, dict) and item.get("is_summary"):
                 continue
             formatted = self._format_memory_item(item)
@@ -642,9 +642,14 @@ class MemoryReadService:
         # Parse tags - can be comma-separated string or array
         tags_value = get_field("tags")
         if isinstance(tags_value, str):
-            tags = tags_value.split(",") if tags_value else []
+            tags = [tag.strip() for tag in tags_value.split(",") if tag.strip()]
         elif isinstance(tags_value, list):
-            tags = tags_value
+            tags = []
+            for tag in tags_value:
+                if isinstance(tag, str):
+                    tag = tag.strip()
+                if tag:
+                    tags.append(tag)
         else:
             tags = []
 
@@ -678,7 +683,7 @@ class MemoryReadService:
                 else:
                     content = ""
             else:
-                # No [TYPE] prefix — use first line as title, rest as content
+                # No [TYPE] prefix ? use first line as title, rest as content
                 title = first_line.strip()
                 content = "\n\n".join(lines[1:]) if len(lines) > 1 else ""
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -42,7 +42,7 @@ class TestSessionService:
         """Test namespace generation"""
         namespace = session_service._generate_namespace("test-agent")
         assert namespace == "memanto_agent_test-agent"
-        print(f"✅ Namespace format correct: {namespace}")
+        print(f"? Namespace format correct: {namespace}")
 
     def test_create_session(self, session_service):
         """Test session creation"""
@@ -62,7 +62,7 @@ class TestSessionService:
         time_diff = (session.expires_at - session.started_at).total_seconds()
         assert 3.9 * 3600 < time_diff < 4.1 * 3600
 
-        print("✅ Session created successfully")
+        print("? Session created successfully")
         print(f"   Session ID: {session.session_id}")
         print(f"   Namespace: {session.namespace}")
         print(f"   Expires in: {time_diff / 3600:.2f} hours")
@@ -80,7 +80,7 @@ class TestSessionService:
         assert token_payload.agent_id == "test-agent"
         assert token_payload.namespace == "memanto_agent_test-agent"
 
-        print("✅ Session validation successful")
+        print("? Session validation successful")
 
     def test_validate_expired_session(self, session_service):
         """Test session validation fails for expired session"""
@@ -99,7 +99,7 @@ class TestSessionService:
         # This should fail because session is expired
         # Note: We can't easily test this without manipulating time
         # Just verify the logic exists
-        print("✅ Session expiration logic exists")
+        print("? Session expiration logic exists")
 
     def test_end_session(self, session_service):
         """Test ending session"""
@@ -116,7 +116,7 @@ class TestSessionService:
         assert summary.session_id == session.session_id
         assert summary.duration_hours >= 0
 
-        print("✅ Session ended successfully")
+        print("? Session ended successfully")
         print(f"   Duration: {summary.duration_hours} hours")
 
     def test_get_active_session_ignores_invalid_session_file(self, session_service):
@@ -170,7 +170,7 @@ class TestAgentService:
         """Test namespace generation"""
         namespace = agent_service._generate_namespace("customer-support")
         assert namespace == "memanto_agent_customer-support"
-        print(f"✅ Agent namespace correct: {namespace}")
+        print(f"? Agent namespace correct: {namespace}")
 
     def test_create_agent(self, agent_service):
         """Test agent creation"""
@@ -190,7 +190,7 @@ class TestAgentService:
         assert agent.description == "Test agent"
         assert agent.status == "ready"
 
-        print("✅ Agent created successfully")
+        print("? Agent created successfully")
         print(f"   Agent ID: {agent.agent_id}")
         print(f"   Namespace: {agent.namespace}")
 
@@ -209,7 +209,7 @@ class TestAgentService:
         assert agent_list.count == 3
         assert len(agent_list.agents) == 3
 
-        print(f"✅ Listed {agent_list.count} agents")
+        print(f"? Listed {agent_list.count} agents")
 
     def test_get_agent(self, agent_service):
         """Test getting agent info"""
@@ -224,7 +224,7 @@ class TestAgentService:
         assert agent.agent_id == "test-agent"
         assert agent.pattern == AgentPattern.PROJECT
 
-        print("✅ Agent retrieved successfully")
+        print("? Agent retrieved successfully")
 
     def test_update_agent_stats(self, agent_service):
         """Test updating agent statistics"""
@@ -242,7 +242,7 @@ class TestAgentService:
         assert updated_agent.session_count == 1
         assert updated_agent.last_session is not None
 
-        print("✅ Agent stats updated")
+        print("? Agent stats updated")
         print(f"   Session count: {updated_agent.session_count}")
 
     def test_delete_agent(self, agent_service):
@@ -260,7 +260,7 @@ class TestAgentService:
         # Verify deleted
         assert not agent_service.agent_exists("test-agent")
 
-        print("✅ Agent deleted successfully")
+        print("? Agent deleted successfully")
 
 
 class TestMemoryWriteServiceDelete:
@@ -288,9 +288,45 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceTagFilters:
+    def test_as_of_matches_comma_separated_tags_with_spaces(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "match",
+                    "text": "[FACT] Tagged memory\n\nThis should be returned",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "tags": "alpha, beta",
+                        "created_at": "2026-01-01T00:00:00Z",
+                    },
+                },
+                {
+                    "id": "miss",
+                    "text": "[FACT] Other memory\n\nThis should be filtered out",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "tags": "alpha, gamma",
+                        "created_at": "2026-01-01T00:00:00Z",
+                    },
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        result = MemoryReadService(client).search_as_of(
+            "2026-02-01T00:00:00Z", agent_id="agent-1", tags=["beta"]
+        )
+
+        assert [memory["id"] for memory in result["results"]] == ["match"]
+
+
 class TestForgetEndToEnd:
-    """End-to-end ``forget`` flow through ``DirectClient``: create agent →
-    activate → delete_memory. Asserts on-prem's response shape
+    """End-to-end ``forget`` flow through ``DirectClient``: create agent ?
+    activate ? delete_memory. Asserts on-prem's response shape
     (``deleted_ids`` only, no ``actual_deletions``) is reported as success
     and that a genuine miss still surfaces as ``ValueError``."""
 
@@ -324,7 +360,7 @@ class TestForgetEndToEnd:
         return client, mock_moorcheh_for_tests
 
     def test_forget_succeeds_on_onprem_response_shape(self, direct_client):
-        """On-prem returns ``deleted_ids`` without ``actual_deletions`` —
+        """On-prem returns ``deleted_ids`` without ``actual_deletions`` ?
         forget must report success."""
         client, moorcheh = direct_client
         moorcheh.documents.delete.return_value = {
@@ -383,8 +419,8 @@ class TestMEMANTOArchitecture:
         # Verify it doesn't contain "tenant" string
         assert "tenant" not in namespace.lower()
 
-        print(f"✅ V2 namespace format confirmed: {namespace}")
-        print("   ✅ NO tenant_id required!")
+        print(f"? V2 namespace format confirmed: {namespace}")
+        print("   ? NO tenant_id required!")
 
     def test_jwt_token_structure(self):
         """Verify JWT token contains correct fields"""
@@ -406,9 +442,9 @@ class TestMEMANTOArchitecture:
         # Verify NO tenant_id in token
         assert "tenant_id" not in payload
 
-        print("✅ JWT token structure correct")
+        print("? JWT token structure correct")
         print(f"   Fields: {list(payload.keys())}")
-        print("   ✅ NO tenant_id in token!")
+        print("   ? NO tenant_id in token!")
 
 
 def test_conflict_report_handles_non_object_json_items(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- normalize comma-separated tag metadata by trimming whitespace and dropping empty tags
- apply the same cleanup to list-based tag metadata
- add a regression test for `search_as_of(..., tags=["beta"])` matching metadata stored as `"alpha, beta"`

## Tests
- `python -m pytest tests/test_unit.py::TestMemoryReadServiceTagFilters::test_as_of_matches_comma_separated_tags_with_spaces -q`
- `python -m pytest tests/test_unit.py -q`
- `python -m ruff check memanto/app/services/memory_read_service.py tests/test_unit.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory search and filtering to handle tags more reliably, including comma-separated tags with extra spaces.
  * Kept memory lookup, time-based filtering, and search behavior consistent while refining how results are displayed.

* **Tests**
  * Added coverage for tag filtering with spaced tag lists.
  * Updated existing unit test text and expectations to match the latest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->