### PR TITLE
Restore conflict resolution and fix update_memory data loss (#1418)

### DIFF
--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -162,6 +162,11 @@ class Settings(BaseSettings):
     PROVISIONAL_TTL_SECONDS: int = 3600  # 1 hour
     PROVISIONAL_MAX_CONFIDENCE: float = 0.5
 
+    # Conflict Resolution Configuration
+    # Similarity score above which a new memory is treated as superseding
+    # an existing active memory of the same type in the same namespace.
+    CONFLICT_SIMILARITY_THRESHOLD: float = 0.82
+
     # Schedule Configuration
     MEMANTO_SCHEDULE_TIME: str = "23:55"
 

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -42,6 +42,9 @@ class MemoryRecord(BaseModel):
     # Provenance
     provenance: ProvenanceType = "explicit_statement"
 
+    # Set when this memory has been superseded by a newer, conflicting one.
+    superseded_by: str | None = None
+
     # Timestamps (auto-populated by server)
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
@@ -89,6 +92,8 @@ class MemoryRecord(BaseModel):
             document["expires_at"] = self.expires_at.isoformat()
         if self.ttl_seconds:
             document["ttl_seconds"] = self.ttl_seconds
+        if self.superseded_by:
+            document["superseded_by"] = self.superseded_by
 
         return document
 
@@ -100,3 +105,50 @@ class MemoryRecord(BaseModel):
         """Set TTL and expiration"""
         self.ttl_seconds = seconds
         self.expires_at = datetime.utcnow() + timedelta(seconds=seconds)
+
+
+class ValidationPolicy:
+    """
+    Decides what happens to a new memory before it's persisted.
+
+    Memory types listed in settings.REQUIRE_VALIDATION_FOR ("fact",
+    "preference" by default) are treated as consequential enough that
+    they shouldn't be trusted at full confidence on a single, unconfirmed
+    mention. Everything else is stored as-is. This intentionally stays
+    simple (no LLM call) so it doesn't add latency/cost to every write.
+    """
+
+    def validate_memory(self, memory: "MemoryRecord", context: dict[str, Any]) -> dict[str, Any]:
+        from memanto.app.config import settings
+
+        if memory.type not in settings.REQUIRE_VALIDATION_FOR:
+            return {"action": "store", "reason": "Non-critical memory type; stored directly"}
+
+        repetition_count = context.get("repetition_count", 0)
+        trusted_source = memory.source in {"tool", "system"} and memory.confidence >= 0.85
+        corroborated = repetition_count >= 2 or memory.provenance in {"validated", "corrected"}
+
+        if trusted_source or corroborated:
+            return {
+                "action": "store",
+                "reason": (
+                    f"Critical memory type '{memory.type}' met validation "
+                    f"requirements (repetition={repetition_count}, source={memory.source})"
+                ),
+            }
+
+        return {
+            "action": "store_provisional",
+            "reason": (
+                f"Critical memory type '{memory.type}' has not been corroborated "
+                "(no repeated mention, not from a trusted source) - stored provisionally"
+            ),
+        }
+
+    def make_provisional(self, memory: "MemoryRecord") -> "MemoryRecord":
+        from memanto.app.config import settings
+
+        memory.status = "provisional"
+        memory.confidence = min(memory.confidence, settings.PROVISIONAL_MAX_CONFIDENCE)
+        memory.set_ttl(settings.PROVISIONAL_TTL_SECONDS)
+        return memory

--- a/memanto/app/services/conflict_resolution_service.py
+++ b/memanto/app/services/conflict_resolution_service.py
@@ -1,0 +1,105 @@
+"""
+Conflict Resolution Service
+
+Detects when a newly-stored memory is a competing claim about the same
+thing as an existing *active* memory of the same type, and marks the
+older one superseded instead of letting both sit there indefinitely as
+equally-valid facts.
+
+This is a similarity-based heuristic, not full semantic contradiction
+detection ("blue" vs. "red" isn't understood as a contradiction, per se -
+it's understood as "another high-confidence preference memory about the
+same subject just got written, so the previous one is presumably stale
+now"). That matches the "new facts always outrank older, outdated ones"
+freshness behavior Memanto already advertises, and it avoids adding an
+LLM call to every single write. A stricter mode that actually asks a
+model "do these two memories conflict?" before superseding anything
+would catch more subtle cases and could be layered on top of this later,
+gated behind its own setting, for teams that want the extra precision at
+the cost of write latency.
+"""
+
+import logging
+from typing import Any
+
+from memanto.app.config import settings
+from memanto.app.core import MemoryRecord
+
+logger = logging.getLogger(__name__)
+
+
+class ConflictResolutionService:
+    def __init__(self, moorcheh_client):
+        self.client = moorcheh_client
+
+    def find_conflicts(self, memory: MemoryRecord) -> list[dict[str, Any]]:
+        """Return existing active memories this one likely supersedes."""
+        try:
+            search_results = self.client.similarity_search.query(
+                query=memory.content,
+                namespaces=[memory.namespace()],
+                top_k=10,
+            )
+        except Exception as e:
+            # Conflict detection failing should never block the write itself.
+            logger.warning(f"Conflict search failed for memory {memory.id}: {e}")
+            return []
+
+        conflicts = []
+        for result in search_results.get("results", []):
+            if result.get("id") == memory.id:
+                continue
+
+            metadata = result.get("metadata", {})
+            if not isinstance(metadata, dict):
+                metadata = {}
+
+            def field(name: str, _result=result, _metadata=metadata):
+                if name in _metadata and _metadata[name] is not None:
+                    return _metadata[name]
+                return _result.get(name)
+
+            if field("memory_type") != memory.type:
+                continue
+            # Anything already superseded/deleted isn't a live conflict.
+            if field("status") not in (None, "active"):
+                continue
+
+            score = result.get("score", 0.0)
+            if score >= settings.CONFLICT_SIMILARITY_THRESHOLD:
+                conflicts.append(result)
+
+        return conflicts
+
+    def supersede(
+        self,
+        conflicts: list[dict[str, Any]],
+        new_memory_id: str,
+        namespace: str,
+        write_service,
+    ) -> list[str]:
+        """
+        Mark each conflicting memory as superseded by the new one.
+
+        Best-effort on purpose: the new memory has already been written
+        by the time this runs, so a failure to update an old, conflicting
+        memory shouldn't roll back or fail the new write - it just means
+        that one old memory didn't get flagged and will need to be caught
+        on a later pass.
+        """
+        superseded_ids = []
+        for conflict in conflicts:
+            old_id = conflict.get("id")
+            if not old_id:
+                continue
+            try:
+                write_service.update_memory(
+                    memory_id=old_id,
+                    namespace=namespace,
+                    updates={"status": "superseded", "superseded_by": new_memory_id},
+                )
+                superseded_ids.append(old_id)
+            except Exception as e:
+                logger.warning(f"Failed to mark memory {old_id} as superseded: {e}")
+
+        return superseded_ids

--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -1,0 +1,61 @@
+"""
+Memory Validation Service
+
+Runs a new memory through ValidationPolicy before it's persisted. This is
+the implementation memory_write_service.store_memory() actually calls -
+the module of the same name under app/legacy/ references a class that no
+longer exists and can't be imported; it's left alone here since nothing
+else depends on it.
+"""
+
+from typing import Any
+
+from memanto.app.core import MemoryRecord, ValidationPolicy
+from memanto.app.utils.errors import ValidationError
+
+
+class MemoryValidationService:
+    def __init__(self, moorcheh_client):
+        self.client = moorcheh_client
+        self.policy = ValidationPolicy()
+
+    def validate_memory(
+        self, memory: MemoryRecord, context: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Validate memory according to policy"""
+        try:
+            context = dict(context or {})
+            context.setdefault("repetition_count", self._check_repetition(memory))
+
+            validation_result = self.policy.validate_memory(memory, context)
+
+            if validation_result.get("action") == "store_provisional":
+                memory = self.policy.make_provisional(memory)
+                validation_result["memory"] = memory
+
+            return validation_result
+
+        except Exception as e:
+            raise ValidationError(f"Validation failed: {e}")
+
+    def _check_repetition(self, memory: MemoryRecord) -> int:
+        """How many times has something like this already been said?"""
+        try:
+            namespace = memory.namespace()
+            search_results = self.client.similarity_search.query(
+                query=memory.content, namespaces=[namespace], top_k=10
+            )
+
+            similar_count = 0
+            for result in search_results.get("results", []):
+                if result.get("id") == memory.id:
+                    continue
+                if result.get("score", 0) > 0.8:
+                    similar_count += 1
+
+            return similar_count
+
+        except Exception:
+            # If the repetition check itself fails, don't block the write
+            # over it - just treat it as unconfirmed.
+            return 0

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -2,6 +2,7 @@
 Memory Write Service
 """
 
+import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -9,7 +10,9 @@ if TYPE_CHECKING:
     from moorcheh_sdk import MoorchehClient
 
 from memanto.app.core import MemoryRecord
+from memanto.app.services.conflict_resolution_service import ConflictResolutionService
 from memanto.app.services.memory_parsing_service import MemoryParsingService
+from memanto.app.services.memory_validation_service import MemoryValidationService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
 
@@ -22,6 +25,8 @@ class MemoryWriteService:
 
         self.client = moorcheh_client
         self._parser = MemoryParsingService()
+        self._validation_service = MemoryValidationService(moorcheh_client)
+        self._conflict_service = ConflictResolutionService(moorcheh_client)
 
     def store_memory(
         self, memory: MemoryRecord, context: dict[str, Any] | None = None
@@ -43,13 +48,12 @@ class MemoryWriteService:
             # Add namespace
             namespace = memory.namespace()
 
-            # skip validation for speed
-            ## Validate memory
-            # validation_result = self.validation_service.validate_memory(memory, context)
-            ## Use validated memory if modified
-            # if "memory" in validation_result:
-            #     memory = validation_result["memory"]
-            validation_result = {"action": "store", "reason": "MVP direct store"}
+            # Validate memory (may downgrade it to provisional in-place)
+            validation_result = self._validation_service.validate_memory(
+                memory, context
+            )
+            if "memory" in validation_result:
+                memory = validation_result["memory"]
 
             from typing import cast
 
@@ -63,6 +67,19 @@ class MemoryWriteService:
                 namespace_name=namespace, documents=[document]
             )
 
+            # Check whether this memory contradicts/replaces an existing
+            # active one, and if so, mark the older one superseded. Skip
+            # this for memories that were just stored provisionally -
+            # unconfirmed information shouldn't be allowed to bump
+            # something that was already trusted.
+            superseded_ids: list[str] = []
+            if validation_result.get("action") != "store_provisional":
+                conflicts = self._conflict_service.find_conflicts(memory)
+                if conflicts:
+                    superseded_ids = self._conflict_service.supersede(
+                        conflicts, memory.id, namespace, self
+                    )
+
             return {
                 "id": memory.id,
                 "namespace": namespace,
@@ -72,6 +89,7 @@ class MemoryWriteService:
                 "confidence": memory.confidence,
                 "memory_status": memory.status,
                 "type": memory.type,
+                "superseded_ids": superseded_ids,
             }
 
         except Exception as e:
@@ -103,6 +121,7 @@ class MemoryWriteService:
             first_namespace = None
             results = []
             validated_documents = []
+            stored_memories: list[tuple[MemoryRecord, dict[str, Any]]] = []
 
             # Enforce server-side timestamps for batch (single timestamp for all)
             now = datetime.utcnow()
@@ -137,16 +156,11 @@ class MemoryWriteService:
                         )
                         continue
 
-                    # skip validation for speed
-                    ## Validate memory
-                    # validation_result = self.validation_service.validate_memory(memory, context)
-                    ## Use validated memory if modified
-                    # if "memory" in validation_result:
-                    #     memory = validation_result["memory"]
-                    validation_result = {
-                        "action": "store",
-                        "reason": "MVP direct store",
-                    }
+                    validation_result = self._validation_service.validate_memory(
+                        memory, context
+                    )
+                    if "memory" in validation_result:
+                        memory = validation_result["memory"]
 
                     from typing import cast
 
@@ -155,6 +169,7 @@ class MemoryWriteService:
                     # Convert to Moorcheh document
                     document = cast(Document, memory.to_moorcheh_document())
                     validated_documents.append(document)
+                    stored_memories.append((memory, validation_result))
 
                     # Store validation result for later
                     results.append(
@@ -195,6 +210,20 @@ class MemoryWriteService:
                 for result in results:
                     if result["status"] == "pending":
                         result["status"] = moorcheh_status
+
+                # Now that everything's durably written, check each stored
+                # memory against existing memories for conflicts. Skipped for
+                # provisional memories - unconfirmed info shouldn't supersede
+                # something already trusted. Same namespace for the whole
+                # batch, so this only needs first_namespace.
+                for memory, validation_result in stored_memories:
+                    if validation_result.get("action") == "store_provisional":
+                        continue
+                    conflicts = self._conflict_service.find_conflicts(memory)
+                    if conflicts:
+                        self._conflict_service.supersede(
+                            conflicts, memory.id, cast(str, first_namespace), self
+                        )
 
             # Count successes and failures
             successful = sum(1 for r in results if r["status"] in ["queued", "success"])
@@ -282,6 +311,9 @@ class MemoryWriteService:
                 confidence=updates.get("confidence", metadata.get("confidence", 0.8)),
                 status=updates.get("status", metadata.get("status", "active")),
                 tags=updates.get("tags", metadata.get("tags", [])),
+                superseded_by=updates.get(
+                    "superseded_by", metadata.get("superseded_by")
+                ),
             )
 
             # Update timestamps (preserve created_at, set updated_at to now)
@@ -306,39 +338,77 @@ class MemoryWriteService:
                 if metadata.get("expires_at"):
                     updated_memory.expires_at = metadata["expires_at"]
 
-            # Step 3: Delete old version
+            # Moorcheh doesn't support in-place updates, so a rewrite still
+            # needs a delete + re-upload under the same id somewhere in the
+            # process. The previous version of this method deleted the old
+            # doc *first*, which meant a failure on the re-upload (timeout,
+            # backend error, whatever) silently destroyed the memory with no
+            # way back. Instead:
+            #   1. upload the new content under a temporary id (old doc is
+            #      untouched the whole time - if this fails, nothing changed)
+            #   2. only once that's confirmed, delete the old doc
+            #   3. re-upload the new content under the real id
+            #   4. clean up the temporary copy
+            # If step 3 fails after step 2 succeeded, the original id is
+            # briefly gone, but the content isn't lost - it's sitting under
+            # the staging id, and the error says so.
             from typing import Any, cast
+
+            from moorcheh_sdk.types.document import Document
+
+            document = cast(Document, updated_memory.to_moorcheh_document())
+            staging_id = f"{memory_id}__staging_{uuid.uuid4().hex[:8]}"
+            staged_document = cast(Document, dict(document))
+            staged_document["id"] = staging_id
+
+            self.client.documents.upload(
+                namespace_name=namespace, documents=[staged_document]
+            )
 
             delete_result = cast(
                 dict[str, Any],
                 self.client.documents.delete(namespace_name=namespace, ids=[memory_id]),
             )
-
             if not self._deletion_succeeded(delete_result):
+                # Old doc is still there - just clean up the stray staged
+                # copy and bail, nothing lost either way.
+                try:
+                    self.client.documents.delete(
+                        namespace_name=namespace, ids=[staging_id]
+                    )
+                except Exception:
+                    pass
                 raise MemoryError(f"Failed to delete old version of memory {memory_id}")
 
-            validation_result = {"action": "store", "reason": "MVP direct store"}
+            try:
+                upload_result = self.client.documents.upload(
+                    namespace_name=namespace, documents=[document]
+                )
+            except Exception as promote_error:
+                raise MemoryError(
+                    f"Failed to finalize update for memory {memory_id}: "
+                    f"{promote_error}. The updated content was not lost - it's "
+                    f"stored under temporary id '{staging_id}' in namespace "
+                    f"'{namespace}'. Retry the update, or restore it manually."
+                )
 
-            # Step 4: Upload new version
-            from typing import cast
-
-            from moorcheh_sdk.types.document import Document
-
-            document = cast(Document, updated_memory.to_moorcheh_document())
-            upload_result = self.client.documents.upload(
-                namespace_name=namespace, documents=[document]
-            )
+            try:
+                self.client.documents.delete(namespace_name=namespace, ids=[staging_id])
+            except Exception:
+                # A leftover staging doc is clutter, not a correctness problem.
+                pass
 
             return {
                 "id": memory_id,
                 "namespace": namespace,
                 "status": upload_result.get("status", "unknown"),
                 "action": "updated",
-                "reason": "Memory updated successfully via delete-and-recreate",
-                "validation": validation_result.get("action", "validated"),
+                "reason": "Memory updated successfully via stage-then-swap",
                 "updated_fields": list(updates.keys()),
             }
 
+        except MemoryError:
+            raise
         except Exception as e:
             raise MemoryError(f"Failed to update memory: {e}")
 

--- a/tests/test_conflict_resolution.py
+++ b/tests/test_conflict_resolution.py
@@ -1,0 +1,202 @@
+"""
+Regression tests for the conflict-resolution / contradiction-handling fix
+and the update_memory data-loss fix (GitHub issue #1418).
+
+All use a mocked Moorcheh client - no live backend needed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.utils.errors import MemoryError
+
+
+def _mem(content, mtype="preference", confidence=0.9):
+    return MemoryRecord(
+        type=mtype,
+        title="t",
+        content=content,
+        agent_id="agent-1",
+        actor_id="user-1",
+        source="user",
+        confidence=confidence,
+    )
+
+
+class TestConflictResolution:
+    def test_conflicting_memory_supersedes_previous_active_one(self):
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "success"}
+        client.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": ["old-1"],
+        }
+
+        # When the second memory is stored, the similarity search that backs
+        # conflict detection returns the first as a high-similarity, same-type
+        # active neighbour. Returning it twice also means the validation
+        # repetition-check sees corroboration, so the new memory is stored as
+        # a full (non-provisional) memory and is allowed to supersede.
+        client.similarity_search.query.return_value = {
+            "results": [
+                {
+                    "id": "old-1",
+                    "score": 0.95,
+                    "metadata": {"memory_type": "preference", "status": "active"},
+                },
+                {
+                    "id": "old-2",
+                    "score": 0.9,
+                    "metadata": {"memory_type": "preference", "status": "active"},
+                },
+            ]
+        }
+
+        svc = MemoryWriteService(client)
+        # get_memory is used by update_memory (invoked during supersede)
+        from memanto.app.services import memory_read_service
+
+        memory_read_service.MemoryReadService.get_memory = lambda self, mid, ns: {
+            "id": mid,
+            "type": "preference",
+            "title": "t",
+            "content": "old",
+            "scope_type": "agent",
+            "scope_id": "agent-1",
+            "actor_id": "user-1",
+            "source": "user",
+            "confidence": 0.9,
+            "status": "active",
+            "tags": [],
+        }
+
+        result = svc.store_memory(_mem("The user's favorite color is red."))
+
+        assert "old-1" in result["superseded_ids"]
+
+    def test_no_conflict_when_types_differ(self):
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "success"}
+        client.similarity_search.query.return_value = {
+            "results": [
+                {
+                    "id": "other",
+                    "score": 0.99,
+                    "metadata": {"memory_type": "fact", "status": "active"},
+                }
+            ]
+        }
+
+        svc = MemoryWriteService(client)
+        result = svc.store_memory(_mem("A preference", mtype="preference"))
+
+        # Different memory_type -> not treated as a conflict
+        assert result["superseded_ids"] == []
+
+    def test_low_similarity_is_not_a_conflict(self):
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "success"}
+        client.similarity_search.query.return_value = {
+            "results": [
+                {
+                    "id": "unrelated",
+                    "score": 0.2,
+                    "metadata": {"memory_type": "preference", "status": "active"},
+                }
+            ]
+        }
+
+        svc = MemoryWriteService(client)
+        result = svc.store_memory(_mem("Totally unrelated preference"))
+
+        assert result["superseded_ids"] == []
+
+
+class TestUpdateMemoryNoDataLoss:
+    def test_failed_promotion_does_not_lose_data(self):
+        """If the final re-upload under the real id fails, the update must
+        raise - but the content must survive under the staging id, and the
+        error must say where."""
+        client = MagicMock()
+        client.similarity_search.query.return_value = {"results": []}
+        client.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": ["mem-1"],
+        }
+
+        # First upload (staging) succeeds; second upload (promotion) fails.
+        client.documents.upload.side_effect = [
+            {"status": "queued"},
+            ConnectionError("Moorcheh upload timed out"),
+        ]
+
+        from memanto.app.services import memory_read_service
+
+        memory_read_service.MemoryReadService.get_memory = lambda self, mid, ns: {
+            "id": mid,
+            "type": "fact",
+            "title": "t",
+            "content": "original",
+            "scope_type": "agent",
+            "scope_id": "agent-1",
+            "actor_id": "user-1",
+            "source": "user",
+            "confidence": 0.9,
+            "status": "active",
+            "tags": [],
+        }
+
+        svc = MemoryWriteService(client)
+        with pytest.raises(MemoryError) as exc:
+            svc.update_memory(
+                "mem-1", "memanto_agent_agent-1", {"content": "new content"}
+            )
+
+        # The staging id is surfaced so the data is recoverable, not silently gone
+        assert "staging" in str(exc.value)
+
+        # And critically: the staged copy was written BEFORE the old doc was
+        # deleted, so at no point did both the original and the replacement
+        # cease to exist.
+        first_upload_docs = client.documents.upload.call_args_list[0].kwargs["documents"]
+        assert first_upload_docs[0]["id"].startswith("mem-1__staging_")
+
+    def test_successful_update_cleans_up_staging(self):
+        client = MagicMock()
+        client.similarity_search.query.return_value = {"results": []}
+        client.documents.delete.return_value = {
+            "status": "success",
+            "deleted_ids": ["mem-1"],
+        }
+        client.documents.upload.return_value = {"status": "queued"}
+
+        from memanto.app.services import memory_read_service
+
+        memory_read_service.MemoryReadService.get_memory = lambda self, mid, ns: {
+            "id": mid,
+            "type": "fact",
+            "title": "t",
+            "content": "original",
+            "scope_type": "agent",
+            "scope_id": "agent-1",
+            "actor_id": "user-1",
+            "source": "user",
+            "confidence": 0.9,
+            "status": "active",
+            "tags": [],
+        }
+
+        svc = MemoryWriteService(client)
+        result = svc.update_memory(
+            "mem-1", "memanto_agent_agent-1", {"content": "new content"}
+        )
+
+        assert result["action"] == "updated"
+        # Staging doc gets cleaned up: a delete call targets a staging id
+        deleted_ids = [
+            c.kwargs.get("ids", [None])[0] for c in client.documents.delete.call_args_list
+        ]
+        assert any(str(i).startswith("mem-1__staging_") for i in deleted_ids)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -329,6 +329,8 @@ class TestMemoryWriteServiceDelete:
             "deleted_ids": ["mem-1"],
         }
         client.documents.upload.return_value = {"status": "queued"}
+        # No conflicting neighbours - keep the update path deterministic.
+        client.similarity_search.query.return_value = {"results": []}
         existing_memory = {
             "id": "mem-1",
             "type": "fact",
@@ -355,10 +357,13 @@ class TestMemoryWriteServiceDelete:
 
         assert result["action"] == "updated"
         assert result["status"] == "queued"
-        client.documents.delete.assert_called_once_with(
-            namespace_name="memanto_agent_test-agent", ids=["mem-1"]
-        )
-        client.documents.upload.assert_called_once()
+        # The old doc must still be deleted under its real id at some point.
+        delete_calls = [
+            c.kwargs.get("ids") for c in client.documents.delete.call_args_list
+        ]
+        assert ["mem-1"] in delete_calls
+        # And the new content is uploaded (staging + final promotion).
+        assert client.documents.upload.call_count >= 1
 
 
 class TestMemoryReadServiceFormatting:


### PR DESCRIPTION
Fixes #1418.

What was broken
Two issues in memory_write_service.py, both traced in #1418:

Conflict resolution didn't run at all. store_memory() and batch_store_memories() hard-coded {"action": "store", "reason": "MVP direct store"} and never called any validation or contradiction handling. The ValidationPolicy class that the validation service depended on had been removed from core.py, so app/legacy/memory_validation_service.py couldn't even be imported. Two directly contradictory memories were both stored active with unchanged confidence and no supersede link.

update_memory() could permanently lose data. It deleted the old document before confirming the new version uploaded. Any failure on the re-upload (timeout, backend 5xx) left the memory gone with no rollback.

What this changes
Re-adds ValidationPolicy to core.py — a lightweight, no-LLM policy keyed off settings.REQUIRE_VALIDATION_FOR. Critical memory types (fact, preference) that aren't corroborated or from a trusted source are stored provisional (capped confidence + TTL) rather than trusted outright.
Adds superseded_by to MemoryRecord.
Adds a working MemoryValidationService and a new ConflictResolutionService on the active services/ path. The orphaned legacy/ modules are left untouched.
Wires both into the write path: after a non-provisional memory is durably stored, any existing active, same-type, high-similarity memory (threshold via new CONFLICT_SIMILARITY_THRESHOLD setting, default 0.82) is marked superseded. Provisional (unconfirmed) writes deliberately don't supersede trusted data.
Rewrites update_memory() as stage-then-swap: upload the new content under a temporary id first, then delete the old doc, then promote to the real id, then clean up staging. A failure at any point leaves the content recoverable — never a state where the memory simply doesn't exist. The error message surfaces the staging id.
Design notes / open questions for maintainers
Conflict detection here is similarity-based, not semantic — it treats "another high-confidence, same-type memory about the same subject just arrived" as "the old one is stale," matching the freshness behavior already advertised, without adding an LLM call to every write. A stricter mode that actually asks a model "do these two conflict?" could be layered on top behind its own setting if you want higher precision at the cost of write latency. Happy to iterate on which behavior you'd prefer as the default.
Thresholds (CONFLICT_SIMILARITY_THRESHOLD, provisional caps) are exposed as settings so they're tunable without code changes.
Tests
New tests/test_conflict_resolution.py (5 tests): supersede-on-conflict, no-conflict-across-types, low-similarity-ignored, and two update_memory data-safety tests (failed promotion keeps data under staging id; successful update cleans up staging).
Updated the existing update_memory unit test to the new stage-then-swap contract.
Full suite passes locally (252 passed, 24 live-backend E2E skipped without an API key).
All reproducible against a mocked Moorcheh client — no live backend required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added similarity-based conflict detection for newly saved memories, with automatic superseding of older active matches.
  * Introduced conflict resolution configuration to tune the similarity threshold.
  * Added provisional storage for memory types that require additional validation before final persistence.
* **Bug Fixes**
  * Made memory updates safer via a stage-then-swap workflow to prevent data loss on partial failures.
  * Ensured update responses no longer include legacy validation details, returning update action/reason and updated fields instead.
* **Tests**
  * Added regression tests covering conflict superseding and staged-artifact recovery/cleanup on failed and successful updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->