### PR TITLE
fix: validate provenance type and restrict daily-summary output_path in API

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from memanto.app.constants import MemoryType, SourceType, StatusType
+from memanto.app.constants import MemoryType, ProvenanceType, SourceType, StatusType
 
 
 # Request Models
@@ -66,7 +66,7 @@ class BatchRememberItem(BaseModel):
     confidence: float = Field(0.8, ge=0.0, le=1.0, description="Confidence score (0-1)")
     tags: list[str] | None = Field(None, description="Tags for this memory")
     source: str = Field("agent", description="Source of memory")
-    provenance: str = Field(
+    provenance: ProvenanceType = Field(
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",
     )

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -800,6 +800,12 @@ async def generate_daily_summary(
     POST ``/{agent_id}/conflicts/generate`` or the scheduled job.
     """
     enforce_session_scope(session, agent_id)
+    
+    if request.output_path:
+        raise HTTPException(
+            status_code=400,
+            detail="Custom output_path is not allowed via the API endpoint.",
+        )
 
     resolved_date = request.date or datetime.now().strftime("%Y-%m-%d")
     try:

--- a/tests/test_provenance_validation.py
+++ b/tests/test_provenance_validation.py
@@ -5,11 +5,15 @@ from memanto.app.main import app
 
 @pytest.fixture
 async def client():
+    # Use ASGITransport to test the FastAPI app directly
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac
 
 @pytest.mark.asyncio
 async def test_remember_with_invalid_provenance(client):
+    # Setup test headers & mock session dependency
+    auth_headers = {"Authorization": "Bearer test-api-key"}
+    
     from datetime import datetime, timezone
     from memanto.app.models.session import Session
     
@@ -35,7 +39,7 @@ async def test_remember_with_invalid_provenance(client):
             json={
                 "content": "This is a test memory",
                 "type": "fact",
-                "provenance": "invalid_provenance_value_123" # Here we use an invalid provenance value to trigger validation error
+                "provenance": "invalid_provenance_value_123"
             }
         )
         
@@ -91,3 +95,35 @@ async def test_batch_remember_with_invalid_provenance(client):
         assert response.status_code == 422
         data = response.json()
         assert "detail" in data
+
+@pytest.mark.asyncio
+async def test_daily_summary_output_path_rejected(client):
+    from datetime import datetime, timezone
+    from memanto.app.models.session import Session
+    from memanto.app.routes.auth_deps import get_current_session
+    
+    mock_session = Session(
+        session_id="mock-session-id",
+        session_token="mock-token",
+        agent_id="test_agent",
+        actor_id="test_actor",
+        moorcheh_api_key="test-api-key",
+        namespace="memanto_agent_test_agent",
+        started_at=datetime.now(timezone.utc),
+        expires_at=datetime.now(timezone.utc)
+    )
+    
+    app.dependency_overrides[get_current_session] = lambda: mock_session
+    
+    response = await client.post(
+        "/api/v2/agents/test_agent/daily-summary",
+        headers={"X-Session-Token": "mock-token"},
+        json={
+            "output_path": "/etc/cron.d/malicious_cron"
+        }
+    )
+    
+    assert response.status_code == 400
+    data = response.json()
+    assert "detail" in data
+    assert "output_path" in data["detail"]

--- a/tests/test_provenance_validation.py
+++ b/tests/test_provenance_validation.py
@@ -1,0 +1,93 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import patch
+from memanto.app.main import app
+
+@pytest.fixture
+async def client():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+@pytest.mark.asyncio
+async def test_remember_with_invalid_provenance(client):
+    from datetime import datetime, timezone
+    from memanto.app.models.session import Session
+    
+    mock_session = Session(
+        session_id="mock-session-id",
+        session_token="mock-token",
+        agent_id="test_agent",
+        actor_id="test_actor",
+        moorcheh_api_key="test-api-key",
+        namespace="memanto_agent_test_agent",
+        started_at=datetime.now(timezone.utc),
+        expires_at=datetime.now(timezone.utc)
+    )
+    
+    from memanto.app.routes.auth_deps import get_current_session
+    app.dependency_overrides[get_current_session] = lambda: mock_session
+    
+    with patch("memanto.app.routes.memory.get_moorcheh_client") as mock_moorcheh:
+        # Send an invalid provenance
+        response = await client.post(
+            "/api/v2/agents/test_agent/remember",
+            headers={"X-Session-Token": "mock-token"},
+            json={
+                "content": "This is a test memory",
+                "type": "fact",
+                "provenance": "invalid_provenance_value_123" # Here we use an invalid provenance value to trigger validation error
+            }
+        )
+        
+        # Before fix, this returns 500 (Internal Server Error)
+        # After fix, this should return 422 (Unprocessable Entity)
+        assert response.status_code == 422
+        
+        # Verify it has a validation error detail
+        data = response.json()
+        assert "detail" in data
+
+@pytest.mark.asyncio
+async def test_batch_remember_with_invalid_provenance(client):
+    # Setup test headers & mock session dependency
+    from datetime import datetime, timezone
+    from memanto.app.models.session import Session
+    from memanto.app.routes.auth_deps import get_current_session
+    
+    mock_session = Session(
+        session_id="mock-session-id",
+        session_token="mock-token",
+        agent_id="test_agent",
+        actor_id="test_actor",
+        moorcheh_api_key="test-api-key",
+        namespace="memanto_agent_test_agent",
+        started_at=datetime.now(timezone.utc),
+        expires_at=datetime.now(timezone.utc)
+    )
+    
+    app.dependency_overrides[get_current_session] = lambda: mock_session
+    
+    with patch("memanto.app.routes.memory.get_moorcheh_client") as mock_moorcheh:
+        # Send an invalid provenance in a batch item
+        response = await client.post(
+            "/api/v2/agents/test_agent/batch-remember",
+            headers={"X-Session-Token": "mock-token"},
+            json={
+                "memories": [
+                    {
+                        "content": "This is valid memory 1",
+                        "type": "fact",
+                        "provenance": "explicit_statement"
+                    },
+                    {
+                        "content": "This is invalid memory 2",
+                        "type": "fact",
+                        "provenance": "invalid_provenance_value_123"
+                    }
+                ]
+            }
+        )
+        
+        assert response.status_code == 422
+        data = response.json()
+        assert "detail" in data

--- a/tests/test_provenance_validation.py
+++ b/tests/test_provenance_validation.py
@@ -8,6 +8,7 @@ async def client():
     # Use ASGITransport to test the FastAPI app directly
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac
+    app.dependency_overrides.clear()
 
 @pytest.mark.asyncio
 async def test_remember_with_invalid_provenance(client):


### PR DESCRIPTION
Hello. I updated the PR with a security fix and resolved the review comments about test overrides.

Here is what this PR now includes:

First, it fixes a bug in the remember and batch-remember endpoints. The provenance field in BatchRememberItem request model was str, which allowed any input and caused a 500 error inside route logic due to a Pydantic ValidationError. I changed the type to ProvenanceType to validate input early and return a clean 422 error.

Second, it fixes an arbitrary file write vulnerability in the daily-summary endpoint. The output_path parameter allowed remote API clients to write files anywhere on the server disk. I restricted custom output_path usage on the API endpoint to return a 400 error, while keeping it working for local CLI usage.

Third, I added test coverage for both issues in tests/test_provenance_validation.py and cleaned up the dependency overrides in the fixture teardown to prevent test state leakage.

Please review and merge. Thanks.