### PR TITLE
fix: report additional semantic search pages

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -98,10 +98,11 @@ class MemoryReadService:
                 metadata_filters=metadata_filters,
             )
 
-            # Build query parameters
-            # Request extra results to handle offset (Moorcheh doesn't have native offset support)
-            requested_limit = limit + offset
-            top_k = min(requested_limit, 100)  # Moorcheh max is 100
+            # Fetch one row beyond the requested page so ``has_more`` can be
+            # derived from actual search results. Moorcheh caps similarity
+            # search at 100 rows.
+            page_end = offset + limit
+            top_k = min(page_end + 1, 100)
 
             # Perform search with server-side filtering.
             # Only enable kiosk_mode when the caller actually set a positive
@@ -138,8 +139,8 @@ class MemoryReadService:
                 )
 
             # Apply pagination (offset + limit)
-            paginated_results = all_results[offset : offset + limit]
-            has_more = len(all_results) > offset + limit
+            has_more = len(all_results) > page_end
+            paginated_results = all_results[offset:page_end]
 
             return {
                 "results": paginated_results,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -441,6 +441,41 @@ class TestMemoryWriteServiceDelete:
 
 
 class TestMemoryReadServiceFormatting:
+    def test_search_memories_reports_lookahead_result(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        search_results = [
+            {
+                "id": "memory-1",
+                "text": "[FACT] First\n\nFirst content",
+                "memory_type": "fact",
+            },
+            {
+                "id": "memory-2",
+                "text": "[FACT] Second\n\nSecond content",
+                "memory_type": "fact",
+            },
+        ]
+        client.similarity_search.query.side_effect = lambda **kwargs: {
+            "results": search_results[: kwargs["top_k"]]
+        }
+        service = MemoryReadService(client)
+
+        result = service.search_memories(
+            "memory", agent_id="agent-1", limit=1, offset=0
+        )
+
+        assert [item["id"] for item in result["results"]] == ["memory-1"]
+        assert result["has_more"] is True
+        client.similarity_search.query.assert_called_once_with(
+            query="memory",
+            namespaces=["memanto_agent_agent-1"],
+            top_k=2,
+            threshold=None,
+            kiosk_mode=False,
+        )
+
     def test_format_memory_item_preserves_falsey_metadata_values(self):
         from memanto.app.services.memory_read_service import MemoryReadService
 


### PR DESCRIPTION
`search_memories()` requested exactly `offset + limit` rows, so it could never see the next result and always returned `has_more: false`.

This fetches one extra row, uses it to set `has_more`, and still returns only the requested page.

Added a regression test. Full test suite, Ruff, and mypy pass.

Related to #770.