### PR TITLE
Validate conflict report path keys

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -39,7 +39,7 @@ from memanto.app.utils.errors import (
     SessionExpiredError,
     SessionNotFoundError,
 )
-from memanto.app.utils.validation import InputLimits
+from memanto.app.utils.validation import InputLimits, validate_safe_id
 from memanto.cli.config.manager import ConfigManager
 
 logger = logging.getLogger(__name__)
@@ -53,6 +53,13 @@ class LowerStr(str):
 
     def capitalize(self):
         return self
+
+
+def _conflict_report_path(agent_id: str, date: str) -> Path:
+    """Return the validated local conflict-report path for an agent/date key."""
+    validate_safe_id(agent_id, "agent_id")
+    validate_safe_id(date, "date")
+    return Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
 
 
 class MoorchehClient:
@@ -1315,9 +1322,7 @@ class DirectClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = _conflict_report_path(agent_id, date)
 
         if not json_path.exists():
             return []
@@ -1359,9 +1364,7 @@ class DirectClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = _conflict_report_path(agent_id, date)
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -36,7 +36,7 @@ from memanto.app.utils.errors import (
     SessionExpiredError,
     SessionNotFoundError,
 )
-from memanto.app.utils.validation import InputLimits
+from memanto.app.utils.validation import InputLimits, validate_safe_id
 from memanto.cli.config.manager import ConfigManager
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,13 @@ __all__ = ["SdkClient"]
 _MAX_BATCH_SIZE = 100
 _MAX_TITLE_LENGTH = 100
 _MAX_CONTENT_LENGTH = InputLimits.MAX_TEXT_LENGTH
+
+
+def _conflict_report_path(agent_id: str, date: str) -> Path:
+    """Return the validated local conflict-report path for an agent/date key."""
+    validate_safe_id(agent_id, "agent_id")
+    validate_safe_id(date, "date")
+    return Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
 
 
 class SdkClient:
@@ -1184,9 +1191,7 @@ class SdkClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = _conflict_report_path(agent_id, date)
 
         if not json_path.exists():
             return []
@@ -1227,9 +1232,7 @@ class SdkClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = _conflict_report_path(agent_id, date)
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -546,6 +546,72 @@ def test_conflict_report_handles_non_object_json_items(tmp_path, monkeypatch):
     assert conflicts[0]["description"] == '["not an object", 1]'
 
 
+@pytest.mark.parametrize(
+    "client_class_path",
+    [
+        "memanto.cli.client.direct_client.DirectClient",
+        "memanto.cli.client.sdk_client.SdkClient",
+    ],
+)
+@pytest.mark.parametrize(
+    "agent_id,date",
+    [
+        ("../../outside", "2026-06-28"),
+        ("agent-1", "../../outside"),
+    ],
+)
+def test_conflict_list_rejects_path_traversal_keys(
+    client_class_path, agent_id, date, tmp_path, monkeypatch
+):
+    """Conflict readers must not resolve reports outside the conflicts dir."""
+    module_name, class_name = client_class_path.rsplit(".", 1)
+    module = __import__(module_name, fromlist=[class_name])
+    client_cls = getattr(module, class_name)
+
+    outside = tmp_path / "outside_2026-06-28_conflicts.json"
+    outside.write_text('[{"title": "leaked", "resolved": false}]', encoding="utf-8")
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+
+    client = client_cls.__new__(client_cls)
+
+    with pytest.raises(ValueError, match="invalid characters"):
+        client.list_conflicts(agent_id, date)
+
+
+@pytest.mark.parametrize(
+    "client_class_path",
+    [
+        "memanto.cli.client.direct_client.DirectClient",
+        "memanto.cli.client.sdk_client.SdkClient",
+    ],
+)
+@pytest.mark.parametrize(
+    "agent_id,date",
+    [
+        ("../../outside", "2026-06-28"),
+        ("agent-1", "../../outside"),
+    ],
+)
+def test_conflict_resolve_rejects_path_traversal_keys(
+    client_class_path, agent_id, date, tmp_path, monkeypatch
+):
+    """Conflict resolvers must not write reports outside the conflicts dir."""
+    module_name, class_name = client_class_path.rsplit(".", 1)
+    module = __import__(module_name, fromlist=[class_name])
+    client_cls = getattr(module, class_name)
+
+    outside = tmp_path / "outside_2026-06-28_conflicts.json"
+    outside.write_text(
+        '[{"old_memory_id": "old", "resolved": false}]', encoding="utf-8"
+    )
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+
+    client = client_cls.__new__(client_cls)
+
+    with pytest.raises(ValueError, match="invalid characters"):
+        client.resolve_conflict(agent_id, date, 0, "keep_both")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])
 


### PR DESCRIPTION
## Summary
- Validate conflict report `agent_id` and `date` keys before local conflict report paths are built.
- Apply the same guard to both DirectClient and SdkClient list/resolve conflict paths.
- Add regression coverage for unsafe `agent_id` and `date` values in both clients.

## Reproduction
1. Put a file outside the conflicts directory, e.g. `~/outside_2026-06-28_conflicts.json`.
2. Call `DirectClient.__new__(DirectClient).list_conflicts("../../outside", "2026-06-28")` with `Path.home()` pointing at that temp home.
3. Before this change, the direct and SDK clients build `~/.memanto/conflicts/{agent_id}_{date}_conflicts.json` with raw values. The list path can resolve outside `~/.memanto/conflicts`; resolve paths also check filesystem paths before validating the key.

The API/UI layers already validate these keys, but direct CLI client methods can be called directly and should enforce the same local-file boundary at the point where they build the path.

## Validation
- Red before fix: `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260709a-venv uv run --python 3.12 --group dev pytest tests/test_unit.py::test_conflict_list_rejects_path_traversal_keys tests/test_unit.py::test_conflict_resolve_rejects_path_traversal_keys -q`
- Green after fix: `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260709a-venv uv run --python 3.12 --group dev pytest tests/test_unit.py::test_conflict_list_rejects_path_traversal_keys tests/test_unit.py::test_conflict_resolve_rejects_path_traversal_keys -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260709a-venv uv run --python 3.12 --group dev pytest tests/test_unit.py tests/test_cli.py::TestMEMANTOCLI::test_detect_conflicts tests/test_cli.py::TestMEMANTOCLI::test_conflicts_list -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260709a-venv uv run --python 3.12 --group dev pytest tests -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260709a-venv uv run --python 3.12 --group dev ruff check .`
- `UV_PROJECT_ENVIRONMENT=/tmp/memanto-770-claim-20260709a-venv uv run --python 3.12 --group dev ruff format --check memanto/cli/client/direct_client.py memanto/cli/client/sdk_client.py tests/test_unit.py`
- `git diff --check`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when loading or resolving conflict reports by preventing invalid file paths.
  * Conflict actions now consistently validate input values before accessing stored reports.
  * Added coverage to ensure path-traversal attempts are rejected in conflict workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->