### PR TITLE
Use unique on-prem upload staging paths

### DIFF
--- a/memanto/app/clients/onprem.py
+++ b/memanto/app/clients/onprem.py
@@ -77,6 +77,7 @@ class _DocumentsAdapter:
         job was accepted, not that indexing has completed.
         """
         import shutil
+        import uuid
 
         ensure_upload_dir, host_path_to_container_upload_path = (
             _import_docker_runtime_helpers()
@@ -87,9 +88,9 @@ class _DocumentsAdapter:
             raise FileNotFoundError(f"upload_file: not a file: {src}")
 
         upload_root = ensure_upload_dir()
-        host_file = (upload_root / src.name).resolve()
-        if host_file != src:
-            shutil.copy2(src, host_file)
+        staged_name = f"{src.stem}-{uuid.uuid4().hex}{src.suffix}"
+        host_file = (upload_root / staged_name).resolve()
+        shutil.copy2(src, host_file)
         container_path = host_path_to_container_upload_path(host_file, upload_root)
 
         resp = self._raw.files.upload(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -108,6 +108,56 @@ class TestOnPremClient:
             result = client.answer.generate(namespace="x", query="y")
             assert result == {"answer": "ok", "namespace": "x"}
 
+    def test_upload_file_uses_distinct_staging_paths_for_same_basename(self, tmp_path):
+        """On-prem file uploads are async, so same-basename sources must not
+        share one staging path under ~/.moorcheh/uploads."""
+        from memanto.app.clients import onprem
+
+        class _FakeFiles:
+            def __init__(self):
+                self.uploaded_paths = []
+
+            def upload(self, namespace_name, files):
+                self.uploaded_paths.append(files[0]["path"])
+                return {"message": f"accepted {namespace_name}"}
+
+        class _FakeRaw:
+            def __init__(self):
+                self.documents = object()
+                self.files = _FakeFiles()
+
+        upload_root = tmp_path / "uploads"
+        first_dir = tmp_path / "first"
+        second_dir = tmp_path / "second"
+        first_dir.mkdir()
+        second_dir.mkdir()
+        first = first_dir / "notes.txt"
+        second = second_dir / "notes.txt"
+        first.write_text("first payload", encoding="utf-8")
+        second.write_text("second payload", encoding="utf-8")
+
+        raw = _FakeRaw()
+
+        def ensure_upload_root():
+            upload_root.mkdir(parents=True, exist_ok=True)
+            return upload_root
+
+        with patch.object(
+            onprem,
+            "_import_docker_runtime_helpers",
+            return_value=(
+                ensure_upload_root,
+                lambda host_file, _root: str(host_file),
+            ),
+        ):
+            adapter = onprem._DocumentsAdapter(raw)
+            adapter.upload_file("memanto_agent_test", first)
+            adapter.upload_file("memanto_agent_test", second)
+
+        assert len(raw.files.uploaded_paths) == 2
+        assert raw.files.uploaded_paths[0] != raw.files.uploaded_paths[1]
+        assert {p.name for p in upload_root.iterdir()} != {"notes.txt"}
+
 
 class TestSingletonDispatch:
     def test_cloud_returns_cloud_client(self):


### PR DESCRIPTION
## Summary
- Stage on-prem uploads under unique filenames before submitting them to the on-prem file API.
- Preserve the user-facing original file name in the upload response.
- Add regression coverage for two different source files with the same basename.

## Repro
1. Create two different files at `first/notes.txt` and `second/notes.txt`.
2. Upload both to an on-prem Memanto namespace back-to-back.
3. Before this fix, both accepted jobs point at the same staged `~/.moorcheh/uploads/notes.txt` path, so the second copy can overwrite the first before async indexing reads it.
4. After this fix, each accepted job receives a distinct staged path.

## Tests
- `uv run pytest tests/test_backend.py::TestOnPremClient::test_upload_file_uses_distinct_staging_paths_for_same_basename -q`
- `uv run pytest tests/test_backend.py tests/test_cli.py::TestMEMANTOCLI::test_upload_file_sdk_accepts_snake_case_file_size -q`
- `uv run pytest tests -q` (live E2E skipped because the configured API key is missing or placeholder `test-api-key`)
- `uv run ruff check .`
- `uv run ruff format --check memanto/app/clients/onprem.py tests/test_backend.py`
- `git diff --check HEAD~1..HEAD`

Bounty: #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed on-premises file uploads so files with the same name no longer overwrite one another during staging.
  * Ensured each uploaded file is staged separately before being sent.

* **Tests**
  * Added coverage verifying distinct staging paths are used for same-named files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->