### PR TITLE
Preserve falsey metadata fields when formatting memories

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -636,8 +636,11 @@ class MemoryReadService:
         def get_field(field_name, flat_field_name=None):
             """Get field from metadata object or fallback to flat field"""
             flat_name = flat_field_name or field_name
-            # Try metadata object first (API spec), then flat field (fallback)
-            return metadata.get(field_name) or item.get(flat_name)
+            # Try metadata object first (API spec), then flat field (fallback).
+            # Preserve valid falsey metadata values such as confidence=0.0.
+            if field_name in metadata and metadata[field_name] is not None:
+                return metadata[field_name]
+            return item.get(flat_name)
 
         # Parse tags - can be comma-separated string or array
         tags_value = get_field("tags")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,30 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceFormatting:
+    def test_format_memory_item_preserves_falsey_metadata_values(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        item = {
+            "id": "m1",
+            "text": "[FACT] Budget cap\n\nKeep spending at zero.",
+            "confidence": 0.8,
+            "status": "active",
+            "metadata": {
+                "memory_type": "fact",
+                "confidence": 0.0,
+                "status": "",
+                "tags": [],
+            },
+        }
+
+        formatted = MemoryReadService(MagicMock())._format_memory_item(item)
+
+        assert formatted["confidence"] == 0.0
+        assert formatted["status"] == ""
+        assert formatted["tags"] == []
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
## Summary
- preserve valid falsey values from nested metadata when formatting memory items
- avoid falling back to flat fields for `confidence: 0.0`, empty status strings, or empty tag arrays
- add regression coverage for falsey metadata values

## Why this matters
`_format_memory_item()` preferred nested Moorcheh metadata, but used `metadata.get(field) or item.get(field)`. That means valid falsey metadata values were silently replaced by flat fallback values. A stored confidence of `0.0`, for example, could be displayed as a different flat value.

## Tests
- `python -m pytest tests/test_unit.py::TestMemoryReadServiceFormatting::test_format_memory_item_preserves_falsey_metadata_values -q`
- `python -m ruff check memanto/app/services/memory_read_service.py tests/test_unit.py`
- `git diff --check`

Part of #770.