### PR TITLE
fix: Enforce strict SourceType validation and fail-closed rate limit

### DIFF
--- a/memanto/app/constants.py
+++ b/memanto/app/constants.py
@@ -18,7 +18,7 @@ MemoryType = Literal[
 ]
 
 # Source Types
-SourceType = str  # e.g., "user", "agent", "tool", "system", or specific "agent_name"
+SourceType = Literal["user", "agent", "tool", "system"]  # e.g., "user", "agent", "tool", "system", or specific "agent_name"
 
 # Status Types
 StatusType = Literal["active", "superseded", "deleted", "provisional"]

--- a/memanto/app/legacy/safe_deletion.py
+++ b/memanto/app/legacy/safe_deletion.py
@@ -144,8 +144,10 @@ class SafeDeletion:
                 },
             )
 
+        from memanto.app.utils.ids import is_valid_memory_id
+        
         # 4. Validate ID format
-        invalid_ids = [id for id in ids if not SafeDeletion._is_valid_memory_id(id)]
+        invalid_ids = [id for id in ids if not is_valid_memory_id(id)]
         if invalid_ids:
             raise HTTPException(
                 status_code=400,
@@ -155,16 +157,6 @@ class SafeDeletion:
                     "invalid_ids": invalid_ids[:10],  # Limit error response size
                 },
             )
-
-    @staticmethod
-    def _is_valid_memory_id(memory_id: str) -> bool:
-        """Validate memory ID format"""
-        if not memory_id or len(memory_id) < 4:
-            return False
-
-        # Should match our ID generation pattern
-
-        return bool(re.match(r"^[a-zA-Z0-9_-]+$", memory_id))
 
     @staticmethod
     def perform_safe_deletion(

--- a/memanto/app/legacy/safe_deletion.py
+++ b/memanto/app/legacy/safe_deletion.py
@@ -144,10 +144,8 @@ class SafeDeletion:
                 },
             )
 
-        from memanto.app.utils.ids import is_valid_memory_id
-        
         # 4. Validate ID format
-        invalid_ids = [id for id in ids if not is_valid_memory_id(id)]
+        invalid_ids = [id for id in ids if not SafeDeletion._is_valid_memory_id(id)]
         if invalid_ids:
             raise HTTPException(
                 status_code=400,
@@ -157,6 +155,16 @@ class SafeDeletion:
                     "invalid_ids": invalid_ids[:10],  # Limit error response size
                 },
             )
+
+    @staticmethod
+    def _is_valid_memory_id(memory_id: str) -> bool:
+        """Validate memory ID format"""
+        if not memory_id or len(memory_id) < 4:
+            return False
+
+        # Should match our ID generation pattern
+
+        return bool(re.match(r"^[a-zA-Z0-9_-]+$", memory_id))
 
     @staticmethod
     def perform_safe_deletion(

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -163,7 +163,7 @@ class ConversationMemoryExtractionService:
                     "title": title,
                     "content": content,
                     "confidence": confidence,
-                    "source": "conversation",
+                    "source": "system",
                     "provenance": "inferred",
                 }
             )

--- a/memanto/app/utils/rate_limiting.py
+++ b/memanto/app/utils/rate_limiting.py
@@ -50,7 +50,7 @@ class RateLimiter:
         Returns: (allowed, retry_after_seconds)
         """
         if operation not in self.limits:
-            return True, None
+            raise ValueError(f"Unknown rate limit operation: {operation}")
 
         limit = self.limits[operation]
         key = self._get_key(operation, agent_id)

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -63,7 +63,7 @@ def test_extract_conversation_memories_normalizes_candidates():
             "title": "Editor preference",
             "content": "The user prefers concise pull request summaries.",
             "confidence": 0.91,
-            "source": "conversation",
+            "source": "system",
             "provenance": "inferred",
         },
         {
@@ -71,7 +71,7 @@ def test_extract_conversation_memories_normalizes_candidates():
             "title": "Fallback type",
             "content": "The project uses pytest for unit tests.",
             "confidence": 1.0,
-            "source": "conversation",
+            "source": "system",
             "provenance": "inferred",
         },
     ]

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -12,7 +12,7 @@ def make_memory(content: str, memory_type: MemoryType | None = None) -> MemoryRe
         type=memory_type or "fact",
         title="test",
         actor_id="user",
-        source="test",
+        source="system",
         agent_id="test",
     )
     if memory_type is None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -416,7 +416,7 @@ class TestMemoryWriteServiceDelete:
             "scope_type": "agent",
             "scope_id": "test-agent",
             "actor_id": "tester",
-            "source": "manual",
+            "source": "system",
             "confidence": 0.8,
             "status": "active",
             "tags": [],
@@ -559,7 +559,7 @@ class TestMemoryWriteServiceTimestamps:
             content="Original imported memory",
             agent_id="test-agent",
             actor_id="test-agent",
-            source="mem0",
+            source="system",
             provenance="imported",
             created_at=source_created,
         )


### PR DESCRIPTION
Fixes #1438. Also fixed the tests that were using incorrect SourceTypes. 

Wallet (Solana): 7jXAK7dDBwkAJT67WjPeu8cg577y3x1oMp7ZCSMV18mR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Memory candidates are now consistently labeled with the `"system"` source.
  - Memory ID validation during deletion now uses the shared validation rules for more consistent results.
  - Unrecognized rate-limit operations now return a clear error instead of being silently allowed.

- **Improvements**
  - Source values are now restricted to supported categories, improving data consistency and preventing invalid classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->