### PR TITLE
fix: resolve memory contradictions at write time (#770)

### DIFF
--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -1,0 +1,194 @@
+"""
+Memory Validation Service
+
+Write-time contradiction detection and resolution for memory records.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from moorcheh_sdk import MoorchehClient
+
+from memanto.app.config import settings
+from memanto.app.core import MemoryRecord
+
+
+class MemoryValidationService:
+    """Detect and resolve direct contradictions before persisting a memory.
+
+    A stored memory contradicts an incoming one when it is active, shares the
+    same memory type and title (case-insensitive), but carries different
+    content. Resolution follows the keep_new convention used by the conflict
+    report pipeline: the old record is preserved with status "superseded"
+    (annotated with superseded_by/superseded_at, matching search_as_of's
+    timeline fields) and the new record is stored as active.
+
+    Detection is deterministic — no LLM calls — so the write path stays cheap.
+    Deeper semantic conflicts remain the job of the offline conflict report.
+    """
+
+    # How many similar memories to inspect per write.
+    SEARCH_LIMIT = 10
+
+    def __init__(self, moorcheh_client: "MoorchehClient"):
+        self.client = moorcheh_client
+
+    def validate_memory(
+        self, memory: MemoryRecord, context: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Validate a memory against existing records, resolving contradictions.
+
+        Returns a dict with at least ``action`` and ``reason``; when
+        contradictions were resolved it also carries ``superseded_ids``.
+        """
+        memory_type = memory.type or "fact"
+        if memory_type not in settings.REQUIRE_VALIDATION_FOR:
+            return {
+                "action": "store",
+                "reason": f"stored: type '{memory_type}' exempt from conflict validation",
+            }
+
+        try:
+            conflicts = self._find_contradictions(memory)
+        except Exception:
+            # A failed lookup must never block a write, but say the check did
+            # not run rather than pretending it passed.
+            return {
+                "action": "store",
+                "reason": "stored: conflict check unavailable",
+            }
+
+        if not conflicts:
+            return {
+                "action": "store",
+                "reason": "validated: no contradicting memories found",
+            }
+
+        superseded: list[str] = []
+        failed: list[str] = []
+        for old_item in conflicts:
+            old_id = str(old_item.get("id"))
+            if self._supersede(old_item, memory):
+                superseded.append(old_id)
+            else:
+                failed.append(old_id)
+
+        reason_parts = []
+        if superseded:
+            reason_parts.append(
+                f"contradiction resolved: superseded {', '.join(superseded)}"
+            )
+        if failed:
+            reason_parts.append(
+                f"contradiction detected but failed to supersede {', '.join(failed)}"
+            )
+
+        return {
+            "action": "store",
+            "reason": "; ".join(reason_parts),
+            "superseded_ids": superseded,
+        }
+
+    def resolve_batch_contradictions(
+        self, memories: list[MemoryRecord]
+    ) -> dict[str, str]:
+        """Resolve contradictions between memories submitted in one batch.
+
+        For memories sharing a type and title but differing in content, the
+        last submission wins; earlier ones are downgraded to
+        status="superseded" in place. Returns a mapping of superseded memory
+        id -> winning memory id.
+        """
+        superseded: dict[str, str] = {}
+        latest_by_key: dict[tuple[str, str], MemoryRecord] = {}
+
+        for memory in memories:
+            memory_type = memory.type or "fact"
+            if memory_type not in settings.REQUIRE_VALIDATION_FOR:
+                continue
+            key = (memory_type, memory.title.strip().lower())
+            previous = latest_by_key.get(key)
+            if (
+                previous is not None
+                and previous.content.strip() != memory.content.strip()
+            ):
+                previous.status = "superseded"
+                superseded[str(previous.id)] = str(memory.id)
+            latest_by_key[key] = memory
+
+        return superseded
+
+    def _find_contradictions(self, memory: MemoryRecord) -> list[dict[str, Any]]:
+        """Find active memories of the same type/title with different content."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        read_service = MemoryReadService(self.client)
+        search = read_service.search_memories(
+            query=memory.content,
+            agent_id=memory.agent_id,
+            type=[memory.type or "fact"],
+            status_filter=["active"],
+            limit=self.SEARCH_LIMIT,
+        )
+
+        title = memory.title.strip().lower()
+        content = memory.content.strip()
+        conflicts = []
+        for item in search.get("results", []):
+            if not item.get("id") or item.get("id") == memory.id:
+                continue
+            if (item.get("status") or "active") != "active":
+                continue
+            if (item.get("title") or "").strip().lower() != title:
+                continue
+            if (item.get("content") or "").strip() == content:
+                # Identical content is a duplicate, not a contradiction.
+                continue
+            conflicts.append(item)
+        return conflicts
+
+    def _supersede(self, old_item: dict[str, Any], new_memory: MemoryRecord) -> bool:
+        """Mark an existing memory as superseded by the new one.
+
+        Moorcheh has no in-place update, so this follows the same
+        delete-and-recreate pattern as update_memory. Returns False instead of
+        raising so one bad record cannot block the new write.
+        """
+        try:
+            old_id = str(old_item.get("id"))
+            namespace = new_memory.namespace()
+
+            delete_result = self.client.documents.delete(
+                namespace_name=namespace, ids=[old_id]
+            )
+            if delete_result.get("actual_deletions", 0) == 0:
+                return False
+
+            now_iso = datetime.utcnow().isoformat()
+            document: dict[str, Any] = {
+                "id": old_id,
+                "text": old_item.get("text") or "",
+                "memory_type": old_item.get("type") or "fact",
+                "agent_id": new_memory.agent_id,
+                "actor_id": old_item.get("actor_id") or "unknown",
+                "source": old_item.get("source") or "system",
+                "confidence": old_item.get("confidence", 0.8),
+                "status": "superseded",
+                "provenance": old_item.get("provenance") or "explicit_statement",
+                "created_at": old_item.get("created_at") or now_iso,
+                "updated_at": now_iso,
+                "superseded_by": new_memory.id,
+                "superseded_at": now_iso,
+            }
+            tags = old_item.get("tags")
+            if tags:
+                document["tags"] = ",".join(tags) if isinstance(tags, list) else tags
+
+            self.client.documents.upload(
+                namespace_name=namespace, documents=[document]
+            )
+            return True
+
+        except Exception:
+            return False

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 from memanto.app.core import MemoryRecord
 from memanto.app.services.memory_parsing_service import MemoryParsingService
+from memanto.app.services.memory_validation_service import MemoryValidationService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
 from memanto.app.utils.temporal_helpers import as_utc_naive
@@ -23,6 +24,7 @@ class MemoryWriteService:
 
         self.client = moorcheh_client
         self._parser = MemoryParsingService()
+        self.validation_service = MemoryValidationService(moorcheh_client)
         self._namespace_service = None
 
     @property
@@ -62,13 +64,13 @@ class MemoryWriteService:
             # Add namespace
             namespace = memory.namespace()
 
-            # skip validation for speed
-            ## Validate memory
-            # validation_result = self.validation_service.validate_memory(memory, context)
-            ## Use validated memory if modified
-            # if "memory" in validation_result:
-            #     memory = validation_result["memory"]
-            validation_result = {"action": "store", "reason": "MVP direct store"}
+            # Validate memory (write-time contradiction resolution)
+            validation_result = self.validation_service.validate_memory(
+                memory, context
+            )
+            # Use validated memory if modified
+            if "memory" in validation_result:
+                memory = validation_result["memory"]
 
             from typing import cast
 
@@ -82,7 +84,7 @@ class MemoryWriteService:
                 namespace_name=namespace, documents=[document]
             )
 
-            return {
+            response = {
                 "id": memory.id,
                 "namespace": namespace,
                 "status": result.get("status", "unknown"),
@@ -92,6 +94,9 @@ class MemoryWriteService:
                 "memory_status": memory.status,
                 "type": memory.type,
             }
+            if validation_result.get("superseded_ids"):
+                response["superseded_ids"] = validation_result["superseded_ids"]
+            return response
 
         except Exception as e:
             raise MemoryError(f"Failed to store memory: {e}")
@@ -122,6 +127,7 @@ class MemoryWriteService:
             first_namespace = None
             results = []
             validated_documents = []
+            prepared: list[MemoryRecord] = []
 
             # Enforce server-side timestamps for batch (single timestamp for all)
             now = datetime.utcnow()
@@ -154,16 +160,43 @@ class MemoryWriteService:
                         )
                         continue
 
-                    # skip validation for speed
-                    ## Validate memory
-                    # validation_result = self.validation_service.validate_memory(memory, context)
-                    ## Use validated memory if modified
-                    # if "memory" in validation_result:
-                    #     memory = validation_result["memory"]
-                    validation_result = {
-                        "action": "store",
-                        "reason": "MVP direct store",
-                    }
+                    prepared.append(memory)
+
+                except Exception as e:
+                    results.append(
+                        {
+                            "id": memory.id
+                            if hasattr(memory, "id") and memory.id
+                            else "unknown",
+                            "status": "failed",
+                            "action": "rejected",
+                            "error": str(e),
+                        }
+                    )
+
+            # Resolve contradictions within the batch itself: for memories of
+            # the same type and title with different content, the last one
+            # wins and earlier ones are stored as superseded history.
+            superseded_in_batch = self.validation_service.resolve_batch_contradictions(
+                prepared
+            )
+
+            for memory in prepared:
+                try:
+                    batch_note = superseded_in_batch.get(memory.id)
+                    if batch_note:
+                        validation_result = {
+                            "action": "store_superseded",
+                            "reason": f"contradiction resolved: superseded within batch by {batch_note}",
+                        }
+                    else:
+                        # Validate memory (write-time contradiction resolution)
+                        validation_result = self.validation_service.validate_memory(
+                            memory, context
+                        )
+                        # Use validated memory if modified
+                        if "memory" in validation_result:
+                            memory = validation_result["memory"]
 
                     from typing import cast
 
@@ -171,20 +204,26 @@ class MemoryWriteService:
 
                     # Convert to Moorcheh document
                     document = cast(Document, memory.to_moorcheh_document())
+                    if batch_note:
+                        document["superseded_by"] = batch_note
+                        document["superseded_at"] = now.isoformat()
                     validated_documents.append(document)
 
                     # Store validation result for later
-                    results.append(
-                        {
-                            "id": memory.id,
-                            "status": "pending",
-                            "action": validation_result.get("action", "store"),
-                            "reason": validation_result.get(
-                                "reason", "Validated successfully"
-                            ),
-                            "type": memory.type,
-                        }
-                    )
+                    result_entry = {
+                        "id": memory.id,
+                        "status": "pending",
+                        "action": validation_result.get("action", "store"),
+                        "reason": validation_result.get(
+                            "reason", "Validated successfully"
+                        ),
+                        "type": memory.type,
+                    }
+                    if validation_result.get("superseded_ids"):
+                        result_entry["superseded_ids"] = validation_result[
+                            "superseded_ids"
+                        ]
+                    results.append(result_entry)
 
                 except Exception as e:
                     results.append(

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import MagicMock
+from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.core import MemoryRecord
+
+class TestContradictionHandling:
+    """
+    Test suite demonstrating that the memory write service fails to properly resolve direct contradictions.
+    """
+
+    def test_store_memory_skips_validation(self):
+        """
+        Demonstrates that store_memory bypasses contradiction validation and forces an MVP direct store.
+        This allows logically contradictory memories to be stored blindly.
+        """
+        mock_client = MagicMock()
+        mock_client.documents.upload.return_value = {"status": "success"}
+        
+        write_service = MemoryWriteService(mock_client)
+        
+        memory = MemoryRecord(
+            content="The user's favorite color is red.",
+            type="fact",
+            title="Favorite Color",
+            agent_id="test-agent"
+        )
+        
+        result = write_service.store_memory(memory)
+        
+        # The test expects proper contradiction validation to be active.
+        # Currently, the code skips validation with the reason "MVP direct store", meaning
+        # it will blindly store contradictions instead of resolving them.
+        assert result.get("reason") != "MVP direct store", "Contradiction validation is completely skipped (MVP direct store)."
+
+    def test_batch_store_memories_skips_validation(self):
+        """
+        Demonstrates that batch_store_memories also bypasses contradiction validation.
+        """
+        mock_client = MagicMock()
+        mock_client.documents.upload.return_value = {"status": "success"}
+        
+        write_service = MemoryWriteService(mock_client)
+        
+        memory1 = MemoryRecord(
+            content="The user lives in New York.",
+            type="fact",
+            title="Location",
+            agent_id="test-agent"
+        )
+        
+        memory2 = MemoryRecord(
+            content="The user lives in London.",
+            type="fact",
+            title="Location",
+            agent_id="test-agent"
+        )
+        
+        result = write_service.batch_store_memories([memory1, memory2])
+        
+        for res in result["results"]:
+            assert res.get("reason") != "MVP direct store", "Contradiction validation is skipped for batch storage (MVP direct store)."

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,61 +1,165 @@
-import pytest
 from unittest.mock import MagicMock
-from memanto.app.services.memory_write_service import MemoryWriteService
+
 from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_write_service import MemoryWriteService
+
+
+def make_memory(**overrides):
+    defaults = dict(
+        content="The user's favorite color is red.",
+        type="fact",
+        title="Favorite Color",
+        agent_id="test-agent",
+        actor_id="user",
+        source="user",
+    )
+    defaults.update(overrides)
+    return MemoryRecord(**defaults)
+
+
+def make_client(search_results=None):
+    client = MagicMock()
+    client.documents.upload.return_value = {"status": "success"}
+    client.documents.delete.return_value = {"actual_deletions": 1}
+    client.similarity_search.query.return_value = {"results": search_results or []}
+    return client
+
+
+def existing_doc(
+    memory_id="old-1",
+    title="Favorite Color",
+    content="The user's favorite color is blue.",
+    memory_type="fact",
+    status="active",
+):
+    """A stored memory as Moorcheh returns it (flat metadata fields)."""
+    return {
+        "id": memory_id,
+        "text": f"[{memory_type.upper()}] {title}\n\n{content}",
+        "memory_type": memory_type,
+        "status": status,
+        "agent_id": "test-agent",
+        "actor_id": "user",
+        "source": "user",
+        "confidence": 0.8,
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+    }
+
 
 class TestContradictionHandling:
-    """
-    Test suite demonstrating that the memory write service fails to properly resolve direct contradictions.
-    """
+    """Write-time contradiction validation in MemoryWriteService."""
 
-    def test_store_memory_skips_validation(self):
-        """
-        Demonstrates that store_memory bypasses contradiction validation and forces an MVP direct store.
-        This allows logically contradictory memories to be stored blindly.
-        """
-        mock_client = MagicMock()
-        mock_client.documents.upload.return_value = {"status": "success"}
-        
-        write_service = MemoryWriteService(mock_client)
-        
-        memory = MemoryRecord(
-            content="The user's favorite color is red.",
-            type="fact",
-            title="Favorite Color",
-            agent_id="test-agent"
+    def test_store_memory_runs_validation(self):
+        """store_memory must not blindly bypass validation (old 'MVP direct store')."""
+        write_service = MemoryWriteService(make_client())
+
+        result = write_service.store_memory(make_memory())
+
+        assert result.get("reason") != "MVP direct store", (
+            "Contradiction validation is completely skipped (MVP direct store)."
         )
-        
+        assert result["reason"] == "validated: no contradicting memories found"
+        assert result["action"] == "store"
+
+    def test_store_memory_supersedes_contradicting_memory(self):
+        """A same-type/same-title active memory with different content is
+        superseded (keep_new) and the resolution is reported."""
+        client = make_client(search_results=[existing_doc()])
+        write_service = MemoryWriteService(client)
+
+        memory = make_memory()
         result = write_service.store_memory(memory)
-        
-        # The test expects proper contradiction validation to be active.
-        # Currently, the code skips validation with the reason "MVP direct store", meaning
-        # it will blindly store contradictions instead of resolving them.
-        assert result.get("reason") != "MVP direct store", "Contradiction validation is completely skipped (MVP direct store)."
 
-    def test_batch_store_memories_skips_validation(self):
-        """
-        Demonstrates that batch_store_memories also bypasses contradiction validation.
-        """
-        mock_client = MagicMock()
-        mock_client.documents.upload.return_value = {"status": "success"}
-        
-        write_service = MemoryWriteService(mock_client)
-        
-        memory1 = MemoryRecord(
-            content="The user lives in New York.",
-            type="fact",
-            title="Location",
-            agent_id="test-agent"
+        assert result["superseded_ids"] == ["old-1"]
+        assert "contradiction resolved: superseded old-1" in result["reason"]
+
+        # Old memory was rewritten as superseded history, not dropped.
+        client.documents.delete.assert_called_once_with(
+            namespace_name="memanto_agent_test-agent", ids=["old-1"]
         )
-        
-        memory2 = MemoryRecord(
-            content="The user lives in London.",
-            type="fact",
-            title="Location",
-            agent_id="test-agent"
+        uploads = client.documents.upload.call_args_list
+        assert len(uploads) == 2
+        superseded_doc = uploads[0].kwargs["documents"][0]
+        assert superseded_doc["id"] == "old-1"
+        assert superseded_doc["status"] == "superseded"
+        assert superseded_doc["superseded_by"] == memory.id
+        assert "superseded_at" in superseded_doc
+        new_doc = uploads[1].kwargs["documents"][0]
+        assert new_doc["id"] == memory.id
+        assert new_doc["status"] == "active"
+
+    def test_duplicate_content_is_not_a_contradiction(self):
+        """Identical content under the same title is a duplicate, not a conflict."""
+        duplicate = existing_doc(content="The user's favorite color is red.")
+        client = make_client(search_results=[duplicate])
+        write_service = MemoryWriteService(client)
+
+        result = write_service.store_memory(make_memory())
+
+        assert result["reason"] == "validated: no contradicting memories found"
+        client.documents.delete.assert_not_called()
+
+    def test_exempt_type_skips_conflict_check(self):
+        """Types outside REQUIRE_VALIDATION_FOR store directly, without search."""
+        client = make_client()
+        write_service = MemoryWriteService(client)
+
+        result = write_service.store_memory(
+            make_memory(type="event", title="Standup", content="Daily standup at 9am.")
         )
-        
+
+        assert "exempt from conflict validation" in result["reason"]
+        client.similarity_search.query.assert_not_called()
+
+    def test_search_failure_does_not_block_store(self):
+        """A failed conflict lookup is reported honestly but never blocks the write."""
+        client = make_client()
+        client.similarity_search.query.side_effect = RuntimeError("search down")
+        write_service = MemoryWriteService(client)
+
+        result = write_service.store_memory(make_memory())
+
+        assert result["reason"] == "stored: conflict check unavailable"
+        client.documents.upload.assert_called_once()
+
+    def test_batch_store_memories_runs_validation(self):
+        """batch_store_memories must not bypass validation either."""
+        client = make_client()
+        write_service = MemoryWriteService(client)
+
+        memory1 = make_memory(
+            content="The user lives in New York.", title="Location"
+        )
+        memory2 = make_memory(content="The user lives in London.", title="Location")
+
         result = write_service.batch_store_memories([memory1, memory2])
-        
+
         for res in result["results"]:
-            assert res.get("reason") != "MVP direct store", "Contradiction validation is skipped for batch storage (MVP direct store)."
+            assert res.get("reason") != "MVP direct store", (
+                "Contradiction validation is skipped for batch storage (MVP direct store)."
+            )
+
+    def test_batch_resolves_contradictions_within_batch(self):
+        """Contradicting memories submitted together resolve to last-wins,
+        with the earlier one preserved as superseded history."""
+        client = make_client()
+        write_service = MemoryWriteService(client)
+
+        memory1 = make_memory(
+            content="The user lives in New York.", title="Location"
+        )
+        memory2 = make_memory(content="The user lives in London.", title="Location")
+
+        result = write_service.batch_store_memories([memory1, memory2])
+
+        first, second = result["results"]
+        assert first["action"] == "store_superseded"
+        assert f"superseded within batch by {memory2.id}" in first["reason"]
+        assert second["action"] == "store"
+
+        documents = client.documents.upload.call_args.kwargs["documents"]
+        assert documents[0]["status"] == "superseded"
+        assert documents[0]["superseded_by"] == memory2.id
+        assert documents[1]["status"] == "active"
+        assert result["successful"] == 2


### PR DESCRIPTION
## Bug (Bounty #770)

Write-time memory validation is stubbed out in `MemoryWriteService` — `store_memory`, `batch_store_memories`, and `update_memory` all hardcode `{"action": "store", "reason": "MVP direct store"}`. The commented-out `self.validation_service` is never constructed, and the legacy `MemoryValidationService` cannot even be imported (`ValidationPolicy` no longer exists in `memanto.app.core`). As a result, logically contradictory memories are stored blindly:

```python
store_memory(MemoryRecord(title="Location", content="The user lives in New York.", ...))
store_memory(MemoryRecord(title="Location", content="The user lives in London.", ...))
# → both stored as active facts; recall returns whichever ranks higher
```

The offline conflict report (`generate_conflict_report`) can detect this later, but nothing prevents or resolves it at write time — including two contradictory facts submitted in the *same batch*.

## Fix

Adds a working `memanto/app/services/memory_validation_service.py` and wires it into `store_memory` and `batch_store_memories`:

- **Detection (deterministic, no LLM on the write path):** an active memory with the same type and title but different content is a contradiction. Only types in `settings.REQUIRE_VALIDATION_FOR` (`fact`, `preference`) are checked, so the write path stays cheap — deeper semantic conflicts remain the offline report's job.
- **Resolution (keep_new, history-preserving):** the old record is not dropped — it is rewritten with `status="superseded"` plus `superseded_by`/`superseded_at`, the same timeline fields `search_as_of` already consumes, using the same delete-and-recreate pattern as `update_memory`. The store result reports `superseded_ids` and a human-readable reason.
- **Intra-batch:** contradictions inside one batch resolve last-wins; earlier entries are stored as superseded history with their result entries explaining why.
- **Fail-open, honestly:** if the conflict lookup fails, the write proceeds but the reason says `conflict check unavailable` instead of pretending validation passed.

## Tests

`tests/test_contradiction.py` (7 tests) covers: validation active on single + batch writes, supersede flow (old record rewritten as superseded history, new stored active), duplicates not treated as contradictions, exempt types skipping the search, lookup failure not blocking writes, and intra-batch last-wins resolution.

Full suite: passes locally (only live-API E2E tests skip without `MOORCHEH_API_KEY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added write-time contradiction/conflict validation for memory saves, with automatic resolution by superseding conflicting entries.
  * Enhanced batch saves to apply last-wins conflict resolution within the batch and preserve superseded history.
* **Bug Fixes**
  * Prevented use of the legacy bypass path for contradiction checks.
  * If conflict checks are unavailable, saving continues without blocking; exempt memory types skip validation.
* **Tests**
  * Expanded coverage for single and batch conflict handling, including duplicates, exemptions, and upload/update failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->