### PR TITLE
Preserve batch import timestamps

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -286,19 +286,11 @@ class MemoryReadService:
                     except (ValueError, AttributeError):
                         pass
 
-            # Sort by parsed timestamps so mixed UTC offsets compare correctly.
-            def _changed_sort_key(memory: dict[str, Any]) -> datetime:
-                raw = memory.get("updated_at") or memory.get("created_at")
-                if not raw:
-                    return datetime.min.replace(tzinfo=timezone.utc)
-                try:
-                    return parse_iso_timestamp(str(raw))
-                except (ValueError, AttributeError):
-                    return datetime.min.replace(tzinfo=timezone.utc)
-
             # Sort by updated_at descending (most recent first)
             changed_memories.sort(
-                key=_changed_sort_key,
+                key=lambda memory: self._temporal_sort_key(
+                    memory.get("updated_at") or memory.get("created_at")
+                ),
                 reverse=True,
             )
 
@@ -331,8 +323,6 @@ class MemoryReadService:
             limit: Max results to return
         """
         try:
-            from memanto.app.utils.temporal_helpers import parse_iso_timestamp
-
             namespaces = self._get_search_namespaces(agent_id)
             if not namespaces:
                 return {"results": [], "total_found": 0}
@@ -340,22 +330,27 @@ class MemoryReadService:
             unique_memories = self._fetch_all_memories(namespaces, type=type)
 
             # Sort by created_at descending (most recent first)
-            def _created_sort_key(m: dict[str, Any]) -> str:
-                raw = m.get("created_at")
-                if not raw:
-                    return ""
-                try:
-                    return parse_iso_timestamp(str(raw)).isoformat()
-                except Exception:
-                    return ""
-
-            unique_memories.sort(key=_created_sort_key, reverse=True)
+            unique_memories.sort(
+                key=lambda memory: self._temporal_sort_key(memory.get("created_at")),
+                reverse=True,
+            )
 
             results = unique_memories if limit is None else unique_memories[:limit]
             return {"results": results, "total_found": len(results)}
 
         except Exception as e:
             raise MemoryError(f"Failed to retrieve recent memories: {e}")
+
+    @staticmethod
+    def _temporal_sort_key(raw: Any) -> datetime:
+        if not raw:
+            return datetime.min.replace(tzinfo=timezone.utc)
+        try:
+            from memanto.app.utils.temporal_helpers import parse_iso_timestamp
+
+            return parse_iso_timestamp(str(raw))
+        except (ValueError, AttributeError):
+            return datetime.min.replace(tzinfo=timezone.utc)
 
     def _fetch_all_memories(
         self,

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -286,9 +286,20 @@ class MemoryReadService:
                     except (ValueError, AttributeError):
                         pass
 
+            # Sort by parsed timestamps so mixed UTC offsets compare correctly.
+            def _changed_sort_key(memory: dict[str, Any]) -> datetime:
+                raw = memory.get("updated_at") or memory.get("created_at")
+                if not raw:
+                    return datetime.min.replace(tzinfo=timezone.utc)
+                try:
+                    return parse_iso_timestamp(str(raw))
+                except (ValueError, AttributeError):
+                    return datetime.min.replace(tzinfo=timezone.utc)
+
             # Sort by updated_at descending (most recent first)
             changed_memories.sort(
-                key=lambda m: m.get("updated_at", m.get("created_at", "")), reverse=True
+                key=_changed_sort_key,
+                reverse=True,
             )
 
             # Apply limit

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -104,7 +104,8 @@ class MemoryWriteService:
             results = []
             validated_documents = []
 
-            # Enforce server-side timestamps for batch (single timestamp for all)
+            # Use one timestamp for regular batch writes while preserving
+            # explicit source timestamps passed by migration/import callers.
             now = datetime.utcnow()
 
             for memory in memories:
@@ -113,9 +114,10 @@ class MemoryWriteService:
                     if not memory.id:
                         memory.id = generate_memory_id()
 
-                    # Enforce server-side timestamps (never trust client)
-                    memory.created_at = now
-                    memory.updated_at = now
+                    if "created_at" not in memory.model_fields_set:
+                        memory.created_at = now
+                    if "updated_at" not in memory.model_fields_set:
+                        memory.updated_at = now
 
                     memory = self._parser.parse_memory(memory)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,7 +4,7 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import jwt
@@ -286,6 +286,39 @@ class TestMemoryWriteServiceDelete:
         client = MagicMock()
         client.documents.delete.return_value = response
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
+
+
+class TestMemoryWriteServiceBatch:
+    """Batch writes are also used by migrations, so explicit source
+    timestamps must survive the upload document conversion."""
+
+    def test_batch_store_preserves_explicit_source_timestamps(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "success"}
+        created_at = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        updated_at = datetime(2024, 1, 3, 4, 5, 6, tzinfo=timezone.utc)
+        memory = MemoryRecord(
+            type="fact",
+            title="Imported memory",
+            content="Historical imported memory",
+            agent_id="agent-1",
+            actor_id="agent-1",
+            source="imported",
+            provenance="imported",
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        result = MemoryWriteService(client).batch_store_memories([memory])
+
+        assert result["successful"] == 1
+        upload_kwargs = client.documents.upload.call_args.kwargs
+        uploaded_doc = upload_kwargs["documents"][0]
+        assert uploaded_doc["created_at"] == created_at.isoformat()
+        assert uploaded_doc["updated_at"] == updated_at.isoformat()
 
 
 class TestForgetEndToEnd:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -321,6 +321,38 @@ class TestMemoryWriteServiceBatch:
         assert uploaded_doc["updated_at"] == updated_at.isoformat()
 
 
+class TestMemoryReadServiceTemporal:
+    def test_search_changed_since_sorts_mixed_timezone_timestamps(self, monkeypatch):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        service = MemoryReadService(MagicMock())
+        monkeypatch.setattr(service, "_get_search_namespaces", lambda agent_id: ["ns"])
+        monkeypatch.setattr(
+            service,
+            "_fetch_all_memories",
+            lambda namespaces, type=None, tags=None: [
+                {
+                    "id": "older",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "updated_at": "2024-01-03T00:30:00+02:00",
+                },
+                {
+                    "id": "newer",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "updated_at": "2024-01-02T23:00:00Z",
+                },
+            ],
+        )
+
+        result = service.search_changed_since(
+            "2024-01-01T00:00:00Z",
+            "agent-1",
+            limit=None,
+        )
+
+        assert [memory["id"] for memory in result["results"]] == ["newer", "older"]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- Preserve explicit `created_at` / `updated_at` values on batch memory writes.
- Keep the existing server timestamp default for ordinary batch records that do not provide source timestamps.
- Add a regression test proving imported source timestamps survive document upload conversion.

## Why
`memanto migrate` maps source-side timestamps into batch payloads so imported history can be recalled and sorted correctly. `MemoryWriteService.batch_store_memories()` was immediately replacing those explicit timestamps with the current import time, which makes imported historical memories look newly created and breaks temporal recall modes such as `recent`, `as-of`, and `changed-since`.

Related to #770.

## Tests
- `python -m pytest tests/test_unit.py::TestMemoryWriteServiceBatch::test_batch_store_preserves_explicit_source_timestamps -q`
- `python -m pytest tests/test_unit.py::TestMemoryWriteServiceDelete -q`
- `python -m pytest tests/test_cli.py::TestMEMANTOCLI::test_migrate_mem0_dry_run tests/test_cli.py::TestMEMANTOCLI::test_migrate_letta_dry_run tests/test_cli.py::TestMEMANTOCLI::test_migrate_supermemory_dry_run -q`
- `python -m pytest tests/test_api.py::TestMEMANTOAPI::test_batch_remember_api tests/test_api.py::TestMEMANTOAPI::test_recall_recent_api -q`
- `python -m ruff check memanto/app/services/memory_write_service.py tests/test_unit.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch memory saves now preserve explicitly provided `created_at`/`updated_at` values, instead of overwriting them for every record in the batch.
  * “Changed since” results are now sorted using parsed timestamps, handling mixed timezone formats more reliably (and missing/invalid values safely).
  * “Recent” results now use the same improved timestamp parsing for consistent ordering.
* **Tests**
  * Added unit coverage for timestamp preservation during batch writes.
  * Added unit coverage for “changed since” sorting with mixed timezone timestamp inputs (using timezone-aware UTC assertions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->