### PR TITLE
Validate recall type filters before search

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field, field_validator
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import settings
-from memanto.app.constants import VALID_MEMORY_TYPES
+from memanto.app.constants import VALID_MEMORY_TYPES, MemoryType
 from memanto.app.core import MemoryRecord
 from memanto.app.models import (
     AnswerRequest,
@@ -69,7 +69,9 @@ class RecallRequest(BaseModel):
     min_similarity: float | None = Field(
         default=None, ge=0.0, le=1.0, description="Minimum similarity score (0-1)"
     )
-    type: list[str] | None = Field(default=None, description="Memory type filters")
+    type: list[MemoryType] | None = Field(
+        default=None, description="Memory type filters"
+    )
 
 
 class RecallAsOfRequest(BaseModel):
@@ -80,7 +82,9 @@ class RecallAsOfRequest(BaseModel):
         description="Point-in-time — YYYY-MM-DD (defaults to end of day) or full ISO datetime e.g. 2025-11-01T14:30:00Z",
     )
     limit: int | None = Field(default=None, ge=1, description="Max results")
-    type: list[str] | None = Field(default=None, description="Memory type filters")
+    type: list[MemoryType] | None = Field(
+        default=None, description="Memory type filters"
+    )
 
     @field_validator("as_of", mode="before")
     @classmethod
@@ -117,7 +121,9 @@ class RecallChangedSinceRequest(BaseModel):
         description="Start of change window — YYYY-MM-DD (defaults to start of day) or full ISO datetime e.g. 2025-11-01T00:00:00Z",
     )
     limit: int | None = Field(default=None, ge=1, description="Max results")
-    type: list[str] | None = Field(default=None, description="Memory type filters")
+    type: list[MemoryType] | None = Field(
+        default=None, description="Memory type filters"
+    )
 
     @field_validator("since", mode="before")
     @classmethod
@@ -150,7 +156,9 @@ class RecallRecentRequest(BaseModel):
     """Request body for retrieving recent memories."""
 
     limit: int | None = Field(default=None, ge=1, description="Max results")
-    type: list[str] | None = Field(default=None, description="Memory type filters")
+    type: list[MemoryType] | None = Field(
+        default=None, description="Memory type filters"
+    )
 
 
 class MemoryEditRequest(BaseModel):

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.config import settings
+from memanto.app.constants import VALID_MEMORY_TYPES
 from memanto.app.core import agent_namespace
 from memanto.app.utils.errors import MemoryError
 
@@ -153,6 +154,8 @@ class MemoryReadService:
                 "execution_time": search_result.get("execution_time", 0),
             }
 
+        except MemoryError:
+            raise
         except Exception as e:
             raise MemoryError(f"Failed to search memories: {e}")
 
@@ -429,6 +432,7 @@ class MemoryReadService:
 
         # Add memory type filters
         if type:
+            self._validate_memory_type_filters(type)
             for mem_type in type:
                 filter_parts.append(f"#memory_type:{mem_type}")
 
@@ -456,6 +460,16 @@ class MemoryReadService:
         if filter_parts:
             return f"{query} {' '.join(filter_parts)}"
         return query
+
+    @staticmethod
+    def _validate_memory_type_filters(types: list[str]) -> None:
+        """Reject invalid memory type filters before query-string composition."""
+        for mem_type in types:
+            if mem_type not in VALID_MEMORY_TYPES:
+                valid = ", ".join(sorted(VALID_MEMORY_TYPES))
+                raise MemoryError(
+                    f"Invalid memory type filter '{mem_type}'. Must be one of: {valid}."
+                )
 
     def _apply_temporal_filter(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -525,6 +525,32 @@ class TestMEMANTOAPI:
         assert "memory_type:fact" in call_kwargs["query"]
 
     @pytest.mark.asyncio
+    async def test_recall_rejects_invalid_type_filter_before_search(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Invalid type filters must not be spliced into Moorcheh query syntax."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        payload = {"query": "test query", "type": ["fact #status:deleted"]}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall",
+            headers=headers,
+            json=payload,
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.similarity_search.query.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_get_agent(self, client, auth_headers):
         """Test getting agent details"""
         await client.post(

--- a/tests/test_memory_read_confidence.py
+++ b/tests/test_memory_read_confidence.py
@@ -1,4 +1,7 @@
+import pytest
+
 from memanto.app.services.memory_read_service import MemoryReadService
+from memanto.app.utils.errors import MemoryError
 
 
 class _FakeSimilaritySearch:
@@ -89,3 +92,18 @@ def test_zero_min_confidence_preserves_results_without_confidence_field():
     )
 
     assert [memory["id"] for memory in result["results"]] == ["legacy"]
+
+
+def test_search_memories_rejects_invalid_type_filter_before_query():
+    client = _FakeClient()
+    service = MemoryReadService(client)
+
+    with pytest.raises(MemoryError, match="Invalid memory type filter"):
+        service.search_memories(
+            query="relevant",
+            agent_id="agent-1",
+            type=["fact #status:deleted"],
+            limit=10,
+        )
+
+    assert client.similarity_search.last_query is None


### PR DESCRIPTION
## Summary

Fixes a recall filter validation flaw for #770. The public recall API accepted arbitrary strings in `type` filters, and `MemoryReadService` spliced those values directly into Moorcheh's `#memory_type:<value>` query syntax. A request such as `{"type": ["fact #status:deleted"]}` could inject an extra backend filter and manipulate or suppress retrieval results.

## Reproduction

1. Create and activate an agent.
2. POST to `/api/v2/agents/{agent_id}/recall` with `{"query": "test query", "type": ["fact #status:deleted"]}`.
3. Before this change, the API returned 200 and forwarded a composed query containing `#memory_type:fact #status:deleted` to `similarity_search.query`.

## Fix

- Type standard, as-of, changed-since, and recent recall request models as `list[MemoryType]`.
- Add service-level validation before composing Moorcheh filter syntax, so direct/CLI callers cannot bypass API model validation.
- Add regression coverage at both the API and service layers.

## Verification

- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260707a-venv uv run --python 3.12 --group dev pytest tests/test_memory_read_confidence.py::test_search_memories_rejects_invalid_type_filter_before_query tests/test_api.py::TestMEMANTOAPI::test_recall_rejects_invalid_type_filter_before_search tests/test_api.py::TestMEMANTOAPI::test_recall_accepts_type_filter -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260707a-venv uv run --python 3.12 --group dev pytest tests/test_memory_read_confidence.py tests/test_api.py -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260707a-venv uv run --python 3.12 --group dev pytest tests -q` (24 live E2E tests skipped because no `MOORCHEH_API_KEY` is configured)
- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260707a-venv uv run --python 3.12 --group dev ruff check memanto/app/routes/memory.py memanto/app/services/memory_read_service.py tests/test_api.py tests/test_memory_read_confidence.py`
- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260707a-venv uv run --python 3.12 --group dev ruff format --check memanto/app/routes/memory.py memanto/app/services/memory_read_service.py tests/test_api.py tests/test_memory_read_confidence.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory recall filtering so only valid memory types are accepted.
  * Invalid filter values are now rejected early with a clear error, preventing failed search requests from being sent.
  * Recall requests now show more accurate validation in the API schema and request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->