### PR TITLE
Preserve provenance metadata on memory update (#770)

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -355,7 +355,9 @@ class MemoryWriteService:
                 confidence=updates.get("confidence", metadata.get("confidence", 0.8)),
                 status=updates.get("status", metadata.get("status", "active")),
                 tags=updates.get("tags", metadata.get("tags", [])),
-                provenance=metadata.get("provenance") or "explicit_statement",
+                provenance=updates.get(
+                    "provenance", metadata.get("provenance") or "explicit_statement"
+                ),
             )
 
             # Update timestamps (preserve created_at, set updated_at to now)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -704,6 +704,44 @@ class TestMemoryWriteService:
         uploaded_doc = mock_client.documents.upload.call_args.kwargs["documents"][0]
         assert uploaded_doc["provenance"] == "validated"
 
+    def test_update_memory_allows_explicit_provenance_override(self):
+        """Explicit provenance updates must take precedence over stored metadata."""
+        mock_client = MagicMock()
+        mock_client.documents.get.return_value = {
+            "items": [
+                {
+                    "id": "mem-123",
+                    "text": "[FACT] Billing plan\n\nCustomer confirmed enterprise plan.",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "agent_id": "agent-1",
+                        "actor_id": "agent-1",
+                        "source": "user",
+                        "confidence": 0.91,
+                        "status": "active",
+                        "provenance": "validated",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    },
+                }
+            ]
+        }
+        mock_client.documents.delete.return_value = {"actual_deletions": 1}
+        mock_client.documents.upload.return_value = {"status": "success"}
+
+        service = MemoryWriteService(mock_client)
+        service.update_memory(
+            "mem-123",
+            "memanto_agent_agent-1",
+            {
+                "content": "Customer confirmed enterprise plus plan.",
+                "provenance": "corrected",
+            },
+        )
+
+        uploaded_doc = mock_client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_doc["provenance"] == "corrected"
+
 
 class TestAgentService:
     """Unit tests for AgentService"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -20,6 +20,7 @@ from memanto.app.config import settings
 from memanto.app.core import MemoryRecord
 from memanto.app.models.session import AgentCreate, AgentPattern, Session, SessionStatus
 from memanto.app.services.agent_service import AgentService
+from memanto.app.services.memory_write_service import MemoryWriteService
 from memanto.app.services.session_service import SessionService
 from memanto.app.utils.errors import InvalidSessionTokenError
 
@@ -657,6 +658,51 @@ class TestMemoryRecord:
         for ttl in (0, -60):
             with pytest.raises(ValueError, match="ttl_seconds must be greater than 0"):
                 memory.set_ttl(ttl)
+
+
+class TestMemoryWriteService:
+    """Unit tests for memory write/update behavior."""
+
+    def test_update_memory_preserves_existing_provenance(self):
+        """Partial updates must not silently downgrade provenance metadata.
+
+        The update path rebuilds a MemoryRecord from stored document metadata.
+        If provenance is omitted there, a `validated`/`corrected`/`inferred`
+        memory is rewritten as the default `explicit_statement`, corrupting
+        memory integrity and future provenance-aware retrieval.
+        """
+        mock_client = MagicMock()
+        mock_client.documents.get.return_value = {
+            "items": [
+                {
+                    "id": "mem-123",
+                    "text": "[FACT] Billing plan\n\nCustomer confirmed enterprise plan.",
+                    "metadata": {
+                        "memory_type": "fact",
+                        "agent_id": "agent-1",
+                        "actor_id": "agent-1",
+                        "source": "user",
+                        "confidence": 0.91,
+                        "status": "active",
+                        "provenance": "validated",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    },
+                }
+            ]
+        }
+        mock_client.documents.delete.return_value = {"actual_deletions": 1}
+        mock_client.documents.upload.return_value = {"status": "success"}
+
+        service = MemoryWriteService(mock_client)
+        service.update_memory(
+            "mem-123",
+            "memanto_agent_agent-1",
+            {"content": "Customer confirmed enterprise plus plan."},
+        )
+
+        uploaded_doc = mock_client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_doc["provenance"] == "validated"
 
 
 class TestAgentService:


### PR DESCRIPTION
## Summary
- Fixes a #770 memory integrity bug where `update_memory()` rebuilt stored memories without copying their existing `provenance` metadata.
- Prevents partial updates from silently downgrading `validated`, `corrected`, or `inferred` memories to the `MemoryRecord` default `explicit_statement`.
- Adds a regression test that reproduces the metadata loss and verifies the uploaded replacement document preserves provenance.

## Repro
1. Store/read a memory whose metadata has `provenance: validated`.
2. Call `MemoryWriteService.update_memory()` with a partial payload, e.g. only `content`.
3. Before this fix, the replacement document is uploaded with `provenance: explicit_statement` because the rebuilt `MemoryRecord` omits provenance.
4. After this fix, the existing provenance is retained unless the caller explicitly updates it.

## Tests
- `python3 -m pytest tests/test_unit.py::TestMemoryWriteService::test_update_memory_preserves_existing_provenance -q`
- `python3 -m pytest tests/test_unit.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved memory provenance when updating existing entries, so partial edits no longer overwrite the original source information.
  * Ensured provenance handling defaults appropriately and that explicitly provided provenance in an update takes precedence over stored metadata.
* **Tests**
  * Added unit tests covering provenance behavior for partial updates and explicit provenance overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->