### PR TITLE
Fix temporal search post-filter truncation

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -98,9 +98,13 @@ class MemoryReadService:
                 metadata_filters=metadata_filters,
             )
 
-            # Build query parameters
-            # Request extra results to handle offset (Moorcheh doesn't have native offset support)
-            requested_limit = limit + offset
+            # Build query parameters.
+            # Request extra results to handle offset (Moorcheh doesn't have
+            # native offset support). When filters are applied client-side
+            # after retrieval, fetch the backend page cap so valid lower-ranked
+            # memories are not lost before post-processing.
+            has_post_filters = bool(created_after or created_before)
+            requested_limit = 100 if has_post_filters else limit + offset
             top_k = min(requested_limit, 100)  # Moorcheh max is 100
 
             # Perform search with server-side filtering.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,57 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryReadServiceSearch:
+    def test_search_memories_fetches_extra_rows_before_temporal_filtering(
+        self, monkeypatch
+    ):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        client.similarity_search.query.return_value = {
+            "results": [
+                {
+                    "id": "old-1",
+                    "text": "[FACT] Old one\n\nExpired before filter",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2024-01-01T00:00:00Z",
+                    },
+                },
+                {
+                    "id": "old-2",
+                    "text": "[FACT] Old two\n\nAlso before filter",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2024-01-02T00:00:00Z",
+                    },
+                },
+                {
+                    "id": "fresh",
+                    "text": "[FACT] Fresh\n\nStill eligible",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2024-02-01T00:00:00Z",
+                    },
+                },
+            ],
+            "execution_time": 0.01,
+        }
+        service = MemoryReadService(client)
+        monkeypatch.setattr(service, "_get_search_namespaces", lambda agent_id: ["ns"])
+
+        result = service.search_memories(
+            "memory",
+            agent_id="agent-1",
+            limit=1,
+            created_after="2024-01-15T00:00:00Z",
+        )
+
+        client.similarity_search.query.assert_called_once()
+        assert client.similarity_search.query.call_args.kwargs["top_k"] == 100
+        assert [memory["id"] for memory in result["results"]] == ["fresh"]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -294,36 +294,41 @@ class TestMemoryReadServiceSearch:
     ):
         from memanto.app.services.memory_read_service import MemoryReadService
 
+        search_items = [
+            {
+                "id": "old-1",
+                "text": "[FACT] Old one\n\nExpired before filter",
+                "metadata": {
+                    "memory_type": "fact",
+                    "created_at": "2024-01-01T00:00:00Z",
+                },
+            },
+            {
+                "id": "old-2",
+                "text": "[FACT] Old two\n\nAlso before filter",
+                "metadata": {
+                    "memory_type": "fact",
+                    "created_at": "2024-01-02T00:00:00Z",
+                },
+            },
+            {
+                "id": "fresh",
+                "text": "[FACT] Fresh\n\nStill eligible",
+                "metadata": {
+                    "memory_type": "fact",
+                    "created_at": "2024-02-01T00:00:00Z",
+                },
+            },
+        ]
+
+        def query(**kwargs):
+            return {
+                "results": search_items[: kwargs["top_k"]],
+                "execution_time": 0.01,
+            }
+
         client = MagicMock()
-        client.similarity_search.query.return_value = {
-            "results": [
-                {
-                    "id": "old-1",
-                    "text": "[FACT] Old one\n\nExpired before filter",
-                    "metadata": {
-                        "memory_type": "fact",
-                        "created_at": "2024-01-01T00:00:00Z",
-                    },
-                },
-                {
-                    "id": "old-2",
-                    "text": "[FACT] Old two\n\nAlso before filter",
-                    "metadata": {
-                        "memory_type": "fact",
-                        "created_at": "2024-01-02T00:00:00Z",
-                    },
-                },
-                {
-                    "id": "fresh",
-                    "text": "[FACT] Fresh\n\nStill eligible",
-                    "metadata": {
-                        "memory_type": "fact",
-                        "created_at": "2024-02-01T00:00:00Z",
-                    },
-                },
-            ],
-            "execution_time": 0.01,
-        }
+        client.similarity_search.query.side_effect = query
         service = MemoryReadService(client)
         monkeypatch.setattr(service, "_get_search_namespaces", lambda agent_id: ["ns"])
 


### PR DESCRIPTION
## Summary
- fetch the backend page cap when search_memories uses client-side temporal post-filters
- prevent valid lower-ranked memories from being dropped before created_after/created_before filtering runs
- add a regression test proving an eligible result beyond the requested page survives filtering

## Reproduction
When search_memories is called with limit=1 and created_after, the code previously requested only one backend result before applying the temporal filter. If that first result was older than the boundary, the caller received no memories even when the next backend result matched the requested time window. This causes temporal recall/search to miss relevant memories because filtering happens after the backend page has already been truncated.

## Fix
For searches that rely on client-side temporal filtering, request Moorcheh's per-query page cap before applying post-processing, then apply the existing offset/limit to the filtered result set.

## Validation
- .\\.venv\\Scripts\\python -m pytest tests/test_unit.py::TestMemoryReadServiceTemporal::test_search_memories_fetches_extra_rows_before_temporal_filtering tests/test_unit.py::TestMemoryReadServiceTemporal::test_search_changed_since_sorts_mixed_timezone_timestamps -q
- .\\.venv\\Scripts\\python -m ruff check memanto\\app\\services\\memory_read_service.py tests\\test_unit.py
- git diff --check

Prepared with Codex assistance for the account owner; no payout details are included publicly.

Related to #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory search pagination when date-based filters are applied, fetching more results before temporal filtering to ensure the final page is accurate.
  * Preserved existing memory search behavior when no date filters are provided.
* **Tests**
  * Added a unit test to verify extra rows are requested when temporal filters are used and that only eligible memories are returned after filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->