### PR TITLE
fix(langgraph): preserve wildcard tag filters

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -276,11 +276,11 @@ class MemantoStore(BaseStore):
     def _do_search(self, op: SearchOp) -> list[SearchItem]:
         """Retrieve memories matching the namespace.
 
-        Uses ``recall_recent`` for wildcard queries (avoids semantic bias
-        when the caller just wants all recent memories in a namespace) and
-        ``recall()`` for actual semantic queries. A single call is made in
-        both cases; namespace isolation is enforced client-side via tag
-        AND-matching after retrieval.
+        Uses ``recall_recent`` for unfiltered wildcard queries (avoids
+        semantic bias when the caller just wants all recent memories in a
+        namespace) and ``recall()`` for semantic or tag-filtered queries. A
+        single call is made in both cases; namespace isolation is enforced
+        by the selected Memanto agent.
         """
         query = op.query or "*"
         filter_dict = op.filter or {}
@@ -313,7 +313,7 @@ class MemantoStore(BaseStore):
         client, agent_id = self._ensure_client(op.namespace_prefix)
 
         try:
-            if query == "*" and not min_similarity:
+            if query == "*" and not min_similarity and not extra_tags:
                 # recall_recent: no semantic bias, returns newest memories first
                 result = client.recall_recent(
                     agent_id=agent_id,

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -202,6 +202,43 @@ def test_do_search_recent(mock_sdk_client):
     )
 
 
+def test_do_search_wildcard_with_tags_uses_backend_tag_filter(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-789",
+                "tags": ["lg:key:key3", "project:apollo"],
+                "type": "fact",
+                "title": "key3",
+                "content": "older tagged memory",
+            }
+        ]
+    }
+
+    op = SearchOp(
+        namespace_prefix=("my_ns",),
+        query="*",
+        filter={"tags": ["project:apollo"]},
+    )
+    items = store._do_search(op)
+
+    assert len(items) == 1
+    assert items[0].key == "key3"
+    client_instance.recall_recent.assert_not_called()
+    client_instance.recall.assert_called_once_with(
+        agent_id="langgraph_my_ns",
+        query="*",
+        limit=10,
+        type=None,
+        tags=["project:apollo"],
+        min_similarity=None,
+    )
+
+
 def test_do_search_semantic(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()


### PR DESCRIPTION
/claim #770

## Summary

This fixes a LangGraph memory retrieval integrity bug in `MemantoStore._do_search`.

Wildcard searches with a tag filter, for example:

```python
SearchOp(
    namespace_prefix=("project",),
    query="*",
    filter={"tags": ["project:apollo"]},
)
```

were routed through `recall_recent()` because the query was `*` and no `min_confidence` filter was set. `recall_recent()` cannot send `tags` to the Memanto backend, so the store fetched only the newest 100 memories first and then filtered tags locally. If the matching tagged memory was older than that newest-100 window, LangGraph callers saw a false negative even though Memanto had the tagged memory.

The fix keeps the fast `recall_recent()` path for truly unfiltered wildcard searches, but routes tag-filtered wildcard searches through `SdkClient.recall(query="*", tags=...)` so tag filtering happens before the backend result cap.

## Reproduction

1. Store more than 100 recent memories in a LangGraph namespace.
2. Store or retain an older memory tagged with a filter such as `project:apollo`.
3. Call `MemantoStore._do_search(SearchOp(namespace_prefix=..., query="*", filter={"tags": ["project:apollo"]}))`.
4. Before this patch, the older tagged memory could be omitted because it was filtered only after `recall_recent(limit=100)` returned an untagged recent window.
5. After this patch, the call uses backend tag filtering and returns the matching tagged memory.

## Validation

- `uv run --with langgraph --with langchain-core --with pydantic --with python-dotenv --with pytest --with pyyaml python -m pytest integrations\langgraph\tests -q`
- `.\.venv\Scripts\python.exe -m ruff check integrations\langgraph\langgraph_memanto\store.py integrations\langgraph\tests\test_store.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wildcard searches now handle tag filters correctly, using the full search path when tags are provided.
  * Unfiltered wildcard queries continue to use the faster recent-memory lookup.
  * Search behavior now better reflects namespace isolation through the selected agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->