### PR TITLE
Reject non-positive relative time windows

### DIFF
--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -156,6 +156,9 @@ def parse_relative_time(relative: str) -> str | None:
                 number = int(parts[1])
                 unit = parts[2]
 
+                if number <= 0:
+                    return None
+
                 if unit in ["day", "days"]:
                     return get_last_n_days(number)
                 elif unit in ["hour", "hours"]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -593,6 +593,14 @@ class TestMEMANTOCLI:
         assert result.exit_code != 0
         assert "multiple temporal query modes" in result.stdout
 
+    def test_recall_rejects_non_positive_relative_window(self, mock_all_clients):
+        """`last N days/hours` must require a positive lookback window."""
+        result = runner.invoke(app, ["recall", "--changed-since", "last -1 days"])
+
+        assert result.exit_code != 0
+        assert "Invalid timestamp format" in result.stdout
+        mock_all_clients.recall_changed_since.assert_not_called()
+
     def test_forget_force(self, mock_all_clients):
         """Test 'memanto forget --force' deletes a memory without prompting."""
         mock_all_clients.delete_memory.return_value = {

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -1,6 +1,6 @@
 from datetime import timezone
 
-from memanto.app.utils.temporal_helpers import parse_iso_timestamp
+from memanto.app.utils.temporal_helpers import parse_iso_timestamp, parse_relative_time
 
 
 def test_parse_iso_timestamp_normalizes_offset_to_utc():
@@ -15,3 +15,10 @@ def test_parse_iso_timestamp_assumes_naive_values_are_utc():
 
     assert parsed.tzinfo == timezone.utc
     assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"
+
+
+def test_parse_relative_time_rejects_non_positive_windows():
+    assert parse_relative_time("last 0 days") is None
+    assert parse_relative_time("last -1 days") is None
+    assert parse_relative_time("last 0 hours") is None
+    assert parse_relative_time("last -2 hours") is None


### PR DESCRIPTION
## Summary
- Reject non-positive `last N days/hours` relative time windows.
- Keep valid positive relative windows and ISO timestamp handling unchanged.
- Add helper and CLI regression coverage for invalid temporal recall windows.

## Repro
1. Run `memanto recall --changed-since "last -1 days"`.
2. Before this fix, the CLI accepts the value because `parse_relative_time()` converts `-1` into a future timestamp boundary and continues to `recall_changed_since`.
3. After this fix, non-positive relative windows are rejected as invalid timestamp input, so temporal recall cannot silently run with an inverted/current window.

## Tests
- `uv run pytest tests/test_temporal_helpers.py tests/test_cli.py -q`
- `uv run pytest tests -q` (live E2E skipped because the configured API key is the placeholder `test-api-key`)
- `uv run ruff check .`
- `uv run ruff format --check memanto/app/utils/temporal_helpers.py tests/test_temporal_helpers.py tests/test_cli.py`
- `git diff --check`

Bounty: #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relative time inputs like “last 0 days” or negative time windows are now rejected instead of being treated as valid dates.
  * CLI commands using invalid relative windows now fail cleanly with an error message and do not proceed with the recall action.
* **Tests**
  * Added coverage for non-positive relative time parsing and CLI rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->