### PR TITLE
Guard malformed config section reads

### DIFF
--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -328,10 +328,7 @@ class ConfigManager:
         knobs (temperature/threshold/answer_limit/kiosk_mode) are shared
         because they describe how to query, not which provider to hit.
         """
-        data = self.load_yaml()
-        answer = data.get("answer", {})
-        if not isinstance(answer, dict):
-            answer = {}
+        answer = self._get_section("answer")
 
         defaults = {
             "model": "anthropic.claude-sonnet-4-6",

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -263,6 +263,17 @@ class ConfigManager:
         """Get a top-level YAML config value."""
         return self.load_yaml().get(key, default)
 
+    def _get_section(self, key: str) -> dict:
+        """Return a config section only when it is a mapping.
+
+        ``config.yaml`` is user-editable, so a malformed section such as
+        ``recall: []`` or ``server: "localhost"`` must not crash read paths that
+        merely need to apply defaults. Treat non-mapping section values like a
+        missing section and let setters replace them with a fresh dict.
+        """
+        value = self.load_yaml().get(key, {})
+        return value if isinstance(value, dict) else {}
+
     def set(self, key: str, value) -> None:
         """Set a top-level YAML config value."""
         data = self.load_yaml()
@@ -273,7 +284,7 @@ class ConfigManager:
 
     def get_server_url(self) -> str:
         """Get MEMANTO server URL."""
-        server = self.load_yaml().get("server", {})
+        server = self._get_section("server")
         host = server.get("url", "localhost")
         port = server.get("port", 8000)
         return f"http://{host}:{port}"
@@ -281,7 +292,7 @@ class ConfigManager:
     def get_server_config(self) -> dict:
         """Get server config dict with defaults."""
         defaults = {"url": "localhost", "port": 8000, "auto_start": False}
-        defaults.update(self.load_yaml().get("server", {}))
+        defaults.update(self._get_section("server"))
         return defaults
 
     def get_session_config(self) -> dict:
@@ -294,7 +305,7 @@ class ConfigManager:
             "auto_renew_enabled": True,
             "auto_renew_interval_hours": 6,
         }
-        defaults.update(self.load_yaml().get("session", {}))
+        defaults.update(self._get_section("session"))
         return defaults
 
     def get_cli_config(self) -> dict:
@@ -305,7 +316,7 @@ class ConfigManager:
             "auto_title": True,
             "color_output": True,
         }
-        defaults.update(self.load_yaml().get("cli", {}))
+        defaults.update(self._get_section("cli"))
         return defaults
 
     def get_answer_config(self) -> dict:
@@ -319,6 +330,8 @@ class ConfigManager:
         """
         data = self.load_yaml()
         answer = data.get("answer", {})
+        if not isinstance(answer, dict):
+            answer = {}
 
         defaults = {
             "model": "anthropic.claude-sonnet-4-6",
@@ -362,8 +375,7 @@ class ConfigManager:
 
     def get_recall_config(self) -> dict:
         """Get Recall/Top-N config dict with defaults."""
-        data = self.load_yaml()
-        recall = data.get("recall", {})
+        recall = self._get_section("recall")
 
         defaults = {"limit": 10, "min_similarity": 0.0}
         defaults.update(recall)

--- a/tests/test_config_manager_resilience.py
+++ b/tests/test_config_manager_resilience.py
@@ -1,0 +1,31 @@
+from memanto.cli.config.manager import ConfigManager
+
+
+def test_config_sections_with_malformed_shapes_fall_back_to_defaults(tmp_path):
+    config_dir = tmp_path / "memanto"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        """
+memanto:
+  server: localhost
+  session:
+    - invalid
+  cli: false
+  answer: 42
+  recall: []
+""".strip(),
+        encoding="utf-8",
+    )
+
+    manager = ConfigManager(config_dir=config_dir)
+
+    assert manager.get_server_url() == "http://localhost:8000"
+    assert manager.get_server_config() == {
+        "url": "localhost",
+        "port": 8000,
+        "auto_start": False,
+    }
+    assert manager.get_session_config()["default_duration_hours"] == 6
+    assert manager.get_cli_config()["interactive_mode"] is True
+    assert manager.get_answer_config()["answer_limit"] == 15
+    assert manager.get_recall_config() == {"limit": 10, "min_similarity": 0.0}


### PR DESCRIPTION
## Summary

Fixes a config resilience bug for #770: user-editable `~/.memanto/config.yaml` could contain non-mapping values for sections that read paths expect to be dictionaries (`server`, `session`, `cli`, `answer`, or `recall`). A malformed-but-valid YAML edit such as `recall: []` or `server: localhost` caused normal config reads to raise `TypeError`/`AttributeError` instead of falling back to documented defaults.

## Reproduction

Create a config like:

```yaml
memanto:
  server: localhost
  session:
    - invalid
  cli: false
  answer: 42
  recall: []
```

Then call `ConfigManager(...).get_server_url()`, `get_server_config()`, `get_session_config()`, `get_cli_config()`, `get_answer_config()`, or `get_recall_config()`. Before this fix, these paths crash while reading config.

## Fix

- Add a small `_get_section()` helper that treats non-dict config sections as missing.
- Use it in config read paths that merge defaults.
- Guard `answer` reads similarly.
- Add a regression test proving malformed section shapes fall back to defaults.

## Validation

- `uv run --with pytest --with pyyaml --with python-dotenv --with pydantic --with pydantic-settings --with fastapi --with typer --with rich --with httpx --with rapidfuzz pytest tests/test_config_manager_resilience.py -q`
- `uv run pytest tests -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading to ignore malformed or non-dictionary YAML sections instead of triggering failures.
  * Updated server, session, CLI, answer, and recall settings to merge defaults reliably when user config is incorrectly shaped.
  * Ensured default values are applied consistently after invalid edits to `config.yaml`.
* **Tests**
  * Added a resilience test that validates fallback-to-default behavior for multiple config accessors when the configuration contains malformed shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->