### PR TITLE
Pytest asyncio marker configuration #770

### DIFF
--- a/fix_pytest_config.md
+++ b/fix_pytest_config.md
@@ -1,0 +1,32 @@
+\## Bug: Pytest asyncio marker not configured
+
+
+
+\### Descripción
+
+Los archivos de prueba (`test\_api.py`, `test\_cors\_fix.py`, `test\_e2e.py`) utilizan el marcador `@pytest.mark.asyncio`, pero el plugin `pytest-asyncio` no está configurado correctamente en el proyecto, lo que provoca que las pruebas fallen con el error: `'asyncio' not found in 'markers' configuration option`.
+
+
+
+\### Pasos para Reproducir
+
+1\. Clonar el repositorio.
+
+2\. Instalar las dependencias: `pip install -e ".\[all]"`
+
+3\. Ejecutar las pruebas: `pytest tests/ -v`
+
+
+
+\### Solución Propuesta
+
+Agregar `pytest-asyncio` a las dependencias de desarrollo y configurarlo en `pyproject.toml` o `pytest.ini` con:
+
+
+
+```ini
+
+\[tool.pytest.ini\_options]
+
+asyncio\_mode = "auto"
+


### PR DESCRIPTION
## Bug: Pytest asyncio marker not configured

### Description
The test files (`test_api.py`, `test_cors_fix.py`, `test_e2e.py`) use the `@pytest.mark.asyncio` marker, but the `pytest-asyncio` plugin is not properly configured in the project. This causes the tests to fail with the error: `'asyncio' not found in 'markers' configuration option`.

### Steps to Reproduce
1. Clone the repository.
2. Install dependencies: `pip install -e ".[all]"`
3. Run the tests: `pytest tests/ -v`

### Proposed Solution
Add `pytest-asyncio` to the development dependencies and configure it in `pyproject.toml` or `pytest.ini` with:

```ini
[tool.pytest.ini_options]
asyncio_mode = "auto"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Spanish-language guide for resolving Pytest errors related to the `asyncio` marker.
  * Documented reproduction steps and configuration guidance for enabling asynchronous test support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->