### PR TITLE
Bug: Ambiguity Guard is systemically bypassed by common auxiliary verbs (is/are/was/were)

### DIFF
--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -41,7 +41,6 @@ class MemoryParsingService:
         for pattern in [
             r"https?://[^\s<>()\[\]{},;:\"']*[^\s<>()\[\]{},;:\"'.,!?]",
             r"\b(?:endpoint|url|api key|path|email|phone|address)\b",
-            r"\b(?:is|are|was|were)\b",
         ]
     ]
 

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -192,12 +192,39 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
     assert memory.type == "fact"
 
 
-def test_ambiguity_guard_not_bypassed_by_common_verbs():
+def test_weak_aux_verb_with_typo_falls_back_to_fuzzy():
     parser = MemoryParsingService()
-
     memory = make_memory("The project uses Django and it is maintained, and we decded on Postgres")
-
     parser.parse_memory(memory)
-
     assert memory.type == "decision"
+
+
+def test_weak_aux_verb_without_is_falls_back_to_fuzzy():
+    parser = MemoryParsingService()
+    memory = make_memory("The project uses Django and it gets maintained, and we decded on Postgres")
+    parser.parse_memory(memory)
+    assert memory.type == "decision"
+
+
+def test_strong_declarative_pattern_still_classified_as_fact():
+    parser = MemoryParsingService()
+    memory = make_memory("The API endpoint is called /v1/search and it was enabled last week")
+    parser.parse_memory(memory)
+    assert memory.type == "fact"
+
+
+def test_bare_auxiliary_alone_no_longer_bypasses_guard():
+    parser = MemoryParsingService()
+    memory = make_memory("It is nice and we decded on the new plan")
+    parser.parse_memory(memory)
+    assert memory.type == "decision"
+
+
+def test_url_or_high_confidence_fact_pattern_unaffected():
+    parser = MemoryParsingService()
+    memory = make_memory("The database port is 5432")
+    parser.parse_memory(memory)
+    assert memory.type == "fact"
+
+
 

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -190,3 +190,14 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
     parser.parse_memory(memory)
 
     assert memory.type == "fact"
+
+
+def test_ambiguity_guard_not_bypassed_by_common_verbs():
+    parser = MemoryParsingService()
+
+    memory = make_memory("The project uses Django and it is maintained, and we decded on Postgres")
+
+    parser.parse_memory(memory)
+
+    assert memory.type == "decision"
+

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -192,39 +192,21 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
     assert memory.type == "fact"
 
 
-def test_weak_aux_verb_with_typo_falls_back_to_fuzzy():
+def test_ambiguity_guard_and_fuzzy_fallback_interactions():
     parser = MemoryParsingService()
-    memory = make_memory("The project uses Django and it is maintained, and we decded on Postgres")
-    parser.parse_memory(memory)
-    assert memory.type == "decision"
 
+    cases = {
+        # "is" should no longer bypass the fuzzy fallback for typos
+        "The project uses Django and it is maintained, and we decded on Postgres": "decision",
+        # Strong fact patterns should still classify as fact
+        "The API endpoint is called /v1/search and it was enabled last week": "fact",
+        # Bare auxiliary alone falls back correctly to decision due to fuzzy matching
+        "It is nice and we decded on the new plan": "decision",
+        # High confidence fact patterns are unaffected
+        "The database port is 5432": "fact",
+    }
 
-def test_weak_aux_verb_without_is_falls_back_to_fuzzy():
-    parser = MemoryParsingService()
-    memory = make_memory("The project uses Django and it gets maintained, and we decded on Postgres")
-    parser.parse_memory(memory)
-    assert memory.type == "decision"
-
-
-def test_strong_declarative_pattern_still_classified_as_fact():
-    parser = MemoryParsingService()
-    memory = make_memory("The API endpoint is called /v1/search and it was enabled last week")
-    parser.parse_memory(memory)
-    assert memory.type == "fact"
-
-
-def test_bare_auxiliary_alone_no_longer_bypasses_guard():
-    parser = MemoryParsingService()
-    memory = make_memory("It is nice and we decded on the new plan")
-    parser.parse_memory(memory)
-    assert memory.type == "decision"
-
-
-def test_url_or_high_confidence_fact_pattern_unaffected():
-    parser = MemoryParsingService()
-    memory = make_memory("The database port is 5432")
-    parser.parse_memory(memory)
-    assert memory.type == "fact"
-
-
-
+    for content, expected_type in cases.items():
+        memory = make_memory(content)
+        parser.parse_memory(memory)
+        assert memory.type == expected_type


### PR DESCRIPTION
Refs: #770
Issue: #1375

# _**Summary**_
The `MemoryParsingService` includes an ambiguity guard intended to filter out weak fact classifications and route them to the fuzzy matching fallback. However, this guard can frequently be bypassed in English sentences containing common auxiliary verbs (`is`, `are`, `was`, `were`) because these verbs are included in the `STRONG_FACT_PATTERNS` list. This can lead to incorrect memory type classifications, such as classifying ambiguous inputs with typoed category keywords as `fact` instead of their intended type (e.g., `decision`).
# _**Steps to Reproduce**_
1. Initialize the `MemoryParsingService`.
2. Parse a memory containing a weak factual verb (e.g., `"uses"`) alongside a misspelled keyword from another category (e.g., `"decded"` for `decision`), and include the word `"is"`.
   * **Input 1:** `"The project uses Django and it is maintained, and we decded on Postgres"`
3. Parse the same sentence but replace `"is"` with a non-matching word like `"gets"`.
   * **Input 2:** `"The project uses Django and it gets maintained, and we decded on Postgres"`
4. Observe the resolved memory types.
**Minimal Reproduction Code:**
```python
from memanto.app.core import MemoryRecord
from memanto.app.services.memory_parsing_service import MemoryParsingService
parser = MemoryParsingService()
# Scenario 1: Contains 'is'
mem1 = MemoryRecord(content="The project uses Django and it is maintained, and we decded on Postgres", type=None, title="t", actor_id="u", source="s", agent_id="a")
parser.parse_memory(mem1)
print(f"Result 1 (with 'is'): {mem1.type}")
# Scenario 2: Does not contain 'is' (replaced with 'gets')
mem2 = MemoryRecord(content="The project uses Django and it gets maintained, and we decded on Postgres", type=None, title="t", actor_id="u", source="s", agent_id="a")
parser.parse_memory(mem2)
print(f"Result 2 (without 'is'): {mem2.type}")
```


# **_Expected Behavior_**

Both inputs should trigger the Ambiguity Guard because the fact score is low (`fact_max < 4` matching only "`uses`"), then fall back to the fuzzy matching logic, and be classified as `decision `(successfully resolving the typo "`decded`").


# _**Actual Behavior**_

- **Input 1 (with 'is'):** Classified as `fact `(Incorrect).
- **Input 2 (without 'is'):** Classified as `decision `(Correct).

The guard was bypassed in Input 1 simply because of the presence of the word "`is`".


# **_Root Cause Analysis_**

The Ambiguity Guard only triggers for weak fact classifications (`fact_max < 4`) if no strong factual patterns are detected in the text:

```
if fact_max < 4 and not any(
    pattern.search(text) for pattern in self.STRONG_FACT_PATTERNS
):
    return None
```

In `memanto/app/services/memory_parsing_service.py`, the `STRONG_FACT_PATTERNS` contains:

`r"\b(?:is|are|was|were)\b"`

Because `is`, `are`, `was`, and `were `are among the most common auxiliary verbs in English, this pattern matches almost every standard sentence. As a result, the guard condition evaluates to `False `for almost all English inputs containing these verbs, letting weak signals pass through as `fact `and bypassing the fuzzy fallback mechanism.


# _**Suggested Fix**_

Remove `r"\b(?:is|are|was|were)\b"` from the `STRONG_FACT_PATTERNS` list.

More specific state-declarative structures (e.g., `is called`, `are located`, `was enabled`) are already mapped with a high confidence score of `4` under `RULES["fact"]`. Standalone auxiliary verbs are too weak to be considered strong factual indicators and should not bypass the ambiguity check.

### Synthetic Benchmark Results (Supporting Evidence)

The following benchmark uses a synthetic dataset of 10 intentionally ambiguous sentences designed to evaluate the ambiguity guard. Each sentence combines:

- a weak fact indicator,
- a common auxiliary verb (`is`, `are`, `was`, `were`),
- and a typoed keyword that should be recovered by the fuzzy matching fallback.

This benchmark is intentionally synthetic because the ambiguity guard specifically targets edge cases where weak factual evidence competes with fuzzy category recovery.

Results:

- **Ambiguous Input Accuracy (Before Fix): 40.0%**
- **Ambiguous Input Accuracy (After Fix): 60.0%**
- **Net Improvement: +20.0 percentage points**

In all benchmark cases containing explicit factual indicators (e.g., URLs, technical keywords, or high-confidence fact patterns), classification behavior remained unchanged.

[benchmark.py](https://github.com/user-attachments/files/29728231/benchmark.py)

Bounty submission for the Memanto Bug & Exploit Challenge.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory classification for ambiguous phrases containing weak auxiliary wording.
  - Corrected typo-tolerant recognition so decision-related entries are classified appropriately.
  - Preserved accurate identification of strong factual statements, including technical details such as port information.
  - Reduced cases where vague wording could incorrectly override the intended classification. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->