### PR TITLE
fix(schedule): reject invalid daily job times

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -188,7 +188,10 @@ async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
         )
 
     if "schedule_time" in updates:
-        _config_manager.set_schedule_time(updates["schedule_time"])
+        try:
+            _config_manager.set_schedule_time(updates["schedule_time"])
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
 
     if "session" in updates and isinstance(updates["session"], dict):
         data = _config_manager.load_yaml()

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -10,12 +10,12 @@ Handles configuration persistence:
 import importlib
 import json
 import os
-import re
 from pathlib import Path
 
 from dotenv import load_dotenv, set_key
 
 from memanto.app.clients.backend import Backend, parse_backend
+from memanto.cli.schedule_time import SCHEDULE_TIME_RE
 
 yaml = importlib.import_module("yaml")
 
@@ -398,9 +398,7 @@ class ConfigManager:
 
     def set_schedule_time(self, time_str: str) -> None:
         """Set daily summary + conflict time."""
-        if not isinstance(time_str, str) or not re.fullmatch(
-            r"(?:[01]\d|2[0-3]):[0-5]\d", time_str
-        ):
+        if not isinstance(time_str, str) or not SCHEDULE_TIME_RE.fullmatch(time_str):
             raise ValueError("schedule_time must use 24-hour HH:MM format")
         self.set("schedule_time", time_str)
 

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -10,6 +10,7 @@ Handles configuration persistence:
 import importlib
 import json
 import os
+import re
 from pathlib import Path
 
 from dotenv import load_dotenv, set_key
@@ -397,6 +398,10 @@ class ConfigManager:
 
     def set_schedule_time(self, time_str: str) -> None:
         """Set daily summary + conflict time."""
+        if not isinstance(time_str, str) or not re.fullmatch(
+            r"(?:[01]\d|2[0-3]):[0-5]\d", time_str
+        ):
+            raise ValueError("schedule_time must use 24-hour HH:MM format")
         self.set("schedule_time", time_str)
 
     # Active session tracking — sourced from SessionService (~/.memanto/sessions/).

--- a/memanto/cli/schedule_manager.py
+++ b/memanto/cli/schedule_manager.py
@@ -6,6 +6,7 @@ Schedules a nightly job that runs daily-summary followed by detect-conflicts
 """
 
 import platform
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -56,6 +57,13 @@ class ScheduleManager:
         return f'"{self.python_exe}" "{self.cli_main.absolute()}" schedule _run'
 
     def enable(self, time_str: str = "23:55") -> dict[str, Any]:
+        if not isinstance(time_str, str) or not re.fullmatch(
+            r"(?:[01]\d|2[0-3]):[0-5]\d", time_str
+        ):
+            return {
+                "status": "error",
+                "message": "Invalid schedule time; expected 24-hour HH:MM format.",
+            }
         self._remove_legacy_tasks()
         if self.os_type == "Windows":
             return self._enable_windows(time_str)

--- a/memanto/cli/schedule_manager.py
+++ b/memanto/cli/schedule_manager.py
@@ -58,6 +58,7 @@ class ScheduleManager:
         return f'"{self.python_exe}" "{self.cli_main.absolute()}" schedule _run'
 
     def enable(self, time_str: str = "23:55") -> dict[str, Any]:
+        """Install the nightly job when ``time_str`` is a valid 24-hour time."""
         if not isinstance(time_str, str) or not SCHEDULE_TIME_RE.fullmatch(time_str):
             return {
                 "status": "error",
@@ -138,6 +139,7 @@ class ScheduleManager:
     # Unix/OSX (crontab)
 
     def _enable_unix(self, time_str: str = "23:55") -> dict[str, Any]:
+        """Add a validated nightly schedule to the current user's crontab."""
         hour, minute = (int(part) for part in time_str.split(":"))
 
         marker = f"# {self.TASK_NAME}"

--- a/memanto/cli/schedule_manager.py
+++ b/memanto/cli/schedule_manager.py
@@ -6,11 +6,12 @@ Schedules a nightly job that runs daily-summary followed by detect-conflicts
 """
 
 import platform
-import re
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+
+from memanto.cli.schedule_time import SCHEDULE_TIME_RE
 
 
 class ScheduleManager:
@@ -57,9 +58,7 @@ class ScheduleManager:
         return f'"{self.python_exe}" "{self.cli_main.absolute()}" schedule _run'
 
     def enable(self, time_str: str = "23:55") -> dict[str, Any]:
-        if not isinstance(time_str, str) or not re.fullmatch(
-            r"(?:[01]\d|2[0-3]):[0-5]\d", time_str
-        ):
+        if not isinstance(time_str, str) or not SCHEDULE_TIME_RE.fullmatch(time_str):
             return {
                 "status": "error",
                 "message": "Invalid schedule time; expected 24-hour HH:MM format.",
@@ -139,11 +138,7 @@ class ScheduleManager:
     # Unix/OSX (crontab)
 
     def _enable_unix(self, time_str: str = "23:55") -> dict[str, Any]:
-        try:
-            parts = time_str.split(":")
-            hour, minute = int(parts[0]), int(parts[1])
-        except (ValueError, IndexError):
-            hour, minute = 23, 55
+        hour, minute = (int(part) for part in time_str.split(":"))
 
         marker = f"# {self.TASK_NAME}"
         cron_entry = f"{minute} {hour} * * * {self._command()}  {marker}"

--- a/memanto/cli/schedule_time.py
+++ b/memanto/cli/schedule_time.py
@@ -1,0 +1,5 @@
+"""Shared validation for daily schedule times."""
+
+import re
+
+SCHEDULE_TIME_RE = re.compile(r"(?:[01]\d|2[0-3]):[0-5]\d")

--- a/tests/test_schedule_manager.py
+++ b/tests/test_schedule_manager.py
@@ -1,0 +1,55 @@
+import pytest
+from fastapi import HTTPException
+
+from memanto.cli.config.manager import ConfigManager
+from memanto.cli.schedule_manager import ScheduleManager
+
+
+@pytest.mark.parametrize("invalid_time", ["9pm", "24:00", "12:60", "12:30:00"])
+def test_config_manager_rejects_invalid_schedule_time(tmp_path, invalid_time):
+    manager = ConfigManager(config_dir=tmp_path)
+    manager.set_schedule_time("08:30")
+
+    with pytest.raises(ValueError, match="HH:MM"):
+        manager.set_schedule_time(invalid_time)
+
+    assert manager.get_schedule_time() == "08:30"
+
+
+@pytest.mark.asyncio
+async def test_ui_config_rejects_invalid_schedule_time(tmp_path, monkeypatch):
+    from memanto.app.ui.routes import ui_router
+
+    manager = ConfigManager(config_dir=tmp_path)
+    manager.set_schedule_time("08:30")
+    monkeypatch.setattr(ui_router, "_config_manager", manager)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ui_router.update_ui_config({"schedule_time": "9pm"}, None)
+
+    assert exc_info.value.status_code == 400
+    assert manager.get_schedule_time() == "08:30"
+
+
+def test_schedule_manager_does_not_install_invalid_cron_time(monkeypatch):
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+
+        class Result:
+            stdout = ""
+
+        return Result()
+
+    monkeypatch.setattr("memanto.cli.schedule_manager.subprocess.run", fake_run)
+    manager = ScheduleManager()
+    manager.os_type = "Darwin"
+
+    result = manager.enable("9pm")
+
+    assert result == {
+        "status": "error",
+        "message": "Invalid schedule time; expected 24-hour HH:MM format.",
+    }
+    assert calls == []


### PR DESCRIPTION
## Summary

- validate `schedule_time` as strict 24-hour `HH:MM` before persisting it
- return HTTP 400 when the Web UI submits an invalid schedule value
- reject malformed schedule values before modifying cron or legacy tasks
- add focused regression coverage for configuration, API, and scheduler behavior

## Root cause and impact

The configuration layer accepted arbitrary schedule strings. On Unix, values such as `9pm` raised during parsing and silently fell back to `23:55`, while the command still reported that a job had been installed for `9pm`. Invalid range values could also reach the OS scheduler. This could make nightly summaries and conflict scans run at an unexpected time or not run at all.

## Validation

- `uv run pytest -q` — full suite passed (live E2E tests skipped without an API key)
- `uv run ruff check memanto/cli/config/manager.py memanto/cli/schedule_manager.py memanto/app/ui/routes/ui_router.py tests/test_schedule_manager.py`
- `uv run ruff format --check memanto/cli/config/manager.py memanto/cli/schedule_manager.py memanto/app/ui/routes/ui_router.py tests/test_schedule_manager.py`

/claim #770

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added strict 24-hour `HH:MM` schedule-time validation across CLI config and scheduling.
  * UI now returns HTTP 400 when `schedule_time` is invalid, without persisting or changing the currently active value.
  * Scheduling no longer proceeds with invalid input (and no longer falls back to `23:55`).
* **Tests**
  * Added coverage for validation behavior across configuration/UI layers, and confirmed cron installation/update does not run for invalid times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->