### PR TITLE
Keep streamed upload writes off the event loop

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -55,7 +55,8 @@ UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
 
 async def _write_upload_file_to_path(file: UploadFile, path: str) -> int:
     bytes_written = 0
-    with open(path, "wb") as tmp:
+    tmp = await asyncio.to_thread(open, path, "wb")
+    try:
         while chunk := await file.read(UPLOAD_CHUNK_SIZE_BYTES):
             bytes_written += len(chunk)
             if bytes_written > MAX_UPLOAD_SIZE_BYTES:
@@ -66,7 +67,9 @@ async def _write_upload_file_to_path(file: UploadFile, path: str) -> int:
                         f"{MAX_UPLOAD_SIZE_BYTES} bytes"
                     ),
                 )
-            tmp.write(chunk)
+            await asyncio.to_thread(tmp.write, chunk)
+    finally:
+        await asyncio.to_thread(tmp.close)
     return bytes_written
 
 

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -48,6 +48,27 @@ router = APIRouter()
 
 _config_manager = ConfigManager()
 
+ALLOWED_UPLOAD_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".json", ".txt", ".csv", ".md"}
+MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024 * 1024
+UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
+
+
+async def _write_upload_file_to_path(file: UploadFile, path: str) -> int:
+    bytes_written = 0
+    with open(path, "wb") as tmp:
+        while chunk := await file.read(UPLOAD_CHUNK_SIZE_BYTES):
+            bytes_written += len(chunk)
+            if bytes_written > MAX_UPLOAD_SIZE_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=(
+                        "File exceeds maximum upload size of "
+                        f"{MAX_UPLOAD_SIZE_BYTES} bytes"
+                    ),
+                )
+            tmp.write(chunk)
+    return bytes_written
+
 
 class RecallRequest(BaseModel):
     query: str = Field(..., min_length=1, description="Search query")
@@ -231,6 +252,8 @@ async def remember(
             "type": result.get("type"),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 
@@ -510,15 +533,14 @@ async def upload_file(
     client = get_moorcheh_client()
 
     # Validate file extension before reading
-    ALLOWED_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".json", ".txt", ".csv", ".md"}
     # Sanitize filename: strip directory components to prevent path traversal (CWE-22)
     original_name = Path(file.filename or "upload").name
     # Guard against empty or dot-only filenames after sanitization
     if not original_name or original_name in (".", ".."):
         original_name = "upload"
     suffix = Path(original_name).suffix.lower()
-    if suffix not in ALLOWED_EXTENSIONS:
-        allowed_str = ", ".join(sorted(ALLOWED_EXTENSIONS))
+    if suffix not in ALLOWED_UPLOAD_EXTENSIONS:
+        allowed_str = ", ".join(sorted(ALLOWED_UPLOAD_EXTENSIONS))
         raise HTTPException(
             status_code=400,
             detail=f"File type '{suffix}' is not supported. Allowed types: {allowed_str}",
@@ -529,7 +551,6 @@ async def upload_file(
 
         # Write upload to a temp file so moorcheh SDK can read it
         # Use original filename so the SDK records it as the source
-        file_bytes = await file.read()
         tmp_dir = tempfile.mkdtemp()
         tmp_path = os.path.join(tmp_dir, original_name)
         # Defense-in-depth: verify resolved path is within tmp_dir
@@ -541,8 +562,7 @@ async def upload_file(
                 detail="Invalid filename",
             )
         try:
-            with open(tmp_path, "wb") as tmp:
-                tmp.write(file_bytes)
+            bytes_written = await _write_upload_file_to_path(file, tmp_path)
             result = await asyncio.to_thread(
                 client.documents.upload_file, namespace, tmp_path
             )
@@ -556,11 +576,13 @@ async def upload_file(
             "session_id": session.session_id,
             "namespace": namespace,
             "file_name": original_name,
-            "file_size": result.get("fileSize"),
+            "file_size": result.get("fileSize", bytes_written),
             "status": "uploaded" if result.get("success") else "failed",
             "message": result.get("message", ""),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise map_error_to_http_exception(e)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1492,7 +1492,13 @@ class TestUploadFileStreaming:
             self.chunks = list(chunks)
 
         async def read(self, size: int = -1) -> bytes:
-            return self.chunks.pop(0) if self.chunks else b""
+            if not self.chunks:
+                return b""
+            chunk = self.chunks.pop(0)
+            if size < 0 or len(chunk) <= size:
+                return chunk
+            self.chunks.insert(0, chunk[size:])
+            return chunk[:size]
 
     @pytest.mark.asyncio
     async def test_writes_upload_in_chunks(self, tmp_path):
@@ -1515,6 +1521,17 @@ class TestUploadFileStreaming:
             )
 
         assert exc_info.value.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_allows_upload_at_exact_size_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(memory_routes, "MAX_UPLOAD_SIZE_BYTES", 5)
+        upload = self.ChunkedUpload([b"abcde"])
+        target = tmp_path / "upload.txt"
+
+        size = await memory_routes._write_upload_file_to_path(upload, str(target))
+
+        assert size == 5
+        assert target.read_bytes() == b"abcde"
 
 
 class TestRealpathGuard:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from memanto.app.config import settings
 from memanto.app.main import app
 from memanto.app.models.session import Session
+from memanto.app.routes import memory as memory_routes
 from memanto.app.routes.auth_deps import get_current_session
 
 # Set test environment
@@ -1225,6 +1227,32 @@ class TestMEMANTOAPI:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_upload_file_over_size_limit_returns_413(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """Oversized uploads return 413 before calling the SDK."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        monkeypatch.setattr(memory_routes, "MAX_UPLOAD_SIZE_BYTES", 5)
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/upload-file",
+            headers=headers,
+            files={"file": ("notes.txt", b"too large", "text/plain")},
+        )
+
+        assert response.status_code == 413
+        mock_moorcheh.documents.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_upload_file_requires_session(self, client, auth_headers):
         """Test that upload requires a valid session token"""
         await client.post(
@@ -1454,6 +1482,39 @@ class TestFilenameSanitizationLogic:
     def test_dotfile(self):
         result = self.sanitize(".env")
         assert result == ".env"
+
+
+class TestUploadFileStreaming:
+    """Direct tests for chunked upload writes."""
+
+    class ChunkedUpload:
+        def __init__(self, chunks: list[bytes]):
+            self.chunks = list(chunks)
+
+        async def read(self, size: int = -1) -> bytes:
+            return self.chunks.pop(0) if self.chunks else b""
+
+    @pytest.mark.asyncio
+    async def test_writes_upload_in_chunks(self, tmp_path):
+        upload = self.ChunkedUpload([b"alpha", b"beta", b"gamma"])
+        target = tmp_path / "upload.txt"
+
+        size = await memory_routes._write_upload_file_to_path(upload, str(target))
+
+        assert size == len(b"alphabetagamma")
+        assert target.read_bytes() == b"alphabetagamma"
+
+    @pytest.mark.asyncio
+    async def test_rejects_upload_over_size_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(memory_routes, "MAX_UPLOAD_SIZE_BYTES", 5)
+        upload = self.ChunkedUpload([b"abc", b"def"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await memory_routes._write_upload_file_to_path(
+                upload, str(tmp_path / "upload.txt")
+            )
+
+        assert exc_info.value.status_code == 413
 
 
 class TestRealpathGuard:


### PR DESCRIPTION
## Summary

Follow-up to the upload streaming work from #1369 for the #770 bounty challenge.

This keeps the uploaded-file write path responsive while preserving the existing upload limit behavior:

- offloads the temporary file `open` / `write` / `close` operations through `asyncio.to_thread`
- keeps async chunk reads and the strict `MAX_UPLOAD_SIZE_BYTES` check unchanged
- preserves `HTTPException` status behavior so upload validation errors such as 400 and 413 are not converted into generic 500s
- updates the test upload stub to respect `read(size)`
- adds an exact-size boundary test proving payloads at `MAX_UPLOAD_SIZE_BYTES` still succeed
- normalizes the touched files back to LF line endings so the review diff stays small

## Validation

- `uv run --group dev pytest tests/test_api.py::TestMEMANTOAPI::test_upload_file_with_session tests/test_api.py::TestMEMANTOAPI::test_upload_file_unsupported_extension tests/test_api.py::TestMEMANTOAPI::test_upload_file_over_size_limit_returns_413 tests/test_api.py::TestMEMANTOAPI::test_upload_file_requires_session tests/test_api.py::TestCWE200ApiKeyLeak::test_traversal_filename_is_sanitized tests/test_api.py::TestCWE200ApiKeyLeak::test_absolute_path_filename_is_sanitized tests/test_api.py::TestUploadFileStreaming -q`
- `uv run --group dev ruff check memanto/app/routes/memory.py tests/test_api.py`
- `git diff --check`

## Notes

This intentionally uses `asyncio.to_thread` instead of adding a new async file I/O dependency. The route already uses `asyncio.to_thread` for SDK calls, so this keeps the fix minimal and consistent with the surrounding implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload handling to reject oversized uploads with a clear error instead of processing them in memory.
  * Preserved direct error responses for memory and upload endpoints, avoiding unnecessary error remapping.
  * Added safer chunked file writing so large uploads are handled more reliably.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->