### PR TITLE
Normalize LangGraph search tag filters

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -239,12 +239,7 @@ class MemantoStore(BaseStore):
         confidence = float(value.pop("confidence", 0.8))
         confidence = max(0.0, min(1.0, confidence))
 
-        raw_tags = value.pop("tags", []) or []
-        if isinstance(raw_tags, str):
-            raw_tags = [t.strip() for t in raw_tags.split(",") if t.strip()]
-        elif not isinstance(raw_tags, (list, tuple, set)):
-            raw_tags = [str(raw_tags)]
-
+        raw_tags = self._normalize_tag_values(value.pop("tags", []))
         user_tags = [
             str(t) for t in raw_tags if not str(t).startswith(_RESERVED_PREFIX)
         ]
@@ -290,7 +285,7 @@ class MemantoStore(BaseStore):
             type_filter = [type_filter]
         # SearchOp uses "min_confidence"; SdkClient.recall() uses "min_similarity"
         min_similarity = filter_dict.get("min_confidence")
-        extra_tags = list(filter_dict.get("tags", []) or [])
+        extra_tags = self._normalize_tag_values(filter_dict.get("tags", []))
 
         cache_key = (
             op.namespace_prefix,
@@ -421,6 +416,18 @@ class MemantoStore(BaseStore):
             if t.startswith(_KEY_TAG_PREFIX):
                 return t[len(_KEY_TAG_PREFIX) :]
         return None
+
+    @staticmethod
+    def _normalize_tag_values(raw: Any) -> list[str]:
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            values = raw.split(",")
+        elif isinstance(raw, (list, tuple, set)):
+            values = raw
+        else:
+            values = [raw]
+        return [text for value in values if (text := str(value).strip())]
 
     @staticmethod
     def _stringify(value: dict[str, Any]) -> str:

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -235,6 +235,41 @@ def test_do_search_semantic(mock_sdk_client):
     )
 
 
+def test_do_search_accepts_comma_separated_tag_filter(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-789",
+                "tags": ["lg:key:key3", "project", "urgent"],
+                "type": "fact",
+                "content": "tagged memory",
+            }
+        ]
+    }
+
+    op = SearchOp(
+        namespace_prefix=("my_ns",),
+        query="tagged",
+        filter={"tags": "project, urgent"},
+    )
+    items = store._do_search(op)
+
+    assert len(items) == 1
+    assert items[0].key == "key3"
+    client_instance.recall.assert_called_once_with(
+        agent_id="langgraph_my_ns",
+        query="tagged",
+        limit=10,
+        type=None,
+        tags=["project", "urgent"],
+        min_similarity=None,
+    )
+
+
 def test_batch_execution(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()


### PR DESCRIPTION
Summary
- Normalize LangGraph store tag inputs through a shared helper.
- Treat SearchOp string tag filters like `"project, urgent"` as two tags instead of individual characters.
- Keep PutOp tag normalization behavior consistent with search filtering.

Flaw reproduction
- Before this change, `_do_search` used `list(filter_dict.get("tags", []) or [])`.
- A caller passing `filter={"tags": "project, urgent"}` produced character tags like `["p", "r", ...]`.
- The client received the wrong tag filter and matching returned memories failed the local `all(t in tags)` check, so search returned no results.

Fix
- Add `_normalize_tag_values` for comma-separated strings, iterables, scalar tags, and empty inputs.
- Use it for both `_do_put` and `_do_search`.

Validation
- Red test first: `pytest tests/test_store.py::test_do_search_accepts_comma_separated_tag_filter -q` failed with `assert 0 == 1` before the fix.
- Green regression: `pytest tests/test_store.py::test_do_search_accepts_comma_separated_tag_filter -q`.
- Full LangGraph integration tests: `pytest tests -q` passed.
- Root test suite: `pytest tests -q` passed; live Moorcheh E2E skipped because no real `MOORCHEH_API_KEY` is configured.
- Lint/format: `ruff check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`; `ruff format --check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`.

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tag filters now handle more input formats consistently, including comma-separated strings, lists, tuples, sets, and single values.
  * Search results and saved entries now treat tag values more reliably by trimming spaces and ignoring empty tags.
  * Improved handling of tag-based search filters so comma-separated tags are applied as separate tags during lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->