### PR TITLE
Fix API recall tag filters

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -56,6 +56,7 @@ class RecallRequest(BaseModel):
         default=None, ge=0.0, le=1.0, description="Minimum similarity score (0-1)"
     )
     type: list[str] | None = Field(default=None, description="Memory type filters")
+    tags: list[str] | None = Field(default=None, description="Tag filters")
 
 
 class RecallAsOfRequest(BaseModel):
@@ -661,6 +662,7 @@ async def recall(
             query=request.query,
             agent_id=agent_id,
             type=request.type,
+            tags=request.tags,
             min_similarity_score=min_similarity,
             limit=limit,
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -525,6 +525,31 @@ class TestMEMANTOAPI:
         assert "memory_type:fact" in call_kwargs["query"]
 
     @pytest.mark.asyncio
+    async def test_recall_accepts_tag_filter(self, client, auth_headers, mock_moorcheh):
+        """Test recall request forwards tag filters to the read service."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        payload = {"query": "deployment notes", "tags": ["release"]}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall",
+            headers=headers,
+            json=payload,
+        )
+
+        assert response.status_code == 200
+        call_kwargs = mock_moorcheh.similarity_search.query.call_args.kwargs
+        assert "#release" in call_kwargs["query"]
+
+    @pytest.mark.asyncio
     async def test_get_agent(self, client, auth_headers):
         """Test getting agent details"""
         await client.post(


### PR DESCRIPTION
Refs #770

## Summary
- add `tags` to the session-based `/api/v2/agents/{agent_id}/recall` request model
- forward API tag filters into `MemoryReadService.search_memories`
- add an API regression test proving a tag filter reaches the generated Moorcheh query

## Reproduction
The CLI and direct client already accept `tags` for standard recall, and `MemoryReadService.search_memories()` supports them. The HTTP API route did not expose `tags` in `RecallRequest` and never passed tags to the read service, so API callers could not narrow semantic recall to a specific tag even though tagged memories can be written through `/remember` and `/batch-remember`.

## Fix
Thread the existing tag filter support through the API boundary by adding `tags: list[str] | None` to `RecallRequest` and passing `request.tags` to `search_memories()`.

## Validation
- `.\.venv\Scripts\python -m pytest tests/test_api.py::TestMEMANTOAPI::test_recall_accepts_tag_filter tests/test_api.py::TestMEMANTOAPI::test_recall_accepts_type_filter -q`
- `.\.venv\Scripts\python -m pytest tests/test_api.py -q`
- `.\.venv\Scripts\python -m ruff check memanto/app/routes/memory.py tests/test_api.py`
- `.\.venv\Scripts\python -m py_compile memanto/app/routes/memory.py tests/test_api.py`
- `git diff --check`

Prepared with Codex assistance for the account owner; no payout details are included publicly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recall searches now support optional tag-based filtering, making it easier to narrow results to relevant memories.
  * The standard recall flow continues to work as before when no tags are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->