### PR TITLE
Stream uploaded files to temp storage

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -48,6 +48,27 @@ router = APIRouter()
 
 _config_manager = ConfigManager()
 
+ALLOWED_UPLOAD_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".json", ".txt", ".csv", ".md"}
+MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024 * 1024
+UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
+
+
+async def _write_upload_file_to_path(file: UploadFile, path: str) -> int:
+    bytes_written = 0
+    with open(path, "wb") as tmp:
+        while chunk := await file.read(UPLOAD_CHUNK_SIZE_BYTES):
+            bytes_written += len(chunk)
+            if bytes_written > MAX_UPLOAD_SIZE_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=(
+                        "File exceeds maximum upload size of "
+                        f"{MAX_UPLOAD_SIZE_BYTES} bytes"
+                    ),
+                )
+            tmp.write(chunk)
+    return bytes_written
+
 
 class RecallRequest(BaseModel):
     query: str = Field(..., min_length=1, description="Search query")
@@ -231,6 +252,8 @@ async def remember(
             "type": result.get("type"),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 
@@ -510,15 +533,14 @@ async def upload_file(
     client = get_moorcheh_client()
 
     # Validate file extension before reading
-    ALLOWED_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".json", ".txt", ".csv", ".md"}
     # Sanitize filename: strip directory components to prevent path traversal (CWE-22)
     original_name = Path(file.filename or "upload").name
     # Guard against empty or dot-only filenames after sanitization
     if not original_name or original_name in (".", ".."):
         original_name = "upload"
     suffix = Path(original_name).suffix.lower()
-    if suffix not in ALLOWED_EXTENSIONS:
-        allowed_str = ", ".join(sorted(ALLOWED_EXTENSIONS))
+    if suffix not in ALLOWED_UPLOAD_EXTENSIONS:
+        allowed_str = ", ".join(sorted(ALLOWED_UPLOAD_EXTENSIONS))
         raise HTTPException(
             status_code=400,
             detail=f"File type '{suffix}' is not supported. Allowed types: {allowed_str}",
@@ -529,7 +551,6 @@ async def upload_file(
 
         # Write upload to a temp file so moorcheh SDK can read it
         # Use original filename so the SDK records it as the source
-        file_bytes = await file.read()
         tmp_dir = tempfile.mkdtemp()
         tmp_path = os.path.join(tmp_dir, original_name)
         # Defense-in-depth: verify resolved path is within tmp_dir
@@ -541,8 +562,7 @@ async def upload_file(
                 detail="Invalid filename",
             )
         try:
-            with open(tmp_path, "wb") as tmp:
-                tmp.write(file_bytes)
+            bytes_written = await _write_upload_file_to_path(file, tmp_path)
             result = await asyncio.to_thread(
                 client.documents.upload_file, namespace, tmp_path
             )
@@ -556,11 +576,13 @@ async def upload_file(
             "session_id": session.session_id,
             "namespace": namespace,
             "file_name": original_name,
-            "file_size": result.get("fileSize"),
+            "file_size": result.get("fileSize", bytes_written),
             "status": "uploaded" if result.get("success") else "failed",
             "message": result.get("message", ""),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from memanto.app.config import settings
 from memanto.app.main import app
 from memanto.app.models.session import Session
+from memanto.app.routes import memory as memory_routes
 from memanto.app.routes.auth_deps import get_current_session
 
 # Set test environment
@@ -1225,6 +1227,32 @@ class TestMEMANTOAPI:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_upload_file_over_size_limit_returns_413(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """Oversized uploads return 413 before calling the SDK."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        monkeypatch.setattr(memory_routes, "MAX_UPLOAD_SIZE_BYTES", 5)
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+            headers=headers,
+            files={"file": ("notes.txt", b"too large", "text/plain")},
+        )
+
+        assert response.status_code == 413
+        mock_moorcheh.documents.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_upload_file_requires_session(self, client, auth_headers):
         """Test that upload requires a valid session token"""
         await client.post(
@@ -1454,6 +1482,39 @@ class TestFilenameSanitizationLogic:
     def test_dotfile(self):
         result = self.sanitize(".env")
         assert result == ".env"
+
+
+class TestUploadFileStreaming:
+    """Direct tests for chunked upload writes."""
+
+    class ChunkedUpload:
+        def __init__(self, chunks: list[bytes]):
+            self.chunks = list(chunks)
+
+        async def read(self, size: int = -1) -> bytes:
+            return self.chunks.pop(0) if self.chunks else b""
+
+    @pytest.mark.asyncio
+    async def test_writes_upload_in_chunks(self, tmp_path):
+        upload = self.ChunkedUpload([b"alpha", b"beta", b"gamma"])
+        target = tmp_path / "upload.txt"
+
+        size = await memory_routes._write_upload_file_to_path(upload, str(target))
+
+        assert size == len(b"alphabetagamma")
+        assert target.read_bytes() == b"alphabetagamma"
+
+    @pytest.mark.asyncio
+    async def test_rejects_upload_over_size_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(memory_routes, "MAX_UPLOAD_SIZE_BYTES", 5)
+        upload = self.ChunkedUpload([b"abc", b"def"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await memory_routes._write_upload_file_to_path(
+                upload, str(tmp_path / "upload.txt")
+            )
+
+        assert exc_info.value.status_code == 413
 
 
 class TestRealpathGuard:


### PR DESCRIPTION
## Summary

- Stream API file uploads into the temporary SDK file instead of reading the full multipart body into memory.
- Enforce the documented 5GB upload cap while streaming and return 413 when exceeded.
- Report the local written byte count when the SDK response omits `fileSize`.

## Why

The upload endpoint advertises support for large document uploads, but it previously called `await file.read()` before writing the temp file. A large upload could allocate the entire file in server memory before the SDK ever processes it.

## Tests

- `.\.venv\Scripts\python.exe -m pytest tests/test_api.py -q`
- `.\.venv\Scripts\python.exe -m ruff check memanto/app/routes/memory.py tests/test_api.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File uploads now stream in fixed-size chunks, improving handling of larger uploads.
  * Uploads are validated against an allowlist of file extensions.

* **Bug Fixes**
  * Oversized uploads are rejected with a clear “request too large” (HTTP 413) response.
  * Upload responses now report file size more reliably, even when size details aren’t returned automatically.

* **Tests**
  * Added coverage to verify chunked streaming behavior and upload-size enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->