### PR TITLE
fix(crewai): normalize recall tags for display

### DIFF
--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -37,6 +37,17 @@ VALID_MEMORY_TYPES = (
 )
 
 
+def _normalize_tags(raw: Any) -> list[str]:
+    """Normalize backend/user tag values for stable display and API calls."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [tag.strip() for tag in raw.split(",") if tag.strip()]
+    if isinstance(raw, (list, tuple, set)):
+        return [str(tag).strip() for tag in raw if str(tag).strip()]
+    return [str(raw).strip()]
+
+
 class MemantoSetup:
     """
     Manages Memanto agent lifecycle for CrewAI integration.
@@ -192,7 +203,7 @@ class MemantoRememberTool(BaseTool):
         confidence: float,
         tags: str = "",
     ) -> str:
-        tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
+        tag_list = _normalize_tags(tags)
 
         result = self._client.remember(
             agent_id=self._agent_id,
@@ -265,7 +276,7 @@ class MemantoRecallTool(BaseTool):
             content = mem.get("content", "")
             mem_type = mem.get("type", "unknown")
             confidence = mem.get("confidence", "N/A")
-            tags = mem.get("tags", [])
+            tags = _normalize_tags(mem.get("tags"))
             tag_str = f" [tags: {', '.join(tags)}]" if tags else ""
 
             lines.append(

--- a/integrations/crewai/tests/test_tools.py
+++ b/integrations/crewai/tests/test_tools.py
@@ -108,6 +108,49 @@ def test_memanto_recall_tool_success():
     )
 
 
+def test_memanto_recall_tool_formats_string_tags():
+    client = MagicMock()
+    client.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-123",
+                "type": "fact",
+                "title": "Fact 1",
+                "content": "Content 1",
+                "confidence": 0.8,
+                "tags": "alpha,beta",
+            }
+        ]
+    }
+
+    tool = MemantoRecallTool(client=client, agent_id="test-agent")
+    result = tool._run(query="test query")
+
+    assert "[tags: alpha, beta]" in result
+    assert "[tags: a, l, p" not in result
+
+
+def test_memanto_recall_tool_formats_scalar_tags():
+    client = MagicMock()
+    client.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-123",
+                "type": "fact",
+                "title": "Fact 1",
+                "content": "Content 1",
+                "confidence": 0.8,
+                "tags": 42,
+            }
+        ]
+    }
+
+    tool = MemantoRecallTool(client=client, agent_id="test-agent")
+    result = tool._run(query="test query")
+
+    assert "[tags: 42]" in result
+
+
 def test_memanto_recall_tool_empty():
     client = MagicMock()
     client.recall.return_value = {"memories": []}


### PR DESCRIPTION
/claim #770

## Summary

Fixes a CrewAI recall-output formatting bug where backend-returned tag values that are not already `list[str]` can render incorrectly or raise.

Before this patch, `MemantoRecallTool._run()` did:

```python
tags = mem.get("tags", [])
tag_str = f" [tags: {', '.join(tags)}]" if tags else ""
```

If a backend/search result contains tags as a comma-separated string such as `"alpha,beta"`, the output becomes character-joined text (`a, l, p, h, a, ...`) instead of `alpha, beta`. If a scalar tag slips through, `join()` can fail.

This patch adds a small `_normalize_tags()` helper and uses it for:

- CrewAI remember tool tag parsing
- CrewAI recall output formatting for list/tuple/set, comma-separated string, scalar, or missing tag values

## Verification

```text
uv run --with pytest --with-editable . --with-editable integrations/crewai pytest integrations/crewai/tests/test_tools.py -q
```

Result: passed (`..........`)

```text
.\.venv\Scripts\python.exe -m ruff check integrations\crewai\crewai_memanto\tools.py integrations\crewai\tests\test_tools.py
```

Result: `All checks passed!`

```text
.\.venv\Scripts\python.exe -m ruff format --check integrations\crewai\crewai_memanto\tools.py integrations\crewai\tests\test_tools.py
```

Result: `2 files already formatted`

```text
git diff --check -- integrations\crewai\crewai_memanto\tools.py integrations\crewai\tests\test_tools.py
```

Result: passed
