### PR TITLE
fix(hermes): bind warmup to scheduled client

### DIFF
--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -550,13 +550,14 @@ class MemantoMemoryProvider(MemoryProvider):
         if not self._api_key:
             return
         try:
-            self._client = _MemantoClient(
+            client = _MemantoClient(
                 self._api_key,
                 self._agent_id,
                 pattern=self._config["pattern"],
                 auto_create=self._config["auto_create"],
                 session_duration_hours=self._config["session_duration_hours"],
             )
+            self._client = client
             self._active = True
         except Exception:
             logger.warning("Memanto initialization failed", exc_info=True)
@@ -567,13 +568,16 @@ class MemantoMemoryProvider(MemoryProvider):
         # Warm up the session in the background so the first turn's recall does
         # not also pay agent-create + activate latency.
         self._warmup_thread = threading.Thread(
-            target=self._warmup, daemon=True, name="memanto-warmup"
+            target=self._warmup,
+            args=(client,),
+            daemon=True,
+            name="memanto-warmup",
         )
         self._warmup_thread.start()
 
-    def _warmup(self) -> None:
+    def _warmup(self, client: _MemantoClient) -> None:
         try:
-            self._client.ensure_session()
+            client.ensure_session()
         except Exception:
             logger.debug("Memanto warmup activation failed", exc_info=True)
 

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -302,6 +302,44 @@ def test_ensure_session_backs_off_then_allows_retry():
     assert client._client.activate_calls == 2
 
 
+def test_warmup_binds_client_at_schedule_time(monkeypatch, tmp_path):
+    """A delayed warmup must not activate a client from a later session."""
+    from hermes_memanto import provider as mod
+
+    scheduled = []
+
+    class DeferredThread:
+        def __init__(self, target=None, args=(), kwargs=None, daemon=None, name=None):
+            scheduled.append(
+                {"target": target, "args": args, "kwargs": kwargs or {}, "name": name}
+            )
+
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return False
+
+        def join(self, timeout=None):
+            pass
+
+    monkeypatch.setenv("MOORCHEH_API_KEY", "test-key")
+    monkeypatch.setattr(PROVIDER_MOD, FakeClient)
+    monkeypatch.setattr(mod.threading, "Thread", DeferredThread)
+
+    p = MemantoMemoryProvider()
+    p.initialize("s1", hermes_home=str(tmp_path), agent_identity="first")
+    first_client = p._client
+
+    p.initialize("s2", hermes_home=str(tmp_path), agent_identity="second")
+    second_client = p._client
+
+    scheduled[0]["target"](*scheduled[0]["args"], **scheduled[0]["kwargs"])
+
+    assert first_client.ensure_calls == 1
+    assert second_client.ensure_calls == 0
+
+
 # -- Prefetch -----------------------------------------------------------------
 
 


### PR DESCRIPTION
/claim #770

## Summary

Fixes a Hermes Memanto provider race where the background warmup thread could activate the wrong client after provider reinitialization.

Before this patch, `initialize()` scheduled `self._warmup`, and `_warmup()` dereferenced `self._client` when the thread actually ran. If Hermes reinitialized the provider for another session/profile before the first warmup thread executed, the first warmup could activate the newer session's client instead of the client it was created for.

This patch:

- binds the newly-created `_MemantoClient` to a local `client` variable during initialization
- passes that exact client into the warmup thread
- makes `_warmup()` activate the scheduled client instead of looking up mutable `self._client`
- adds a regression test that defers thread execution, initializes two sessions, then verifies the first scheduled warmup touches only the first client

## Verification

```text
New-Item -ItemType Directory -Force C:\tmp\codex-pytest-memanto | Out-Null; $env:TEMP = 'C:\tmp\codex-pytest-memanto'; $env:TMP = 'C:\tmp\codex-pytest-memanto'; $env:TMPDIR = 'C:\tmp\codex-pytest-memanto'; $env:PYTHONPATH = ".;integrations\hermes-agents"; .\.venv\Scripts\python.exe -m pytest integrations\hermes-agents\tests\test_provider.py -q
```

Result: `39 passed`

```text
.\.venv\Scripts\python.exe -m ruff check integrations\hermes-agents\hermes_memanto\provider.py integrations\hermes-agents\tests\test_provider.py
```

Result: `All checks passed!`

```text
.\.venv\Scripts\python.exe -m ruff format --check integrations\hermes-agents\hermes_memanto\provider.py integrations\hermes-agents\tests\test_provider.py
```

Result: `2 files already formatted`

```text
git diff --check -- integrations\hermes-agents\hermes_memanto\provider.py integrations\hermes-agents\tests\test_provider.py
```

Result: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background session warmup reliability so the correct connection is used even if the provider is reinitialized.
  * Reduced the chance of warmup affecting a newer session setup by binding it to the session created at startup.
* **Tests**
  * Added coverage for warmup behavior across repeated initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->