### PR TITLE
Guard list agents live namespace counts

### DIFF
--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -63,11 +63,23 @@ async def _namespace_item_counts(moorcheh_api_key: str) -> dict[str, int]:
     try:
         client = moorcheh_clients.get_moorcheh_client()
         ns_resp = await asyncio.to_thread(client.namespaces.list)
-        return {
-            ns["namespace_name"]: ns.get("item_count", 0)
-            for ns in ns_resp.get("namespaces", [])
-            if ns.get("namespace_name")
-        }
+        namespaces = ns_resp.get("namespaces", []) if isinstance(ns_resp, dict) else []
+        if not isinstance(namespaces, list):
+            return {}
+
+        counts: dict[str, int] = {}
+        for ns in namespaces:
+            if not isinstance(ns, dict):
+                continue
+            namespace_name = ns.get("namespace_name")
+            if not isinstance(namespace_name, str) or not namespace_name:
+                continue
+            raw_count = ns.get("item_count", 0)
+            try:
+                counts[namespace_name] = int(raw_count)
+            except (TypeError, ValueError):
+                counts[namespace_name] = 0
+        return counts
     except Exception:
         return {}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -195,6 +195,31 @@ class TestMEMANTOAPI:
             assert "metadata" not in data["agents"][0]
 
     @pytest.mark.asyncio
+    async def test_list_agents_skips_malformed_namespace_count_rows(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Malformed namespace rows must not hide valid live memory counts."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID, "pattern": "support"},
+        )
+        mock_moorcheh.namespaces.list.return_value = {
+            "namespaces": [
+                "truncated-row",
+                {"namespace_name": None, "item_count": 99},
+                {"namespace_name": f"memanto_agent_{self.TEST_AGENT_ID}", "item_count": "7"},
+            ]
+        }
+
+        response = await client.get("/api/v2/agents", headers=auth_headers)
+
+        assert response.status_code == 200
+        agents = response.json()["agents"]
+        agent = next(a for a in agents if a["agent_id"] == self.TEST_AGENT_ID)
+        assert agent["memory_count"] == 7
+
+    @pytest.mark.asyncio
     async def test_activate_session(self, client, auth_headers):
         """Test activating an agent session"""
         # Ensure agent exists (will be created in memory by AgentService for this test session)


### PR DESCRIPTION
## Summary
- Make live namespace memory-count lookup for `GET /api/v2/agents` tolerate malformed namespace rows returned by the backend/SDK
- Skip non-object or nameless namespace entries instead of discarding all valid counts
- Coerce numeric count strings while falling back to 0 for malformed count values

## Bug / impact
A single malformed entry in `client.namespaces.list()["namespaces"]` (for example a truncated string in an otherwise valid response) caused `_namespace_item_counts()` to raise inside its dict comprehension. The broad fallback then returned `{}`, so every listed agent showed stale local `memory_count` values (usually 0) even when valid namespace count rows were present. This made the agent list/status UI misreport memory integrity and usage.

## Validation
- `uv run pytest tests/test_api.py::TestMEMANTOAPI::test_list_agents_skips_malformed_namespace_count_rows -q`
- `uv run pytest tests/test_api.py::TestMEMANTOAPI::test_list_agents tests/test_api.py::TestMEMANTOAPI::test_list_agents_skips_malformed_namespace_count_rows -q`
- `uv run ruff check memanto/app/routes/sessions.py tests/test_api.py`
- `git diff --check`
- `uv run pytest tests/test_api.py -q`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent memory counts to handle unexpected or malformed namespace data more safely.
  * Prevented incorrect counts when namespace entries are missing fields, invalid, or returned in an unexpected format.
  * Kept agent list and detail responses unchanged aside from more reliable memory totals.

* **Tests**
  * Added regression coverage for agent memory counts when namespace results contain malformed rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->