### PR TITLE
Fetch extra search rows before TTL filtering

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -14,6 +14,8 @@ from memanto.app.config import settings
 from memanto.app.core import agent_namespace
 from memanto.app.utils.errors import MemoryError
 
+SEARCH_OVERFETCH_BUFFER = 10
+
 
 class MemoryReadService:
     def __init__(self, moorcheh_client: "MoorchehClient"):
@@ -98,39 +100,47 @@ class MemoryReadService:
                 metadata_filters=metadata_filters,
             )
 
-            # Build query parameters
-            # Request extra results to handle offset (Moorcheh doesn't have native offset support)
-            requested_limit = limit + offset
-            top_k = min(requested_limit, 100)  # Moorcheh max is 100
-
             # Perform search with server-side filtering.
             # Only enable kiosk_mode when the caller actually set a positive
             # threshold; min_similarity=0.0 means "no filter", but on-prem
             # kiosk_mode + threshold=0.0 still filters everything out.
             use_kiosk = min_similarity_score is not None and min_similarity_score > 0
-            search_result = self.client.similarity_search.query(
-                query=enhanced_query,
-                namespaces=namespaces,
-                top_k=top_k,
-                threshold=min_similarity_score if use_kiosk else None,
-                kiosk_mode=use_kiosk,
-            )
 
-            search_items = search_result.get("results", [])
-
-            # Format results
-            all_results = [self._format_memory_item(item) for item in search_items]
-
-            # Apply temporal filtering (post-processing since Moorcheh metadata filters are string-based)
-            if created_after or created_before:
-                all_results = self._apply_temporal_filter(
-                    all_results,
-                    created_after=created_after,
-                    created_before=created_before,
+            def run_search(top_k: int) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+                search_result = self.client.similarity_search.query(
+                    query=enhanced_query,
+                    namespaces=namespaces,
+                    top_k=top_k,
+                    threshold=min_similarity_score if use_kiosk else None,
+                    kiosk_mode=use_kiosk,
                 )
 
-            # Apply TTL enforcement - filter out expired memories
-            all_results = self._filter_expired_memories(all_results)
+                # Format results and apply local filters.
+                all_results = [
+                    self._format_memory_item(item)
+                    for item in search_result.get("results", [])
+                ]
+
+                # Apply temporal filtering (post-processing since Moorcheh metadata filters are string-based)
+                if created_after or created_before:
+                    all_results = self._apply_temporal_filter(
+                        all_results,
+                        created_after=created_after,
+                        created_before=created_before,
+                    )
+
+                # Apply TTL enforcement - filter out expired memories
+                return search_result, self._filter_expired_memories(all_results)
+
+            # Request the caller's window plus a small buffer first. TTL and
+            # temporal filters run locally, so widen to the backend cap only
+            # when the initial page was not enough to fill the requested slice.
+            initial_top_k = min(limit + offset + SEARCH_OVERFETCH_BUFFER, 100)
+            search_result, all_results = run_search(initial_top_k)
+
+            needs_more = len(all_results) < offset + limit and initial_top_k < 100
+            if needs_more:
+                search_result, all_results = run_search(100)
 
             # Apply pagination (offset + limit)
             paginated_results = all_results[offset : offset + limit]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,7 +4,7 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import jwt
@@ -286,6 +286,59 @@ class TestMemoryWriteServiceDelete:
         client = MagicMock()
         client.documents.delete.return_value = response
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
+
+
+class TestMemoryReadServiceSearch:
+    def test_search_fetches_extra_rows_before_ttl_filtering(self, monkeypatch):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        now = datetime.now(timezone.utc)
+        expired_at = (now - timedelta(days=1)).isoformat()
+        valid_until = (now + timedelta(days=1)).isoformat()
+        search_items = [
+            {
+                "id": f"expired-memory-{index}",
+                "text": "[FACT] Expired\n\nOld answer",
+                "metadata": {
+                    "memory_type": "fact",
+                    "created_at": "2025-01-01T00:00:00Z",
+                    "expires_at": expired_at,
+                },
+            }
+            for index in range(11)
+        ]
+        search_items.append(
+            {
+                "id": "valid-memory",
+                "text": "[FACT] Valid\n\nCurrent answer",
+                "metadata": {
+                    "memory_type": "fact",
+                    "created_at": "2025-01-02T00:00:00Z",
+                    "expires_at": valid_until,
+                },
+            }
+        )
+
+        def query(**kwargs):
+            return {
+                "results": search_items[: kwargs["top_k"]],
+                "execution_time": 0.01,
+            }
+
+        client = MagicMock()
+        client.similarity_search.query.side_effect = query
+        service = MemoryReadService(client)
+        monkeypatch.setattr(service, "_get_search_namespaces", lambda agent_id: ["ns"])
+
+        result = service.search_memories("answer", agent_id="agent-1", limit=1)
+
+        top_k_calls = [
+            call.kwargs["top_k"]
+            for call in client.similarity_search.query.call_args_list
+        ]
+        assert top_k_calls == [11, 100]
+        assert [memory["id"] for memory in result["results"]] == ["valid-memory"]
+        assert result["total_available"] == 1
 
 
 class TestForgetEndToEnd:


### PR DESCRIPTION
## Summary
- fetch a buffered search window first, then retry with Moorcheh's page cap only when local filtering leaves the requested page underfilled
- prevent expired high-ranking rows from hiding valid lower-ranking memories
- add regression coverage for `limit=1` with expired rows ahead of the first valid result

## Bug / Impact
`search_memories()` sizes the backend request before applying local filters. TTL enforcement and temporal bounds are applied after retrieval. If the most similar rows are already expired and the caller asks for a small page such as `limit=1`, the service can request too few rows, filter them all out, and return no results even when a lower-ranked memory is still valid.

That hurts recall accuracy: a valid fact can be hidden by expired facts that happen to rank higher.

## Reproduction
The unit test reproduces the failure with eleven expired search rows followed by one valid row. The mock honors the requested `top_k`, so the old `limit + offset` sizing would only return expired rows and produce an empty response.

After the fix, `search_memories("answer", agent_id="agent-1", limit=1)`:
1. fetches the requested window plus a small buffer
2. applies temporal and TTL filtering locally
3. retries with `top_k=100` only if the filtered result set cannot fill the requested page
4. returns the valid memory after pagination

## Fix
Move the formatting and local filters into a small search helper, then use adaptive fetch sizing:
- initial request: `min(limit + offset + 10, 100)`
- retry request: `100`, only when the filtered results are still too short to satisfy `offset + limit`

This preserves the correctness fix while avoiding a full 100-row fetch for common queries that do not need it.

Related to #770.

## Tests
- `.\.venv\Scripts\python -m pytest tests\test_unit.py::TestMemoryReadServiceSearch::test_search_fetches_extra_rows_before_ttl_filtering -q`
- `.\.venv\Scripts\python -m pytest tests\test_unit.py -q`
- `.\.venv\Scripts\python -m ruff check memanto\app\services\memory_read_service.py tests\test_unit.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory search pagination so results stay accurate even when some items are filtered out by date or expiration rules.
  * Search pages now over-fetch when needed, helping ensure the requested number of valid results is returned.
  * Added coverage for expired-result handling to prevent pagination gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->