### PR TITLE
Reject blank memory records before persistence

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -21,6 +21,21 @@ def agent_namespace(agent_id: str) -> str:
     return f"memanto_agent_{agent_id}"
 
 
+def require_non_blank_text(value: Any) -> Any:
+    """Reject empty/whitespace-only memory text before persistence.
+
+    Pydantic's ``max_length`` constraint accepts ``""`` and ``"   "``.
+    Those values produce useless Moorcheh documents such as ``[FACT]\n\n``
+    and pollute retrieval with blank memories, so enforce semantic content
+    at every memory input boundary.
+    """
+    if value is None:
+        return value
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Memory title and content must be non-empty")
+    return value
+
+
 class MemoryRecord(BaseModel):
     """Structured memory record with standardized format"""
 
@@ -51,16 +66,7 @@ class MemoryRecord(BaseModel):
     @field_validator("title", "content")
     @classmethod
     def _require_non_blank_text(cls, value: str) -> str:
-        """Reject empty/whitespace-only memory text before persistence.
-
-        Pydantic's ``max_length`` constraint accepts ``""`` and ``"   "``.
-        Those values produce useless Moorcheh documents such as ``[FACT]\n\n``
-        and pollute retrieval with blank memories, so enforce semantic content
-        at the core record boundary used by API, SDK, and batch writes.
-        """
-        if not isinstance(value, str) or not value.strip():
-            raise ValueError("Memory title and content must be non-empty")
-        return value
+        return require_non_blank_text(value)
 
     def to_moorcheh_document(self) -> dict[str, Any]:
         """

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from memanto.app.constants import (
     MemoryType,
@@ -47,6 +47,20 @@ class MemoryRecord(BaseModel):
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     expires_at: datetime | None = None
     ttl_seconds: int | None = None
+
+    @field_validator("title", "content")
+    @classmethod
+    def _require_non_blank_text(cls, value: str) -> str:
+        """Reject empty/whitespace-only memory text before persistence.
+
+        Pydantic's ``max_length`` constraint accepts ``""`` and ``"   "``.
+        Those values produce useless Moorcheh documents such as ``[FACT]\n\n``
+        and pollute retrieval with blank memories, so enforce semantic content
+        at the core record boundary used by API, SDK, and batch writes.
+        """
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("Memory title and content must be non-empty")
+        return value
 
     def to_moorcheh_document(self) -> dict[str, Any]:
         """

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from memanto.app.constants import MemoryType, SourceType, StatusType
+from memanto.app.core import require_non_blank_text
 
 
 # Request Models
@@ -29,9 +30,7 @@ class MemoryStoreRequest(BaseModel):
     @field_validator("title", "content")
     @classmethod
     def validate_non_blank_text(cls, value: str) -> str:
-        if not isinstance(value, str) or not value.strip():
-            raise ValueError("Memory title and content must be non-empty")
-        return value
+        return require_non_blank_text(value)
 
 
 class MemoryBatchItem(BaseModel):
@@ -50,9 +49,7 @@ class MemoryBatchItem(BaseModel):
     @field_validator("title", "content")
     @classmethod
     def validate_non_blank_text(cls, value: str) -> str:
-        if not isinstance(value, str) or not value.strip():
-            raise ValueError("Memory title and content must be non-empty")
-        return value
+        return require_non_blank_text(value)
 
 
 class MemoryBatchWriteRequest(BaseModel):
@@ -88,9 +85,7 @@ class BatchRememberItem(BaseModel):
     @field_validator("content", "title")
     @classmethod
     def validate_non_blank_text(cls, value: str | None) -> str | None:
-        if value is not None and not value.strip():
-            raise ValueError("Memory title and content must be non-empty")
-        return value
+        return require_non_blank_text(value)
 
 
 class RememberRequest(BatchRememberItem):

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,7 +5,7 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from memanto.app.constants import MemoryType, SourceType, StatusType
 
@@ -26,6 +26,13 @@ class MemoryStoreRequest(BaseModel):
     ttl_seconds: int | None = None
     user_confirmed: bool = False
 
+    @field_validator("title", "content")
+    @classmethod
+    def validate_non_blank_text(cls, value: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("Memory title and content must be non-empty")
+        return value
+
 
 class MemoryBatchItem(BaseModel):
     """Single memory item for batch write"""
@@ -39,6 +46,13 @@ class MemoryBatchItem(BaseModel):
     tags: list[str] = Field(default_factory=list)
     ttl_seconds: int | None = None
     id: str | None = None  # Optional custom ID
+
+    @field_validator("title", "content")
+    @classmethod
+    def validate_non_blank_text(cls, value: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("Memory title and content must be non-empty")
+        return value
 
 
 class MemoryBatchWriteRequest(BaseModel):
@@ -70,6 +84,13 @@ class BatchRememberItem(BaseModel):
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",
     )
+
+    @field_validator("content", "title")
+    @classmethod
+    def validate_non_blank_text(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("Memory title and content must be non-empty")
+        return value
 
 
 class RememberRequest(BatchRememberItem):

--- a/tests/test_memory_non_blank_validation.py
+++ b/tests/test_memory_non_blank_validation.py
@@ -44,11 +44,31 @@ def test_memory_record_rejects_blank_title() -> None:
             },
         ),
         (
+            MemoryStoreRequest,
+            {
+                "type": "fact",
+                "title": "\t\n ",
+                "content": "valid content",
+                "agent_id": "agent-1",
+                "actor_id": "agent-1",
+                "source": "agent",
+            },
+        ),
+        (
             MemoryBatchItem,
             {
                 "type": "fact",
                 "title": "valid title",
                 "content": "\t\n ",
+                "source": "agent",
+            },
+        ),
+        (
+            MemoryBatchItem,
+            {
+                "type": "fact",
+                "title": "\t\n ",
+                "content": "valid content",
                 "source": "agent",
             },
         ),

--- a/tests/test_memory_non_blank_validation.py
+++ b/tests/test_memory_non_blank_validation.py
@@ -1,0 +1,79 @@
+import pytest
+from pydantic import ValidationError
+
+from memanto.app.core import MemoryRecord
+from memanto.app.models import BatchRememberItem, MemoryBatchItem, MemoryStoreRequest
+
+
+def test_memory_record_rejects_blank_content() -> None:
+    with pytest.raises(ValidationError):
+        MemoryRecord(
+            type="fact",
+            title="valid title",
+            content="   \n\t",
+            agent_id="agent-1",
+            actor_id="agent-1",
+            source="agent",
+        )
+
+
+def test_memory_record_rejects_blank_title() -> None:
+    with pytest.raises(ValidationError):
+        MemoryRecord(
+            type="fact",
+            title="   ",
+            content="User prefers concise answers",
+            agent_id="agent-1",
+            actor_id="agent-1",
+            source="agent",
+        )
+
+
+@pytest.mark.parametrize(
+    "model,kwargs",
+    [
+        (
+            MemoryStoreRequest,
+            {
+                "type": "fact",
+                "title": "valid title",
+                "content": "\t\n ",
+                "agent_id": "agent-1",
+                "actor_id": "agent-1",
+                "source": "agent",
+            },
+        ),
+        (
+            MemoryBatchItem,
+            {
+                "type": "fact",
+                "title": "valid title",
+                "content": "\t\n ",
+                "source": "agent",
+            },
+        ),
+        (
+            BatchRememberItem,
+            {
+                "content": "\t\n ",
+                "source": "agent",
+            },
+        ),
+    ],
+)
+def test_api_memory_models_reject_blank_content(model, kwargs) -> None:
+    with pytest.raises(ValidationError):
+        model(**kwargs)
+
+
+def test_memory_record_accepts_non_blank_text() -> None:
+    record = MemoryRecord(
+        type="preference",
+        title="Communication style",
+        content="User prefers concise answers",
+        agent_id="agent-1",
+        actor_id="agent-1",
+        source="agent",
+    )
+
+    assert record.content == "User prefers concise answers"


### PR DESCRIPTION
## Summary
- Reject empty or whitespace-only memory titles/content at the core `MemoryRecord` boundary.
- Add the same non-blank validation to API request models used by single, batch, and remember writes.
- Cover the regression with unit tests so blank memories cannot be persisted or uploaded as useless retrieval documents.

## Verification
- `uv run pytest tests/test_memory_non_blank_validation.py -q`
- `uv run ruff check memanto/app/core.py memanto/app/models/__init__.py tests/test_memory_non_blank_validation.py`
- `uv run pytest tests/test_unit.py tests/test_api.py tests/test_memory_non_blank_validation.py -q`

Addresses bounty issue #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened memory validation by rejecting blank or whitespace-only `title` and `content`.
  * Applied consistent non-blank checks across memory request and batch item models, allowing `None` where supported.
  * Confirmed non-blank text is accepted and preserved as provided.
* **Tests**
  * Added pytest coverage to ensure whitespace-only inputs raise validation errors and valid inputs pass for `MemoryRecord` and related request models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->