### PR TITLE
Recover malformed config sections in setters

### DIFF
--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -259,6 +259,21 @@ class ConfigManager:
         except OSError:
             pass
 
+    @staticmethod
+    def _dict_section(data: dict, key: str, *, repair: bool = False) -> dict:
+        """Return a dict section.
+
+        When repair is true, malformed or missing sections are replaced in
+        ``data`` so callers can populate them before saving.
+        """
+        section = data.get(key)
+        if isinstance(section, dict):
+            return section
+        if repair:
+            data[key] = {}
+            return data[key]
+        return {}
+
     def get(self, key: str, default=None):
         """Get a top-level YAML config value."""
         return self.load_yaml().get(key, default)
@@ -273,7 +288,7 @@ class ConfigManager:
 
     def get_server_url(self) -> str:
         """Get MEMANTO server URL."""
-        server = self.load_yaml().get("server", {})
+        server = self._dict_section(self.load_yaml(), "server")
         host = server.get("url", "localhost")
         port = server.get("port", 8000)
         return f"http://{host}:{port}"
@@ -281,7 +296,7 @@ class ConfigManager:
     def get_server_config(self) -> dict:
         """Get server config dict with defaults."""
         defaults = {"url": "localhost", "port": 8000, "auto_start": False}
-        defaults.update(self.load_yaml().get("server", {}))
+        defaults.update(self._dict_section(self.load_yaml(), "server"))
         return defaults
 
     def get_session_config(self) -> dict:
@@ -294,7 +309,7 @@ class ConfigManager:
             "auto_renew_enabled": True,
             "auto_renew_interval_hours": 6,
         }
-        defaults.update(self.load_yaml().get("session", {}))
+        defaults.update(self._dict_section(self.load_yaml(), "session"))
         return defaults
 
     def get_cli_config(self) -> dict:
@@ -305,7 +320,7 @@ class ConfigManager:
             "auto_title": True,
             "color_output": True,
         }
-        defaults.update(self.load_yaml().get("cli", {}))
+        defaults.update(self._dict_section(self.load_yaml(), "cli"))
         return defaults
 
     def get_answer_config(self) -> dict:
@@ -318,7 +333,7 @@ class ConfigManager:
         because they describe how to query, not which provider to hit.
         """
         data = self.load_yaml()
-        answer = data.get("answer", {})
+        answer = self._dict_section(data, "answer")
 
         defaults = {
             "model": "anthropic.claude-sonnet-4-6",
@@ -346,7 +361,7 @@ class ConfigManager:
     ) -> None:
         """Set Answer config values."""
         data = self.load_yaml()
-        answer = data.setdefault("answer", {})
+        answer = self._dict_section(data, "answer", repair=True)
         if model is not None:
             answer["model"] = model
         if temperature is not None:
@@ -363,7 +378,7 @@ class ConfigManager:
     def get_recall_config(self) -> dict:
         """Get Recall/Top-N config dict with defaults."""
         data = self.load_yaml()
-        recall = data.get("recall", {})
+        recall = self._dict_section(data, "recall")
 
         defaults = {"limit": 10, "min_similarity": 0.0}
         defaults.update(recall)
@@ -374,7 +389,7 @@ class ConfigManager:
     ) -> None:
         """Set Recall config values."""
         data = self.load_yaml()
-        recall = data.setdefault("recall", {})
+        recall = self._dict_section(data, "recall", repair=True)
         if limit is not None:
             recall["limit"] = limit
         if min_similarity is not None:
@@ -420,19 +435,17 @@ class ConfigManager:
     def set_server_config(self, url: str, port: int) -> None:
         """Set fallback server configuration."""
         data = self.load_yaml()
-        if "server" not in data:
-            data["server"] = {}
-        data["server"]["url"] = url
-        data["server"]["port"] = port
+        server = self._dict_section(data, "server", repair=True)
+        server["url"] = url
+        server["port"] = port
         self.save_yaml(data)
 
     def set_cli_config(self, interactive_mode: bool, smart_parse: bool) -> None:
         """Set fallback CLI configuration."""
         data = self.load_yaml()
-        if "cli" not in data:
-            data["cli"] = {}
-        data["cli"]["interactive_mode"] = interactive_mode
-        data["cli"]["smart_parse"] = smart_parse
+        cli = self._dict_section(data, "cli", repair=True)
+        cli["interactive_mode"] = interactive_mode
+        cli["smart_parse"] = smart_parse
         self.save_yaml(data)
 
     # Connections registry — tracks which agents have memanto installed where.

--- a/tests/test_config_manager_setters.py
+++ b/tests/test_config_manager_setters.py
@@ -1,0 +1,43 @@
+from memanto.cli.config.manager import ConfigManager
+
+
+def test_config_setters_recover_malformed_sections(tmp_path):
+    manager = ConfigManager(config_dir=tmp_path)
+    manager.config_file.write_text(
+        "\n".join(
+            [
+                "memanto:",
+                "  server: localhost",
+                "  session: 6",
+                "  cli: false",
+                "  answer: 42",
+                "  recall:",
+                "    - invalid",
+                "",
+            ]
+        )
+    )
+
+    assert manager.get_server_url() == "http://localhost:8000"
+    assert manager.get_server_config() == {
+        "url": "localhost",
+        "port": 8000,
+        "auto_start": False,
+    }
+    assert manager.get_session_config()["default_duration_hours"] == 6
+    assert manager.get_cli_config()["interactive_mode"] is True
+    assert manager.get_answer_config()["model"] == "anthropic.claude-sonnet-4-6"
+    assert manager.get_recall_config() == {"limit": 10, "min_similarity": 0.0}
+
+    manager.set_server_config("127.0.0.1", 9999)
+    manager.set_cli_config(interactive_mode=False, smart_parse=False)
+    manager.set_answer_config(model="local-model", temperature=0.2)
+    manager.set_recall_config(limit=7, min_similarity=0.4)
+
+    data = manager.load_yaml()
+
+    assert data["server"] == {"url": "127.0.0.1", "port": 9999}
+    assert data["cli"] == {"interactive_mode": False, "smart_parse": False}
+    assert data["answer"]["model"] == "local-model"
+    assert data["answer"]["temperature"] == 0.2
+    assert data["recall"] == {"limit": 7, "min_similarity": 0.4}


### PR DESCRIPTION
﻿## Summary

Bounty #770 submission: fixes a config resilience bug where user-editable `~/.memanto/config.yaml` can contain malformed-but-valid section shapes that break normal config reads and block the normal repair path.

If a user has config like:

```yaml
memanto:
  server: localhost
  session: 6
  cli: false
  answer: 42
  recall:
    - invalid
```

then read paths such as `get_server_url()` / `get_answer_config()` and setter paths such as `set_server_config()` / `set_recall_config()` can crash because they assume those nested sections are dictionaries. That means normal CLI/UI config commands may fail before they can restore a usable config.

## Fix

- Add a shared dict-section guard for config reads and repairs.
- Make `server`, `session`, `cli`, `answer`, and `recall` reads fall back to documented defaults when malformed.
- Make `server`, `cli`, `answer`, and `recall` setters replace malformed sections with valid mappings before writing.
- Add a regression test that starts from broken YAML, verifies read defaults, then verifies setter repair.

## Validation

- `python -m pytest tests\test_config_manager_setters.py -q`
- `python -m py_compile memanto\cli\config\manager.py tests\test_config_manager_setters.py`
- `python -m ruff check memanto\cli\config\manager.py tests\test_config_manager_setters.py`
- `git diff --check`

Prepared with Codex assistance for the account owner. Payout details can be provided privately if accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling by normalizing missing or malformed sections (server, session, CLI, answer, recall) into valid dictionary structures before merging or saving.
  * Updated configuration updates so malformed/non-dictionary values are corrected when updating server, CLI, answer, and recall settings.
* **Tests**
  * Added a test that creates a configuration with malformed recall content, then verifies recovery and that normalized settings are persisted after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->