### PR TITLE
Add hatch-vcs fallback version for source archives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+fallback-version = "0.0.0"
 
 [tool.hatch.version.raw-options]
 git_describe_command = "git describe --dirty --tags --long --match v*"


### PR DESCRIPTION
## Summary
Adds a hatch-vcs fallback version so source archive/editable installs do not fail when `.git` metadata is unavailable.

## Reproduction
1. Download the repository as the GitHub ZIP archive.
2. Run `python -m pip install -e ./memanto-main[all]`.
3. Before this change, metadata generation fails because setuptools-scm cannot detect a version without VCS metadata.

## Verification
- Reproduced the install failure from the GitHub ZIP archive.
- Confirmed `fallback-version = "0.0.0"` allows the editable install to complete.
- Ran focused tests: `pytest tests/test_temporal_helpers.py tests/test_output_path_traversal.py tests/test_memory_parsing.py -q`
- Confirmed package import: `import memanto; import memanto.app.config`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version handling when version control metadata is unavailable.
  * Packages now fall back to version `0.0.0` instead of failing to determine a version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->