### PR TITLE
Avoid local storage writes during service initialization

### DIFF
--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -29,7 +29,6 @@ class AgentService:
             agents_dir: Directory for agent metadata storage (defaults to ~/.memanto/agents/)
         """
         self.agents_dir = agents_dir or get_data_dir() / "agents"
-        self.agents_dir.mkdir(parents=True, exist_ok=True)
 
     def _generate_namespace(self, agent_id: str) -> str:
         """
@@ -134,6 +133,9 @@ class AgentService:
             AgentList with all agents
         """
         agents = []
+        if not self.agents_dir.exists():
+            return AgentList(agents=agents, count=0)
+
         for agent_file in self.agents_dir.glob("*.json"):
             with open(agent_file) as f:
                 data = json.load(f)
@@ -207,6 +209,7 @@ class AgentService:
 
     def _save_agent(self, agent: AgentInfo) -> None:
         """Save agent metadata to file"""
+        self.agents_dir.mkdir(parents=True, exist_ok=True)
         agent_file = self._get_agent_file(agent.agent_id)
         with open(agent_file, "w") as f:
             json.dump(agent.model_dump(mode="json"), f, indent=2)

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -63,13 +63,14 @@ class SessionService:
             sessions_dir: Directory for session storage (defaults to ~/.memanto/sessions/)
         """
         self.sessions_dir = sessions_dir or get_data_dir() / "sessions"
-        self.sessions_dir.mkdir(parents=True, exist_ok=True)
-        resolved_secret_key = (
-            secret_key
-            or settings.MEMANTO_SECRET_KEY
-            or self._generate_secure_secret_key()
-        )
-        self.secret_key: str = resolved_secret_key
+        self._secret_key: str | None = secret_key or settings.MEMANTO_SECRET_KEY or None
+
+    @property
+    def secret_key(self) -> str:
+        """JWT signing key, generated only when token operations need it."""
+        if self._secret_key is None:
+            self._secret_key = self._generate_secure_secret_key()
+        return self._secret_key
 
     def _generate_secure_secret_key(self) -> str:
         """Generate (or reuse) a persisted fallback secret for JWT signing.
@@ -84,6 +85,7 @@ class SessionService:
         treated as absent and rewritten.
         """
         secret_file = self.sessions_dir.parent / "secret_key"
+        secret_file.parent.mkdir(parents=True, exist_ok=True)
         existing = self._read_persisted_secret(secret_file)
         if existing is not None:
             return existing
@@ -384,6 +386,7 @@ class SessionService:
     def _save_session(self, session: Session) -> None:
         """Save session to file"""
         validate_safe_id(session.agent_id, "agent_id")
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
         session_file = self.sessions_dir / f"{session.agent_id}.json"
         with open(session_file, "w") as f:
             json.dump(session.model_dump(mode="json"), f, indent=2)
@@ -427,6 +430,7 @@ class SessionService:
         summary_file = (
             self.sessions_dir / f"{agent_id}_{date_str}_{session_id}_summary.md"
         )
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
 
         # Determine if we need to write the header
         write_header = not summary_file.exists()
@@ -489,6 +493,7 @@ class SessionService:
         summary_file = (
             self.sessions_dir / f"{agent_id}_{date_str}_{session_id}_summary.md"
         )
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
 
         write_header = not summary_file.exists()
 
@@ -506,6 +511,7 @@ class SessionService:
     def _set_active_session(self, agent_id: str) -> None:
         """Mark session as active"""
         validate_safe_id(agent_id, "agent_id")
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
         active_link = self.sessions_dir / "active"
 
         # Remove existing active link

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -43,9 +43,6 @@ class ConfigManager:
         self.env_file = self.config_dir / ".env"
         self.connections_file = self.config_dir / "connections.json"
 
-        # Ensure config directory exists
-        self.config_dir.mkdir(parents=True, exist_ok=True)
-
         # Load env vars from the memanto .env file
         if self.env_file.exists():
             load_dotenv(self.env_file, override=True)
@@ -113,6 +110,7 @@ class ConfigManager:
 
     def _set_env_var(self, name: str, value: str) -> None:
         """Write a single variable to ~/.memanto/.env and update os.environ."""
+        self.config_dir.mkdir(parents=True, exist_ok=True)
         if not self.env_file.exists():
             self.env_file.write_text("# MEMANTO Environment\n")
         set_key(str(self.env_file), name, value)
@@ -252,6 +250,7 @@ class ConfigManager:
 
     def save_yaml(self, data: dict) -> None:
         """Save dict to config.yaml under the 'memanto' key."""
+        self.config_dir.mkdir(parents=True, exist_ok=True)
         with open(self.config_file, "w") as f:
             yaml.dump({"memanto": data}, f, default_flow_style=False, sort_keys=False)
         try:
@@ -451,6 +450,7 @@ class ConfigManager:
 
     def _save_connections(self, data: dict) -> None:
         """Atomically write the connections registry."""
+        self.config_dir.mkdir(parents=True, exist_ok=True)
         tmp = self.connections_file.with_suffix(".json.tmp")
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=True)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -155,6 +155,7 @@ class TestSessionService:
     def test_get_active_session_ignores_invalid_session_file(self, session_service):
         """A corrupt active session file should not crash status checks."""
         active_marker = session_service.sessions_dir / "active"
+        active_marker.parent.mkdir(parents=True, exist_ok=True)
         active_marker.write_text("broken-agent")
         (session_service.sessions_dir / "broken-agent.json").write_text("{")
 
@@ -294,6 +295,29 @@ class TestAgentService:
         assert not agent_service.agent_exists("test-agent")
 
         print("✅ Agent deleted successfully")
+
+
+def test_local_services_do_not_create_storage_on_init(tmp_path, monkeypatch):
+    """Constructing local helpers should not write to disk until they save state."""
+    from memanto.cli.config.manager import ConfigManager
+
+    monkeypatch.delenv("MEMANTO_SECRET_KEY", raising=False)
+    monkeypatch.setattr(settings, "MEMANTO_SECRET_KEY", "")
+
+    config_dir = tmp_path / "config"
+    agents_dir = tmp_path / "agents"
+    sessions_dir = tmp_path / "sessions"
+
+    ConfigManager(config_dir=config_dir)
+    agent_service = AgentService(agents_dir=agents_dir)
+    session_service = SessionService(sessions_dir=sessions_dir)
+
+    assert not config_dir.exists()
+    assert not agents_dir.exists()
+    assert not sessions_dir.exists()
+    assert not (tmp_path / "secret_key").exists()
+    assert agent_service.list_agents().count == 0
+    assert session_service._generate_namespace("test-agent") == "memanto_agent_test-agent"
 
 
 class TestMemoryWriteServiceDelete:
@@ -482,11 +506,14 @@ class TestMEMANTOArchitecture:
         print(f"✅ V2 namespace format confirmed: {namespace}")
         print("   ✅ NO tenant_id required!")
 
-    def test_jwt_token_structure(self):
+    def test_jwt_token_structure(self, tmp_path):
         """Verify JWT token contains correct fields"""
         from memanto.app.services.session_service import SessionService
 
-        service = SessionService(secret_key="test-secret-min-32-bytes-abcdefg")
+        service = SessionService(
+            secret_key="test-secret-min-32-bytes-abcdefg",
+            sessions_dir=tmp_path / "sessions",
+        )
         session = service.create_session(agent_id="test-agent", duration_hours=4)
 
         # Decode token (without verification, just to check structure)


### PR DESCRIPTION
## Summary
This fixes a setup and CI friction issue where importing route modules or constructing local helper services can eagerly create files under the default data directory (~/.memanto). In restricted environments, read-only home directories, sandboxes, or import-only checks, that side effect can fail before the caller performs any state-changing operation.
## Problem
ConfigManager.__init__() created the config directory immediately.
AgentService.__init__() created the agents directory immediately.
SessionService.__init__() created the sessions directory immediately and generated/persisted a fallback JWT secret immediately when no secret was configured.
Route modules instantiate some of these helpers at import time, so the write can happen during collection/import instead of during an explicit save/create operation.
## Reproduction
Use an environment where the default home data path is not writable, or run tests/imports under a sandbox that denies writes to ~/.memanto.
Import modules that construct local helpers at module scope, or instantiate SessionService() without a configured secret.
The process can fail with a permission error while creating ~/.memanto, before any command actually saves config, agents, or sessions.
## Fix
Defer config directory creation until writing .env, config.yaml, or connections.json.
Defer agent directory creation until saving an agent; listing agents now returns an empty list when storage does not exist.
Defer session directory creation until saving session state or summary files.
Lazily generate the persisted fallback JWT secret only when token signing/verification needs a secret.
Add a regression test that constructing these services does not create local storage or a secret file.
Update existing tests that intentionally write session files to use explicit temporary storage.
## Validation
python -m pytest tests -q
Result:
Passing: all non-live tests.
Skipped: live Moorcheh E2E tests that require a real MOORCHEH_API_KEY.
Notes:
This is primarily a usability and setup-friction fix for import-time side effects. It should make the package more reliable in CI, sandboxed execution, read-only home environments, and applications that import Memanto modules before deciding whether to persist local state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when working with agents, sessions, and configuration by creating storage folders only when needed.
  * Prevents errors when listing agents or saving session data if the expected directories do not already exist.
  * Makes local setup less intrusive by avoiding automatic creation of files and folders during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->