### PR TITLE
fix: remove weak auxiliary verbs from strong fact patterns to prevent ambiguity guard bypass (#1375)

### DIFF
--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -41,7 +41,6 @@ class MemoryParsingService:
         for pattern in [
             r"https?://[^\s<>()\[\]{},;:\"']*[^\s<>()\[\]{},;:\"'.,!?]",
             r"\b(?:endpoint|url|api key|path|email|phone|address)\b",
-            r"\b(?:is|are|was|were)\b",
         ]
     ]
 

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -190,3 +190,17 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
     parser.parse_memory(memory)
 
     assert memory.type == "fact"
+
+
+def test_ambiguity_guard_not_bypassed_by_auxiliary_verbs():
+    parser = MemoryParsingService()
+
+    # Scenario 1: With auxiliary verb 'is'
+    memory1 = make_memory("The project uses Django and it is maintained, and we decded on Postgres")
+    parser.parse_memory(memory1)
+    assert memory1.type == "decision"
+
+    # Scenario 2: Without auxiliary verb 'is' (gets)
+    memory2 = make_memory("The project uses Django and it gets maintained, and we decded on Postgres")
+    parser.parse_memory(memory2)
+    assert memory2.type == "decision"

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -195,12 +195,19 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
 def test_ambiguity_guard_not_bypassed_by_auxiliary_verbs():
     parser = MemoryParsingService()
 
-    # Scenario 1: With auxiliary verb 'is'
+    # 1. Direct validation of rule-based ambiguity guard:
+    # Weak fact-only sentences with/without "is" should be rejected (return None) by _rule_based,
+    # preventing them from being classified as fact at the rule stage.
+    assert parser._rule_based("The project uses Django and it is maintained") is None
+    assert parser._rule_based("The project uses Django and it gets maintained") is None
+
+    # 2. End-to-end validation:
+    # A sentence with a weak fact signal and a misspelled decision keyword ('decded')
+    # should successfully trigger the fallback and classify as "decision".
     memory1 = make_memory("The project uses Django and it is maintained, and we decded on Postgres")
     parser.parse_memory(memory1)
     assert memory1.type == "decision"
 
-    # Scenario 2: Without auxiliary verb 'is' (gets)
     memory2 = make_memory("The project uses Django and it gets maintained, and we decded on Postgres")
     parser.parse_memory(memory2)
     assert memory2.type == "decision"


### PR DESCRIPTION
## Summary

This PR addresses issue #1375: "Bug: Ambiguity Guard is systemically bypassed by common auxiliary verbs (is/are/was/were)".

## Changes

- `memanto/app/services/memory_parsing_service.py`:
  - Removed `r"\b(?:is|are|was|were)\b"` pattern from `MemoryParsingService.STRONG_FACT_PATTERNS`. Since auxiliary verbs like "is" are extremely common in standard English sentences, their presence in this list systematically bypassed the ambiguity guard check and incorrectly classified weak fact signals as `fact`.
- `tests/test_memory_parsing.py`:
  - Added `test_ambiguity_guard_not_bypassed_by_auxiliary_verbs` to assert both the presence and absence of "is" resolves correct fuzzy-matching behavior.

## Testing

Ran the full test suite showing 100% success rate:
- `python -m pytest` passed (248 passed, 24 skipped).

/claim #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory classification logic to handle weak “fact-only” sentences more consistently, avoiding premature/ambiguous matches.
  * Strengthened ambiguity guarding for auxiliary-verb variants (e.g., “is maintained” vs “gets maintained”), ensuring correct handling when combined with weak fact signals and misspelled decision phrases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->