### PR TITLE
fix: stack history stat cards on narrow viewports

### DIFF
--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -1381,7 +1381,8 @@
 
             .charts-row,
             .form-row,
-            .conflict-memories {
+            .conflict-memories,
+            .hh-stats {
                 grid-template-columns: 1fr;
             }
         }


### PR DESCRIPTION
I identified a responsive layout issue on the History tab where the .hh-stats stat cards were not stacking on small screens, causing them to crush together. Added .hh-stats to the existing 900px media query to ensure the stat cards stack into a single column on narrow viewports, improving mobile usability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the mobile layout for the History stats section so it now stacks into a single column on narrow screens, matching the existing behavior of similar content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->