### PR TITLE
Count ok batch upload responses as successful

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -204,7 +204,7 @@ class MemoryWriteService:
                 for r in results
                 if str(r["status"]).lower() in SUCCESSFUL_UPLOAD_STATUSES
             )
-            failed = sum(1 for r in results if r["status"] == "failed")
+            failed = sum(1 for r in results if str(r["status"]).lower() == "failed")
 
             return {
                 "total_submitted": len(memories),

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -13,6 +13,8 @@ from memanto.app.services.memory_parsing_service import MemoryParsingService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
 
+SUCCESSFUL_UPLOAD_STATUSES = {"queued", "success", "ok"}
+
 
 class MemoryWriteService:
     """Persist memory records to Moorcheh-backed namespaces."""
@@ -197,7 +199,11 @@ class MemoryWriteService:
                         result["status"] = moorcheh_status
 
             # Count successes and failures
-            successful = sum(1 for r in results if r["status"] in ["queued", "success"])
+            successful = sum(
+                1
+                for r in results
+                if str(r["status"]).lower() in SUCCESSFUL_UPLOAD_STATUSES
+            )
             failed = sum(1 for r in results if r["status"] == "failed")
 
             return {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -318,6 +318,27 @@ class TestMemoryWriteServiceBatch:
         assert result["failed"] == 0
         assert [item["status"] for item in result["results"]] == ["ok", "ok"]
 
+    def test_batch_store_counts_failed_upload_status_case_insensitively(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "FAILED"}
+        memories = [
+            MemoryRecord(
+                title="Failed write",
+                content="This write should be counted as failed.",
+                agent_id="agent-1",
+                actor_id="user-1",
+                source="test",
+            )
+        ]
+
+        result = MemoryWriteService(client).batch_store_memories(memories)
+
+        assert result["successful"] == 0
+        assert result["failed"] == 1
+
 
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,37 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryWriteServiceBatch:
+    def test_batch_store_counts_ok_upload_status_as_success(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "ok"}
+        memories = [
+            MemoryRecord(
+                title="First preference",
+                content="Alex prefers concise status updates.",
+                agent_id="agent-1",
+                actor_id="user-1",
+                source="test",
+            ),
+            MemoryRecord(
+                title="Second preference",
+                content="Alex prefers weekly summaries.",
+                agent_id="agent-1",
+                actor_id="user-1",
+                source="test",
+            ),
+        ]
+
+        result = MemoryWriteService(client).batch_store_memories(memories)
+
+        assert result["successful"] == 2
+        assert result["failed"] == 0
+        assert [item["status"] for item in result["results"]] == ["ok", "ok"]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
Closes #770

## Summary

Fixes a batch upload accounting bug in `MemoryWriteService.batch_store_memories`.

On-prem/self-hosted Moorcheh responses are already treated as successful when deletion returns `{"status": "ok"}`, but batch uploads only counted `"queued"` and `"success"` as successful. If the backend returned `{"status": "ok"}` after accepting a batch upload, every pending result was updated to `"ok"` while the summary reported:

```text
successful: 0
failed: 0
total_submitted: N
```

That makes successful batch writes look like an empty/no-op result to API and CLI callers.

## Changes

- Adds `"ok"` to the accepted upload success statuses.
- Normalizes status comparison with `lower()` so equivalent response casing is counted correctly.
- Adds a regression test for batch upload responses returning `{"status": "ok"}`.

## Tests

- `.venv\Scripts\python.exe -m pytest tests\test_unit.py -q`
- `.venv\Scripts\python.exe -m pytest tests\test_api.py -q`
- `.venv\Scripts\python.exe -m ruff check memanto\app\services\memory_write_service.py tests\test_unit.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch memory uploads now treat additional statuses (including `ok`) as successful when tallying completed items.
  * Batch upload failure detection is now case-insensitive, improving consistency across varying backend response formats.
* **Tests**
  * Added unit tests covering batch uploads with `ok` responses and case-insensitive `FAILED` responses to verify correct `successful`, `failed`, and per-item status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->