### PR TITLE
fix: fail closed for unknown rate limit operations

### DIFF
--- a/memanto/app/legacy/safe_deletion.py
+++ b/memanto/app/legacy/safe_deletion.py
@@ -3,7 +3,6 @@ Safer Deletion with Audit Logging for MEMANTO
 """
 
 import json
-import re
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Any
@@ -159,12 +158,9 @@ class SafeDeletion:
     @staticmethod
     def _is_valid_memory_id(memory_id: str) -> bool:
         """Validate memory ID format"""
-        if not memory_id or len(memory_id) < 4:
-            return False
+        from memanto.app.utils.ids import is_valid_memory_id
 
-        # Should match our ID generation pattern
-
-        return bool(re.match(r"^[a-zA-Z0-9_-]+$", memory_id))
+        return is_valid_memory_id(memory_id)
 
     @staticmethod
     def perform_safe_deletion(

--- a/memanto/app/utils/rate_limiting.py
+++ b/memanto/app/utils/rate_limiting.py
@@ -77,13 +77,24 @@ class RateLimiter:
         try:
             allowed, retry_after = self.check_rate_limit(operation, agent_id)
         except ValueError as exc:
+            from memanto.app.utils.logging import MemantoLogger
+
+            MemantoLogger.log_request(
+                request_id="rate_limit",
+                route=f"/{operation}",
+                method="POST",
+                status_code=500,
+                latency_ms=0,
+                agent_id=agent_id,
+                errors=["rate_limit_misconfigured"],
+            )
             raise HTTPException(
                 status_code=500,
                 detail={
                     "error": "rate_limit_misconfigured",
                     "message": str(exc),
                 },
-            )
+            ) from exc
 
         if not allowed:
             # Log rate limit event

--- a/memanto/app/utils/rate_limiting.py
+++ b/memanto/app/utils/rate_limiting.py
@@ -50,7 +50,7 @@ class RateLimiter:
         Returns: (allowed, retry_after_seconds)
         """
         if operation not in self.limits:
-            return True, None
+            raise ValueError(f"Unknown rate-limited operation: {operation}")
 
         limit = self.limits[operation]
         key = self._get_key(operation, agent_id)
@@ -74,7 +74,16 @@ class RateLimiter:
 
     def enforce_rate_limit(self, operation: str, agent_id: str):
         """Enforce rate limit, raise HTTPException if exceeded"""
-        allowed, retry_after = self.check_rate_limit(operation, agent_id)
+        try:
+            allowed, retry_after = self.check_rate_limit(operation, agent_id)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": "rate_limit_misconfigured",
+                    "message": str(exc),
+                },
+            )
 
         if not allowed:
             # Log rate limit event

--- a/tests/test_rate_limit_validation.py
+++ b/tests/test_rate_limit_validation.py
@@ -1,0 +1,44 @@
+import pytest
+from fastapi import HTTPException
+
+from memanto.app.legacy.safe_deletion import SafeDeletion
+from memanto.app.utils.ids import is_valid_memory_id
+from memanto.app.utils.rate_limiting import RateLimiter
+
+
+def test_unknown_rate_limit_operation_fails_closed():
+    limiter = RateLimiter()
+
+    with pytest.raises(ValueError, match="Unknown rate-limited operation"):
+        limiter.check_rate_limit("namespace_list", "agent-1")
+
+
+def test_enforce_rate_limit_reports_misconfiguration_for_unknown_operation():
+    limiter = RateLimiter()
+
+    with pytest.raises(HTTPException) as exc_info:
+        limiter.enforce_rate_limit("namespace_list", "agent-1")
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail["error"] == "rate_limit_misconfigured"
+
+
+def test_known_rate_limit_operation_still_allows_first_request():
+    limiter = RateLimiter()
+
+    allowed, retry_after = limiter.check_rate_limit("memory_read", "agent-1")
+
+    assert allowed is True
+    assert retry_after is None
+
+
+@pytest.mark.parametrize(
+    "memory_id",
+    [
+        "mem_123456789abc",
+        "abc-123",
+        "abcd",
+    ],
+)
+def test_safe_deletion_uses_canonical_memory_id_validator(memory_id):
+    assert SafeDeletion._is_valid_memory_id(memory_id) is is_valid_memory_id(memory_id)

--- a/tests/test_rate_limit_validation.py
+++ b/tests/test_rate_limit_validation.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from fastapi import HTTPException
 
@@ -13,7 +15,7 @@ def test_unknown_rate_limit_operation_fails_closed():
         limiter.check_rate_limit("namespace_list", "agent-1")
 
 
-def test_enforce_rate_limit_reports_misconfiguration_for_unknown_operation():
+def test_enforce_rate_limit_reports_misconfiguration_for_unknown_operation(capsys):
     limiter = RateLimiter()
 
     with pytest.raises(HTTPException) as exc_info:
@@ -21,6 +23,12 @@ def test_enforce_rate_limit_reports_misconfiguration_for_unknown_operation():
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail["error"] == "rate_limit_misconfigured"
+
+    log_entry = json.loads(capsys.readouterr().out)
+    assert log_entry["status_code"] == 500
+    assert log_entry["route"] == "/namespace_list"
+    assert log_entry["agent_id"] == "agent-1"
+    assert log_entry["errors"] == ["rate_limit_misconfigured"]
 
 
 def test_known_rate_limit_operation_still_allows_first_request():


### PR DESCRIPTION
## Summary
- fail closed when `RateLimiter` receives an unknown operation instead of silently allowing the request
- return a structured 500 `rate_limit_misconfigured` response from enforcement paths so misconfigured wrappers are visible
- reuse the canonical `is_valid_memory_id` helper in legacy `SafeDeletion` so deletion validation matches the rest of the codebase

## Bounty context
Addresses the rate limiter fail-open and memory ID validation inconsistency reported in #1438.
Related to the Memanto Bug & Exploit Challenge #770.

I intentionally did not narrow `SourceType = str` in this PR because the public API currently accepts custom source identifiers for agents/tools. That should be handled as a separate compatibility decision if maintainers want a stricter source enum.

## Validation
- `python -m pytest tests\test_rate_limit_validation.py -q`
- `python -m pytest tests\test_unit.py::TestMemoryWriteServiceDelete -q`
- `python -m ruff check memanto\app\utils\rate_limiting.py memanto\app\legacy\safe_deletion.py tests\test_rate_limit_validation.py`
- `git diff --check` (passes; Git only warned about LF->CRLF on this Windows checkout)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory ID validation now consistently uses the application’s standard format checks.
  * Rate limiting now fails closed when an operation isn’t configured, rather than proceeding.
  * Rate-limit misconfiguration is returned as a structured server error (HTTP 500) with `error: rate_limit_misconfigured`.

* **Tests**
  * Added coverage for rate-limit misconfiguration handling (including logging details).
  * Added coverage to confirm known operations are still allowed and memory ID validation stays consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->