### PR TITLE
fix(mcp): normalize batch remember tags

### DIFF
--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -194,6 +194,18 @@ def _format_exception(exc: Exception) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
+def _normalize_tags(raw: Any) -> list[str]:
+    """Accept MCP client tag shapes while preserving SDK list semantics."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [tag.strip() for tag in raw.split(",") if tag.strip()]
+    if isinstance(raw, list):
+        return [str(tag).strip() for tag in raw if str(tag).strip()]
+    tag = str(raw).strip()
+    return [tag] if tag else []
+
+
 # ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
@@ -326,7 +338,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 title=resolved_title,
                 content=content,
                 confidence=confidence,
-                tags=tags or [],
+                tags=_normalize_tags(tags),
                 source=source,
                 provenance=provenance,
             )
@@ -377,6 +389,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         try:
             resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
             # Validate before round-trip so we fail fast with a clear error.
+            normalized_memories: list[dict[str, Any]] = []
             for i, item in enumerate(memories):
                 if not isinstance(item, dict):
                     raise ValueError(
@@ -398,10 +411,13 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                         f"memories[{i}].provenance={prov!r} is not valid. "
                         f"Choose one of: {sorted(VALID_PROVENANCE_TYPES)}"
                     )
+                normalized_item = dict(item)
+                normalized_item["tags"] = _normalize_tags(item.get("tags"))
+                normalized_memories.append(normalized_item)
 
             result = lifecycle.client.batch_remember(
                 agent_id=resolved,
-                memories=memories,
+                memories=normalized_memories,
             )
             sub_results = [
                 BatchRememberItemResult(

--- a/integrations/mcp/tests/test_tools.py
+++ b/integrations/mcp/tests/test_tools.py
@@ -1,0 +1,108 @@
+"""Tool-level regressions for MCP request shaping."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from memanto_mcp.tools import _normalize_tags, register_tools
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, name: str, description: str) -> Any:
+        def decorator(fn: Any) -> Any:
+            self.tools[name] = fn
+            return fn
+
+        return decorator
+
+
+class FakeLifecycle:
+    def __init__(self) -> None:
+        self.settings = SimpleNamespace(
+            default_agent_id="agent-1",
+            expose_admin_tools=False,
+        )
+        self.client = MagicMock()
+        self.client.batch_remember.return_value = {
+            "namespace": "memanto_agent_agent-1",
+            "total_submitted": 1,
+            "successful": 1,
+            "failed": 0,
+            "results": [{"id": "mem-1", "status": "ok"}],
+        }
+        self.client.remember.return_value = {
+            "memory_id": "mem-1",
+            "namespace": "memanto_agent_agent-1",
+            "confidence": 0.85,
+        }
+
+    def resolve_agent_id(self, agent_id: str | None) -> str:
+        return agent_id or self.settings.default_agent_id
+
+    def ensure_ready(self, agent_id: str) -> str:
+        return agent_id
+
+
+def test_batch_remember_normalizes_comma_separated_tags() -> None:
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+    memories = [
+        {
+            "content": "Uses Memanto MCP for durable memory.",
+            "type": "fact",
+            "tags": "mcp, batch, ",
+        }
+    ]
+
+    result = mcp.tools["batch_remember"](memories=memories)
+
+    assert result.status == "ok"
+    sent_memories = lifecycle.client.batch_remember.call_args.kwargs["memories"]
+    assert sent_memories[0]["tags"] == ["mcp", "batch"]
+    assert memories[0]["tags"] == "mcp, batch, "
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, []),
+        ("", []),
+        ("  ", []),
+        ("mcp, batch, ", ["mcp", "batch"]),
+        (["mcp", "batch"], ["mcp", "batch"]),
+        (["", "  ", "mcp"], ["mcp"]),
+        (42, ["42"]),
+    ],
+)
+def test_normalize_tags_accepts_mcp_client_shapes(
+    raw: Any,
+    expected: list[str],
+) -> None:
+    assert _normalize_tags(raw) == expected
+
+
+def test_remember_uses_same_tag_normalization_without_mutating_input() -> None:
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+    tags = ["mcp", " ", "remember"]
+
+    result = mcp.tools["remember"](
+        content="Uses Memanto MCP for durable memory.",
+        tags=tags,
+    )
+
+    assert result.status == "ok"
+    assert lifecycle.client.remember.call_args.kwargs["tags"] == [
+        "mcp",
+        "remember",
+    ]
+    assert tags == ["mcp", " ", "remember"]


### PR DESCRIPTION
## Summary
- normalize MCP `remember` and `batch_remember` tags before calling the SDK
- preserve `batch_remember` caller input while passing SDK-ready memory dicts
- add regression coverage for batch tags, direct tag normalization, and the `remember` path

## Bug
The MCP `batch_remember` tool documents that each memory item supports the same fields as `remember`, including `tags`, but it forwards raw item dicts to `SdkClient.batch_remember`. If a client emits a common MCP/LLM JSON shape like `"tags": "mcp, batch"`, the SDK builds a `MemoryRecord(tags="mcp, batch")` and Pydantic rejects it because the model expects `list[str]`.

Single-memory writes are now shaped through the same helper, and batch writes normalize strings, lists, scalar values, and blanks before crossing the SDK boundary without mutating caller-provided memory dicts.

## Verification
- `PYTHONPATH='.;integrations/mcp' uv run --with pytest --with pydantic --with pydantic-settings --with mcp python -m pytest integrations/mcp/tests/test_tools.py integrations/mcp/tests/test_server.py -q`
- `uv run --with ruff ruff check integrations/mcp/memanto_mcp/tools.py integrations/mcp/tests/test_tools.py`
- `git diff --check`
