### PR TITLE
Fix temporal recall tag filters

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -65,6 +65,7 @@ class RecallAsOfRequest(BaseModel):
     )
     limit: int | None = Field(default=None, ge=1, description="Max results")
     type: list[str] | None = Field(default=None, description="Memory type filters")
+    tags: list[str] | None = Field(default=None, description="Tag filters")
 
     @field_validator("as_of", mode="before")
     @classmethod
@@ -99,6 +100,7 @@ class RecallChangedSinceRequest(BaseModel):
     )
     limit: int | None = Field(default=None, ge=1, description="Max results")
     type: list[str] | None = Field(default=None, description="Memory type filters")
+    tags: list[str] | None = Field(default=None, description="Tag filters")
 
     @field_validator("since", mode="before")
     @classmethod
@@ -129,6 +131,7 @@ class RecallChangedSinceRequest(BaseModel):
 class RecallRecentRequest(BaseModel):
     limit: int | None = Field(default=None, ge=1, description="Max results")
     type: list[str] | None = Field(default=None, description="Memory type filters")
+    tags: list[str] | None = Field(default=None, description="Tag filters")
 
 
 class MemoryEditRequest(BaseModel):
@@ -951,6 +954,7 @@ async def recall_as_of(
             as_of_date=request.as_of.isoformat(),
             agent_id=agent_id,
             type=request.type,
+            tags=request.tags,
             limit=limit,
         )
 
@@ -999,6 +1003,7 @@ async def recall_changed_since(
             since_date=request.since.isoformat(),
             agent_id=agent_id,
             type=request.type,
+            tags=request.tags,
             limit=limit,
         )
 
@@ -1047,6 +1052,7 @@ async def recall_recent(
             read_service.search_recent,
             agent_id=agent_id,
             type=request.type,
+            tags=request.tags,
             limit=limit,
         )
 

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -309,6 +309,7 @@ class MemoryReadService:
         self,
         agent_id: str,
         type: list[str] | None = None,
+        tags: list[str] | None = None,
         limit: int | None = 10,
     ) -> dict[str, Any]:
         """
@@ -317,6 +318,7 @@ class MemoryReadService:
         Args:
             agent_id: Agent whose memories to search
             type: Optional memory type filters
+            tags: Optional tag filters
             limit: Max results to return
         """
         try:
@@ -326,7 +328,9 @@ class MemoryReadService:
             if not namespaces:
                 return {"results": [], "total_found": 0}
 
-            unique_memories = self._fetch_all_memories(namespaces, type=type)
+            unique_memories = self._fetch_all_memories(
+                namespaces, type=type, tags=tags
+            )
 
             # Sort by created_at descending (most recent first)
             def _created_sort_key(m: dict[str, Any]) -> str:

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -998,6 +998,7 @@ class DirectClient:
         as_of: str,
         limit: int | None = None,
         type: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Point-in-time recall: what memories existed at a given moment?
@@ -1007,6 +1008,7 @@ class DirectClient:
             as_of: ISO-8601 date/datetime string.
             limit: Max results (defaults to config).
             type: Optional type filter.
+            tags: Optional tag filter.
 
         Returns:
             Dict with ``memories`` and ``count``.
@@ -1021,6 +1023,7 @@ class DirectClient:
             as_of_date=as_of,
             agent_id=agent_id,
             type=type,
+            tags=tags,
             limit=limit,
         )
 
@@ -1037,6 +1040,7 @@ class DirectClient:
         since: str,
         limit: int | None = None,
         type: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Differential retrieval: what changed since a given date?
@@ -1046,6 +1050,7 @@ class DirectClient:
             since: ISO-8601 date/datetime string.
             limit: Max results (defaults to config).
             type: Optional type filter.
+            tags: Optional tag filter.
 
         Returns:
             Dict with ``memories`` and ``count``.
@@ -1060,6 +1065,7 @@ class DirectClient:
             since_date=since,
             agent_id=agent_id,
             type=type,
+            tags=tags,
             limit=limit,
         )
 
@@ -1075,6 +1081,7 @@ class DirectClient:
         agent_id: str,
         limit: int | None = None,
         type: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Recall the most recently stored memories (newest first).
@@ -1083,6 +1090,7 @@ class DirectClient:
             agent_id: Target agent.
             limit: Max results (defaults to config).
             type: Optional type filter.
+            tags: Optional tag filter.
 
         Returns:
             Dict with ``memories`` and ``count``.
@@ -1096,6 +1104,7 @@ class DirectClient:
         result = self._get_read_service().search_recent(
             agent_id=agent_id,
             type=type,
+            tags=tags,
             limit=limit,
         )
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -871,6 +871,7 @@ class SdkClient:
         as_of: str,
         limit: int | None = None,
         type: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Point-in-time recall: what memories existed at a given moment?
@@ -880,6 +881,7 @@ class SdkClient:
             as_of: ISO-8601 date/datetime string.
             limit: Max results (defaults to config).
             type: Optional type filter.
+            tags: Optional tag filter.
 
         Returns:
             Dict with ``memories`` and ``count``.
@@ -894,6 +896,7 @@ class SdkClient:
             as_of_date=as_of,
             agent_id=agent_id,
             type=type,
+            tags=tags,
             limit=limit,
         )
 
@@ -910,6 +913,7 @@ class SdkClient:
         since: str,
         limit: int | None = None,
         type: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Differential retrieval: what changed since a given date?
@@ -919,6 +923,7 @@ class SdkClient:
             since: ISO-8601 date/datetime string.
             limit: Max results (defaults to config).
             type: Optional type filter.
+            tags: Optional tag filter.
 
         Returns:
             Dict with ``memories`` and ``count``.
@@ -933,6 +938,7 @@ class SdkClient:
             since_date=since,
             agent_id=agent_id,
             type=type,
+            tags=tags,
             limit=limit,
         )
 
@@ -948,6 +954,7 @@ class SdkClient:
         agent_id: str,
         limit: int | None = None,
         type: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Recall the most recently stored memories (newest first).
@@ -956,6 +963,7 @@ class SdkClient:
             agent_id: Target agent.
             limit: Max results (defaults to config).
             type: Optional type filter.
+            tags: Optional tag filter.
 
         Returns:
             Dict with ``memories`` and ``count``.
@@ -969,6 +977,7 @@ class SdkClient:
         result = self._get_read_service().search_recent(
             agent_id=agent_id,
             type=type,
+            tags=tags,
             limit=limit,
         )
 

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -546,6 +546,7 @@ def recall(
                     as_of=as_of,
                     limit=limit,
                     type=type,
+                    tags=tag_list,
                 )
                 temporal_mode = "as_of"
             elif changed_since:
@@ -554,6 +555,7 @@ def recall(
                     since=changed_since,
                     limit=limit,
                     type=type,
+                    tags=tag_list,
                 )
                 temporal_mode = "changed_since"
             elif recent:
@@ -561,6 +563,7 @@ def recall(
                     agent_id=agent_id,
                     limit=limit,
                     type=type,
+                    tags=tag_list,
                 )
                 temporal_mode = "recent"
             elif query:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1043,6 +1043,54 @@ class TestMEMANTOAPI:
         assert response.json()["temporal_mode"] == "recent"
 
     @pytest.mark.asyncio
+    async def test_recall_recent_accepts_tag_filter(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Test recall/recent forwards tags to temporal retrieval."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        mock_moorcheh.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "m1",
+                    "metadata": {
+                        "created_at": "2025-06-01T10:00:00",
+                        "tags": "release,backend",
+                    },
+                    "text": "release note",
+                },
+                {
+                    "id": "m2",
+                    "metadata": {
+                        "created_at": "2025-06-02T10:00:00",
+                        "tags": "design",
+                    },
+                    "text": "design note",
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers=headers,
+            json={"tags": ["release"]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+        assert response.json()["memories"][0]["id"] == "m1"
+
+    @pytest.mark.asyncio
     async def test_conflicts_list_api(self, client, auth_headers):
         """Test listing conflicts via API."""
         await client.post(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1091,6 +1091,104 @@ class TestMEMANTOAPI:
         assert response.json()["memories"][0]["id"] == "m1"
 
     @pytest.mark.asyncio
+    async def test_recall_as_of_accepts_tag_filter(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Test recall/as-of forwards tags to temporal retrieval."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        mock_moorcheh.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "m1",
+                    "metadata": {
+                        "created_at": "2025-06-01T10:00:00",
+                        "tags": "release,backend",
+                    },
+                    "text": "release note",
+                },
+                {
+                    "id": "m2",
+                    "metadata": {
+                        "created_at": "2025-06-01T10:00:00",
+                        "tags": "design",
+                    },
+                    "text": "design note",
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/as-of",
+            headers=headers,
+            json={"as_of": "2025-06-02T00:00:00Z", "tags": ["release"]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+        assert response.json()["memories"][0]["id"] == "m1"
+
+    @pytest.mark.asyncio
+    async def test_recall_changed_since_accepts_tag_filter(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Test recall/changed-since forwards tags to temporal retrieval."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+        headers = {**auth_headers, "X-Session-Token": token}
+
+        mock_moorcheh.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "m1",
+                    "metadata": {
+                        "created_at": "2025-06-01T10:00:00",
+                        "updated_at": "2025-06-03T10:00:00",
+                        "tags": "release,backend",
+                    },
+                    "text": "release note",
+                },
+                {
+                    "id": "m2",
+                    "metadata": {
+                        "created_at": "2025-06-01T10:00:00",
+                        "updated_at": "2025-06-03T10:00:00",
+                        "tags": "design",
+                    },
+                    "text": "design note",
+                },
+            ],
+            "pagination": {"has_more": False},
+        }
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/changed-since",
+            headers=headers,
+            json={"since": "2025-06-02T00:00:00Z", "tags": ["release"]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+        assert response.json()["memories"][0]["id"] == "m1"
+
+    @pytest.mark.asyncio
     async def test_conflicts_list_api(self, client, auth_headers):
         """Test listing conflicts via API."""
         await client.post(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -489,6 +489,19 @@ class TestMEMANTOCLI:
         call_kwargs = mock_all_clients.recall_recent.call_args.kwargs
         assert call_kwargs["limit"] == 5
 
+    def test_recall_recent_forwards_tags(self, mock_all_clients):
+        """`memanto recall --recent --tags` forwards tag filters."""
+        mock_all_clients.recall_recent.return_value = {"memories": [], "count": 0}
+
+        result = runner.invoke(
+            app,
+            ["recall", "--recent", "--tags", "release, backend", "--limit", "5"],
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_all_clients.recall_recent.call_args.kwargs
+        assert call_kwargs["tags"] == ["release", "backend"]
+
     def test_recall_recent_rejects_query(self, mock_all_clients):
         """`--recent` is chronological; passing a query alongside is an error."""
         result = runner.invoke(app, ["recall", "some query", "--recent"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -502,6 +502,47 @@ class TestMEMANTOCLI:
         call_kwargs = mock_all_clients.recall_recent.call_args.kwargs
         assert call_kwargs["tags"] == ["release", "backend"]
 
+    def test_recall_as_of_forwards_tags(self, mock_all_clients):
+        """`memanto recall --as-of --tags` forwards tag filters."""
+        mock_all_clients.recall_as_of.return_value = {"memories": [], "count": 0}
+
+        result = runner.invoke(
+            app,
+            [
+                "recall",
+                "--as-of",
+                "2025-06-02T00:00:00Z",
+                "--tags",
+                "release, backend",
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_all_clients.recall_as_of.call_args.kwargs
+        assert call_kwargs["tags"] == ["release", "backend"]
+
+    def test_recall_changed_since_forwards_tags(self, mock_all_clients):
+        """`memanto recall --changed-since --tags` forwards tag filters."""
+        mock_all_clients.recall_changed_since.return_value = {
+            "memories": [],
+            "count": 0,
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "recall",
+                "--changed-since",
+                "2025-06-02T00:00:00Z",
+                "--tags",
+                "release, backend",
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_all_clients.recall_changed_since.call_args.kwargs
+        assert call_kwargs["tags"] == ["release", "backend"]
+
     def test_recall_recent_rejects_query(self, mock_all_clients):
         """`--recent` is chronological; passing a query alongside is an error."""
         result = runner.invoke(app, ["recall", "some query", "--recent"])


### PR DESCRIPTION
## Summary
- Add `tags` support to temporal recall request models (`as-of`, `changed-since`, `recent`).
- Forward tag filters through API routes, CLI commands, and direct/SDK clients.
- Apply tags to `search_recent` so recent recall matches the existing temporal filtering behavior.

## Why
`memanto recall --recent --tags ...` already parses the tag flag, but temporal recall modes dropped the parsed filter before reaching the read service. The API temporal endpoints also accepted type filters but not tag filters, leaving users unable to narrow chronological recall by tags.

Related to #770.

## Tests
- `python -m pytest tests/test_api.py::TestMEMANTOAPI::test_recall_recent_api tests/test_api.py::TestMEMANTOAPI::test_recall_recent_accepts_tag_filter -q`
- `python -m pytest tests/test_cli.py::TestMEMANTOCLI::test_recall_recent tests/test_cli.py::TestMEMANTOCLI::test_recall_recent_forwards_tags -q`
- `python -m ruff check memanto/app/routes/memory.py memanto/app/services/memory_read_service.py memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py memanto/cli/commands/memory.py tests/test_cli.py tests/test_api.py`
- `python -m py_compile memanto/app/routes/memory.py memanto/app/services/memory_read_service.py memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py memanto/cli/commands/memory.py tests/test_cli.py tests/test_api.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tag filtering to temporal recall requests and client commands.
  * You can now narrow recent, point-in-time, and changed-since recall results by tags.
* **Bug Fixes**
  * Temporal recall paths now apply the same tag filtering behavior as standard recall.
* **Tests**
  * Added coverage for API and CLI recall flows to confirm tag-based filtering works end-to-end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->