### PR TITLE
fix: account for partial batch upload results

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -215,7 +215,11 @@ class MemoryWriteService:
 
             # Count successes and failures
             successful = sum(1 for r in results if r["status"] in ["queued", "success"])
-            failed = sum(1 for r in results if r["status"] == "failed")
+            # Anything not positively acknowledged by the backend is not a
+            # successful upload. In particular, Moorcheh can return a terminal
+            # aggregate status such as ``partial`` or ``unknown``; leaving
+            # those out of both counters silently loses documents.
+            failed = len(results) - successful
 
             return {
                 "total_submitted": len(memories),

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -599,6 +599,36 @@ class TestMemoryWriteServiceTimestamps:
         assert before_store <= parsed_created_at <= after_store
 
 
+class TestMemoryWriteServiceBatchCounts:
+    """Batch summaries must account for every submitted memory."""
+
+    def test_partial_uploads_are_counted_as_unconfirmed_failures(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "partial"}
+        service = MemoryWriteService(client)
+        memories = [
+            MemoryRecord(
+                title=f"Memory {index}",
+                content=f"Content {index}",
+                agent_id="test-agent",
+                actor_id="test-agent",
+                source="user",
+                provenance="explicit_statement",
+            )
+            for index in range(2)
+        ]
+
+        result = service.batch_store_memories(memories)
+
+        assert result["successful"] == 0
+        assert result["failed"] == 2
+        assert result["successful"] + result["failed"] == result["total_submitted"]
+        assert all(item["status"] == "partial" for item in result["results"])
+
+
 class TestMEMANTOArchitecture:
     """Tests for MEMANTO architecture principles"""
 


### PR DESCRIPTION
## Summary

Fix batch upload summaries so every submitted memory is accounted for when the backend returns an aggregate status such as `partial` or `unknown`.

## Reproduction

When two uploads return `{"status": "partial"}`, the previous implementation reported `successful=0` and `failed=0` despite `total_submitted=2`.

## Changes

- Count every non-successful acknowledgement as failed for summary purposes.
- Add a regression test covering partial upload results.

## Validation

- Targeted pytest passed
- Batch-related tests passed
- Ruff passed
- Compile check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected batch memory upload failure counts when results have partial, unknown, or otherwise unconfirmed statuses.
  * Preserved individual result statuses while accurately reporting successful and failed totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->