### PR TITLE
fix(connect): avoid false installed status from shared skill dirs

### DIFF
--- a/memanto/cli/connect/agent_registry.py
+++ b/memanto/cli/connect/agent_registry.py
@@ -305,9 +305,10 @@ def detect_memanto_installed(project_dir: Path) -> list[AgentDef]:
     """Detect which agents have MEMANTO already installed (local)."""
     installed = []
     for agent in AGENT_REGISTRY.values():
-        skill_dir = agent.resolve_skill_local(project_dir)
-        skill_file = skill_dir / "SKILL.md"
-        if skill_file.exists():
+        if _has_memanto_skill(agent, project_dir, is_global=False) and (
+            not agent.instruction_file
+            or _has_memanto_instruction(agent, project_dir, is_global=False)
+        ):
             installed.append(agent)
     return installed
 
@@ -316,8 +317,31 @@ def detect_memanto_installed_global() -> list[AgentDef]:
     """Detect which agents have MEMANTO installed globally."""
     installed = []
     for agent in AGENT_REGISTRY.values():
-        skill_dir = agent.resolve_skill_global()
-        skill_file = skill_dir / "SKILL.md"
-        if skill_file.exists():
+        if _has_memanto_skill(agent, Path.home(), is_global=True) and (
+            not agent.instruction_file
+            or _has_memanto_instruction(agent, Path.home(), is_global=True)
+        ):
             installed.append(agent)
     return installed
+
+
+def _has_memanto_skill(agent: AgentDef, project_dir: Path, is_global: bool) -> bool:
+    skill_dir = (
+        agent.resolve_skill_global()
+        if is_global
+        else agent.resolve_skill_local(project_dir)
+    )
+    return (skill_dir / "SKILL.md").is_file()
+
+
+def _has_memanto_instruction(
+    agent: AgentDef, project_dir: Path, is_global: bool
+) -> bool:
+    instr_path = agent.resolve_instruction_file(project_dir, is_global)
+    if instr_path is None or not instr_path.is_file():
+        return False
+    try:
+        content = instr_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return agent.sentinel in content and agent.sentinel_end in content

--- a/tests/test_connect_detection.py
+++ b/tests/test_connect_detection.py
@@ -1,0 +1,57 @@
+from memanto.cli.connect.agent_registry import AGENT_REGISTRY, detect_memanto_installed
+from memanto.cli.connect.templates import MEMANTO_SENTINEL, MEMANTO_SENTINEL_END
+
+
+def _write_shared_agents_skill(project_dir):
+    skill_dir = project_dir / ".agents" / "skills" / "memanto"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("memanto skill\n", encoding="utf-8")
+
+
+def _write_agent_skill(project_dir, agent_name):
+    skill_dir = AGENT_REGISTRY[agent_name].resolve_skill_local(project_dir)
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("memanto skill\n", encoding="utf-8")
+
+
+def test_shared_agents_skill_alone_does_not_mark_instruction_agents_installed(
+    tmp_path,
+):
+    """The shared .agents skill path is used by several agents.
+
+    A leftover SKILL.md without the matching agent instruction file is not a
+    complete install and must not make every agent that uses that shared skill
+    directory appear installed.
+    """
+    _write_shared_agents_skill(tmp_path)
+
+    installed = {agent.name for agent in detect_memanto_installed(tmp_path)}
+
+    assert installed.isdisjoint({"codex", "cline", "opencode", "github-copilot"})
+
+
+def test_cline_install_detection_requires_cline_rule_file(tmp_path):
+    """Cline should be detected only when its own rule file is present."""
+    _write_shared_agents_skill(tmp_path)
+    cline_rule = tmp_path / ".clinerules" / "memanto.md"
+    cline_rule.parent.mkdir(parents=True)
+    cline_rule.write_text(
+        f"{MEMANTO_SENTINEL}\n## MEMANTO\n{MEMANTO_SENTINEL_END}\n",
+        encoding="utf-8",
+    )
+
+    installed = {agent.name for agent in detect_memanto_installed(tmp_path)}
+
+    assert "cline" in installed
+    assert installed.isdisjoint({"codex", "opencode", "github-copilot"})
+
+
+def test_skills_only_agent_detected_from_skill_file_alone(tmp_path):
+    """Agents without an instruction file are detected from SKILL.md alone."""
+    skills_only_agent = AGENT_REGISTRY["antigravity"]
+    assert skills_only_agent.instruction_file is None
+    _write_agent_skill(tmp_path, skills_only_agent.name)
+
+    installed = {agent.name for agent in detect_memanto_installed(tmp_path)}
+
+    assert skills_only_agent.name in installed


### PR DESCRIPTION
## Summary
- Fixes `memanto connect list` false positives when several supported agents share `.agents/skills/memanto/SKILL.md`.
- Installed detection now requires the shared skill plus the agent-specific MEMANTO instruction marker for instruction-based agents.
- Adds regression coverage for shared-skill-only projects and Cline-specific detection.

## Root Cause
`detect_memanto_installed()` and `detect_memanto_installed_global()` treated `SKILL.md` as sufficient proof of installation. That works for agents with unique skill directories, but `codex`, `cline`, `opencode`, and `github-copilot` all resolve their local skill path to `.agents/skills/memanto`. A single leftover/shared skill file therefore made multiple agents appear installed even when their own instruction files were missing.

## Reproduction
1. Create `.agents/skills/memanto/SKILL.md` in a project without `AGENTS.md`, `.clinerules/memanto.md`, or `.github/copilot-instructions.md` containing MEMANTO markers.
2. Run the local installed detection used by `memanto connect list`.
3. Before this fix, the project is reported as installed for `codex`, `cline`, `opencode`, and `github-copilot`.

## Fix
For instruction-based agents, installed detection now checks both:
- the resolved MEMANTO skill file exists; and
- the agent-specific instruction file exists and contains the MEMANTO sentinel pair.

Skills-only agents keep the previous skill-file detection behavior.

## Validation
- `uv run --extra all python -m pytest tests/test_connect_detection.py -q`
- `uv run --extra all python -m pytest tests/test_connect_detection.py tests/test_cli.py::TestMEMANTOCLI::test_connect_list -q`
- `uv run --extra all python -m pytest tests/test_cli.py -q`
- `uv run --extra all ruff check memanto/cli/connect/agent_registry.py tests/test_connect_detection.py`
- `git diff --check -- memanto/cli/connect/agent_registry.py tests/test_connect_detection.py`

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent installation detection for both local and global setups.
  * Agents are now considered installed only when their expected instruction configuration is present (in addition to the shared skill).
  * Missing or unreadable instruction configuration is handled gracefully to avoid false positives.

* **Tests**
  * Expanded automated coverage for shared skills vs agent-specific rules.
  * Added scenarios covering agents without an instruction configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->