### PR TITLE
Normalize MCP recall tags from metadata strings

### DIFF
--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -903,7 +903,7 @@ def _to_memory_hit(raw: dict[str, Any]) -> MemoryHit:
         title=raw.get("title"),
         content=raw.get("content"),
         confidence=raw.get("confidence"),
-        tags=list(raw.get("tags") or []),
+        tags=_normalize_tags(raw.get("tags")),
         status=raw.get("status"),
         source=raw.get("source"),
         source_ref=raw.get("source_ref"),
@@ -915,3 +915,18 @@ def _to_memory_hit(raw: dict[str, Any]) -> MemoryHit:
             else raw.get("similarity_score")
         ),
     )
+
+
+def _normalize_tags(raw_tags: Any) -> list[str]:
+    """Return tags as a clean string list for MCP clients.
+
+    Core Memanto paths usually return tags as a list, but some backend and SDK
+    surfaces expose the stored comma-separated metadata string. Treating that
+    string with ``list(...)`` turns ``"alpha,beta"`` into characters, which
+    makes agent-side filtering and display misleading.
+    """
+    if isinstance(raw_tags, str):
+        return [tag.strip() for tag in raw_tags.split(",") if tag.strip()]
+    if isinstance(raw_tags, list):
+        return [str(tag).strip() for tag in raw_tags if str(tag).strip()]
+    return []

--- a/integrations/mcp/tests/test_tools.py
+++ b/integrations/mcp/tests/test_tools.py
@@ -1,0 +1,35 @@
+"""Tool-layer helpers should preserve Memanto result shape for MCP clients."""
+
+from __future__ import annotations
+
+from memanto_mcp.tools import _to_memory_hit
+
+
+def test_to_memory_hit_splits_comma_separated_tag_metadata() -> None:
+    hit = _to_memory_hit(
+        {
+            "id": "mem-1",
+            "content": "User prefers concise updates.",
+            "tags": "alpha, beta,release-notes",
+        }
+    )
+
+    assert hit.tags == ["alpha", "beta", "release-notes"]
+
+
+def test_to_memory_hit_keeps_tag_lists_clean() -> None:
+    hit = _to_memory_hit(
+        {
+            "id": "mem-1",
+            "content": "User prefers concise updates.",
+            "tags": ["alpha", " beta ", ""],
+        }
+    )
+
+    assert hit.tags == ["alpha", "beta"]
+
+
+def test_to_memory_hit_defaults_missing_tags_to_empty_list() -> None:
+    hit = _to_memory_hit({"id": "mem-1", "content": "No tags here."})
+
+    assert hit.tags == []


### PR DESCRIPTION
## Summary

Fixes a Memanto MCP tool-shaping bug where recall results with comma-separated tag metadata (for example `"alpha, beta"`) were exposed to MCP clients as a character list via `list(raw.get("tags"))`. That can mislead agent-side filtering, display, and downstream reasoning over recalled memories.

## Reproduction

Before this change, `_to_memory_hit({"tags": "alpha, beta"}).tags` returned characters instead of tag names. This can happen when a backend or SDK surface returns the stored flat metadata value rather than the already-normalized list shape.

## Fix

- Add `_normalize_tags()` for MCP memory-hit shaping.
- Split comma-separated tag strings and trim whitespace.
- Keep list inputs clean and default missing tags to an empty list.
- Add regression tests for string, list, and missing tag inputs.

## Validation

- `.\.venv\Scripts\python -m pytest integrations\mcp\tests\test_tools.py -q` -> 3 passed
- `.\.venv\Scripts\python -m pytest integrations\mcp\tests -q` -> 28 passed
- `.\.venv\Scripts\python -m ruff check integrations\mcp\memanto_mcp\tools.py integrations\mcp\tests\test_tools.py` -> passed

Bounty context: #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag handling so memory results now return tags consistently as a clean list.
  * Comma-separated tag values are split and trimmed correctly, list values are cleaned up, and missing tags now default to an empty list.
* **Tests**
  * Added coverage for tag normalization across string, list, and missing-value cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->