### PR TITLE
Preserve memory provenance during edits

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -279,6 +279,9 @@ class MemoryWriteService:
                 actor_id=updates.get("actor_id", metadata.get("actor_id", "unknown")),
                 source=updates.get("source", metadata.get("source", "system")),
                 source_ref=updates.get("source_ref", metadata.get("source_ref")),
+                provenance=updates.get(
+                    "provenance", metadata.get("provenance", "explicit_statement")
+                ),
                 confidence=updates.get("confidence", metadata.get("confidence", 0.8)),
                 status=updates.get("status", metadata.get("status", "active")),
                 tags=updates.get("tags", metadata.get("tags", [])),

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -360,6 +360,41 @@ class TestMemoryWriteServiceDelete:
         )
         client.documents.upload.assert_called_once()
 
+    def test_update_memory_preserves_existing_provenance(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.return_value = {"status": "queued"}
+        existing_memory = {
+            "id": "mem-1",
+            "type": "fact",
+            "title": "Imported title",
+            "content": "Imported content",
+            "agent_id": "test-agent",
+            "actor_id": "tester",
+            "source": "migration",
+            "source_ref": "mem0:42",
+            "provenance": "imported",
+            "confidence": 0.8,
+            "status": "active",
+            "tags": [],
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            MemoryWriteService(client).update_memory(
+                "mem-1",
+                "memanto_agent_test-agent",
+                {"content": "Updated imported content"},
+            )
+
+        uploaded_document = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded_document["provenance"] == "imported"
+        assert uploaded_document["source_ref"] == "mem0:42"
+
 
 class TestMemoryReadServiceFormatting:
     def test_format_memory_item_preserves_falsey_metadata_values(self):


### PR DESCRIPTION
## Summary
Fixes a provenance attribution bug in memory edits. Updating a memory uses a delete-and-recreate flow, but the recreated `MemoryRecord` did not preserve the existing `provenance`, causing imported/inferred/observed/corrected memories to be rewritten as `explicit_statement`.

## Why it matters
Provenance is part of Memanto's trust and attribution model. Losing it during edits can make imported or inferred memories appear as directly stated facts, weakening contradiction handling, source attribution, and auditability.

## Reproduction steps
1. Store or load a memory with `provenance="imported"` and `source_ref`.
2. Edit only its content.
3. Inspect the re-uploaded Moorcheh document.
4. Before this fix, `provenance` becomes `explicit_statement`.

## What changed
- Added a regression test for provenance preservation during `MemoryWriteService.update_memory`.
- Preserved existing `provenance` when rebuilding the updated memory record.

## Test results
- `.\.venv\Scripts\python -m pytest tests/test_unit.py::TestMemoryWriteServiceDelete::test_update_memory_preserves_existing_provenance -q`
- `.\.venv\Scripts\python -m pytest tests/test_unit.py -q`
- `.\.venv\Scripts\python -m pytest -q`

Full suite passed locally. Live Moorcheh E2E tests were skipped because no real API key was configured.

Fixes/addresses #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory updates now preserve the original provenance information when editing an existing item, falling back to a sensible default if none is present.
  * Added coverage to verify that updating a memory keeps its existing provenance and source reference intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->