### PR TITLE
Guard recall filter tokens

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -11,8 +11,23 @@ if TYPE_CHECKING:
 
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.config import settings
+from memanto.app.constants import VALID_MEMORY_TYPES
 from memanto.app.core import agent_namespace
 from memanto.app.utils.errors import MemoryError
+
+
+_FILTER_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _validate_filter_token(value: Any, field_name: str) -> str:
+    """Return a safe Moorcheh filter token or reject query-syntax injection."""
+    token = str(value).strip()
+    if not token or not _FILTER_TOKEN_RE.fullmatch(token):
+        raise ValueError(
+            f"Invalid {field_name} filter value: only letters, digits, '.', '_', "
+            "and '-' are allowed"
+        )
+    return token
 
 
 class MemoryReadService:
@@ -430,16 +445,21 @@ class MemoryReadService:
         # Add memory type filters
         if type:
             for mem_type in type:
+                mem_type = _validate_filter_token(mem_type, "memory_type")
+                if mem_type not in VALID_MEMORY_TYPES:
+                    raise ValueError(f"Invalid memory_type filter value: {mem_type}")
                 filter_parts.append(f"#memory_type:{mem_type}")
 
         # Add tag filters (keyword syntax)
         if tags:
             for tag in tags:
+                tag = _validate_filter_token(tag, "tag")
                 filter_parts.append(f"#{tag}")
 
         # Add status filters
         if status_filter:
             for status in status_filter:
+                status = _validate_filter_token(status, "status")
                 filter_parts.append(f"#status:{status}")
 
         # Numeric confidence is stored as a number in memory documents. Applying
@@ -450,6 +470,8 @@ class MemoryReadService:
         # Add custom metadata filters
         if metadata_filters:
             for key, value in metadata_filters.items():
+                key = _validate_filter_token(key, "metadata key")
+                value = _validate_filter_token(value, f"metadata '{key}'")
                 filter_parts.append(f"#{key}:{value}")
 
         # Combine query with filters

--- a/tests/test_memory_read_filter_sanitization.py
+++ b/tests/test_memory_read_filter_sanitization.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def test_build_filtered_query_accepts_safe_filters():
+    service = MemoryReadService(MagicMock())
+
+    query = service._build_filtered_query(
+        query="deployment notes",
+        type=["fact"],
+        tags=["prod-db"],
+        status_filter=["active"],
+        metadata_filters={"source": "cli.import"},
+    )
+
+    assert query == (
+        "deployment notes #memory_type:fact #prod-db "
+        "#status:active #source:cli.import"
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"type": ["fact #status:deleted"]},
+        {"tags": ["prod #status:deleted"]},
+        {"status_filter": ["active #memory_type:error"]},
+        {"metadata_filters": {"source": "cli #status:deleted"}},
+        {"metadata_filters": {"source #status": "active"}},
+    ],
+)
+def test_build_filtered_query_rejects_filter_clause_injection(kwargs):
+    service = MemoryReadService(MagicMock())
+
+    with pytest.raises(ValueError, match="Invalid"):
+        service._build_filtered_query(query="deployment notes", **kwargs)
+
+
+def test_build_filtered_query_rejects_unknown_memory_type():
+    service = MemoryReadService(MagicMock())
+
+    with pytest.raises(ValueError, match="Invalid memory_type"):
+        service._build_filtered_query(query="deployment notes", type=["not-a-type"])


### PR DESCRIPTION
## Summary

Tightens recall filter construction before values are appended to Moorcheh query syntax.

The previous code concatenated `type`, `tags`, `status_filter`, and custom metadata filters directly into `#...` filter clauses. A value containing whitespace plus another `#key:value` fragment could change the server-side filter set used for retrieval. This adds a small token validator and rejects unknown memory types before building the enhanced query.

## Why

Recall filters are part of memory retrieval integrity. Rejecting malformed filter tokens prevents callers from accidentally or deliberately smuggling additional Moorcheh filter clauses through a single filter value.

## Tests

- `python -m pytest tests/test_memory_read_filter_sanitization.py -q`
- `python -m pytest tests/test_memory_read_confidence.py tests/test_memory_parsing.py -q`

BountyHub context: moorcheh-ai/memanto#770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when building filtered memory searches by rejecting invalid filter values.
  * Invalid memory type, tag, status, and custom metadata inputs now raise an error instead of being included in the query.
  * This helps prevent malformed search filters from affecting results.

* **Tests**
  * Added coverage for valid filtered queries and multiple invalid-input cases to verify sanitization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->