### PR TITLE
fix(recall): temporal/confidence filters silently drop matching memories (timeline amnesia)

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -15,6 +15,15 @@ from memanto.app.core import agent_namespace
 from memanto.app.utils.errors import MemoryError
 
 
+# Moorcheh caps a single similarity search at 100 rows.
+MOORCHEH_MAX_TOP_K = 100
+# When post-retrieval filters (temporal / confidence) are active we widen
+# the fetched candidate pool to this size (bounded by MOORCHEH_MAX_TOP_K) so
+# that filtering does not discard relevant rows that rank outside the
+# caller's page. See MemoryReadService.search_memories.
+POST_FILTER_CANDIDATE_POOL = 100
+
+
 class MemoryReadService:
     def __init__(self, moorcheh_client: "MoorchehClient"):
         self.client = moorcheh_client
@@ -101,7 +110,27 @@ class MemoryReadService:
             # Build query parameters
             # Request extra results to handle offset (Moorcheh doesn't have native offset support)
             requested_limit = limit + offset
-            top_k = min(requested_limit, 100)  # Moorcheh max is 100
+
+            # Temporal, confidence and TTL constraints are enforced as
+            # post-processing on the rows the backend returns (see below), so
+            # the candidate pool we fetch must be large enough that those
+            # filters do not silently drop relevant rows. If we only fetched
+            # `limit + offset` rows, a date-scoped or confidence-scoped query
+            # would filter *within the top-N most-similar rows*, causing
+            # in-window memories that rank just outside the top-N to be lost
+            # entirely (timeline amnesia / poor recall). When such a filter is
+            # active, over-fetch up to Moorcheh's hard cap so the filter runs
+            # over a much wider candidate set.
+            post_retrieval_filter_active = bool(
+                created_after or created_before or min_confidence
+            )
+            if post_retrieval_filter_active:
+                top_k = min(
+                    max(requested_limit, POST_FILTER_CANDIDATE_POOL),
+                    MOORCHEH_MAX_TOP_K,
+                )
+            else:
+                top_k = min(requested_limit, MOORCHEH_MAX_TOP_K)  # Moorcheh max is 100
 
             # Perform search with server-side filtering.
             # Only enable kiosk_mode when the caller actually set a positive

--- a/tests/test_memory_read_temporal_recall.py
+++ b/tests/test_memory_read_temporal_recall.py
@@ -1,0 +1,97 @@
+"""
+Regression tests for temporal / post-retrieval recall.
+
+Covers the "timeline amnesia" bug where date-scoped (and other
+post-retrieval) filters were applied only to the top ``limit + offset``
+rows, silently dropping in-window memories that ranked just outside the
+requested page.
+"""
+
+from memanto.app.services.memory_read_service import (
+    MOORCHEH_MAX_TOP_K,
+    MemoryReadService,
+)
+
+
+def _mem(mem_id: str, created_at: str) -> dict:
+    return {
+        "id": mem_id,
+        "text": f"[FACT] Apollo note {mem_id}\n\nProject Apollo status",
+        "memory_type": "fact",
+        "scope_type": "agent",
+        "scope_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+
+
+class _RankedSimilaritySearch:
+    """Fake backend that honours ``top_k`` like the real vector store."""
+
+    def __init__(self, ranked_rows):
+        self._ranked_rows = ranked_rows
+        self.last_kwargs = None
+
+    def query(self, **kwargs):
+        self.last_kwargs = kwargs
+        top_k = kwargs.get("top_k")
+        rows = self._ranked_rows[:top_k] if top_k else self._ranked_rows
+        return {"results": rows, "execution_time": 0}
+
+
+class _Client:
+    def __init__(self, ranked_rows):
+        self.similarity_search = _RankedSimilaritySearch(ranked_rows)
+
+
+def _make_service():
+    # 20 recent (June) rows rank ABOVE 5 older (January) rows by similarity.
+    recent = [_mem(f"jun{i}", "2026-06-20T00:00:00Z") for i in range(20)]
+    january = [_mem(f"jan{i}", "2026-01-10T00:00:00Z") for i in range(5)]
+    return MemoryReadService(_Client(recent + january)), january
+
+
+def test_temporal_window_recalls_rows_outside_the_top_page():
+    """A January-scoped query must recall the January rows even though 20
+    more-similar June rows precede them in the ranking."""
+    service, january = _make_service()
+
+    result = service.search_memories(
+        query="Apollo",
+        agent_id="agent-1",
+        created_after="2026-01-01T00:00:00Z",
+        created_before="2026-01-31T23:59:59Z",
+        limit=10,
+    )
+
+    returned = {m["id"] for m in result["results"]}
+    assert returned == {m["id"] for m in january}
+
+
+def test_post_retrieval_filter_widens_candidate_pool():
+    """When a temporal filter is active the backend must be asked for a wide
+    candidate pool, not just ``limit + offset`` rows."""
+    service, _ = _make_service()
+
+    service.search_memories(
+        query="Apollo",
+        agent_id="agent-1",
+        created_after="2026-01-01T00:00:00Z",
+        limit=5,
+    )
+
+    assert service.client.similarity_search.last_kwargs["top_k"] == MOORCHEH_MAX_TOP_K
+
+
+def test_unfiltered_query_keeps_narrow_fetch():
+    """Without post-retrieval filters we must not over-fetch: top_k stays at
+    the requested page size so ordinary searches are unaffected."""
+    service, _ = _make_service()
+
+    service.search_memories(query="Apollo", agent_id="agent-1", limit=5)
+
+    assert service.client.similarity_search.last_kwargs["top_k"] == 5


### PR DESCRIPTION
## Summary

`MemoryReadService.search_memories()` enforces temporal (`created_after` /
`created_before`), `min_confidence`, and TTL constraints **as Python
post-processing on the rows the backend returns**. But the candidate pool it
fetches from Moorcheh is only `top_k = min(limit + offset, 100)`.

Because the vector store returns rows **ranked by similarity**, any in-window
memory that ranks *below* the top `limit` most-similar rows is never fetched,
so the post-retrieval filter can never include it. A date-scoped question like
*"what did we decide about Apollo in January?"* returns **zero** results even
when many matching January memories exist — and `has_more` comes back `False`,
telling the caller to stop paginating. The memory is effectively invisible.

This hits the core recall/timeline path (retrieval accuracy + "loses track of
when an event occurred") and also silently degrades any `min_confidence`-scoped
query.

## Affected code

`memanto/app/services/memory_read_service.py`, `search_memories()`:

```python
requested_limit = limit + offset
top_k = min(requested_limit, 100)   # candidate pool is only the page size
...
# temporal / confidence / TTL filters run AFTER this truncation
if created_after or created_before:
    all_results = self._apply_temporal_filter(...)
all_results = self._filter_expired_memories(all_results)
if min_confidence is not None:
    all_results = self._filter_by_min_confidence(all_results, min_confidence)
```

## Reproduction (no backend required)

Using a fake similarity-search client that honours `top_k` exactly like the
real vector store — 20 recent (June) memories rank above 5 older (January)
memories, and the user asks for the January window with `limit=10`:

**Before the fix**
```
top_k sent to backend : 10
January memories that EXIST & match : 5
January memories RETURNED           : 0
has_more flag                        : False
```

**After the fix**
```
top_k sent to backend : 100
January memories RETURNED           : 5
```

## Fix

When a post-retrieval filter is active, widen the fetched candidate pool to
Moorcheh's hard cap (100) so filtering runs over a much larger set instead of
just the caller's page. Ordinary (unfiltered) searches are unchanged — they
still fetch only `limit + offset` rows.

```python
post_retrieval_filter_active = bool(created_after or created_before or min_confidence)
if post_retrieval_filter_active:
    top_k = min(max(requested_limit, POST_FILTER_CANDIDATE_POOL), MOORCHEH_MAX_TOP_K)
else:
    top_k = min(requested_limit, MOORCHEH_MAX_TOP_K)
```

## Tests

`tests/test_memory_read_temporal_recall.py` adds three regression tests:

- a January-scoped query recalls the January rows despite 20 higher-ranked June rows;
- an active temporal filter widens `top_k` to the candidate-pool cap;
- an unfiltered query keeps the narrow `top_k` (no over-fetch regression).

Full suite passes locally (`273 passed, 24 skipped`) with the patch applied.

## Known limitation / suggested follow-up

This maximizes recall **within** Moorcheh's 100-row cap. If more than 100 rows
match a query before filtering, rows beyond the cap can still be missed. The
durable fix is to push temporal/confidence predicates into the backend query
(native server-side range/numeric filters) instead of filtering in Python, or
to page the backend fetch until the requested page is filled. Happy to follow
up with that as a separate issue/PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory searches with date or confidence filters so relevant results are not missed when higher-ranked memories fall outside the requested criteria.
  * Preserved efficient result fetching for searches without post-retrieval filters.

* **Tests**
  * Added coverage for date-scoped recall, expanded candidate retrieval, and standard unfiltered searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->