### PR TITLE
Handle on-prem delete result during memory updates

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -311,7 +311,7 @@ class MemoryWriteService:
                 namespace_name=namespace, ids=[memory_id]
             )
 
-            if delete_result.get("actual_deletions", 0) == 0:
+            if not self._delete_succeeded(delete_result):
                 raise MemoryError(f"Failed to delete old version of memory {memory_id}")
 
             validation_result = {"action": "store", "reason": "MVP direct store"}
@@ -349,18 +349,22 @@ class MemoryWriteService:
                 self.client.documents.delete(namespace_name=namespace, ids=[memory_id]),
             )
 
-            # Cloud returns ``actual_deletions``; on-prem's /items/delete only
-            # returns ``deleted_ids`` (and ``status``). Mirror the cloud SDK's
-            # ``_deletion_processed_count`` so both backends report success.
-            raw = result.get("actual_deletions")
-            if isinstance(raw, int):
-                return raw > 0
-            for key in ("deleted_ids", "requested_ids"):
-                ids = result.get(key)
-                if isinstance(ids, list):
-                    return len(ids) > 0
-            # Some on-prem builds only return ``{"status": "success"}``.
-            return str(result.get("status", "")).lower() in {"success", "ok"}
+            return self._delete_succeeded(result)
 
         except Exception as e:
             raise MemoryError(f"Failed to delete memory: {e}")
+
+    @staticmethod
+    def _delete_succeeded(result: dict[str, Any]) -> bool:
+        # Cloud returns ``actual_deletions``; on-prem's /items/delete only
+        # returns ``deleted_ids`` (and ``status``). Mirror the cloud SDK's
+        # ``_deletion_processed_count`` so both backends report success.
+        raw = result.get("actual_deletions")
+        if isinstance(raw, int):
+            return raw > 0
+        for key in ("deleted_ids", "requested_ids"):
+            ids = result.get(key)
+            if isinstance(ids, list):
+                return len(ids) > 0
+        # Some on-prem builds only return ``{"status": "success"}``.
+        return str(result.get("status", "")).lower() in {"success", "ok"}

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -287,6 +287,52 @@ class TestMemoryWriteServiceDelete:
         client.documents.delete.return_value = response
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
+    def test_update_memory_accepts_onprem_delete_response(self, monkeypatch):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": ["m1"],
+        }
+        client.documents.upload.return_value = {"status": "success"}
+
+        class FakeReadService:
+            def __init__(self, client):
+                self.client = client
+
+            def get_memory(self, memory_id, namespace):
+                return {
+                    "id": memory_id,
+                    "type": "fact",
+                    "title": "Old title",
+                    "content": "Old content",
+                    "agent_id": "agent-1",
+                    "actor_id": "agent-1",
+                    "source": "manual",
+                    "confidence": 0.8,
+                    "status": "active",
+                    "tags": [],
+                }
+
+        monkeypatch.setattr(
+            "memanto.app.services.memory_read_service.MemoryReadService",
+            FakeReadService,
+        )
+
+        result = MemoryWriteService(client).update_memory(
+            "m1",
+            "memanto_agent_agent-1",
+            {"title": "Updated title"},
+        )
+
+        assert result["status"] == "success"
+        client.documents.delete.assert_called_once_with(
+            namespace_name="memanto_agent_agent-1",
+            ids=["m1"],
+        )
+        client.documents.upload.assert_called_once()
+
 
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →


### PR DESCRIPTION
## Summary
- reuse a single delete-result success helper for memory update and delete paths
- let update_memory accept on-prem delete responses such as `deleted_ids`/`status`, matching delete_memory behavior
- add regression coverage proving an on-prem delete response still allows the updated memory to be uploaded

## Why this matters
`update_memory()` uses a delete-and-recreate flow. On on-prem backends, `documents.delete()` can report success with `deleted_ids` instead of cloud-only `actual_deletions`. The previous update path treated that successful delete as a failure, so editing an existing memory could fail after the old version was deleted.

## Tests
- `python -m pytest tests/test_unit.py::TestMemoryWriteServiceDelete -q`
- `python -m ruff check memanto/app/services/memory_write_service.py tests/test_unit.py`
- `git diff --check`

Part of #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory update and delete handling so successful deletions are recognized across different response formats, including cloud and on-premise styles.
  * Fixed delete-and-recreate flows to proceed correctly when a deletion succeeds with alternative success indicators.

* **Tests**
  * Added coverage for successful update behavior when deletion responses return an on-premise-style success payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->