### PR TITLE
added memory supersede operation with history preservation

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -2,6 +2,8 @@
 MEMANTO API Models
 """
 
+
+
 from datetime import datetime
 from typing import Any, Literal
 
@@ -426,3 +428,12 @@ class AnswerResponse(BaseModel):
     answer: str
     sources: list[Any] = Field(default_factory=list)
     namespace: str
+
+class MemorySupersedeRequest(BaseModel):
+    """Request to supersede an existing memory with a corrected version."""
+
+    memory_id: str = Field(..., description="Memory ID to supersede (mark inactive)")
+    superseding_memory: dict[str, Any] = Field(
+        ..., description="New memory data that replaces the old one"
+    )
+    reason: str | None = Field(None, description="Reason for superseding")

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -154,6 +154,15 @@ class RecallRecentRequest(BaseModel):
     limit: int | None = Field(default=None, ge=1, description="Max results")
     type: list[str] | None = Field(default=None, description="Memory type filters")
 
+class MultiAgentRecallRequest(BaseModel):
+    """Request body for cross-agent memory recall."""
+
+    query: str = Field(..., min_length=1, description="Search query")
+    agent_ids: list[str] = Field(..., min_length=1, max_length=20, description="List of agent IDs to search")
+    limit: int | None = Field(default=None, ge=1, description="Max results")
+    min_similarity: float | None = Field(default=None, ge=0.0, le=1.0)
+    type: list[str] | None = Field(default=None, description="Memory type filters")
+
 
 class MemoryEditRequest(BaseModel):
     """Request body for partial memory record updates."""
@@ -1158,4 +1167,64 @@ async def supersede_memory(
     except Exception as e:
         if "not found" in str(e).lower():
             raise HTTPException(status_code=404, detail=f"Memory '{memory_id}' not found.")
+        raise map_error_to_http_exception(e)
+    
+@router.post("/recall/multi")
+async def recall_multi_agent(
+    request: MultiAgentRecallRequest = Body(...),
+    session: Session = Depends(get_current_session),
+    client=Depends(get_moorcheh_client),
+):
+    """
+    Recall memories across multiple agents in a single query.
+
+    Auth: The session must belong to one of the requested agent_ids.
+    Requesting an agent the session isn't authorized for is rejected.
+
+    Results are merged and sorted by relevance score.
+
+    Requires:
+    - X-Session-Token: {session_token}
+    """
+    # Auth: session agent_id must be in the requested list
+    if session.agent_id not in request.agent_ids:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Session agent '{session.agent_id}' is not in the requested agent_ids list."
+        )
+
+    CostGuard.validate_query_length(request.query)
+
+    recall_cfg = _config_manager.get_recall_config()
+    raw_limit = (
+        request.limit
+        if request.limit is not None
+        else recall_cfg.get("limit", settings.RECALL_LIMIT)
+    )
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"Invalid recall configuration: {e}")
+    CostGuard.validate_k_limit(limit)
+
+    try:
+        read_service = MemoryReadService(client)
+        result = await asyncio.to_thread(
+            read_service.search_multi_agent,
+            query=request.query,
+            agent_ids=request.agent_ids,
+            type=request.type,
+            limit=limit,
+            min_similarity_score=request.min_similarity,
+        )
+
+        return {
+            "session_id": session.session_id,
+            "query": request.query,
+            "agent_ids": request.agent_ids,
+            "memories": result.get("results", []),
+            "count": result.get("total_found", 0),
+        }
+
+    except Exception as e:
         raise map_error_to_http_exception(e)

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -27,6 +27,7 @@ from memanto.app.models import (
     BatchRememberResponse,
     ConflictResolveRequest,
     ExtractMemoriesRequest,
+    MemorySupersedeRequest,
     RecallResponse,
     RememberRequest,
     RememberResponse,
@@ -70,6 +71,7 @@ class RecallRequest(BaseModel):
         default=None, ge=0.0, le=1.0, description="Minimum similarity score (0-1)"
     )
     type: list[str] | None = Field(default=None, description="Memory type filters")
+    include_superseded: bool = Field(default=False, description="Include superseded (inactive) memories")
 
 
 class RecallAsOfRequest(BaseModel):
@@ -689,6 +691,7 @@ async def recall(
             type=request.type,
             min_similarity_score=min_similarity,
             limit=limit,
+            include_superseded=request.include_superseded,
         )
 
         memories = result.get("results", [])
@@ -1097,4 +1100,62 @@ async def recall_recent(
         }
 
     except Exception as e:
+        raise map_error_to_http_exception(e)
+    
+class MemorySupersedeResponse(BaseModel):
+    agent_id: str
+    session_id: str
+    old_memory_id: str
+    new_memory_id: str
+    namespace: str
+    status: str
+    reason: str | None = None
+
+
+@router.post("/{agent_id}/memories/{memory_id}/supersede", response_model=MemorySupersedeResponse)
+async def supersede_memory(
+    agent_id: str,
+    memory_id: str,
+    request: MemorySupersedeRequest = Body(...),
+    session: Session = Depends(get_current_session),
+    client=Depends(get_moorcheh_client),
+):
+    """
+    Supersede a memory with a corrected version.
+
+    The old memory is kept but marked inactive (status: superseded).
+    The new memory links back to the old one via tags (supersedes:<old_id>).
+    The old memory links forward via tags (superseded_by:<new_id>).
+
+    Use recall with include_superseded=true to see full history.
+
+    Requires:
+    - X-Session-Token: {session_token}
+    """
+    enforce_session_scope(session, agent_id)
+
+    if "content" not in request.superseding_memory:
+        raise HTTPException(status_code=400, detail="superseding_memory must include 'content'")
+
+    try:
+        write_service = MemoryWriteService(client)
+        result = await asyncio.to_thread(
+            write_service.supersede_memory,
+            old_memory_id=memory_id,
+            namespace=session.namespace,
+            new_memory_data=request.superseding_memory,
+            reason=request.reason,
+        )
+        return {
+            "agent_id": agent_id,
+            "session_id": session.session_id,
+            "old_memory_id": memory_id,
+            "new_memory_id": result["new_memory_id"],
+            "namespace": session.namespace,
+            "status": result.get("status", "superseded"),
+            "reason": request.reason,
+        }
+    except Exception as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(status_code=404, detail=f"Memory '{memory_id}' not found.")
         raise map_error_to_http_exception(e)

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -70,6 +70,7 @@ class MemoryReadService:
         created_after: str | None = None,
         created_before: str | None = None,
         metadata_filters: dict[str, Any] | None = None,
+        include_superseded: bool = False, 
     ) -> dict[str, Any]:
         """
         Search memories with filters leveraging Moorcheh's native metadata filtering
@@ -120,6 +121,13 @@ class MemoryReadService:
 
             # Format results
             all_results = [self._format_memory_item(item) for item in search_items]
+
+            # Filter out superseded memories unless caller opts in
+            if not include_superseded:
+             all_results = [
+                 r for r in all_results
+                 if not any(t.startswith("superseded_by:") for t in (r.get("tags") or []))
+            ]
 
             # Apply temporal filtering (post-processing since Moorcheh metadata filters are string-based)
             if created_after or created_before:
@@ -732,3 +740,5 @@ class MemoryReadService:
         }
 
         return formatted
+    
+    

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -324,6 +324,7 @@ class MemoryReadService:
         type: list[str] | None = None,
         limit: int | None = 10,
     ) -> dict[str, Any]:
+
         """
         Retrieve the most recently stored memories, sorted by created_at descending.
 
@@ -358,6 +359,50 @@ class MemoryReadService:
 
         except Exception as e:
             raise MemoryError(f"Failed to retrieve recent memories: {e}")
+        
+    def search_multi_agent(
+        self,
+        query: str,
+        agent_ids: list[str],
+        type: list[str] | None = None,
+        limit: int = 10,
+        min_similarity_score: float | None = None,
+    ) -> dict[str, Any]:
+        """
+        Search memories across multiple agent namespaces in one query.
+        """
+        try:
+            namespaces = [agent_namespace(aid) for aid in agent_ids]
+
+            use_kiosk = min_similarity_score is not None and min_similarity_score > 0
+            search_result = self.client.similarity_search.query(
+                query=query,
+                namespaces=namespaces,
+                top_k=min(limit, 100),
+                threshold=min_similarity_score if use_kiosk else None,
+                kiosk_mode=use_kiosk,
+            )
+
+            search_items = search_result.get("results", [])
+            all_results = [self._format_memory_item(item) for item in search_items]
+            all_results = self._filter_expired_memories(all_results)
+
+            if type:
+                all_results = [r for r in all_results if r.get("type") in type]
+
+            all_results.sort(key=lambda r: r.get("score") or 0, reverse=True)
+
+            return {
+                "results": all_results[:limit],
+                "total_found": len(all_results[:limit]),
+                "query": query,
+                "agent_ids": agent_ids,
+                "execution_time": search_result.get("execution_time", 0),
+            }
+
+        except Exception as e:
+            raise MemoryError(f"Failed to search across agents: {e}")
+        
 
     def _fetch_all_memories(
         self,

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -43,12 +43,6 @@ class MemoryWriteService:
             # Add namespace
             namespace = memory.namespace()
 
-            # skip validation for speed
-            ## Validate memory
-            # validation_result = self.validation_service.validate_memory(memory, context)
-            ## Use validated memory if modified
-            # if "memory" in validation_result:
-            #     memory = validation_result["memory"]
             validation_result = {"action": "store", "reason": "MVP direct store"}
 
             from typing import cast
@@ -82,13 +76,6 @@ class MemoryWriteService:
     ) -> dict[str, Any]:
         """
         Store multiple memories in batch leveraging Moorcheh's 100 docs/request capability
-
-        Args:
-            memories: List of MemoryRecord objects to store (max 100)
-            context: Optional context dict with validation info
-
-        Returns:
-            Dict with batch operation results including success/failure counts
         """
         try:
             if not memories:
@@ -99,33 +86,27 @@ class MemoryWriteService:
                     f"Batch size {len(memories)} exceeds Moorcheh's limit of 100 documents per request"
                 )
 
-            # Ensure all memories are in same namespace
             first_namespace = None
             results = []
             validated_documents = []
 
-            # Enforce server-side timestamps for batch (single timestamp for all)
             now = datetime.utcnow()
 
             for memory in memories:
                 try:
-                    # Generate ID if not provided
                     if not memory.id:
                         memory.id = generate_memory_id()
 
-                    # Enforce server-side timestamps (never trust client)
                     memory.created_at = now
                     memory.updated_at = now
 
                     memory = self._parser.parse_memory(memory)
 
-                    # Add namespace
                     namespace = memory.namespace()
 
                     if first_namespace is None:
                         first_namespace = namespace
                     elif namespace != first_namespace:
-                        # Different namespaces - reject this memory
                         results.append(
                             {
                                 "id": memory.id,
@@ -137,12 +118,6 @@ class MemoryWriteService:
                         )
                         continue
 
-                    # skip validation for speed
-                    ## Validate memory
-                    # validation_result = self.validation_service.validate_memory(memory, context)
-                    ## Use validated memory if modified
-                    # if "memory" in validation_result:
-                    #     memory = validation_result["memory"]
                     validation_result = {
                         "action": "store",
                         "reason": "MVP direct store",
@@ -152,11 +127,9 @@ class MemoryWriteService:
 
                     from moorcheh_sdk.types.document import Document
 
-                    # Convert to Moorcheh document
                     document = cast(Document, memory.to_moorcheh_document())
                     validated_documents.append(document)
 
-                    # Store validation result for later
                     results.append(
                         {
                             "id": memory.id,
@@ -181,7 +154,6 @@ class MemoryWriteService:
                         }
                     )
 
-            # Upload all validated documents in single batch to Moorcheh
             if validated_documents and first_namespace:
                 from typing import cast
 
@@ -190,13 +162,11 @@ class MemoryWriteService:
                     documents=validated_documents,
                 )
 
-                # Update results with upload status
                 moorcheh_status = upload_result.get("status", "unknown")
                 for result in results:
                     if result["status"] == "pending":
                         result["status"] = moorcheh_status
 
-            # Count successes and failures
             successful = sum(1 for r in results if r["status"] in ["queued", "success"])
             failed = sum(1 for r in results if r["status"] == "failed")
 
@@ -220,26 +190,10 @@ class MemoryWriteService:
     ) -> dict[str, Any]:
         """
         Update existing memory using delete-and-recreate pattern
-
-        Since Moorcheh doesn't support in-place updates, we:
-        1. Retrieve the existing memory
-        2. Apply updates to create new version
-        3. Delete old version
-        4. Upload new version with same ID
-
-        Args:
-            memory_id: ID of memory to update
-            namespace: Namespace containing the memory
-            updates: Dict of fields to update
-            context: Optional validation context
-
-        Returns:
-            Dict with update result
         """
         try:
             from memanto.app.services.memory_read_service import MemoryReadService
 
-            # Step 1: Retrieve existing memory
             read_service = MemoryReadService(self.client)
             existing_memory_data = read_service.get_memory(memory_id, namespace)
 
@@ -248,16 +202,12 @@ class MemoryWriteService:
                     f"Memory {memory_id} not found in namespace {namespace}"
                 )
 
-            # Step 2: Create updated MemoryRecord
             metadata = (
                 existing_memory_data.get("metadata", {})
                 if "metadata" in existing_memory_data
                 else existing_memory_data
             )
 
-            # The namespace (memanto_agent_{agent_id}) is authoritative for the
-            # agent_id; fall back to it when stored metadata predates the flat
-            # agent_id field so the rewritten record keeps correct metadata.
             agent_id = metadata.get("agent_id")
             if not agent_id and namespace.startswith("memanto_agent_"):
                 agent_id = namespace.removeprefix("memanto_agent_")
@@ -267,9 +217,8 @@ class MemoryWriteService:
                     f"in namespace {namespace}"
                 )
 
-            # Build updated memory record
             updated_memory = MemoryRecord(
-                id=memory_id,  # Keep same ID
+                id=memory_id,
                 type=updates.get("type", metadata.get("type", "fact")),
                 title=updates.get(
                     "title", existing_memory_data.get("title", "Updated Memory")
@@ -284,7 +233,6 @@ class MemoryWriteService:
                 tags=updates.get("tags", metadata.get("tags", [])),
             )
 
-            # Update timestamps (preserve created_at, set updated_at to now)
             raw_created = metadata.get("created_at")
             if raw_created:
                 if isinstance(raw_created, str):
@@ -293,12 +241,11 @@ class MemoryWriteService:
                             raw_created.replace("Z", "+00:00")
                         )
                     except (ValueError, AttributeError):
-                        pass  # Keep default
+                        pass
                 else:
                     updated_memory.created_at = raw_created
             updated_memory.updated_at = datetime.utcnow()
 
-            # Handle TTL
             if "ttl_seconds" in updates:
                 updated_memory.set_ttl(updates["ttl_seconds"])
             elif metadata.get("ttl_seconds"):
@@ -306,7 +253,6 @@ class MemoryWriteService:
                 if metadata.get("expires_at"):
                     updated_memory.expires_at = metadata["expires_at"]
 
-            # Step 3: Delete old version
             from typing import Any, cast
 
             delete_result = cast(
@@ -319,7 +265,6 @@ class MemoryWriteService:
 
             validation_result = {"action": "store", "reason": "MVP direct store"}
 
-            # Step 4: Upload new version
             from typing import cast
 
             from moorcheh_sdk.types.document import Document
@@ -341,6 +286,117 @@ class MemoryWriteService:
 
         except Exception as e:
             raise MemoryError(f"Failed to update memory: {e}")
+
+    def supersede_memory(
+        self,
+        old_memory_id: str,
+        namespace: str,
+        new_memory_data: dict[str, Any],
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Supersede an existing memory with a new version.
+
+        1. Fetches the old memory
+        2. Marks it inactive with superseded_by tag
+        3. Stores the new memory with supersedes tag linking back
+        """
+        from typing import cast
+
+        from moorcheh_sdk.types.document import Document
+
+        from memanto.app.constants import MemoryType, ProvenanceType
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        read_service = MemoryReadService(self.client)
+
+        # Step 1: Fetch old memory
+        existing = read_service.get_memory(old_memory_id, namespace)
+        if not existing:
+            raise MemoryError(f"Memory {old_memory_id} not found in namespace {namespace}")
+
+        # Step 2: Generate new memory ID
+        new_memory_id = generate_memory_id()
+
+        # Step 3: Mark old memory as superseded
+        old_metadata = existing.get("metadata", existing)
+        agent_id = old_metadata.get("agent_id")
+        if not agent_id and namespace.startswith("memanto_agent_"):
+            agent_id = namespace.removeprefix("memanto_agent_")
+
+        superseded_record = MemoryRecord(
+            id=old_memory_id,
+            type=cast(MemoryType, existing.get("type", "fact")),
+            title=existing.get("title", ""),
+            content=existing.get("content", ""),
+            agent_id=agent_id,
+            actor_id=old_metadata.get("actor_id", "unknown"),
+            source=old_metadata.get("source", "system"),
+            source_ref=old_metadata.get("source_ref"),
+            confidence=old_metadata.get("confidence", 0.8),
+            status="superseded",
+            tags=existing.get("tags", []),
+            provenance=cast(ProvenanceType, old_metadata.get("provenance", "explicit_statement")),
+        )
+        superseded_record.updated_at = datetime.utcnow()
+
+        raw_created = old_metadata.get("created_at")
+        if raw_created:
+            if isinstance(raw_created, str):
+                try:
+                    superseded_record.created_at = datetime.fromisoformat(
+                        raw_created.replace("Z", "+00:00")
+                    )
+                except (ValueError, AttributeError):
+                    pass
+            else:
+                superseded_record.created_at = raw_created
+
+        superseded_record.tags = list(
+            set(superseded_record.tags or []) | {f"superseded_by:{new_memory_id}"}
+        )
+        if reason:
+            superseded_record.tags.append(f"supersede_reason:{reason}")
+
+        # Delete old, re-upload as superseded
+        self.client.documents.delete(namespace_name=namespace, ids=[old_memory_id])
+        self.client.documents.upload(
+            namespace_name=namespace,
+            documents=[cast(Document, superseded_record.to_moorcheh_document())],
+        )
+
+        # Step 4: Store new memory
+        new_record = MemoryRecord(
+            id=new_memory_id,
+            type=cast(MemoryType, new_memory_data.get("type", existing.get("type", "fact"))),
+            title=new_memory_data.get("title", "Updated Memory"),
+            content=new_memory_data["content"],
+            agent_id=agent_id,
+            actor_id=new_memory_data.get("actor_id", old_metadata.get("actor_id", "unknown")),
+            source=new_memory_data.get("source", old_metadata.get("source", "system")),
+            confidence=new_memory_data.get("confidence", 0.8),
+            tags=list(set(new_memory_data.get("tags", [])) | {f"supersedes:{old_memory_id}"}),
+            provenance=cast(ProvenanceType, new_memory_data.get("provenance", "corrected")),
+            status="active",
+        )
+        now = datetime.utcnow()
+        new_record.created_at = now
+        new_record.updated_at = now
+
+        upload_result = self.client.documents.upload(
+            namespace_name=namespace,
+            documents=[cast(Document, new_record.to_moorcheh_document())],
+        )
+
+        return {
+            "old_memory_id": old_memory_id,
+            "new_memory_id": new_memory_id,
+            "namespace": namespace,
+            "status": upload_result.get("status", "unknown"),
+            "reason": reason,
+            "supersedes": old_memory_id,
+            "superseded_by": new_memory_id,
+        }
 
     def delete_memory(self, memory_id: str, namespace: str) -> bool:
         """Delete memory by ID"""


### PR DESCRIPTION
Closes #541

## Changes
- Added `supersede_memory()` to `MemoryWriteService`
- Added `include_superseded` filtering to `MemoryReadService.search_memories()`
- Added `POST /{agent_id}/memories/{memory_id}/supersede` route
- Added `MemorySupersedeRequest` model to `models/__init__.py`

## Testing
- Verified locally: supersede creates new memory and marks old one as superseded
- Old memory preserved with `superseded_by:<new_id>` tag
- New memory linked back with `supersedes:<old_id>` tag
- `recall` excludes superseded memories by default
- `recall` with `include_superseded: true` returns full history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a memory supersede action to replace an existing memory with corrected content while preserving the linked history.
  * Enhanced recall with an option to include superseded memories.
  * Added multi-agent recall to search across multiple agent namespaces in one request.

* **Bug Fixes**
  * Improved batch memory uploads and namespace consistency.
  * Refined memory metadata/timestamp handling for more reliable saves and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->