### PR TITLE
fix(conversation): preserve recent turns when extraction hits the context limit

### DIFF
--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -75,13 +75,24 @@ class ConversationMemoryExtractionService:
     def _conversation_text(self, messages: list[dict[str, str]]) -> str:
         lines: list[str] = []
         total = 0
-        for message in messages:
+        # Recent turns usually contain the latest decisions and corrections.
+        # Build from the end, then restore chronological order for the model.
+        for message in reversed(messages):
             line = f"{message['role'].strip()}: {message['content'].strip()}"
-            total += len(line)
-            if total > self.MAX_CONTENT_CHARS:
+            separator_length = 1 if lines else 0
+            remaining = self.MAX_CONTENT_CHARS - total - separator_length
+            if remaining <= 0:
                 break
+
+            truncated = len(line) > remaining
+            if truncated:
+                line = line[:remaining]
             lines.append(line)
-        return "\n".join(lines)
+            total += separator_length + len(line)
+            if truncated:
+                break
+
+        return "\n".join(reversed(lines))
 
     def _header_prompt(self, max_memories: int) -> str:
         memory_types = ", ".join(sorted(VALID_MEMORY_TYPES))

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -95,3 +95,19 @@ def test_extract_requires_messages():
 
     with pytest.raises(ValueError, match="at least one message"):
         service.extract(namespace="memanto_agent_test", messages=[])
+
+
+def test_conversation_text_preserves_latest_messages_when_budget_is_exceeded():
+    service = ConversationMemoryExtractionService(FakeClient("[]"))
+    latest_decision = "FINAL DECISION: deploy to Tokyo on Friday"
+    messages = [
+        {"role": "user", "content": "old context " + ("x" * 12_000)},
+        {"role": "assistant", "content": "acknowledged"},
+        {"role": "user", "content": latest_decision},
+    ]
+
+    query = service._conversation_text(messages)
+
+    assert len(query) <= service.MAX_CONTENT_CHARS
+    assert latest_decision in query
+    assert query.endswith(f"user: {latest_decision}")


### PR DESCRIPTION
### Summary

Conversation memory extraction processed messages from oldest to newest and stopped once the 12,000-character budget was exceeded. A long early message could therefore remove every recent turn from the extraction query, including the user's latest decisions and corrections.

This change builds the bounded query from the newest messages first, then restores chronological order before sending it to the model.

### Impact

This is a memory-integrity and retrieval-accuracy flaw in long conversations. The extractor could save stale context while silently missing the newest durable information.

### Reproduction

```python
from memanto.app.services.conversation_memory_extraction_service import (
    ConversationMemoryExtractionService,
)

service = ConversationMemoryExtractionService(None)
latest_decision = "FINAL DECISION: deploy to Tokyo on Friday"
messages = [
    {"role": "user", "content": "old context " + ("x" * 12_000)},
    {"role": "assistant", "content": "acknowledged"},
    {"role": "user", "content": latest_decision},
]

query = service._conversation_text(messages)
assert latest_decision in query
```

On `main`, `query` is empty and the assertion fails. With this fix, the query stays within the configured budget and ends with the latest decision.

### Fix

- Select messages from newest to oldest until the character budget is full.
- Restore chronological order before model inference.
- Truncate only the boundary message when needed.
- Add a regression test proving that the latest decision survives an over-budget conversation.

### Relation to Existing Work

Open PR #1325 prevents an overlong first message from producing an empty query, but it keeps the oldest-first selection order. Recent decisions can therefore still be excluded whenever earlier turns fill the budget. This PR fixes that separate priority problem.

### Validation

- `python -m pytest -q`: 274 passed, 24 live Moorcheh E2E tests skipped because no API key was configured.
- `python -m ruff check .`: passed.
- `python -m ruff format --check ...`: passed for both changed files.
- `git diff --check`: passed.
- Additional boundary checks passed for normal ordering, 200-message input, and a single overlong message.

Related bounty: #770

Disclosure: I found this bounty manually. Codex assisted me with the implementation, test design, and validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation memory extraction now prioritizes the most recent messages when content exceeds the size limit.
  * Truncated conversation text maintains chronological order and includes the latest user message.

* **Tests**
  * Added coverage to verify message prioritization and accurate length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->