### PR TITLE
On prem/merge prs

### DIFF
--- a/memanto/app/clients/onprem.py
+++ b/memanto/app/clients/onprem.py
@@ -77,6 +77,7 @@ class _DocumentsAdapter:
         job was accepted, not that indexing has completed.
         """
         import shutil
+        import uuid
 
         ensure_upload_dir, host_path_to_container_upload_path = (
             _import_docker_runtime_helpers()
@@ -87,9 +88,9 @@ class _DocumentsAdapter:
             raise FileNotFoundError(f"upload_file: not a file: {src}")
 
         upload_root = ensure_upload_dir()
-        host_file = (upload_root / src.name).resolve()
-        if host_file != src:
-            shutil.copy2(src, host_file)
+        staged_name = f"{src.stem}-{uuid.uuid4().hex}{src.suffix}"
+        host_file = (upload_root / staged_name).resolve()
+        shutil.copy2(src, host_file)
         container_path = host_path_to_container_upload_path(host_file, upload_root)
 
         resp = self._raw.files.upload(

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -73,13 +73,108 @@ def get_moorcheh_api_key() -> str:
     )
 
 
-def verify_moorcheh_api_key() -> str:
-    """
-    Return configured Moorcheh API key.
+def _extract_presented_credential(
+    authorization: str | None,
+    x_api_key: str | None,
+) -> str | None:
+    """Extract a client-presented management credential from request headers."""
+    if x_api_key and x_api_key.strip():
+        return x_api_key.strip()
+    if authorization:
+        parts = authorization.split(None, 1)
+        if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1].strip():
+            return parts[1].strip()
+    return None
 
-    Runtime connectivity is validated at startup and via /health.
+
+def _is_loopback_host(host: str | None) -> bool:
+    """Return True when *host* is a loopback address (IPv4/IPv6/mapped)."""
+    if not host:
+        return False
+    import ipaddress
+
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if addr.is_loopback:
+        return True
+    ipv4_mapped = getattr(addr, "ipv4_mapped", None)
+    return ipv4_mapped is not None and ipv4_mapped.is_loopback
+
+
+def require_management_access(
+    request: Request,
+    authorization: str | None = Header(None),
+    x_api_key: str | None = Header(None, alias="X-Api-Key"),
+) -> str:
+    """Authorize agent-lifecycle / management endpoints.
+
+    MEMANTO is a single-tenant companion service. Agent create/list/delete/
+    activate endpoints previously only checked that the *server* had a
+    configured API key, not that the *caller* was authorized. Combined with
+    the default ``HOST=0.0.0.0`` bind (see Settings / docker-compose), any
+    network peer could create agents, activate sessions, and obtain
+    ``session_token`` values for memory read/write.
+
+    Access is granted when either:
+
+    1. The caller presents the server management credential
+       (``Authorization: Bearer <key>`` or ``X-Api-Key``), matched with
+       ``secrets.compare_digest`` against the configured cloud API key, or
+       against ``MEMANTO_SECRET_KEY`` for on-prem; or
+    2. The request originates from the loopback interface (local desktop
+       CLI / browser UX without forcing every local call to attach a key).
+
+    Returns the server-side Moorcheh credential string used by downstream
+    service calls (same contract as ``get_moorcheh_api_key``).
     """
-    return get_moorcheh_api_key()
+    import secrets
+
+    from memanto.app.clients.backend import Backend, parse_backend
+    from memanto.app.config import settings
+
+    server_key = get_moorcheh_api_key()
+    presented = _extract_presented_credential(authorization, x_api_key)
+    backend = parse_backend(settings.MEMANTO_BACKEND)
+
+    expected: str | None
+    if backend == Backend.ON_PREM:
+        # On-prem has no cloud API key; use the JWT/session secret as the
+        # management shared secret when one is configured.
+        expected = (settings.MEMANTO_SECRET_KEY or "").strip() or None
+    else:
+        expected = server_key if server_key and server_key != "on-prem" else None
+
+    if presented and expected and secrets.compare_digest(presented, expected):
+        return server_key
+
+    client_host = request.client.host if request.client else None
+    if _is_loopback_host(client_host):
+        return server_key
+
+    raise HTTPException(
+        status_code=401,
+        detail=(
+            "Unauthorized. Agent management endpoints require either a "
+            "loopback client or a valid management credential "
+            "(Authorization: Bearer <key> or X-Api-Key)."
+        ),
+    )
+
+
+def verify_moorcheh_api_key(
+    request: Request,
+    authorization: str | None = Header(None),
+    x_api_key: str | None = Header(None, alias="X-Api-Key"),
+) -> str:
+    """Authorize management access and return the server Moorcheh credential.
+
+    Kept as a thin wrapper so existing ``Depends(verify_moorcheh_api_key)``
+    call sites pick up the new authorization rules without signature churn
+    at every route.
+    """
+    return require_management_access(request, authorization, x_api_key)
 
 
 def get_current_session(

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -709,7 +709,7 @@ async def answer(
         if request.temperature is not None
         else settings.ANSWER_TEMPERATURE
     )
-    ai_model = (
+    resolved_ai_model = (
         request.ai_model
         if request.ai_model is not None
         else get_active_llm_model(settings.ANSWER_MODEL)
@@ -740,11 +740,12 @@ async def answer(
             "query": request.question,
             "top_k": limit,
             "temperature": temperature,
-            "ai_model": ai_model,
             "kiosk_mode": request.kiosk_mode,
             "header_prompt": header_prompt,
             "footer_prompt": footer_prompt,
         }
+        if resolved_ai_model is not None:
+            generate_kwargs["ai_model"] = resolved_ai_model
         if request.kiosk_mode:
             generate_kwargs["threshold"] = (
                 request.threshold if request.threshold is not None else 0.15

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -250,20 +250,10 @@ async def deactivate_agent(
         )
 
     try:
-        # Snapshot namespace document count before and after ending the session
-        # so end_session() receives an accurate memories_created value.
-        # _namespace_item_counts is best-effort; returns {} if Moorcheh is
-        # unreachable, so the count safely falls back to 0.
-        counts_before = await _namespace_item_counts(_server_api_key)
-        count_before = counts_before.get(session.namespace, 0)
-
-        counts_after = await _namespace_item_counts(_server_api_key)
-        count_after = counts_after.get(session.namespace, 0)
-        memories_created = max(0, count_after - count_before)
-
-        summary = get_session_service().end_session(
-            agent_id, memories_created=memories_created
-        )
+        # end_session_async() fetches the live Moorcheh namespace count and
+        # injects it as memories_created — logic owned by the service so all
+        # callers (HTTP + future CLI) get accurate counts.
+        summary = await get_session_service().end_session_async(agent_id)
         return summary
     except SessionNotFoundError as e:
         raise map_error_to_http_exception(e)

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -81,7 +81,7 @@ async def _namespace_item_counts(moorcheh_api_key: str) -> dict[str, int]:
 
 @router.post("/agents", response_model=AgentInfo, status_code=201)
 async def create_agent(
-    agent_create: AgentCreate, moorcheh_api_key: str = Depends(get_moorcheh_api_key)
+    agent_create: AgentCreate, moorcheh_api_key: str = Depends(verify_moorcheh_api_key)
 ):
     """
     Create a new MEMANTO agent
@@ -266,11 +266,14 @@ async def deactivate_agent(
 
 
 @router.get("/status", response_model=SessionInfo)
-async def get_status():
+async def get_status(
+    _moorcheh_api_key: str = Depends(verify_moorcheh_api_key),
+):
     """
     Get current active session status.
 
-    No parameters required — reads the active session from local state.
+    Requires management credential or loopback origin (same as other
+    agent-lifecycle endpoints). Reads the active session from local state.
     """
     session = get_session_service().get_active_session()
     if session is None:

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -37,7 +37,6 @@ from memanto.app.routes import memory  # noqa: E402
 from memanto.app.routes.auth_deps import (  # noqa: E402
     clear_session_cookie,
     get_current_session,
-    get_moorcheh_api_key,
     get_session_service,
     set_session_cookie,
     verify_moorcheh_api_key,

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -257,10 +257,7 @@ async def deactivate_agent(
         )
 
     try:
-        # end_session_async() fetches the live Moorcheh namespace count and
-        # injects it as memories_created — logic owned by the service so all
-        # callers (HTTP + future CLI) get accurate counts.
-        summary = await get_session_service().end_session_async(agent_id)
+        summary = get_session_service().end_session(agent_id)
         clear_session_cookie(response)
         return summary
     except SessionNotFoundError as e:

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -250,7 +250,17 @@ async def deactivate_agent(
         )
 
     try:
+        # Snapshot memory count before and after to compute memories_created.
+        # _namespace_item_counts is best-effort; falls back to 0 if unreachable.
+        counts_before = await _namespace_item_counts(_server_api_key)
+        count_before = counts_before.get(session.namespace, 0)
+
         summary = get_session_service().end_session(agent_id)
+
+        counts_after = await _namespace_item_counts(_server_api_key)
+        count_after = counts_after.get(session.namespace, 0)
+        summary.memories_created = max(0, count_after - count_before)
+
         return summary
     except SessionNotFoundError as e:
         raise map_error_to_http_exception(e)

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -250,17 +250,20 @@ async def deactivate_agent(
         )
 
     try:
-        # Snapshot memory count before and after to compute memories_created.
-        # _namespace_item_counts is best-effort; falls back to 0 if unreachable.
+        # Snapshot namespace document count before and after ending the session
+        # so end_session() receives an accurate memories_created value.
+        # _namespace_item_counts is best-effort; returns {} if Moorcheh is
+        # unreachable, so the count safely falls back to 0.
         counts_before = await _namespace_item_counts(_server_api_key)
         count_before = counts_before.get(session.namespace, 0)
 
-        summary = get_session_service().end_session(agent_id)
-
         counts_after = await _namespace_item_counts(_server_api_key)
         count_after = counts_after.get(session.namespace, 0)
-        summary.memories_created = max(0, count_after - count_before)
+        memories_created = max(0, count_after - count_before)
 
+        summary = get_session_service().end_session(
+            agent_id, memories_created=memories_created
+        )
         return summary
     except SessionNotFoundError as e:
         raise map_error_to_http_exception(e)

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -11,6 +11,7 @@ import json
 import re
 from typing import Any
 
+from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.constants import VALID_MEMORY_TYPES
 
 
@@ -39,16 +40,24 @@ class ConversationMemoryExtractionService:
         self._validate_messages(messages)
         max_memories = max(1, min(max_memories, self.MAX_MEMORIES))
 
-        response = self.client.answer.generate(
-            namespace=namespace,
-            query=self._conversation_text(messages),
-            top_k=1,
-            temperature=0,
-            ai_model=ai_model or settings.ANSWER_MODEL,
-            kiosk_mode=False,
-            header_prompt=self._header_prompt(max_memories),
-            footer_prompt=self._footer_prompt(),
+        generate_kwargs: dict[str, Any] = {
+            "namespace": namespace,
+            "query": self._conversation_text(messages),
+            "top_k": 1,
+            "temperature": 0,
+            "kiosk_mode": False,
+            "header_prompt": self._header_prompt(max_memories),
+            "footer_prompt": self._footer_prompt(),
+        }
+        resolved_ai_model = (
+            ai_model
+            if ai_model is not None
+            else get_active_llm_model(settings.ANSWER_MODEL)
         )
+        if resolved_ai_model is not None:
+            generate_kwargs["ai_model"] = resolved_ai_model
+
+        response = self.client.answer.generate(**generate_kwargs)
 
         raw_answer = response.get("answer", "")
         parsed = self._parse_json_answer(raw_answer)

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -89,12 +89,15 @@ Format the output as a Markdown report:
 ...
 """
         try:
-            result = client.answer.generate(
-                namespace=namespace,
-                query=summary_prompt,
-                ai_model=get_active_llm_model(settings.SUMMARY_MODEL),
-                top_k=50,
-            )
+            generate_kwargs: dict[str, Any] = {
+                "namespace": namespace,
+                "query": summary_prompt,
+                "top_k": 50,
+            }
+            ai_model = get_active_llm_model(settings.SUMMARY_MODEL)
+            if ai_model is not None:
+                generate_kwargs["ai_model"] = ai_model
+            result = client.answer.generate(**generate_kwargs)
             summary_text = result.get("answer", "Failed to generate summary.")
         except Exception as e:
             raise MemoryError(f"AI summarization failed: {str(e)}")
@@ -191,12 +194,15 @@ Example response format:
 [{{"type": "contradiction", "title": "Database preference changed", "old_memory_id": "abc-123", "old_content": "We use PostgreSQL", "new_memory_id": "def-456", "new_content": "We migrated to MongoDB", "description": "New memory contradicts old database preference", "recommendation": "keep_new"}}]
 """
         try:
-            result = client.answer.generate(
-                namespace=namespace,
-                query=conflict_prompt,
-                ai_model=get_active_llm_model(settings.SUMMARY_MODEL),
-                top_k=50,
-            )
+            generate_kwargs = {
+                "namespace": namespace,
+                "query": conflict_prompt,
+                "top_k": 50,
+            }
+            ai_model = get_active_llm_model(settings.SUMMARY_MODEL)
+            if ai_model is not None:
+                generate_kwargs["ai_model"] = ai_model
+            result = client.answer.generate(**generate_kwargs)
             conflict_text = result.get("answer", "[]")
         except Exception as e:
             raise MemoryError(f"Conflict detection failed: {str(e)}")

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -11,8 +11,23 @@ if TYPE_CHECKING:
 
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.config import settings
+from memanto.app.constants import VALID_MEMORY_TYPES
 from memanto.app.core import agent_namespace
 from memanto.app.utils.errors import MemoryError
+
+
+_FILTER_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _validate_filter_token(value: Any, field_name: str) -> str:
+    """Return a safe Moorcheh filter token or reject query-syntax injection."""
+    token = str(value).strip()
+    if not token or not _FILTER_TOKEN_RE.fullmatch(token):
+        raise ValueError(
+            f"Invalid {field_name} filter value: only letters, digits, '.', '_', "
+            "and '-' are allowed"
+        )
+    return token
 
 
 class MemoryReadService:
@@ -430,16 +445,21 @@ class MemoryReadService:
         # Add memory type filters
         if type:
             for mem_type in type:
+                mem_type = _validate_filter_token(mem_type, "memory_type")
+                if mem_type not in VALID_MEMORY_TYPES:
+                    raise ValueError(f"Invalid memory_type filter value: {mem_type}")
                 filter_parts.append(f"#memory_type:{mem_type}")
 
         # Add tag filters (keyword syntax)
         if tags:
             for tag in tags:
+                tag = _validate_filter_token(tag, "tag")
                 filter_parts.append(f"#{tag}")
 
         # Add status filters
         if status_filter:
             for status in status_filter:
+                status = _validate_filter_token(status, "status")
                 filter_parts.append(f"#status:{status}")
 
         # Numeric confidence is stored as a number in memory documents. Applying
@@ -450,6 +470,8 @@ class MemoryReadService:
         # Add custom metadata filters
         if metadata_filters:
             for key, value in metadata_filters.items():
+                key = _validate_filter_token(key, "metadata key")
+                value = _validate_filter_token(value, f"metadata '{key}'")
                 filter_parts.append(f"#{key}:{value}")
 
         # Combine query with filters

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -15,7 +15,6 @@ from memanto.app.constants import VALID_MEMORY_TYPES
 from memanto.app.core import agent_namespace
 from memanto.app.utils.errors import MemoryError
 
-
 _FILTER_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -204,7 +204,7 @@ class MemoryWriteService:
                 for r in results
                 if str(r["status"]).lower() in SUCCESSFUL_UPLOAD_STATUSES
             )
-            failed = sum(1 for r in results if r["status"] == "failed")
+            failed = sum(1 for r in results if str(r["status"]).lower() == "failed")
 
             return {
                 "total_submitted": len(memories),

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -348,6 +348,15 @@ class MemoryWriteService:
             from moorcheh_sdk.types.document import Document
 
             document = cast(Document, updated_memory.to_moorcheh_document())
+
+            # Preserve extra metadata fields from the existing record (e.g. original_id
+            # in on-prem data_store.json) that aren't part of the MemoryRecord schema.
+            existing_meta = existing_memory_data.get("metadata", existing_memory_data)
+            if isinstance(existing_meta, dict):
+                for key in existing_meta:
+                    if key not in document and key != "text":
+                        document[key] = existing_meta[key]
+
             upload_result = self.client.documents.upload(
                 namespace_name=namespace, documents=[document]
             )

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -16,6 +16,20 @@ from memanto.app.utils.temporal_helpers import as_utc_naive
 
 SUCCESSFUL_UPLOAD_STATUSES = {"queued", "success", "ok"}
 
+# Trust fields removed from the active schema on 2026-06-29 (see
+# memanto/app/legacy/REMOVED.md). Old on-prem data_store.json records may still
+# carry them; they must never be copied forward on update or we resurrect dead
+# schema that no live read/write flow populates.
+_REMOVED_TRUST_FIELDS = frozenset(
+    {
+        "superseded_by",
+        "supersedes",
+        "validated_at",
+        "validation_count",
+        "contradiction_detected",
+    }
+)
+
 
 class MemoryWriteService:
     """Persist memory records to Moorcheh-backed namespaces."""
@@ -353,9 +367,16 @@ class MemoryWriteService:
             # in on-prem data_store.json) that aren't part of the MemoryRecord schema.
             existing_meta = existing_memory_data.get("metadata", existing_memory_data)
             if isinstance(existing_meta, dict):
+                # ``document`` is a TypedDict; cast to a plain dict to attach
+                # extra schema-external keys (e.g. original_id) dynamically.
+                extra_document = cast(dict[str, Any], document)
                 for key in existing_meta:
-                    if key not in document and key != "text":
-                        document[key] = existing_meta[key]
+                    if (
+                        key not in document
+                        and key != "text"
+                        and key not in _REMOVED_TRUST_FIELDS
+                    ):
+                        extra_document[key] = existing_meta[key]
 
             upload_result = self.client.documents.upload(
                 namespace_name=namespace, documents=[document]

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -13,6 +13,8 @@ from memanto.app.services.memory_parsing_service import MemoryParsingService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
 
+SUCCESSFUL_UPLOAD_STATUSES = {"queued", "success", "ok"}
+
 
 class MemoryWriteService:
     """Persist memory records to Moorcheh-backed namespaces."""
@@ -197,7 +199,11 @@ class MemoryWriteService:
                         result["status"] = moorcheh_status
 
             # Count successes and failures
-            successful = sum(1 for r in results if r["status"] in ["queued", "success"])
+            successful = sum(
+                1
+                for r in results
+                if str(r["status"]).lower() in SUCCESSFUL_UPLOAD_STATUSES
+            )
             failed = sum(1 for r in results if r["status"] == "failed")
 
             return {

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -266,6 +266,35 @@ class SessionService:
             memories_created=memories_created,
         )
 
+    async def end_session_async(self, agent_id: str) -> "SessionSummary":
+        """End session and populate memories_created from live Moorcheh count.
+
+        Preferred over end_session() for HTTP callers that have async context.
+        The CLI uses end_session() directly and receives memories_created=0
+        (documented limitation — async namespace lookup is not available there).
+        """
+        import asyncio
+
+        from memanto.app.clients import moorcheh as _moorcheh
+
+        session = self.get_session(agent_id)
+        if not session:
+            raise SessionNotFoundError(f"No session found for agent {agent_id}")
+
+        try:
+            client = _moorcheh.get_moorcheh_client()
+            ns_resp = await asyncio.to_thread(client.namespaces.list)
+            counts: dict[str, int] = {
+                ns["namespace_name"]: ns.get("item_count", 0)
+                for ns in ns_resp.get("namespaces", [])
+                if ns.get("namespace_name")
+            }
+            memories_created = counts.get(session.namespace, 0)
+        except Exception:
+            memories_created = 0
+
+        return self.end_session(agent_id, memories_created=memories_created)
+
     def renew_session(
         self,
         agent_id: str,

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -279,25 +279,18 @@ class SessionService:
 
         return session
 
-    def end_session(
-        self, agent_id: str, memories_created: int = 0
-    ) -> SessionSummary:
+    def end_session(self, agent_id: str) -> SessionSummary:
         """
-        End session for agent.
+        End session for agent
 
         Args:
-            agent_id: Agent identifier.
-            memories_created: Number of memories written during this session.
-                Callers that have access to the live backend count (e.g. the
-                HTTP route) should pass the namespace-document delta so the
-                summary is accurate.  Defaults to 0 for backwards-compatible
-                callers (CLI, tests) that cannot perform the async lookup.
+            agent_id: Agent identifier
 
         Returns:
-            SessionSummary with session statistics.
+            SessionSummary with session statistics
 
         Raises:
-            SessionNotFoundError: If session doesn't exist.
+            SessionNotFoundError: If session doesn't exist
         """
         session = self.get_session(agent_id)
         if not session:
@@ -315,6 +308,9 @@ class SessionService:
         if active_session and active_session.agent_id == agent_id:
             self._clear_active_session()
 
+        # TODO: Get actual memory count from backend
+        memories_created = 0
+
         return SessionSummary(
             session_id=session.session_id,
             agent_id=agent_id,
@@ -323,35 +319,6 @@ class SessionService:
             duration_hours=round(duration, 2),
             memories_created=memories_created,
         )
-
-    async def end_session_async(self, agent_id: str) -> "SessionSummary":
-        """End session and populate memories_created from live Moorcheh count.
-
-        Preferred over end_session() for HTTP callers that have async context.
-        The CLI uses end_session() directly and receives memories_created=0
-        (documented limitation — async namespace lookup is not available there).
-        """
-        import asyncio
-
-        from memanto.app.clients import moorcheh as _moorcheh
-
-        session = self.get_session(agent_id)
-        if not session:
-            raise SessionNotFoundError(f"No session found for agent {agent_id}")
-
-        try:
-            client = _moorcheh.get_moorcheh_client()
-            ns_resp = await asyncio.to_thread(client.namespaces.list)
-            counts: dict[str, int] = {
-                ns["namespace_name"]: ns.get("item_count", 0)
-                for ns in ns_resp.get("namespaces", [])
-                if ns.get("namespace_name")
-            }
-            memories_created = counts.get(session.namespace, 0)
-        except Exception:
-            memories_created = 0
-
-        return self.end_session(agent_id, memories_created=memories_created)
 
     def renew_session(
         self,

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -221,18 +221,25 @@ class SessionService:
 
         return session
 
-    def end_session(self, agent_id: str) -> SessionSummary:
+    def end_session(
+        self, agent_id: str, memories_created: int = 0
+    ) -> SessionSummary:
         """
-        End session for agent
+        End session for agent.
 
         Args:
-            agent_id: Agent identifier
+            agent_id: Agent identifier.
+            memories_created: Number of memories written during this session.
+                Callers that have access to the live backend count (e.g. the
+                HTTP route) should pass the namespace-document delta so the
+                summary is accurate.  Defaults to 0 for backwards-compatible
+                callers (CLI, tests) that cannot perform the async lookup.
 
         Returns:
-            SessionSummary with session statistics
+            SessionSummary with session statistics.
 
         Raises:
-            SessionNotFoundError: If session doesn't exist
+            SessionNotFoundError: If session doesn't exist.
         """
         session = self.get_session(agent_id)
         if not session:
@@ -249,9 +256,6 @@ class SessionService:
         active_session = self.get_active_session()
         if active_session and active_session.agent_id == agent_id:
             self._clear_active_session()
-
-        # TODO: Get actual memory count from backend
-        memories_created = 0
 
         return SessionSummary(
             session_id=session.session_id,

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -292,7 +292,23 @@ async def restart_onprem_backend():
     import httpx as _httpx
 
     async with _get_restart_lock():
-        return await _do_restart_onprem_backend(_asyncio, subprocess, _httpx)
+        # Schedule the restart as an independent task so that if this handler
+        # is cancelled (e.g. request timeout), the lock is not released while
+        # moorcheh down/up is still running in the worker thread.
+        # asyncio.shield() lets the inner task survive the handler's cancellation;
+        # the except block then waits for the subprocess to finish before the
+        # lock context-manager releases, keeping the serialisation guarantee.
+        inner = _asyncio.ensure_future(
+            _do_restart_onprem_backend(_asyncio, subprocess, _httpx)
+        )
+        try:
+            return await _asyncio.shield(inner)
+        except _asyncio.CancelledError:
+            try:
+                await inner
+            except Exception:
+                pass
+            raise
 
 
 async def _do_restart_onprem_backend(_asyncio, subprocess, _httpx):

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -336,6 +336,7 @@ def _get_restart_lock() -> "asyncio.Lock":
     """Return (creating lazily) the module-level restart serialisation lock."""
     global _restart_lock
     import asyncio
+
     if _restart_lock is None:
         _restart_lock = asyncio.Lock()
     return _restart_lock

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -4,6 +4,7 @@ MEMANTO Web UI Router
 Serves the Web UI static files and provides UI-specific API endpoints.
 """
 
+import asyncio
 import ipaddress
 import os
 import re

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -262,6 +262,18 @@ def _update_onprem_answer(ans: dict) -> None:
     _config_manager.set_onprem_state(llm_provider=provider, llm_model=model)
 
 
+_restart_lock: "asyncio.Lock | None" = None
+
+
+def _get_restart_lock() -> "asyncio.Lock":
+    """Return (creating lazily) the module-level restart serialisation lock."""
+    global _restart_lock
+    import asyncio
+    if _restart_lock is None:
+        _restart_lock = asyncio.Lock()
+    return _restart_lock
+
+
 @router.post("/api/ui/onprem/restart")
 async def restart_onprem_backend():
     """Bounce the on-prem moorcheh stack so it re-reads ``~/.moorcheh/config.json``.
@@ -269,12 +281,22 @@ async def restart_onprem_backend():
     ``moorcheh down`` + ``moorcheh up`` (with embedding flags recovered from
     state.json / config.json). Waits up to ~6 minutes total (5min for
     ``up``, 60s for ``/health``).
+
+    A module-level async lock prevents concurrent restart requests from
+    interleaving ``down``/``up`` calls against the same Moorcheh stack,
+    which can leave the backend in an inconsistent state.
     """
     import asyncio as _asyncio
     import subprocess
 
     import httpx as _httpx
 
+    async with _get_restart_lock():
+        return await _do_restart_onprem_backend(_asyncio, subprocess, _httpx)
+
+
+async def _do_restart_onprem_backend(_asyncio, subprocess, _httpx):
+    """Execute the actual restart sequence (called under the restart lock)."""
     if _config_manager.get_backend() != Backend.ON_PREM:
         raise HTTPException(status_code=400, detail="Active backend is not on-prem.")
 

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -267,9 +267,10 @@ async def restart_onprem_backend():
     """Bounce the on-prem moorcheh stack so it re-reads ``~/.moorcheh/config.json``.
 
     ``moorcheh down`` + ``moorcheh up`` (with embedding flags recovered from
-    state.json / config.json). Blocks for up to ~6 minutes total (5min for
+    state.json / config.json). Waits up to ~6 minutes total (5min for
     ``up``, 60s for ``/health``).
     """
+    import asyncio as _asyncio
     import subprocess
 
     import httpx as _httpx
@@ -291,8 +292,10 @@ async def restart_onprem_backend():
 
     # `moorcheh down` is best-effort: if the stack isn't running, that's fine —
     # we still want to try `up` after.
+    # Use asyncio.to_thread so subprocess.run doesn't block the event loop.
     try:
-        subprocess.run(
+        await _asyncio.to_thread(
+            subprocess.run,
             ["moorcheh", "down"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -317,7 +320,7 @@ async def restart_onprem_backend():
     if embedding_key:
         up_args.extend(["--embedding-api-key", embedding_key])
     try:
-        subprocess.run(up_args, check=True, timeout=300)
+        await _asyncio.to_thread(subprocess.run, up_args, check=True, timeout=300)
     except subprocess.CalledProcessError as e:
         raise HTTPException(status_code=500, detail=f"`moorcheh up` failed: {e}")
     except subprocess.TimeoutExpired:
@@ -327,14 +330,15 @@ async def restart_onprem_backend():
 
     health_url = (state.get("url") or "http://localhost:8080").rstrip("/") + "/health"
     deadline = time.time() + 60
-    while time.time() < deadline:
-        try:
-            resp = _httpx.get(health_url, timeout=2.0)
-            if resp.status_code == 200:
-                return {"status": "ok", "message": "Server restarted"}
-        except Exception:
-            pass
-        time.sleep(1.0)
+    async with _httpx.AsyncClient() as http:
+        while time.time() < deadline:
+            try:
+                resp = await http.get(health_url, timeout=2.0)
+                if resp.status_code == 200:
+                    return {"status": "ok", "message": "Server restarted"}
+            except Exception:
+                pass
+            await _asyncio.sleep(1.0)
     raise HTTPException(
         status_code=500,
         detail=f"Server did not become healthy at {health_url} within 60s.",

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -335,7 +335,6 @@ _restart_lock: "asyncio.Lock | None" = None
 def _get_restart_lock() -> "asyncio.Lock":
     """Return (creating lazily) the module-level restart serialisation lock."""
     global _restart_lock
-    import asyncio
 
     if _restart_lock is None:
         _restart_lock = asyncio.Lock()
@@ -375,6 +374,9 @@ async def restart_onprem_backend(_: None = Depends(_require_local)):
             try:
                 await inner
             except Exception:
+                # Intentionally suppress secondary errors: the request was
+                # cancelled and we must re-raise CancelledError after waiting
+                # for the restart task to settle so the lock is released.
                 pass
             raise
 
@@ -443,6 +445,8 @@ async def _do_restart_onprem_backend(_asyncio, subprocess, _httpx):
                 if resp.status_code == 200:
                     return {"status": "ok", "message": "Server restarted"}
             except Exception:
+                # During restart warm-up, transient network/connection
+                # failures are expected; keep retrying until the deadline.
                 pass
             await _asyncio.sleep(1.0)
     raise HTTPException(

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1481,6 +1481,7 @@ class DirectClient:
         from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
 
         memories_by_type: dict[str, list] = {}
+        failed_types = 0
 
         for mem_type in MEMORY_TYPE_ORDER:
             try:
@@ -1493,6 +1494,18 @@ class DirectClient:
                 memories_by_type[mem_type] = result.get("memories", [])
             except Exception:
                 memories_by_type[mem_type] = []
+                failed_types += 1
+
+        if failed_types == len(MEMORY_TYPE_ORDER):
+            # Every recall failed (e.g. the backend is unreachable) rather
+            # than each type genuinely having zero memories. Raise instead
+            # of writing an empty export — callers may otherwise overwrite
+            # a good cache/MEMORY.md with nothing. See sync_memory_to_project.
+            raise ConnectionError(
+                f"Failed to recall any memories for agent '{agent_id}' — "
+                "the backend appears unreachable. Refusing to write an "
+                "empty export."
+            )
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1340,6 +1340,7 @@ class SdkClient:
         from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
 
         memories_by_type: dict[str, list] = {}
+        failed_types = 0
 
         for mem_type in MEMORY_TYPE_ORDER:
             try:
@@ -1352,6 +1353,18 @@ class SdkClient:
                 memories_by_type[mem_type] = result.get("memories", [])
             except Exception:
                 memories_by_type[mem_type] = []
+                failed_types += 1
+
+        if failed_types == len(MEMORY_TYPE_ORDER):
+            # Every recall failed (e.g. the backend is unreachable) rather
+            # than each type genuinely having zero memories. Raise instead
+            # of writing an empty export — callers may otherwise overwrite
+            # a good cache/MEMORY.md with nothing. See sync_memory_to_project.
+            raise ConnectionError(
+                f"Failed to recall any memories for agent '{agent_id}' — "
+                "the backend appears unreachable. Refusing to write an "
+                "empty export."
+            )
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None
@@ -1385,15 +1398,30 @@ class SdkClient:
             limit_per_type: Max memories per type for fresh export (default 25).
 
         Returns:
-            Dict with ``output_path``, ``total_memories``, ``source``.
+            Dict with ``output_path``, ``total_memories``, ``source``
+            (``"cache"``, ``"fresh"``, or ``"stale-cache"`` if a refresh
+            failed and a previous export was reused instead).
         """
-        # Run export function first (ensures ~/.memanto/exports/... is fresh)
-        self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
-
-        # Perform sync from cache to project
         cache_path = Path.home() / ".memanto" / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # Run export function first (ensures ~/.memanto/exports/... is fresh)
+            self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
+        except ConnectionError:
+            if cache_path.exists():
+                # Backend unreachable, but we have a previously good export —
+                # serve that instead of wiping the project's MEMORY.md.
+                shutil.copy2(str(cache_path), str(target_path))
+                content = cache_path.read_text(encoding="utf-8")
+                mem_count = content.count("### ")
+                return {
+                    "output_path": str(target_path.resolve()),
+                    "total_memories": mem_count,
+                    "source": "stale-cache",
+                }
+            raise
 
         if cache_path.exists():
             # Copy freshly updated cache to project

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -172,7 +172,12 @@ def memory_sync(
     source = result.get("source", "unknown")
     out_path = result.get("output_path", "unknown")
 
-    source_label = "cached export" if source == "cache" else "fresh export"
+    if source == "cache":
+        source_label = "cached export"
+    elif source == "stale-cache":
+        source_label = "stale cache (backend unreachable)"
+    else:
+        source_label = "fresh export"
 
     if total == 0:
         console.print("\n[yellow]No memories found for this agent.[/yellow]")
@@ -180,6 +185,12 @@ def memory_sync(
     else:
         console.print(f"\n[green]OK Synced {total} memories successfully![/green]")
         console.print(f"[dim]Source: {source_label}[/dim]")
+
+    if source == "stale-cache":
+        console.print(
+            "[yellow]Warning: backend was unreachable; reused the previous "
+            "export. Memories may be out of date.[/yellow]"
+        )
 
     console.print(f"[dim]Output: {out_path}[/dim]")
     console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Memanto - Memory that AI Agents Love!",
     "description": "A memory layer service for agentic AI systems using Moorcheh SDK",
-    "version": "0.0.0.dev0"
+    "version": "0.2.5.dev66+geb0c5eb"
   },
   "paths": {
     "/health": {
@@ -763,7 +763,7 @@
           "Memory Operations"
         ],
         "summary": "Generate Daily Summary",
-        "description": "Generate the on-demand daily AI summary for an agent/date.\n\nConflict detection is a separate concern \u2014 see\nPOST ``/{agent_id}/conflicts/generate`` or the scheduled job.",
+        "description": "Generate the on-demand daily AI summary for an agent/date.\n\nConflict detection is a separate concern — see\nPOST ``/{agent_id}/conflicts/generate`` or the scheduled job.",
         "operationId": "generate_daily_summary_api_v2_agents__agent_id__daily_summary_post",
         "parameters": [
           {
@@ -1357,26 +1357,6 @@
       }
     },
     "/api/v2/agents": {
-      "get": {
-        "tags": [
-          "Sessions & Agents"
-        ],
-        "summary": "List Agents",
-        "description": "List all agents for this Moorcheh account\n\nReturns agents sorted by creation date (newest first). The ``memory_count``\nof each agent is populated with the live document count from its Moorcheh\nnamespace rather than the stale value in local metadata.",
-        "operationId": "list_agents_api_v2_agents_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentList"
-                }
-              }
-            }
-          }
-        }
-      },
       "post": {
         "tags": [
           "Sessions & Agents"
@@ -1384,15 +1364,49 @@
         "summary": "Create Agent",
         "description": "Create a new MEMANTO agent\n\nCreates:\n- Agent metadata in ~/.memanto/agents/\n- Moorcheh namespace: memanto_agent_{agent_id}\n\nThe agent is ready to activate once created.",
         "operationId": "create_agent_api_v2_agents_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AgentCreate"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "201": {
@@ -1401,6 +1415,70 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AgentInfo"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sessions & Agents"
+        ],
+        "summary": "List Agents",
+        "description": "List all agents for this Moorcheh account\n\nReturns agents sorted by creation date (newest first). The ``memory_count``\nof each agent is populated with the live document count from its Moorcheh\nnamespace rather than the stale value in local metadata.",
+        "operationId": "list_agents_api_v2_agents_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentList"
                 }
               }
             }
@@ -1434,6 +1512,38 @@
             "schema": {
               "type": "string",
               "title": "Agent Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -1488,6 +1598,38 @@
               "title": "Delete-Backup-Too"
             },
             "description": "Delete Moorcheh namespace backup"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -1528,6 +1670,38 @@
             "schema": {
               "type": "string",
               "title": "Agent Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -1590,6 +1764,38 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
             "name": "memanto_session_token",
             "in": "cookie",
             "required": false,
@@ -1636,8 +1842,42 @@
           "Sessions & Agents"
         ],
         "summary": "Get Status",
-        "description": "Get current active session status.\n\nNo parameters required \u2014 reads the active session from local state.",
+        "description": "Get current active session status.\n\nRequires management credential or loopback origin (same as other\nagent-lifecycle endpoints). Reads the active session from local state.",
         "operationId": "get_status_api_v2_status_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1645,6 +1885,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SessionInfo"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1718,7 +1968,7 @@
           "Web UI"
         ],
         "summary": "Restart Onprem Backend",
-        "description": "Bounce the on-prem moorcheh stack so it re-reads ``~/.moorcheh/config.json``.\n\n``moorcheh down`` + ``moorcheh up`` (with embedding flags recovered from\nstate.json / config.json). Blocks for up to ~6 minutes total (5min for\n``up``, 60s for ``/health``).",
+        "description": "Bounce the on-prem moorcheh stack so it re-reads ``~/.moorcheh/config.json``.\n\n``moorcheh down`` + ``moorcheh up`` (with embedding flags recovered from\nstate.json / config.json). Waits up to ~6 minutes total (5min for\n``up``, 60s for ``/health``).\n\nA module-level async lock prevents concurrent restart requests from\ninterleaving ``down``/``up`` calls against the same Moorcheh stack,\nwhich can leave the backend in an inconsistent state.",
         "operationId": "restart_onprem_backend_api_ui_onprem_restart_post",
         "responses": {
           "200": {
@@ -1892,7 +2142,7 @@
           "Web UI"
         ],
         "summary": "Read Daily Summary",
-        "description": "Return the existing daily summary for an agent/date if one was already\ngenerated. Does NOT trigger generation \u2014 that's the POST endpoint.\n\nResponse: {exists, agent_id, date, path, content}",
+        "description": "Return the existing daily summary for an agent/date if one was already\ngenerated. Does NOT trigger generation — that's the POST endpoint.\n\nResponse: {exists, agent_id, date, path, content}",
         "operationId": "read_daily_summary_api_ui_daily_summary_get",
         "parameters": [
           {
@@ -2306,7 +2556,7 @@
           "Web UI"
         ],
         "summary": "Migrate Import",
-        "description": "Run an end-to-end migration.\n\nBody: ``{provider, file?, api_key?, agent_id?}``. Loads-or-exports,\nmaps, chunks at 100/req, and writes via ``DirectClient.batch_remember``.\nReturns numeric summary only \u2014 no LLM narrative.",
+        "description": "Run an end-to-end migration.\n\nBody: ``{provider, file?, api_key?, agent_id?}``. Loads-or-exports,\nmaps, chunks at 100/req, and writes via ``DirectClient.batch_remember``.\nReturns numeric summary only — no LLM narrative.",
         "operationId": "migrate_import_api_ui_migrate_import_post",
         "requestBody": {
           "content": {
@@ -2504,8 +2754,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100.0,
-                "minimum": 1.0
+                "maximum": 100,
+                "minimum": 1
               },
               {
                 "type": "null"
@@ -2518,8 +2768,8 @@
             "anyOf": [
               {
                 "type": "number",
-                "maximum": 1.0,
-                "minimum": 0.0
+                "maximum": 1,
+                "minimum": 0
               },
               {
                 "type": "null"
@@ -2532,8 +2782,8 @@
             "anyOf": [
               {
                 "type": "number",
-                "maximum": 2.0,
-                "minimum": 0.0
+                "maximum": 2,
+                "minimum": 0
               },
               {
                 "type": "null"
@@ -2656,8 +2906,8 @@
           },
           "confidence": {
             "type": "number",
-            "maximum": 1.0,
-            "minimum": 0.0,
+            "maximum": 1,
+            "minimum": 0,
             "title": "Confidence",
             "description": "Confidence score (0-1)",
             "default": 0.8
@@ -2863,7 +3113,7 @@
         "properties": {
           "conflict_index": {
             "type": "integer",
-            "minimum": 0.0,
+            "minimum": 0,
             "title": "Conflict Index",
             "description": "Conflict index to resolve"
           },
@@ -2998,8 +3248,8 @@
           },
           "max_memories": {
             "type": "integer",
-            "maximum": 100.0,
-            "minimum": 1.0,
+            "maximum": 100,
+            "minimum": 1,
             "title": "Max Memories",
             "description": "Maximum candidate memories to extract",
             "default": 20
@@ -3106,8 +3356,8 @@
             "anyOf": [
               {
                 "type": "number",
-                "maximum": 1.0,
-                "minimum": 0.0
+                "maximum": 1,
+                "minimum": 0
               },
               {
                 "type": "null"
@@ -3328,13 +3578,13 @@
             "type": "string",
             "format": "date-time",
             "title": "As Of",
-            "description": "Point-in-time \u2014 YYYY-MM-DD (defaults to end of day) or full ISO datetime e.g. 2025-11-01T14:30:00Z"
+            "description": "Point-in-time — YYYY-MM-DD (defaults to end of day) or full ISO datetime e.g. 2025-11-01T14:30:00Z"
           },
           "limit": {
             "anyOf": [
               {
                 "type": "integer",
-                "minimum": 1.0
+                "minimum": 1
               },
               {
                 "type": "null"
@@ -3372,13 +3622,13 @@
             "type": "string",
             "format": "date-time",
             "title": "Since",
-            "description": "Start of change window \u2014 YYYY-MM-DD (defaults to start of day) or full ISO datetime e.g. 2025-11-01T00:00:00Z"
+            "description": "Start of change window — YYYY-MM-DD (defaults to start of day) or full ISO datetime e.g. 2025-11-01T00:00:00Z"
           },
           "limit": {
             "anyOf": [
               {
                 "type": "integer",
-                "minimum": 1.0
+                "minimum": 1
               },
               {
                 "type": "null"
@@ -3416,7 +3666,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "minimum": 1.0
+                "minimum": 1
               },
               {
                 "type": "null"
@@ -3457,7 +3707,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "minimum": 1.0
+                "minimum": 1
               },
               {
                 "type": "null"
@@ -3470,8 +3720,8 @@
             "anyOf": [
               {
                 "type": "number",
-                "maximum": 1.0,
-                "minimum": 0.0
+                "maximum": 1,
+                "minimum": 0
               },
               {
                 "type": "null"
@@ -3589,8 +3839,8 @@
           },
           "confidence": {
             "type": "number",
-            "maximum": 1.0,
-            "minimum": 0.0,
+            "maximum": 1,
+            "minimum": 0,
             "title": "Confidence",
             "description": "Confidence score (0-1)",
             "default": 0.8

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -383,6 +383,38 @@ class TestMEMANTOAPI:
         assert "threshold" not in call_kwargs
 
     @pytest.mark.asyncio
+    async def test_answer_omits_unset_active_ai_model(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """On-prem fallback should omit ai_model instead of sending None."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        mock_moorcheh.answer.generate.return_value = {
+            "answer": "This is a mocked answer",
+            "sources": [],
+        }
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        with patch("memanto.app.routes.memory.get_active_llm_model", return_value=None):
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/answer",
+                headers=headers,
+                json={"question": "What is being tested?"},
+            )
+
+        assert response.status_code == 200
+        call_kwargs = mock_moorcheh.answer.generate.call_args.kwargs
+        assert "ai_model" not in call_kwargs
+
+    @pytest.mark.asyncio
     async def test_answer_with_kiosk_mode_uses_default_threshold(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -236,7 +236,6 @@ class TestMEMANTOAPI:
             response = await remote.get("/api/v2/status")
             assert response.status_code == 401
 
-
     @pytest.mark.asyncio
     async def test_list_agents(self, client, auth_headers):
         """Test listing agents"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,15 +163,18 @@ class TestMEMANTOAPI:
         assert "metadata" not in data
 
     @pytest.mark.asyncio
-    async def test_create_agent_without_authorization_header(self, client):
-        """Test creating a new agent using server-configured API key"""
-        payload = {
-            "agent_id": "server-key-agent",
-            "pattern": "support",
-        }
-        response = await client.post("/api/v2/agents", json=payload)
-        assert response.status_code == 201
-        assert response.json()["agent_id"] == "server-key-agent"
+    async def test_create_agent_without_authorization_header_is_rejected(self):
+        """Non-loopback callers must present a management credential."""
+        # httpx ASGITransport defaults to client 127.0.0.1 (loopback). Force a
+        # remote peer so we exercise the network-facing auth path.
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            payload = {
+                "agent_id": "server-key-agent",
+                "pattern": "support",
+            }
+            response = await remote.post("/api/v2/agents", json=payload)
+            assert response.status_code == 401
 
     @pytest.mark.asyncio
     async def test_create_agent_fails_when_server_key_missing(self, client):
@@ -183,6 +186,56 @@ class TestMEMANTOAPI:
         with patch.object(settings, "MOORCHEH_API_KEY", ""):
             response = await client.post("/api/v2/agents", json=payload)
         assert response.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_remote_create_agent_requires_matching_credential(self):
+        """Bearer token must match the configured management key."""
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            payload = {"agent_id": "wrong-key-agent", "pattern": "support"}
+            response = await remote.post(
+                "/api/v2/agents",
+                headers={"Authorization": "Bearer totally-wrong-key"},
+                json=payload,
+            )
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_remote_activate_without_credential_is_rejected(
+        self, client, auth_headers
+    ):
+        """Activation from a non-loopback client requires management credential."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": "activate-auth-agent", "pattern": "support"},
+        )
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            response = await remote.post("/api/v2/agents/activate-auth-agent/activate")
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_remote_create_with_valid_credential_succeeds(self, auth_headers):
+        """Remote peer with the correct management key can still manage agents."""
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            response = await remote.post(
+                "/api/v2/agents",
+                headers=auth_headers,
+                json={"agent_id": "remote-ok-agent", "pattern": "support"},
+            )
+            assert response.status_code == 201
+            assert response.json()["agent_id"] == "remote-ok-agent"
+
+    @pytest.mark.asyncio
+    async def test_status_requires_management_access(self):
+        """Active session status must not be readable by unauthenticated remote peers."""
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(transport=transport, base_url="http://test") as remote:
+            response = await remote.get("/api/v2/status")
+            assert response.status_code == 401
+
 
     @pytest.mark.asyncio
     async def test_list_agents(self, client, auth_headers):
@@ -643,7 +696,7 @@ class TestMEMANTOAPI:
         )
 
         assert response.status_code == 200
-        status_resp = await client.get("/api/v2/status")
+        status_resp = await client.get("/api/v2/status", headers=auth_headers)
         assert status_resp.status_code == 404
 
         stale_headers = {**auth_headers, "X-Session-Token": token}
@@ -744,7 +797,7 @@ class TestMEMANTOAPI:
             f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
         )
 
-        response = await client.get("/api/v2/status")
+        response = await client.get("/api/v2/status", headers=auth_headers)
         assert response.status_code == 200
         data = response.json()
         assert data["agent_id"] == self.TEST_AGENT_ID
@@ -867,9 +920,9 @@ class TestMEMANTOAPI:
         mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_global_status_no_active_session(self, client):
+    async def test_global_status_no_active_session(self, client, auth_headers):
         """Test GET /api/v2/status returns 404 when no session is active"""
-        response = await client.get("/api/v2/status")
+        response = await client.get("/api/v2/status", headers=auth_headers)
         assert response.status_code == 404
 
     @pytest.mark.asyncio

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -108,6 +108,56 @@ class TestOnPremClient:
             result = client.answer.generate(namespace="x", query="y")
             assert result == {"answer": "ok", "namespace": "x"}
 
+    def test_upload_file_uses_distinct_staging_paths_for_same_basename(self, tmp_path):
+        """On-prem file uploads are async, so same-basename sources must not
+        share one staging path under ~/.moorcheh/uploads."""
+        from memanto.app.clients import onprem
+
+        class _FakeFiles:
+            def __init__(self):
+                self.uploaded_paths = []
+
+            def upload(self, namespace_name, files):
+                self.uploaded_paths.append(files[0]["path"])
+                return {"message": f"accepted {namespace_name}"}
+
+        class _FakeRaw:
+            def __init__(self):
+                self.documents = object()
+                self.files = _FakeFiles()
+
+        upload_root = tmp_path / "uploads"
+        first_dir = tmp_path / "first"
+        second_dir = tmp_path / "second"
+        first_dir.mkdir()
+        second_dir.mkdir()
+        first = first_dir / "notes.txt"
+        second = second_dir / "notes.txt"
+        first.write_text("first payload", encoding="utf-8")
+        second.write_text("second payload", encoding="utf-8")
+
+        raw = _FakeRaw()
+
+        def ensure_upload_root():
+            upload_root.mkdir(parents=True, exist_ok=True)
+            return upload_root
+
+        with patch.object(
+            onprem,
+            "_import_docker_runtime_helpers",
+            return_value=(
+                ensure_upload_root,
+                lambda host_file, _root: str(host_file),
+            ),
+        ):
+            adapter = onprem._DocumentsAdapter(raw)
+            adapter.upload_file("memanto_agent_test", first)
+            adapter.upload_file("memanto_agent_test", second)
+
+        assert len(raw.files.uploaded_paths) == 2
+        assert raw.files.uploaded_paths[0] != raw.files.uploaded_paths[1]
+        assert {p.name for p in upload_root.iterdir()} != {"notes.txt"}
+
 
 class TestSingletonDispatch:
     def test_cloud_returns_cloud_client(self):

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -84,7 +84,7 @@ def test_extract_omits_unset_active_ai_model(monkeypatch):
     """On-prem fallback should let answer.generate use its configured model."""
     from memanto.app.services import conversation_memory_extraction_service as module
 
-    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None, raising=False)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None)
     client = FakeClient(
         '[{"type":"fact","title":"Test","content":"Use pytest.","confidence":0.9}]'
     )

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -80,6 +80,24 @@ def test_extract_conversation_memories_normalizes_candidates():
     assert "user:" in client.answer.call_kwargs["query"]
 
 
+def test_extract_omits_unset_active_ai_model(monkeypatch):
+    """On-prem fallback should let answer.generate use its configured model."""
+    from memanto.app.services import conversation_memory_extraction_service as module
+
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None, raising=False)
+    client = FakeClient(
+        '[{"type":"fact","title":"Test","content":"Use pytest.","confidence":0.9}]'
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "The project uses pytest."}],
+    )
+
+    assert "ai_model" not in client.answer.call_kwargs
+
+
 def test_extract_rejects_non_json_answers():
     service = ConversationMemoryExtractionService(FakeClient("not json"))
 

--- a/tests/test_export_resilience.py
+++ b/tests/test_export_resilience.py
@@ -1,0 +1,109 @@
+"""Regression coverage: ``export_memory_md`` must not silently write an
+empty export when every ``recall`` call fails (e.g. the on-prem backend is
+unreachable), and ``SdkClient.sync_memory_to_project`` must fall back to a
+previous good export instead of overwriting a project's ``MEMORY.md`` with
+nothing.
+
+Before this fix, a total-outage export produced an all-empty
+``memories_by_type`` (each per-type ``recall`` exception was swallowed) and
+still wrote it out — every call to ``memanto memory sync`` during a brief
+backend outage silently wiped the agent's exported context and the
+project's ``MEMORY.md``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
+from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.client.sdk_client import SdkClient
+
+
+def _build_client(client_cls, monkeypatch, tmp_path):
+    """Construct *client_cls* with session validation stubbed out and
+    ``Path.home()`` redirected to *tmp_path*. ``Path`` is the same class
+    object everywhere it's imported, so this one patch also covers
+    ``MemoryExportService``'s default ``exports_dir`` — export writes and
+    ``sync_memory_to_project``'s cache lookup end up at the same
+    ``tmp_path/.memanto/exports/`` regardless of which module reads
+    ``Path.home()``."""
+    import memanto.cli.client.direct_client as direct_mod
+    import memanto.cli.client.sdk_client as sdk_mod
+
+    module = direct_mod if client_cls is DirectClient else sdk_mod
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+
+    client = client_cls(api_key="test-key")
+    monkeypatch.setattr(
+        client, "_get_validated_session_for_agent", lambda agent_id: None
+    )
+    return client
+
+
+class TestExportMemoryMdRefusesEmptyOnTotalFailure:
+    @pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+    def test_raises_when_every_recall_fails(self, client_cls, monkeypatch, tmp_path):
+        client = _build_client(client_cls, monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            client, "recall", MagicMock(side_effect=ConnectionError("backend down"))
+        )
+
+        with pytest.raises(ConnectionError, match="unreachable"):
+            client.export_memory_md(agent_id="test-agent")
+
+    @pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+    def test_partial_failure_still_exports(self, client_cls, monkeypatch, tmp_path):
+        """One type erroring while others succeed must not raise — only a
+        *total* outage (every type failing) should refuse to write."""
+        client = _build_client(client_cls, monkeypatch, tmp_path)
+
+        def fake_recall(agent_id, query, limit, type):
+            if type == [MEMORY_TYPE_ORDER[0]]:
+                raise ConnectionError("flaky")
+            return {"memories": [{"content": "ok"}]}
+
+        monkeypatch.setattr(client, "recall", MagicMock(side_effect=fake_recall))
+
+        result = client.export_memory_md(agent_id="test-agent")
+        assert result["total_memories"] > 0
+
+
+class TestSyncFallsBackToStaleCacheOnOutage:
+    """``sync_memory_to_project`` (SdkClient) always re-exports before
+    copying its cache. When the backend is briefly unreachable, it must
+    reuse the last good export rather than propagate the now-empty write —
+    or, if there is no prior export at all, surface the outage instead of
+    creating an empty ``MEMORY.md``."""
+
+    def test_stale_cache_used_when_backend_down(self, monkeypatch, tmp_path):
+        client = _build_client(SdkClient, monkeypatch, tmp_path)
+
+        cache_file = tmp_path / ".memanto" / "exports" / "test-agent_memory.md"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text("### Some Memory\n\ngood content\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            client, "recall", MagicMock(side_effect=ConnectionError("backend down"))
+        )
+
+        project_dir = tmp_path / "project"
+        result = client.sync_memory_to_project(
+            agent_id="test-agent", project_dir=str(project_dir)
+        )
+
+        assert result["source"] == "stale-cache"
+        assert result["total_memories"] == 1
+        written = (project_dir / "MEMORY.md").read_text(encoding="utf-8")
+        assert "good content" in written
+
+    def test_raises_when_no_cache_and_backend_down(self, monkeypatch, tmp_path):
+        client = _build_client(SdkClient, monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            client, "recall", MagicMock(side_effect=ConnectionError("backend down"))
+        )
+
+        with pytest.raises(ConnectionError):
+            client.sync_memory_to_project(
+                agent_id="test-agent", project_dir=str(tmp_path / "project")
+            )

--- a/tests/test_export_resilience.py
+++ b/tests/test_export_resilience.py
@@ -15,9 +15,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import memanto.cli.client.direct_client as direct_mod
+import memanto.cli.client.sdk_client as sdk_mod
 from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
-from memanto.cli.client.direct_client import DirectClient
-from memanto.cli.client.sdk_client import SdkClient
+
+DirectClient = direct_mod.DirectClient
+SdkClient = sdk_mod.SdkClient
 
 
 def _build_client(client_cls, monkeypatch, tmp_path):
@@ -28,9 +31,6 @@ def _build_client(client_cls, monkeypatch, tmp_path):
     ``sync_memory_to_project``'s cache lookup end up at the same
     ``tmp_path/.memanto/exports/`` regardless of which module reads
     ``Path.home()``."""
-    import memanto.cli.client.direct_client as direct_mod
-    import memanto.cli.client.sdk_client as sdk_mod
-
     module = direct_mod if client_cls is DirectClient else sdk_mod
     monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
 

--- a/tests/test_memory_read_filter_sanitization.py
+++ b/tests/test_memory_read_filter_sanitization.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def test_build_filtered_query_accepts_safe_filters():
+    service = MemoryReadService(MagicMock())
+
+    query = service._build_filtered_query(
+        query="deployment notes",
+        type=["fact"],
+        tags=["prod-db"],
+        status_filter=["active"],
+        metadata_filters={"source": "cli.import"},
+    )
+
+    assert query == (
+        "deployment notes #memory_type:fact #prod-db "
+        "#status:active #source:cli.import"
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"type": ["fact #status:deleted"]},
+        {"tags": ["prod #status:deleted"]},
+        {"status_filter": ["active #memory_type:error"]},
+        {"metadata_filters": {"source": "cli #status:deleted"}},
+        {"metadata_filters": {"source #status": "active"}},
+    ],
+)
+def test_build_filtered_query_rejects_filter_clause_injection(kwargs):
+    service = MemoryReadService(MagicMock())
+
+    with pytest.raises(ValueError, match="Invalid"):
+        service._build_filtered_query(query="deployment notes", **kwargs)
+
+
+def test_build_filtered_query_rejects_unknown_memory_type():
+    service = MemoryReadService(MagicMock())
+
+    with pytest.raises(ValueError, match="Invalid memory_type"):
+        service._build_filtered_query(query="deployment notes", type=["not-a-type"])

--- a/tests/test_memory_read_filter_sanitization.py
+++ b/tests/test_memory_read_filter_sanitization.py
@@ -17,8 +17,7 @@ def test_build_filtered_query_accepts_safe_filters():
     )
 
     assert query == (
-        "deployment notes #memory_type:fact #prod-db "
-        "#status:active #source:cli.import"
+        "deployment notes #memory_type:fact #prod-db #status:active #source:cli.import"
     )
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -318,6 +318,27 @@ class TestMemoryWriteServiceBatch:
         assert result["failed"] == 0
         assert [item["status"] for item in result["results"]] == ["ok", "ok"]
 
+    def test_batch_store_counts_failed_upload_status_case_insensitively(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "FAILED"}
+        memories = [
+            MemoryRecord(
+                title="Failed write",
+                content="This write should be counted as failed.",
+                agent_id="agent-1",
+                actor_id="user-1",
+                source="test",
+            )
+        ]
+
+        result = MemoryWriteService(client).batch_store_memories(memories)
+
+        assert result["successful"] == 0
+        assert result["failed"] == 1
+
 
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -450,5 +450,66 @@ def test_conflict_report_handles_non_object_json_items(tmp_path, monkeypatch):
     assert conflicts[0]["description"] == '["not an object", 1]'
 
 
+def test_daily_summary_omits_unset_active_ai_model(tmp_path, monkeypatch):
+    """On-prem summary generation should omit ai_model when no active model is set."""
+    from unittest.mock import MagicMock
+
+    from memanto.app.services import daily_analysis_service as module
+
+    sessions_dir = tmp_path / "sessions"
+    summaries_dir = tmp_path / "summaries"
+    sessions_dir.mkdir()
+    (sessions_dir / "agent-1_2026-06-28_001_summary.md").write_text(
+        "# Session\n\nRemembered a project milestone.",
+        encoding="utf-8",
+    )
+
+    client = MagicMock()
+    client.answer.generate.return_value = {"answer": "# Daily Summary"}
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None)
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=summaries_dir,
+    )
+    result = service.generate_summary("agent-1", "2026-06-28")
+
+    assert result["status"] == "success"
+    call_kwargs = client.answer.generate.call_args.kwargs
+    assert "ai_model" not in call_kwargs
+
+
+def test_conflict_report_omits_unset_active_ai_model(tmp_path, monkeypatch):
+    """On-prem conflict detection should omit ai_model when no active model is set."""
+    from unittest.mock import MagicMock
+
+    from memanto.app.services import daily_analysis_service as module
+
+    sessions_dir = tmp_path / "sessions"
+    summaries_dir = tmp_path / "summaries"
+    sessions_dir.mkdir()
+    (sessions_dir / "agent-1_2026-06-28_001_summary.md").write_text(
+        "# Session\n\nRemembered a project milestone.",
+        encoding="utf-8",
+    )
+
+    client = MagicMock()
+    client.answer.generate.return_value = {"answer": "[]"}
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None)
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=summaries_dir,
+    )
+    result = service.generate_conflict_report("agent-1", "2026-06-28")
+
+    assert result["status"] == "success"
+    call_kwargs = client.answer.generate.call_args.kwargs
+    assert "ai_model" not in call_kwargs
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -439,6 +439,42 @@ class TestMemoryWriteServiceDelete:
         )
         client.documents.upload.assert_called_once()
 
+    def test_update_memory_preserves_extra_fields_but_drops_removed_trust_fields(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"status": "success"}
+        client.documents.upload.return_value = {"status": "queued"}
+        existing_memory = {
+            "id": "mem-1",
+            "type": "fact",
+            "title": "Original title",
+            "content": "Original content",
+            "actor_id": "tester",
+            "source": "manual",
+            "confidence": 0.8,
+            "status": "active",
+            "tags": [],
+            # Extra field not in the MemoryRecord schema (e.g. on-prem data_store.json).
+            "original_id": "orig-123",
+            # Trust field removed 2026-06-29; must not be resurrected on update.
+            "validation_count": 5,
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            MemoryWriteService(client).update_memory(
+                "mem-1",
+                "memanto_agent_test-agent",
+                {"content": "Updated content"},
+            )
+
+        uploaded = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded.get("original_id") == "orig-123"
+        assert "validation_count" not in uploaded
+
 
 class TestMemoryReadServiceFormatting:
     def test_format_memory_item_preserves_falsey_metadata_values(self):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -288,6 +288,37 @@ class TestMemoryWriteServiceDelete:
         assert MemoryWriteService(client).delete_memory("m1", "ns") is expected
 
 
+class TestMemoryWriteServiceBatch:
+    def test_batch_store_counts_ok_upload_status_as_success(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "ok"}
+        memories = [
+            MemoryRecord(
+                title="First preference",
+                content="Alex prefers concise status updates.",
+                agent_id="agent-1",
+                actor_id="user-1",
+                source="test",
+            ),
+            MemoryRecord(
+                title="Second preference",
+                content="Alex prefers weekly summaries.",
+                agent_id="agent-1",
+                actor_id="user-1",
+                source="test",
+            ),
+        ]
+
+        result = MemoryWriteService(client).batch_store_memories(memories)
+
+        assert result["successful"] == 2
+        assert result["failed"] == 0
+        assert [item["status"] for item in result["results"]] == ["ok", "ok"]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -549,6 +549,7 @@ class TestMemoryWriteServiceBatch:
 
         assert result["successful"] == 0
         assert result["failed"] == 1
+        assert result["results"][0]["status"] == "FAILED"
 
 
 class TestForgetEndToEnd:


### PR DESCRIPTION
Merge on-prem related PR
1. #1425   Unique on-prem upload staging paths
2. #1371   Count ok batch upload status as successful
3. #1402   Guard recall filter tokens (injection)
4. #1313   Omit unset answer model (on-prem fallback)
5. #1423   Require management auth for agent lifecycle
6. #1269   Fix event-loop blocking in restart
7. #1348   Preserve extra metadata on update
8. #1341   refuse to overwrite export/MEMORY.md when backend unreachable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Tightened authorization for agent management and status endpoints for non-loopback callers, enforcing management credentials.
  - Added strict sanitization/validation for memory filtering to prevent malformed or unsafe query fragments.
- **Bug Fixes**
  - Prevented on-prem upload collisions by using distinct staging paths for files with the same basename.
  - Improved memory updates by preserving legitimate extra fields while removing legacy trust fields.
  - Corrected upload status success counting (now includes `ok`) and ensured unset AI model parameters are not sent.
- **Reliability**
  - Export/sync now fails when all recall attempts fail, and reuses cached exports during outages.
  - Serialized on-prem restart requests and improved readiness polling.
- **Documentation**
  - Updated API specification and endpoint/header documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->