### PR TITLE
fix(memory-write): same-ID update preserves data and metadata (#770)

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -345,6 +345,8 @@ class MemoryWriteService:
                 "updated_fields": list(updates.keys()),
             }
 
+        except MemoryError:
+            raise
         except Exception as e:
             raise MemoryError(f"Failed to update memory: {e}")
 

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -307,9 +307,11 @@ class MemoryWriteService:
                     updated_memory.expires_at = metadata["expires_at"]
 
 
-            # Step 3: Upload new version FIRST (before deleting old)
-            # This prevents data loss if delete succeeds but upload fails
-            validation_result = {"action": "store", "reason": "MVP direct store"}
+
+            # Step 3: Upload new version (same-ID overwrite semantics)
+            # Moorcheh documents are immutable by ID — upload with the same memory_id
+            # replaces the old document atomically on the server side. No local delete needed.
+            validation_result = {'action': 'store', 'reason': 'MVP direct store'}
 
             from typing import cast
 
@@ -320,23 +322,15 @@ class MemoryWriteService:
                 namespace_name=namespace, documents=[document]
             )
 
-            if upload_result.get("status") not in ("success", "queued", "ok"):
+            status = upload_result.get('status', 'unknown')
+            if status not in ('success', 'queued', 'ok'):
                 raise MemoryError(
-                    f"Failed to upload updated memory {memory_id}: {upload_result.get('status')}"
+                    f'Failed to upload updated memory {memory_id}: {status}'
                 )
 
-            # Step 4: Now safely delete old version (new version already stored)
-            from typing import Any
-            delete_result = cast(
-                dict[str, Any],
-                self.client.documents.delete(namespace_name=namespace, ids=[memory_id]),
-            )
-
-            if not self._deletion_succeeded(delete_result):
-                # New version is already stored safely above; old version deletion
-                # failure is non-fatal — the memory update is still correct.
-                pass
-
+            # Upload succeeded (or queued for async processing). The old version
+            # is replaced on the server by this same-ID upload — no local delete needed.
+            # Returning early avoids a race where we'd delete the just-uploaded doc.
             return {
                 "id": memory_id,
                 "namespace": namespace,

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -221,11 +221,10 @@ class MemoryWriteService:
         """
         Update existing memory using same-ID overwrite pattern
 
-        Since Moorcheh doesn't support in-place updates, we:
+        Since Moorcheh overwrites documents by ID, we:
         1. Retrieve the existing memory
-        2. Apply updates to create new version
-        3. Delete old version
-        4. Upload new version with same ID
+        2. Apply updates to create a replacement version
+        3. Upload the replacement with the same ID
 
         Args:
             memory_id: ID of memory to update
@@ -270,7 +269,9 @@ class MemoryWriteService:
             # Build updated memory record
             updated_memory = MemoryRecord(
                 id=memory_id,  # Keep same ID
-                type=updates.get("type", metadata.get("type", "fact")),
+                type=updates.get(
+                    "type", metadata.get("type", metadata.get("memory_type", "fact"))
+                ),
                 title=updates.get(
                     "title", existing_memory_data.get("title", "Updated Memory")
                 ),
@@ -282,6 +283,10 @@ class MemoryWriteService:
                 confidence=updates.get("confidence", metadata.get("confidence", 0.8)),
                 status=updates.get("status", metadata.get("status", "active")),
                 tags=updates.get("tags", metadata.get("tags", [])),
+                provenance=updates.get(
+                    "provenance",
+                    metadata.get("provenance", "explicit_statement"),
+                ),
             )
 
             # Update timestamps (preserve created_at, set updated_at to now)
@@ -306,12 +311,11 @@ class MemoryWriteService:
                 if metadata.get("expires_at"):
                     updated_memory.expires_at = metadata["expires_at"]
 
-
-
             # Step 3: Upload new version (same-ID overwrite semantics)
-            # Moorcheh documents are immutable by ID — upload with the same memory_id
-            # replaces the old document atomically on the server side. No local delete needed.
-            validation_result = {'action': 'store', 'reason': 'MVP direct store'}
+            # Moorcheh documents are immutable by ID; uploading with the same
+            # memory_id replaces the old document server-side. No local delete
+            # is needed, so there is no destructive gap between delete/upload.
+            validation_result = {"action": "store", "reason": "MVP direct store"}
 
             from typing import cast
 
@@ -322,14 +326,14 @@ class MemoryWriteService:
                 namespace_name=namespace, documents=[document]
             )
 
-            status = upload_result.get('status', 'unknown')
-            if status not in ('success', 'queued', 'ok'):
+            status = upload_result.get("status", "unknown")
+            if status not in ("success", "queued", "ok"):
                 raise MemoryError(
-                    f'Failed to upload updated memory {memory_id}: {status}'
+                    f"Failed to upload updated memory {memory_id}: {status}"
                 )
 
             # Upload succeeded (or queued for async processing). The old version
-            # is replaced on the server by this same-ID upload — no local delete needed.
+            # is replaced on the server by this same-ID upload; no local delete needed.
             # Returning early avoids a race where we'd delete the just-uploaded doc.
             return {
                 "id": memory_id,

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -380,7 +380,7 @@ class MemoryWriteService:
             )
 
             status = upload_result.get("status", "unknown")
-            if status not in ("success", "queued", "ok"):
+            if str(status).lower() not in SUCCESSFUL_UPLOAD_STATUSES:
                 raise MemoryError(
                     f"Failed to upload updated memory {memory_id}: {status}"
                 )

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -219,7 +219,7 @@ class MemoryWriteService:
         context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """
-        Update existing memory using delete-and-recreate pattern
+        Update existing memory using same-ID overwrite pattern
 
         Since Moorcheh doesn't support in-place updates, we:
         1. Retrieve the existing memory
@@ -334,9 +334,9 @@ class MemoryWriteService:
             return {
                 "id": memory_id,
                 "namespace": namespace,
-                "status": upload_result.get("status", "unknown"),
+                "status": status,
                 "action": "updated",
-                "reason": "Memory updated successfully via delete-and-recreate",
+                "reason": "Memory updated successfully via same-ID overwrite",
                 "validation": validation_result.get("action", "validated"),
                 "updated_fields": list(updates.keys()),
             }

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -306,20 +306,11 @@ class MemoryWriteService:
                 if metadata.get("expires_at"):
                     updated_memory.expires_at = metadata["expires_at"]
 
-            # Step 3: Delete old version
-            from typing import Any, cast
 
-            delete_result = cast(
-                dict[str, Any],
-                self.client.documents.delete(namespace_name=namespace, ids=[memory_id]),
-            )
-
-            if not self._deletion_succeeded(delete_result):
-                raise MemoryError(f"Failed to delete old version of memory {memory_id}")
-
+            # Step 3: Upload new version FIRST (before deleting old)
+            # This prevents data loss if delete succeeds but upload fails
             validation_result = {"action": "store", "reason": "MVP direct store"}
 
-            # Step 4: Upload new version
             from typing import cast
 
             from moorcheh_sdk.types.document import Document
@@ -328,6 +319,23 @@ class MemoryWriteService:
             upload_result = self.client.documents.upload(
                 namespace_name=namespace, documents=[document]
             )
+
+            if upload_result.get("status") not in ("success", "queued", "ok"):
+                raise MemoryError(
+                    f"Failed to upload updated memory {memory_id}: {upload_result.get('status')}"
+                )
+
+            # Step 4: Now safely delete old version (new version already stored)
+            from typing import Any
+            delete_result = cast(
+                dict[str, Any],
+                self.client.documents.delete(namespace_name=namespace, ids=[memory_id]),
+            )
+
+            if not self._deletion_succeeded(delete_result):
+                # New version is already stored safely above; old version deletion
+                # failure is non-fatal — the memory update is still correct.
+                pass
 
             return {
                 "id": memory_id,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -450,6 +450,27 @@ class TestMemoryWriteServiceUpdate:
 
         client.documents.delete.assert_not_called()
 
+    def test_update_memory_timeout_does_not_delete_old_memory(
+        self, memory_reader
+    ):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"actual_deletions": 1}
+        client.documents.upload.side_effect = TimeoutError("network timeout")
+
+        with pytest.raises(
+            MemoryError, match="^Failed to update memory: network timeout$"
+        ):
+            MemoryWriteService(client).update_memory(
+                "mem-1",
+                "memanto_agent_agent-1",
+                {"content": "New content"},
+            )
+
+        client.documents.delete.assert_not_called()
+
     def test_update_memory_preserves_type_and_provenance_from_metadata(
         self, monkeypatch
     ):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -320,14 +320,10 @@ class TestMemoryWriteServiceDelete:
         client.documents.delete.return_value = response
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
-    def test_update_memory_accepts_onprem_delete_response(self):
+    def test_update_memory_does_not_require_onprem_delete_response(self):
         from memanto.app.services.memory_write_service import MemoryWriteService
 
         client = MagicMock()
-        client.documents.delete.return_value = {
-            "status": "success",
-            "deleted_ids": ["mem-1"],
-        }
         client.documents.upload.return_value = {"status": "queued"}
         existing_memory = {
             "id": "mem-1",
@@ -355,9 +351,7 @@ class TestMemoryWriteServiceDelete:
 
         assert result["action"] == "updated"
         assert result["status"] == "queued"
-        client.documents.delete.assert_called_once_with(
-            namespace_name="memanto_agent_test-agent", ids=["mem-1"]
-        )
+        client.documents.delete.assert_not_called()
         client.documents.upload.assert_called_once()
 
 
@@ -382,6 +376,121 @@ class TestMemoryReadServiceFormatting:
 
         assert formatted["confidence"] == 0.0
         assert formatted["tags"] == []
+
+
+class TestMemoryWriteServiceUpdate:
+    """``update_memory`` must preserve the old memory until the replacement
+    upload has been accepted by Moorcheh."""
+
+    @pytest.fixture
+    def existing_memory(self):
+        return {
+            "id": "mem-1",
+            "title": "Old title",
+            "content": "Old content",
+            "metadata": {
+                "agent_id": "agent-1",
+                "type": "fact",
+                "actor_id": "user",
+                "source": "test",
+                "confidence": 0.9,
+                "status": "active",
+                "tags": ["regression"],
+            },
+        }
+
+    @pytest.fixture
+    def memory_reader(self, monkeypatch, existing_memory):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        def get_memory(self, memory_id, namespace):
+            return existing_memory
+
+        monkeypatch.setattr(MemoryReadService, "get_memory", get_memory)
+
+    def test_update_memory_uses_same_id_overwrite_without_delete(self, memory_reader):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "queued"}
+        namespace = "memanto_agent_agent-1"
+
+        result = MemoryWriteService(client).update_memory(
+            "mem-1",
+            namespace,
+            {"content": "New content"},
+        )
+
+        assert result["status"] == "queued"
+        client.documents.delete.assert_not_called()
+        client.documents.upload.assert_called_once()
+
+        upload_kwargs = client.documents.upload.call_args.kwargs
+        assert upload_kwargs["namespace_name"] == namespace
+        document = upload_kwargs["documents"][0]
+        assert document["id"] == "mem-1"
+        assert "New content" in document["text"]
+
+    def test_update_memory_upload_failure_does_not_delete_old_memory(
+        self, memory_reader
+    ):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "failed"}
+
+        with pytest.raises(MemoryError, match="Failed to upload updated memory mem-1"):
+            MemoryWriteService(client).update_memory(
+                "mem-1",
+                "memanto_agent_agent-1",
+                {"content": "New content"},
+            )
+
+        client.documents.delete.assert_not_called()
+
+    def test_update_memory_preserves_type_and_provenance_from_metadata(
+        self, monkeypatch
+    ):
+        from memanto.app.services.memory_read_service import MemoryReadService
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        existing_memory = {
+            "id": "mem-2",
+            "title": "Architecture decision",
+            "content": "Use same-ID document replacement for edits.",
+            "metadata": {
+                "agent_id": "agent-1",
+                "memory_type": "decision",
+                "actor_id": "user",
+                "source": "test",
+                "source_ref": "issue-770",
+                "confidence": 0.95,
+                "status": "active",
+                "tags": ["integrity"],
+                "provenance": "validated",
+            },
+        }
+
+        def get_memory(self, memory_id, namespace):
+            return existing_memory
+
+        monkeypatch.setattr(MemoryReadService, "get_memory", get_memory)
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "queued"}
+
+        MemoryWriteService(client).update_memory(
+            "mem-2",
+            "memanto_agent_agent-1",
+            {"content": "Updated without losing original metadata."},
+        )
+
+        document = client.documents.upload.call_args.kwargs["documents"][0]
+        assert document["memory_type"] == "decision"
+        assert document["provenance"] == "validated"
+        assert document["source_ref"] == "issue-770"
+        assert document["tags"] == "integrity"
 
 
 class TestForgetEndToEnd:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -546,6 +546,21 @@ class TestMemoryWriteServiceUpdate:
         assert document["id"] == "mem-1"
         assert "New content" in document["text"]
 
+    def test_update_memory_accepts_case_insensitive_success_status(self, memory_reader):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "OK"}
+
+        result = MemoryWriteService(client).update_memory(
+            "mem-1",
+            "memanto_agent_agent-1",
+            {"content": "New content"},
+        )
+
+        assert result["status"] == "OK"
+        client.documents.delete.assert_not_called()
+
     def test_update_memory_upload_failure_does_not_delete_old_memory(
         self, memory_reader
     ):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -440,12 +440,13 @@ class TestMemoryWriteServiceUpdate:
         client = MagicMock()
         client.documents.upload.return_value = {"status": "failed"}
 
-        with pytest.raises(MemoryError, match="Failed to upload updated memory mem-1"):
+        with pytest.raises(MemoryError) as exc_info:
             MemoryWriteService(client).update_memory(
                 "mem-1",
                 "memanto_agent_agent-1",
                 {"content": "New content"},
             )
+        assert str(exc_info.value) == "Failed to upload updated memory mem-1: failed"
 
         client.documents.delete.assert_not_called()
 


### PR DESCRIPTION
## Summary

Bounty #770 submission for the high-severity update rollback/data-loss flaw reported in #1384.

`MemoryWriteService.update_memory()` previously deleted the existing document before uploading its replacement. A timeout, network error, backend failure, or rejected upload after the delete could permanently remove the memory.

This PR replaces that destructive sequence with a same-ID overwrite:

1. Retrieve the existing memory.
2. Rebuild the replacement with the original `memory_id`.
3. Preserve the existing type/provenance metadata during partial edits.
4. Upload the replacement under that same ID.
5. Validate the upload result.
6. Never issue a separate `documents.delete(...)` during update.

## Reproduction

The regression test models the realistic failure path directly:

```bash
python -m pytest   tests/test_unit.py::TestMemoryWriteServiceUpdate::test_update_memory_timeout_does_not_delete_old_memory   -q
```

The test configures a successful delete response and then makes the replacement upload raise `TimeoutError("network timeout")`.

- Against the vulnerable delete-then-upload implementation, the test fails because `documents.delete()` was already called once before the timeout.
- On this branch, the timeout surfaces as `MemoryError` and `documents.delete.assert_not_called()` passes, so the old memory is never deliberately removed.

Additional regressions prove that:

- queued same-ID uploads do not call delete;
- failed/unknown upload statuses raise a specific `MemoryError`;
- mixed-case successful statuses such as `OK` are accepted;
- partial updates preserve `memory_type`, `provenance`, `source_ref`, and tags.

## Why This Fix

A backup-and-restore or upload-then-delete flow still leaves extra failure states: rollback can fail, temporary documents can leak, and a follow-up delete can target the wrong same-ID replacement.

Same-ID overwrite removes the destructive delete step from the update path entirely. It is smaller, keeps the public API unchanged, and preserves the caller-visible memory ID.

## Changes

- Remove the separate delete operation from `update_memory()`.
- Keep the original `memory_id` on the replacement document.
- Accept `success`, `queued`, or `ok` upload statuses case-insensitively via the centralized status set.
- Preserve already-typed `MemoryError` messages.
- Preserve existing memory type and provenance during partial updates.
- Add focused regression coverage for queued, failed-status, timeout, no-delete, and metadata-preservation paths.

## Validation

```bash
python -m pytest -q
python -m ruff check .
python -m ruff format --check .
python -m mypy memanto
git diff --check
```

Results on the current PR head:

- 303 non-live tests passed.
- 24 live Moorcheh E2E tests were skipped because no real API key is configured locally.
- Ruff lint and formatting passed across the repository.
- MyPy passed across 75 source files.
- `git diff --check` passed.
- The latest actionable CodeRabbit finding was reproduced, fixed in `3817a4e`, and covered by a regression test.

Current upstream `main` (`47e91c6`) is merged into this branch. The only merge conflict was in the shared unit-test file; both the upstream batch tests and this PR's update regressions were retained. GitHub now reports the PR as mergeable.

## Scope and Related Work

- #809 and #1364 improve delete-response handling but retain the destructive delete path.
- #1270 adds best-effort rollback after deletion; this PR avoids entering that recovery state.
- #1400 contains the minimal same-ID overwrite idea; this PR adds failure-path and metadata/provenance regressions.
- #828, #1385, and #1390 demonstrate the metadata/provenance drift risk that this PR also covers.
- #1420 and #1421 use staging or upload/delete flows with more failure states and broader scope.

## Reviewer Focus

The core invariant is simple:

> `update_memory()` must not delete the existing memory before or after attempting the same-ID replacement upload.

A failed status or upload exception must leave the old record untouched by Memanto, while a successful partial update must preserve the original memory semantics unless the caller explicitly changes them.

## Related

- Bounty: #770
- Original bug report: #1384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory updates now overwrite using the existing memory ID instead of deleting and recreating records.
  * Failed, timed-out, or non-success uploads no longer remove the prior memory, and report errors more clearly.
  * Upload success is accepted case-insensitively (e.g., “OK”).
  * Updates preserve key metadata, including memory type, provenance, source references, and tags.

* **Tests**
  * Expanded unit coverage for overwrite behavior, failure/timeout handling, case-insensitive success statuses, and metadata preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

\n\n## Social / Technical Write-up\n\nPublic engineering thread documenting the data-loss failure mode, same-ID overwrite invariant, and regression approach:\n\n- https://x.com/evoesco_studio/status/2076705341933252982\n