### PR TITLE
fix(client): prevent silent data overwrites in export_memory_md during backend outages

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1503,6 +1503,7 @@ class DirectClient:
 
         memories_by_type: dict[str, list] = {}
 
+        exceptions = []
         for mem_type in MEMORY_TYPE_ORDER:
             try:
                 result = self.recall(
@@ -1512,8 +1513,15 @@ class DirectClient:
                     type=[mem_type],
                 )
                 memories_by_type[mem_type] = result.get("memories", [])
-            except Exception:
+            except Exception as e:
+                exceptions.append(e)
                 memories_by_type[mem_type] = []
+
+        if len(exceptions) == len(MEMORY_TYPE_ORDER):
+            raise ConnectionError(
+                f"Failed to export memories: Backend unreachable or all recall requests failed. "
+                f"First error: {exceptions[0]}"
+            )
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1365,6 +1365,7 @@ class SdkClient:
 
         memories_by_type: dict[str, list] = {}
 
+        exceptions = []
         for mem_type in MEMORY_TYPE_ORDER:
             try:
                 result = self.recall(
@@ -1374,8 +1375,15 @@ class SdkClient:
                     type=[mem_type],
                 )
                 memories_by_type[mem_type] = result.get("memories", [])
-            except Exception:
+            except Exception as e:
+                exceptions.append(e)
                 memories_by_type[mem_type] = []
+
+        if len(exceptions) == len(MEMORY_TYPE_ORDER):
+            raise ConnectionError(
+                f"Failed to export memories: Backend unreachable or all recall requests failed. "
+                f"First error: {exceptions[0]}"
+            )
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None


### PR DESCRIPTION
Fixes #1340.

### Problem
In both `SdkClient.export_memory_md()` and `DirectClient.export_memory_md()`, the exporter loops through all memory types to retrieve their values. If a transient backend outage or connection error occurs, the `self.recall()` call throws an exception for every type. 

Previously, these exceptions were swallowed inside the loop, causing the exporter to return empty memory lists for all types. This empty payload was then written to disk, silently wiping out existing cache files (`~/.memanto/exports/{agent}_memory.md`) and project `MEMORY.md` backups during an outage.

### Solution
We now track exceptions raised inside the recall loop. If *all* recall requests raise exceptions, we raise a `ConnectionError` instead of writing the output. This propagates the failure to the caller (e.g. `sync_memory_to_project`) and prevents silent data overwrites.

This has been successfully verified locally against the reproduction case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory exports now report a connection error when retrieving all memory types fails.
  * Exports continue with successfully retrieved memory types when only some requests fail.
  * Partial failures are no longer silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->