### PR TITLE
Fix LangGraph min_confidence search filtering

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -17,7 +17,8 @@ Mapping between abstractions
     value["tags"]                     ->  user tags (non-reserved)
     SearchOp.query                    ->  recall query   (``recall_recent`` if ``"*"``)
     SearchOp.filter["type"]           ->  type filter
-    SearchOp.filter["min_confidence"] ->  min_similarity
+    SearchOp.filter["min_similarity"] ->  semantic similarity threshold
+    SearchOp.filter["min_confidence"] ->  memory confidence threshold
 
 Documented limitations
 ----------------------
@@ -103,7 +104,7 @@ class MemantoStore(BaseStore):
         self._lock = threading.RLock()
         self._client_pool: dict[str, SdkClient] = {}
         self._agent_prefix = "langgraph_"
-        # (namespace, query, limit, type, min_sim) -> (timestamp, list[SearchItem])
+        # (namespace, query, limit, tags, type, min_sim, min_conf) -> (timestamp, items)
         self._search_cache: dict[tuple, tuple[float, list[SearchItem]]] = {}
         # Survives 429s without flashing the UI panel to zero.
         self._last_good: dict[tuple[str, ...], list[SearchItem]] = {}
@@ -288,8 +289,8 @@ class MemantoStore(BaseStore):
         type_filter = filter_dict.get("type") or filter_dict.get("kind")
         if isinstance(type_filter, str):
             type_filter = [type_filter]
-        # SearchOp uses "min_confidence"; SdkClient.recall() uses "min_similarity"
-        min_similarity = filter_dict.get("min_confidence")
+        min_similarity = filter_dict.get("min_similarity")
+        min_confidence = filter_dict.get("min_confidence")
         extra_tags = list(filter_dict.get("tags", []) or [])
 
         cache_key = (
@@ -299,6 +300,7 @@ class MemantoStore(BaseStore):
             tuple(extra_tags),
             tuple(type_filter) if type_filter else None,
             min_similarity,
+            min_confidence,
         )
         with self._lock:
             cached = self._search_cache.get(cache_key)
@@ -348,6 +350,10 @@ class MemantoStore(BaseStore):
         for mem in result.get("memories", []):
             tags = mem.get("tags") or []
             if extra_tags and not all(t in tags for t in extra_tags):
+                continue
+            if min_confidence is not None and not self._passes_min_confidence(
+                mem, min_confidence
+            ):
                 continue
             key = self._tags_to_key(tags) or mem.get("id", "")
             out.append(self._memory_to_search_item(mem, op.namespace_prefix, key))
@@ -421,6 +427,18 @@ class MemantoStore(BaseStore):
             if t.startswith(_KEY_TAG_PREFIX):
                 return t[len(_KEY_TAG_PREFIX) :]
         return None
+
+    @staticmethod
+    def _passes_min_confidence(mem: dict[str, Any], min_confidence: Any) -> bool:
+        try:
+            threshold = float(min_confidence)
+        except (TypeError, ValueError):
+            return False
+        try:
+            confidence = float(mem.get("confidence"))
+        except (TypeError, ValueError):
+            return threshold <= 0
+        return confidence >= threshold
 
     @staticmethod
     def _stringify(value: dict[str, Any]) -> str:

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -235,6 +235,78 @@ def test_do_search_semantic(mock_sdk_client):
     )
 
 
+def test_do_search_filters_min_confidence_without_changing_similarity(
+    mock_sdk_client,
+):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-high",
+                "tags": ["lg:key:key-high"],
+                "type": "fact",
+                "content": "high confidence",
+                "confidence": 0.95,
+            },
+            {
+                "id": "mem-low",
+                "tags": ["lg:key:key-low"],
+                "type": "fact",
+                "content": "low confidence",
+                "confidence": 0.4,
+            },
+        ]
+    }
+
+    op = SearchOp(
+        namespace_prefix=("my_ns",),
+        query="test query",
+        filter={"min_confidence": 0.9, "min_similarity": 0.2},
+        limit=10,
+    )
+    items = store._do_search(op)
+
+    assert [item.key for item in items] == ["key-high"]
+    client_instance.recall.assert_called_once_with(
+        agent_id="langgraph_my_ns",
+        query="test query",
+        limit=10,
+        type=None,
+        tags=None,
+        min_similarity=0.2,
+    )
+
+
+def test_do_search_min_confidence_zero_keeps_legacy_memories(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall_recent.return_value = {
+        "memories": [
+            {
+                "id": "legacy-memory",
+                "tags": ["lg:key:legacy"],
+                "type": "fact",
+                "content": "stored before confidence existed",
+            }
+        ]
+    }
+
+    op = SearchOp(
+        namespace_prefix=("my_ns",),
+        query="*",
+        filter={"min_confidence": 0.0},
+        limit=10,
+    )
+    items = store._do_search(op)
+
+    assert [item.key for item in items] == ["legacy"]
+
+
 def test_batch_execution(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()


### PR DESCRIPTION
## Summary
- stop treating LangGraph `filter["min_confidence"]` as Memanto semantic `min_similarity`
- add explicit `filter["min_similarity"]` forwarding for semantic thresholds
- filter returned memories by numeric confidence, while keeping legacy memories when the threshold is zero

## Repro
A LangGraph search such as:

```python
SearchOp(
    namespace_prefix=("my_ns",),
    query="test query",
    filter={"min_confidence": 0.9, "min_similarity": 0.2},
)
```

previously sent `min_similarity=0.9` to `SdkClient.recall()` and returned low-confidence memories because confidence was never checked. That silently changed recall semantics and could drop relevant high-confidence memories while retaining low-confidence ones.

## Tests
- `uv run --with pytest --with pytest-asyncio pytest -c /dev/null -p no:cacheprovider tests -q` from `integrations/langgraph`
- `uv run pytest tests/test_memory_read_confidence.py tests/test_cli.py -q`
- `uv run --with ruff ruff check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`
- `uv run --with ruff ruff format --check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`
- `git diff --check`

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate controls for semantic similarity and memory confidence when filtering search results.
  * Search results now exclude memories below the specified confidence threshold.

* **Bug Fixes**
  * Preserved existing recent-recall behavior when the confidence threshold is set to zero.
  * Improved search caching so results respect confidence settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->