### PR TITLE
[BOUNTY] Fix rate limiter fail-open → fail-closed (#1438)

### DIFF
--- a/memanto/app/utils/rate_limiting.py
+++ b/memanto/app/utils/rate_limiting.py
@@ -50,7 +50,26 @@ class RateLimiter:
         Returns: (allowed, retry_after_seconds)
         """
         if operation not in self.limits:
-            return True, None
+            # Fail-closed: unknown operations are denied by default.
+            # This prevents silent rate-limit bypass when new operations
+            # are added without registering limits. (See #1438)
+            from memanto.app.utils.logging import MemantoLogger
+            MemantoLogger.log_request(
+                request_id="rate_limit_unknown",
+                route=f"/{operation}",
+                method="POST",
+                status_code=429,
+                latency_ms=0,
+                agent_id=agent_id,
+                errors=["unknown_rate_limit_operation"],
+            )
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "error": "rate_limit_config_error",
+                    "message": f"No rate limit configured for operation '{operation}'",
+                },
+            )
 
         limit = self.limits[operation]
         key = self._get_key(operation, agent_id)


### PR DESCRIPTION
Closes #1438

## What

Changes the rate limiter `check_rate_limit()` from fail-open to fail-closed for unknown operations.

Previously, calling `enforce_rate_limit` with a misspelled or unregistered operation name silently bypassed rate limiting.

Now it raises HTTP 429 with a clear error message, following the principle of least privilege.

## PoC (Before Fix)
```python
from memanto.app.utils.rate_limiting import rate_limiter
allowed, _ = rate_limiter.check_rate_limit("nonexistent_op", "test")
assert allowed == True  # Bug: silently passed
```

## Files Changed
- `memanto/app/utils/rate_limiting.py`: `check_rate_limit()` now denies unknown operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests for operations without a configured rate limit are now blocked with a clear rate-limit configuration error.
  * Unknown rate-limit events are recorded for improved monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->