### PR TITLE
fix(parser): remove weak auxiliary verbs from STRONG_FACT_PATTERNS to prevent ambiguity guard bypass

### DIFF
--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -41,7 +41,6 @@ class MemoryParsingService:
         for pattern in [
             r"https?://[^\s<>()\[\]{},;:\"']*[^\s<>()\[\]{},;:\"'.,!?]",
             r"\b(?:endpoint|url|api key|path|email|phone|address)\b",
-            r"\b(?:is|are|was|were)\b",
         ]
     ]
 


### PR DESCRIPTION
Fixes #1375.

### Problem
The MemoryParsingService includes an ambiguity guard that filters out weak fact classifications and triggers the fuzzy matching fallback mechanism. However, this guard was systemically bypassed for almost all English sentences because very common auxiliary verbs (`is`, `are`, `was`, `were`) were included in the `STRONG_FACT_PATTERNS` list. 

This resulted in incorrect classifications of weak signals containing these verbs (e.g. classifying sentences containing spelling typos like "decded" as `fact` instead of their correct type like `decision`).

### Solution
We removed `r"\b(?:is|are|was|were)\b"` from the `STRONG_FACT_PATTERNS` list. More specific state-declarative structures (e.g. `is called`, `was enabled`) are already mapped with high confidence scores under `RULES["fact"]`, so standalone auxiliary verbs are too weak and should not bypass the ambiguity check.

This has been successfully verified locally against the reproduction cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory classification accuracy by narrowing the conditions used to identify strong factual statements.
  * Reduced cases where ambiguous statements are incorrectly accepted as facts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->