### PR TITLE
Fix LangGraph comma key tag encoding

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -40,6 +40,7 @@ import time
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import quote, unquote
 
 from langgraph.store.base import (
     BaseStore,
@@ -56,6 +57,7 @@ from memanto.cli.client.sdk_client import SdkClient
 logger = logging.getLogger(__name__)
 
 _KEY_TAG_PREFIX = "lg:key:"
+_ENCODED_KEY_TAG_PREFIX = "lg:key:v1:"
 _RESERVED_PREFIX = "lg:"
 
 _VALID_MEMORY_TYPES = {
@@ -413,10 +415,15 @@ class MemantoStore(BaseStore):
 
     @staticmethod
     def _key_to_tag(key: str) -> str:
+        if "," in key:
+            return f"{_ENCODED_KEY_TAG_PREFIX}{quote(key, safe='')}"
         return f"{_KEY_TAG_PREFIX}{key}"
 
     @staticmethod
     def _tags_to_key(tags: list[str]) -> str | None:
+        for t in tags:
+            if t.startswith(_ENCODED_KEY_TAG_PREFIX):
+                return unquote(t[len(_ENCODED_KEY_TAG_PREFIX) :])
         for t in tags:
             if t.startswith(_KEY_TAG_PREFIX):
                 return t[len(_KEY_TAG_PREFIX) :]

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -165,6 +165,27 @@ def test_do_put_success(mock_sdk_client):
     )
 
 
+def test_do_put_escapes_commas_in_key_tags(mock_sdk_client):
+    """LangGraph keys may contain commas; tags are comma-serialized downstream."""
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    op = PutOp(namespace=("my_ns",), key="thread,checkpoint", value={"content": "c"})
+    store._do_put(op)
+
+    client_instance.remember.assert_called_once()
+    assert client_instance.remember.call_args.kwargs["tags"] == [
+        "lg:key:v1:thread%2Ccheckpoint"
+    ]
+
+
+def test_tags_to_key_unescapes_encoded_key_tags():
+    assert MemantoStore._tags_to_key(["lg:key:v1:thread%2Ccheckpoint"]) == (
+        "thread,checkpoint"
+    )
+
+
 def test_do_put_delete_not_supported(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     op = PutOp(namespace=("my_ns",), key="my_key", value=None)


### PR DESCRIPTION
## Summary
- Encode LangGraph store key tags when keys contain commas, avoiding corruption in comma-delimited Memanto tag metadata.
- Decode the versioned encoded key tag when reconstructing LangGraph `SearchItem` / `Item` keys.
- Preserve the legacy `lg:key:<key>` format for existing simple keys.

## Reproduction
`MemantoStore._do_put()` writes each LangGraph key as a reserved tag. Downstream Memanto metadata stores tags as a comma-separated string, so a key such as `thread,checkpoint` is split and cannot be matched/read back as the original key.

## Tests
- `PYTHONPATH=integrations/langgraph:. uv run --with pytest --with langgraph --with langchain-core pytest -q integrations/langgraph/tests/test_store.py`
- `PYTHONPATH=integrations/langgraph:. uv run --with pytest --with langgraph --with langchain-core pytest -q integrations/langgraph/tests`
- `uv run --with ruff ruff check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`
- `uv run --with ruff ruff format --check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py`
- `git diff --check`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed storage and retrieval of LangGraph memory keys containing commas.
  * Preserved compatibility with existing unencoded keys.

* **Tests**
  * Added coverage verifying comma-containing keys are correctly encoded and restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->