### PR TITLE
feat(connect): add Pi (coding agent) integration

### DIFF
--- a/memanto/cli/commands/connect.py
+++ b/memanto/cli/commands/connect.py
@@ -137,6 +137,28 @@ def connect_codex(
     _run_connect_for_agent("codex", project_dir, is_global)
 
 
+@connect_app.command("pi")
+def connect_pi(
+    project_dir: str = typer.Option(
+        ".", "--project-dir", "-p", help="Target project directory"
+    ),
+    is_global: bool = typer.Option(
+        False, "--global", "-g", help="Install globally to ~/.pi/agent/"
+    ),
+):
+    """Connect MEMANTO to Pi (coding agent).
+
+    Adds MEMANTO instructions to AGENTS.md, deploys the skill, and installs a
+    Pi extension that auto-syncs MEMORY.md on each fresh session start.
+
+    Examples:
+        memanto connect pi
+        memanto connect pi --project-dir ./my-project
+        memanto connect pi --global
+    """
+    _run_connect_for_agent("pi", project_dir, is_global)
+
+
 @connect_app.command("cursor")
 def connect_cursor(
     project_dir: str = typer.Option(

--- a/memanto/cli/connect/agent_registry.py
+++ b/memanto/cli/connect/agent_registry.py
@@ -52,6 +52,11 @@ class AgentDef:
     permissions_file: str | None = None  # e.g. "settings.local.json"
     permissions_payload: dict | None = None
 
+    # Code extension file (for agents that load native extensions, e.g. Pi .ts)
+    extension_file: str | None = None  # e.g. "memanto-sync.ts"
+    extension_global_dir: str | None = None  # e.g. "~/.pi/agent/extensions"
+    extension_local_dir: str | None = None  # e.g. ".pi/extensions"
+
     def resolve_skill_local(self, project_dir: Path) -> Path:
         """Resolve local skill directory path."""
         if self.skill_local_dir:
@@ -77,6 +82,20 @@ class AgentDef:
                 base = Path.home()
             return base / self.instruction_file
         return project_dir / self.instruction_file
+
+    def resolve_extension_file(self, project_dir: Path, is_global: bool) -> Path | None:
+        """Resolve code extension file path (for agents that support one)."""
+        if not self.extension_file:
+            return None
+        if is_global:
+            if not self.extension_global_dir:
+                return None
+            base = Path.home() / self.extension_global_dir.lstrip("~/")
+        else:
+            if not self.extension_local_dir:
+                return None
+            base = project_dir / self.extension_local_dir
+        return base / self.extension_file
 
 
 # Agent Definitions
@@ -118,6 +137,20 @@ CODEX = AgentDef(
     skill_global_dir="~/.codex/skills",
     config_local_dir=".agents",
     config_global_dir="~/.codex",
+)
+
+PI = AgentDef(
+    name="pi",
+    display_name="Pi (coding agent)",
+    instruction_file="AGENTS.md",
+    instruction_format="markdown",
+    skill_local_dir=".pi/skills",
+    skill_global_dir="~/.pi/agent/skills",
+    config_local_dir=".pi",
+    config_global_dir="~/.pi/agent",
+    extension_file="memanto-sync.ts",
+    extension_global_dir="~/.pi/agent/extensions",
+    extension_local_dir=".pi/extensions",
 )
 
 CURSOR = AgentDef(
@@ -248,6 +281,7 @@ AGENT_REGISTRY: dict[str, AgentDef] = {
     for a in [
         CLAUDE_CODE,
         CODEX,
+        PI,
         CURSOR,
         WINDSURF,
         ANTIGRAVITY,

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -15,6 +15,7 @@ from memanto.cli.connect.agent_registry import AGENT_REGISTRY, AgentDef
 from memanto.cli.connect.templates import (
     MEMANTO_SENTINEL,
     MEMANTO_SENTINEL_END,
+    get_extension_content,
     get_instruction_content,
     get_skill_content,
 )
@@ -76,6 +77,15 @@ def install_agent(
         except Exception as e:
             errors.append(f"Permissions: {e}")
 
+    # Code extension (Pi .ts extension that runs memanto memory sync on startup)
+    if agent.extension_file:
+        try:
+            ext_result = _install_extension(agent, project_path, is_global)
+            if ext_result:
+                steps.append(ext_result)
+        except Exception as e:
+            errors.append(f"Extension: {e}")
+
     if steps:
         try:
             ConfigManager().add_connection(
@@ -120,6 +130,14 @@ def remove_agent(
             steps.append(result)
     except Exception as e:
         errors.append(f"Skill removal: {e}")
+
+    # Remove code extension
+    try:
+        result = _remove_extension(agent, project_path, is_global)
+        if result:
+            steps.append(result)
+    except Exception as e:
+        errors.append(f"Extension removal: {e}")
 
     try:
         ConfigManager().remove_connection(
@@ -296,6 +314,47 @@ def _remove_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str |
             pass
         return f"Removed skill from {_display_path(skill_dir, is_global)}"
     return None
+
+
+# Internal: Code extension deployment (Pi)
+
+
+def _install_extension(
+    agent: AgentDef, project_path: Path, is_global: bool
+) -> str | None:
+    """Deploy the agent's code extension file (e.g. the Pi .ts extension)."""
+    if not agent.extension_file:
+        return None
+
+    ext_path = agent.resolve_extension_file(project_path, is_global)
+    if not ext_path:
+        return None
+
+    ext_path.parent.mkdir(parents=True, exist_ok=True)
+    ext_path.write_text(get_extension_content(), encoding="utf-8")
+
+    return f"Deployed extension to {_display_path(ext_path, is_global)}"
+
+
+def _remove_extension(
+    agent: AgentDef, project_path: Path, is_global: bool
+) -> str | None:
+    """Remove the agent's code extension file."""
+    if not agent.extension_file:
+        return None
+
+    ext_path = agent.resolve_extension_file(project_path, is_global)
+    if not ext_path or not ext_path.exists():
+        return None
+
+    ext_path.unlink()
+    # Clean up empty parent dirs
+    try:
+        if ext_path.parent.exists() and not any(ext_path.parent.iterdir()):
+            ext_path.parent.rmdir()
+    except Exception:
+        pass
+    return f"Removed extension from {_display_path(ext_path.parent, is_global)}"
 
 
 # Internal: Hook configuration (Claude Code)

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -422,7 +422,7 @@ export default function (pi: ExtensionAPI) {
     const child = spawn(
       "memanto",
       ["memory", "sync", "--project-dir", ctx.cwd],
-      { stdio: "ignore", detached: true, shell: process.platform === "win32" },
+      { stdio: "ignore", detached: true },
     );
     child.unref();
 

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -429,8 +429,8 @@ export default function (pi: ExtensionAPI) {
     child.on("error", () => {
       /* memanto CLI not installed / not on PATH — ignore. */
     });
-    child.on("close", () => {
-      if (ctx.hasUI) {
+    child.on("close", (code) => {
+      if (code === 0 && ctx.hasUI) {
         try {
           ctx.ui.notify("Memanto: memory synced", "info");
         } catch {

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -285,6 +285,10 @@ def get_instruction_content(agent_name: str) -> str:
             tool_phrase="the terminal",
             note_suffix="The `memanto-memory` skill in `.agents/skills/memanto/` contains detailed reference guidelines (best practices, confidence levels, tagging).",
         ),
+        "pi": _base_instruction_content(
+            tool_phrase="the terminal",
+            note_suffix="A Pi extension auto-syncs MEMORY.md on each fresh session start; the `memanto-memory` skill in `.pi/skills/memanto/` (or `~/.pi/agent/skills/memanto/`) contains detailed reference guidelines.",
+        ),
         "cursor": _get_mdc_content(),
         "windsurf": _base_instruction_content(
             tool_phrase="the terminal",
@@ -392,3 +396,53 @@ to?"). Equal priority — pick by intent.
 def get_skill_content() -> str:
     """Get the SKILL.md content (shared across all agents)."""
     return SKILL_MD_CONTENT.strip() + "\n"
+
+
+# Pi .ts extension content (auto-syncs MEMORY.md on each fresh session start).
+# Installed by `memanto connect pi` into ~/.pi/agent/extensions/ (or .pi/extensions/).
+
+EXTENSION_TS_CONTENT = """/**
+ * MEMANTO auto-sync extension for Pi.
+ *
+ * On a fresh process start, runs `memanto memory sync` in the background so the
+ * project's MEMORY.md is up to date before you begin working. It is
+ * fire-and-forget: it never blocks startup, and errors are swallowed (e.g. when
+ * memanto is not installed, not on PATH, or no agent is active).
+ *
+ * Installed by `memanto connect pi`. Remove with `memanto connect remove pi`.
+ */
+import { spawn } from "node:child_process";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", (event, ctx) => {
+    // Only on a fresh process start — not on /resume, /fork, or /reload.
+    if (event.reason !== "startup") return;
+
+    const child = spawn(
+      "memanto",
+      ["memory", "sync", "--project-dir", ctx.cwd],
+      { stdio: "ignore", detached: true, shell: process.platform === "win32" },
+    );
+    child.unref();
+
+    child.on("error", () => {
+      /* memanto CLI not installed / not on PATH — ignore. */
+    });
+    child.on("close", () => {
+      if (ctx.hasUI) {
+        try {
+          ctx.ui.notify("Memanto: memory synced", "info");
+        } catch {
+          /* notification unavailable in this mode — ignore. */
+        }
+      }
+    });
+  });
+}
+"""
+
+
+def get_extension_content() -> str:
+    """Get the Pi .ts extension content (memanto auto-sync on session start)."""
+    return EXTENSION_TS_CONTENT.strip() + "\n"


### PR DESCRIPTION
## Summary
- Adds `memanto connect pi` by direct analogy with the existing `codex` integration — same `--project-dir/-p` and `--global/-g` flags, same AGENTS.md instruction + skill deployment.
- Introduces a new **"extension" installer artifact** (`_install_extension`/`_remove_extension`, mirroring `_install_skill`/`_remove_skill`) so `memanto connect pi` is a one-shot install: it injects the AGENTS.md section, deploys the skill, and drops a self-contained `memanto-sync.ts` Pi extension.
- The extension mirrors the Claude Code `SessionStart` hook: on a fresh session start it runs `memanto memory sync --project-dir <cwd>` **fire-and-forget** (never blocking startup), swallowing errors when memanto is not installed/configured.

## Why
Pi (the `pi` coding agent) has **no built-in MCP support and no Claude-style JSON hooks** — its hook mechanism is a TypeScript extension auto-discovered from `~/.pi/agent/extensions/`. This PR gives Pi the same memory experience the other 12 agents already get, using the CLI-skill model every existing integration uses, plus the minimal TS extension needed to reproduce Claude Code's auto-sync-on-startup behavior. No new backend, no MCP, no per-call LLM override — fully consistent with the established integration architecture.

## What changes
| File | Change |
|------|--------|
| `agent_registry.py` | `PI` AgentDef (mirrors `CODEX`); new optional fields `extension_file` / `extension_global_dir` / `extension_local_dir` + `resolve_extension_file()` resolver; `PI` registered in `AGENT_REGISTRY` |
| `engine.py` | `_install_extension()` / `_remove_extension()` (mirror `_install_skill` / `_remove_skill`), wired into `install_agent` / `remove_agent` |
| `templates.py` | `pi` instruction entry; `EXTENSION_TS_CONTENT` + `get_extension_content()` |
| `commands/connect.py` | `connect pi` command (same flags as siblings) |

Purely additive: ~170 lines, 0 deletions. **No existing agent's behavior changes** — agents without `extension_file` are unaffected (the new fields default to `None` and the install/remove branches are skipped).

## How tested
```bash
# Lint + format (clean)
ruff check memanto/cli/connect/agent_registry.py memanto/cli/connect/templates.py memanto/cli/connect/engine.py memanto/cli/commands/connect.py
ruff format --check memanto/cli/connect/agent_registry.py memanto/cli/connect/templates.py memanto/cli/connect/engine.py memanto/cli/commands/connect.py
# Compile (clean)
python -m py_compile memanto/cli/connect/agent_registry.py memanto/cli/connect/templates.py memanto/cli/connect/engine.py memanto/cli/commands/connect.py
```
Manual end-to-end in a temp project:
- `memanto connect pi --project-dir <tmp>` → created `AGENTS.md` (with MEMANTO sentinel pair), `.pi/skills/memanto/SKILL.md`, `.pi/extensions/memanto-sync.ts`.
- Re-running → "Updated MEMANTO section" (idempotent — sentinel count unchanged, single extension file).
- `memanto connect remove pi --project-dir <tmp>` → removed all three cleanly.
- Global path resolution → `~/.pi/agent/extensions/memanto-sync.ts` and `~/.pi/agent/skills/memanto` (verified without writing to the real home dir).

## Notes
- The `memanto-sync.ts` is a single self-contained file with **no npm dependencies** (only `node:child_process` + the `memanto` CLI), so deployment is a plain file copy — no `npm install` step.
- Consistent with the existing integrations: the `connect`/install subsystem currently has no dedicated automated tests in `main`, and this PR follows that same pattern. Happy to add a `tests/test_connect.py` (seam = `CliRunner` + `tmp_path`) if maintainers prefer — kept it out to stay minimal and additive.

No related issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for connecting Memanto to Pi via a new `connect pi` command.
  * Pi setup supports `--project-dir` and `--global` options.
  * Pi now performs automatic memory synchronization on session startup, with optional UI notification after sync.
  * Pi includes dedicated instructions/skill integration and can automatically install/remove a supporting Pi code extension during connect/disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->