### PR TITLE
fix: require management auth for agent lifecycle endpoints

### DIFF
--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -73,13 +73,108 @@ def get_moorcheh_api_key() -> str:
     )
 
 
-def verify_moorcheh_api_key() -> str:
-    """
-    Return configured Moorcheh API key.
+def _extract_presented_credential(
+    authorization: str | None,
+    x_api_key: str | None,
+) -> str | None:
+    """Extract a client-presented management credential from request headers."""
+    if x_api_key and x_api_key.strip():
+        return x_api_key.strip()
+    if authorization:
+        parts = authorization.split(None, 1)
+        if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1].strip():
+            return parts[1].strip()
+    return None
 
-    Runtime connectivity is validated at startup and via /health.
+
+def _is_loopback_host(host: str | None) -> bool:
+    """Return True when *host* is a loopback address (IPv4/IPv6/mapped)."""
+    if not host:
+        return False
+    import ipaddress
+
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if addr.is_loopback:
+        return True
+    ipv4_mapped = getattr(addr, "ipv4_mapped", None)
+    return ipv4_mapped is not None and ipv4_mapped.is_loopback
+
+
+def require_management_access(
+    request: Request,
+    authorization: str | None = Header(None),
+    x_api_key: str | None = Header(None, alias="X-Api-Key"),
+) -> str:
+    """Authorize agent-lifecycle / management endpoints.
+
+    MEMANTO is a single-tenant companion service. Agent create/list/delete/
+    activate endpoints previously only checked that the *server* had a
+    configured API key, not that the *caller* was authorized. Combined with
+    the default ``HOST=0.0.0.0`` bind (see Settings / docker-compose), any
+    network peer could create agents, activate sessions, and obtain
+    ``session_token`` values for memory read/write.
+
+    Access is granted when either:
+
+    1. The caller presents the server management credential
+       (``Authorization: Bearer <key>`` or ``X-Api-Key``), matched with
+       ``secrets.compare_digest`` against the configured cloud API key, or
+       against ``MEMANTO_SECRET_KEY`` for on-prem; or
+    2. The request originates from the loopback interface (local desktop
+       CLI / browser UX without forcing every local call to attach a key).
+
+    Returns the server-side Moorcheh credential string used by downstream
+    service calls (same contract as ``get_moorcheh_api_key``).
     """
-    return get_moorcheh_api_key()
+    import secrets
+
+    from memanto.app.clients.backend import Backend, parse_backend
+    from memanto.app.config import settings
+
+    server_key = get_moorcheh_api_key()
+    presented = _extract_presented_credential(authorization, x_api_key)
+    backend = parse_backend(settings.MEMANTO_BACKEND)
+
+    expected: str | None
+    if backend == Backend.ON_PREM:
+        # On-prem has no cloud API key; use the JWT/session secret as the
+        # management shared secret when one is configured.
+        expected = (settings.MEMANTO_SECRET_KEY or "").strip() or None
+    else:
+        expected = server_key if server_key and server_key != "on-prem" else None
+
+    if presented and expected and secrets.compare_digest(presented, expected):
+        return server_key
+
+    client_host = request.client.host if request.client else None
+    if _is_loopback_host(client_host):
+        return server_key
+
+    raise HTTPException(
+        status_code=401,
+        detail=(
+            "Unauthorized. Agent management endpoints require either a "
+            "loopback client or a valid management credential "
+            "(Authorization: Bearer <key> or X-Api-Key)."
+        ),
+    )
+
+
+def verify_moorcheh_api_key(
+    request: Request,
+    authorization: str | None = Header(None),
+    x_api_key: str | None = Header(None, alias="X-Api-Key"),
+) -> str:
+    """Authorize management access and return the server Moorcheh credential.
+
+    Kept as a thin wrapper so existing ``Depends(verify_moorcheh_api_key)``
+    call sites pick up the new authorization rules without signature churn
+    at every route.
+    """
+    return require_management_access(request, authorization, x_api_key)
 
 
 def get_current_session(

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -81,7 +81,7 @@ async def _namespace_item_counts(moorcheh_api_key: str) -> dict[str, int]:
 
 @router.post("/agents", response_model=AgentInfo, status_code=201)
 async def create_agent(
-    agent_create: AgentCreate, moorcheh_api_key: str = Depends(get_moorcheh_api_key)
+    agent_create: AgentCreate, moorcheh_api_key: str = Depends(verify_moorcheh_api_key)
 ):
     """
     Create a new MEMANTO agent
@@ -266,11 +266,14 @@ async def deactivate_agent(
 
 
 @router.get("/status", response_model=SessionInfo)
-async def get_status():
+async def get_status(
+    _moorcheh_api_key: str = Depends(verify_moorcheh_api_key),
+):
     """
     Get current active session status.
 
-    No parameters required — reads the active session from local state.
+    Requires management credential or loopback origin (same as other
+    agent-lifecycle endpoints). Reads the active session from local state.
     """
     session = get_session_service().get_active_session()
     if session is None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,15 +163,18 @@ class TestMEMANTOAPI:
         assert "metadata" not in data
 
     @pytest.mark.asyncio
-    async def test_create_agent_without_authorization_header(self, client):
-        """Test creating a new agent using server-configured API key"""
-        payload = {
-            "agent_id": "server-key-agent",
-            "pattern": "support",
-        }
-        response = await client.post("/api/v2/agents", json=payload)
-        assert response.status_code == 201
-        assert response.json()["agent_id"] == "server-key-agent"
+    async def test_create_agent_without_authorization_header_is_rejected(self):
+        """Non-loopback callers must present a management credential."""
+        # httpx ASGITransport defaults to client 127.0.0.1 (loopback). Force a
+        # remote peer so we exercise the network-facing auth path.
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            payload = {
+                "agent_id": "server-key-agent",
+                "pattern": "support",
+            }
+            response = await remote.post("/api/v2/agents", json=payload)
+            assert response.status_code == 401
 
     @pytest.mark.asyncio
     async def test_create_agent_fails_when_server_key_missing(self, client):
@@ -183,6 +186,56 @@ class TestMEMANTOAPI:
         with patch.object(settings, "MOORCHEH_API_KEY", ""):
             response = await client.post("/api/v2/agents", json=payload)
         assert response.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_remote_create_agent_requires_matching_credential(self):
+        """Bearer token must match the configured management key."""
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            payload = {"agent_id": "wrong-key-agent", "pattern": "support"}
+            response = await remote.post(
+                "/api/v2/agents",
+                headers={"Authorization": "Bearer totally-wrong-key"},
+                json=payload,
+            )
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_remote_activate_without_credential_is_rejected(
+        self, client, auth_headers
+    ):
+        """Activation from a non-loopback client requires management credential."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": "activate-auth-agent", "pattern": "support"},
+        )
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            response = await remote.post("/api/v2/agents/activate-auth-agent/activate")
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_remote_create_with_valid_credential_succeeds(self, auth_headers):
+        """Remote peer with the correct management key can still manage agents."""
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            response = await remote.post(
+                "/api/v2/agents",
+                headers=auth_headers,
+                json={"agent_id": "remote-ok-agent", "pattern": "support"},
+            )
+            assert response.status_code == 201
+            assert response.json()["agent_id"] == "remote-ok-agent"
+
+    @pytest.mark.asyncio
+    async def test_status_requires_management_access(self):
+        """Active session status must not be readable by unauthenticated remote peers."""
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            response = await remote.get("/api/v2/status")
+            assert response.status_code == 401
+
 
     @pytest.mark.asyncio
     async def test_list_agents(self, client, auth_headers):
@@ -643,7 +696,7 @@ class TestMEMANTOAPI:
         )
 
         assert response.status_code == 200
-        status_resp = await client.get("/api/v2/status")
+        status_resp = await client.get("/api/v2/status", headers=auth_headers)
         assert status_resp.status_code == 404
 
         stale_headers = {**auth_headers, "X-Session-Token": token}
@@ -744,7 +797,7 @@ class TestMEMANTOAPI:
             f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
         )
 
-        response = await client.get("/api/v2/status")
+        response = await client.get("/api/v2/status", headers=auth_headers)
         assert response.status_code == 200
         data = response.json()
         assert data["agent_id"] == self.TEST_AGENT_ID
@@ -867,9 +920,9 @@ class TestMEMANTOAPI:
         mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_global_status_no_active_session(self, client):
+    async def test_global_status_no_active_session(self, client, auth_headers):
         """Test GET /api/v2/status returns 404 when no session is active"""
-        response = await client.get("/api/v2/status")
+        response = await client.get("/api/v2/status", headers=auth_headers)
         assert response.status_code == 404
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## fix: require management auth for agent lifecycle endpoints

### Summary
- Agent create/list/delete/activate previously only checked that the **server** had `MOORCHEH_API_KEY` configured, not that the **caller** was authorized.
- Default bind is `HOST=0.0.0.0` and docker-compose publishes `:8000`, so any network peer could mint agents + `session_token`s and then R/W memory under the server API key.
- `/api/v2/status` was fully unauthenticated and leaked active session metadata.

### Fix
- `verify_moorcheh_api_key` / new `require_management_access` requires either:
  - matching management credential (`Authorization: Bearer` or `X-Api-Key`) via `secrets.compare_digest`, or
  - a loopback client (local CLI/UI).
- `create_agent` and `/status` use the same gate.
- Regression tests use a non-loopback ASGI client (`203.0.113.10`) to assert 401 without credentials and 201 with the correct key.

### Test plan
- [x] `pytest tests/test_api.py` (93 passed in researcher env)
- [x] Remote unauthenticated create/activate/status → 401
- [x] Remote with correct Bearer → 201
- [x] Existing session-token memory tests still pass

### Security
- Coordinated disclosure; please review privately if this PR was opened after advisory acceptance.
- Refs: CWE-306, CWE-862; bounty tracker #770

### Notes for reviewers
- Loopback exception preserves local desktop UX without forcing every `curl localhost` to attach a key.
- On-prem uses `MEMANTO_SECRET_KEY` as the management shared secret when set.
- Happy to tighten further (e.g. require credential even on loopback, or bind default to `127.0.0.1`) if you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added management access controls for agent creation, activation, and status endpoints.
  * Requests can authenticate using an API key or Bearer token.
  * Local requests remain available without credentials where permitted.

* **Bug Fixes**
  * Remote unauthenticated requests to protected management endpoints are now rejected.
  * Valid management credentials continue to allow authorized remote operations.

* **Tests**
  * Expanded coverage for local, remote, authenticated, and unauthenticated access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->