### PR TITLE
Reject non-positive memory TTLs

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -46,7 +46,7 @@ class MemoryRecord(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     expires_at: datetime | None = None
-    ttl_seconds: int | None = None
+    ttl_seconds: int | None = Field(default=None, gt=0)
 
     def to_moorcheh_document(self) -> dict[str, Any]:
         """
@@ -98,5 +98,7 @@ class MemoryRecord(BaseModel):
 
     def set_ttl(self, seconds: int):
         """Set TTL and expiration"""
+        if seconds <= 0:
+            raise ValueError("ttl_seconds must be greater than 0")
         self.ttl_seconds = seconds
         self.expires_at = datetime.utcnow() + timedelta(seconds=seconds)

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -35,7 +35,7 @@ class MemoryStoreRequest(BaseModel):
     source_ref: str | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
     tags: list[str] = Field(default_factory=list)
-    ttl_seconds: int | None = None
+    ttl_seconds: int | None = Field(default=None, gt=0)
     user_confirmed: bool = False
 
     @field_validator("content")
@@ -55,7 +55,7 @@ class MemoryBatchItem(BaseModel):
     source_ref: str | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
     tags: list[str] = Field(default_factory=list)
-    ttl_seconds: int | None = None
+    ttl_seconds: int | None = Field(default=None, gt=0)
     id: str | None = None  # Optional custom ID
 
     @field_validator("content")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -11,6 +11,7 @@ import jwt
 import pytest
 
 from memanto.app.config import settings
+from memanto.app.core import MemoryRecord
 from memanto.app.models.session import AgentCreate, AgentPattern, Session, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
@@ -250,6 +251,25 @@ class TestSessionService:
         sessions = session_service.list_sessions()
 
         assert [session.agent_id for session in sessions] == [valid_session.agent_id]
+
+
+class TestMemoryRecord:
+    """Unit tests for core memory record invariants."""
+
+    def test_set_ttl_rejects_non_positive_values(self):
+        """Zero/negative TTLs should not create immediately expired memories."""
+        memory = MemoryRecord(
+            type="fact",
+            title="TTL guard",
+            content="This memory should require a positive TTL.",
+            agent_id="agent-ttl",
+            actor_id="agent-ttl",
+            source="agent",
+        )
+
+        for ttl in (0, -60):
+            with pytest.raises(ValueError, match="ttl_seconds must be greater than 0"):
+                memory.set_ttl(ttl)
 
 
 class TestAgentService:


### PR DESCRIPTION
## Summary
- reject zero or negative `ttl_seconds` on memory records and write request models
- make `MemoryRecord.set_ttl()` fail fast instead of creating immediately-expired/hidden memories
- add a regression test for non-positive TTL values

## Bug / reproducibility
Before this change, callers could pass `ttl_seconds=0` or a negative value into the core write path. `set_ttl()` accepted it and computed `expires_at` as now/past, so a newly stored memory could disappear immediately under TTL filtering. Direct model construction could also carry invalid TTL metadata.

Minimal repro before the fix:
```python
from memanto.app.core import MemoryRecord
m = MemoryRecord(type="fact", title="ttl", content="keep me", agent_id="a", actor_id="a", source="agent")
m.set_ttl(0)      # accepted before; expires_at <= now
m.set_ttl(-60)    # accepted before; expires in the past
```

## Validation
- `python3 -m pytest tests/test_unit.py::TestMemoryRecord::test_set_ttl_rejects_non_positive_values -q`
- `python3 -m pytest tests/test_unit.py tests/test_api.py::TestMEMANTOAPI -q`
- `python3 -m pytest tests -q` (passes; live E2E tests are skipped because no real Moorcheh API key is configured)

/claim #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced positive values for memory expiration times.
  * Invalid zero or negative TTL values are now rejected with a clear validation error.
  * Applies consistently to individual and batch memory operations.

* **Tests**
  * Added coverage confirming invalid TTL values are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->