### PR TITLE
Match Claude hook command exactly

### DIFF
--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -329,11 +329,18 @@ def _install_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str 
     hooks = settings.setdefault("hooks", {})
     session_start = hooks.setdefault("SessionStart", [])
 
-    # Check if memanto hook already exists
+    expected_commands = {
+        hook.get("command")
+        for hook in agent.hook_config.hook_payload.get("hooks", [])
+        if isinstance(hook, dict) and hook.get("command")
+    }
+
+    # Check if the specific MEMANTO sync hook already exists. A user may have
+    # unrelated hooks that mention "memanto" but do not perform memory sync.
     memanto_exists = any(
         isinstance(group, dict)
         and any(
-            isinstance(h, dict) and "memanto" in h.get("command", "")
+            isinstance(h, dict) and h.get("command") in expected_commands
             for h in group.get("hooks", [])
         )
         for group in session_start

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -1,0 +1,60 @@
+import json
+
+from memanto.cli.connect.agent_registry import CLAUDE_CODE
+from memanto.cli.connect.engine import _install_hooks
+
+
+def _session_start_commands(settings_path):
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    return [
+        hook.get("command")
+        for group in settings.get("hooks", {}).get("SessionStart", [])
+        for hook in group.get("hooks", [])
+    ]
+
+
+def test_install_hooks_ignores_unrelated_memanto_commands(tmp_path):
+    """A different hook mentioning memanto must not suppress the sync hook."""
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    settings_path = settings_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "startup",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "echo memanto diagnostics",
+                                    "timeout": 5,
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _install_hooks(CLAUDE_CODE, tmp_path, is_global=False)
+
+    assert result == "Added SessionStart hook"
+    commands = _session_start_commands(settings_path)
+    assert "echo memanto diagnostics" in commands
+    assert "memanto memory sync --project-dir ." in commands
+
+
+def test_install_hooks_is_idempotent_for_existing_sync_hook(tmp_path):
+    settings_path = tmp_path / ".claude" / "settings.json"
+
+    first = _install_hooks(CLAUDE_CODE, tmp_path, is_global=False)
+    second = _install_hooks(CLAUDE_CODE, tmp_path, is_global=False)
+
+    assert first == "Added SessionStart hook"
+    assert second is None
+    commands = _session_start_commands(settings_path)
+    assert commands.count("memanto memory sync --project-dir .") == 1


### PR DESCRIPTION
## Summary
- Fix Claude Code hook install detection so unrelated SessionStart commands containing `memanto` do not suppress the real sync hook.
- Match against the configured `memanto memory sync --project-dir .` command instead of any `memanto` substring.
- Add regression coverage for the false-positive hook and idempotent reinstall path.

## Repro
1. Create `.claude/settings.json` with a SessionStart hook command such as `echo memanto diagnostics`.
2. Run `memanto connect claude-code`.
3. Before this fix, MEMANTO reports no hook change because the unrelated command contains `memanto`.
4. After this fix, the unrelated hook remains and the actual MEMANTO sync hook is added once.

## Tests
- `pytest tests/test_connect_engine.py -q`
- `pytest tests/test_cli.py tests/test_unit.py tests/test_connect_engine.py -q`
- `pytest tests -q` (live E2E skipped because the configured API key is the placeholder `test-api-key`)
- `ruff check .`
- `ruff format --check memanto/cli/connect/engine.py tests/test_connect_engine.py`
- `git diff --check`

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of existing session-start hook settings so only the exact configured command is treated as a duplicate.
  * Prevents unrelated hook entries that mention the same tool from blocking the expected sync command.
  * Ensures hook setup remains idempotent when run multiple times, avoiding duplicate entries in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->