### PR TITLE
fix: isolate conflict reports by backend

### DIFF
--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -147,7 +147,7 @@ Format the output as a Markdown report:
         validate_safe_id(agent_id, "agent_id")
         validate_safe_id(date, "date")
 
-        conflicts_dir = Path.home() / ".memanto" / "conflicts"
+        conflicts_dir = get_data_dir() / "conflicts"
         conflicts_dir.mkdir(parents=True, exist_ok=True)
         pattern = f"{agent_id}_{date}_*_summary.md"
         session_files = list(self.sessions_dir.glob(pattern))

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -24,7 +24,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from memanto.app.clients.backend import Backend
-from memanto.app.config import settings
+from memanto.app.config import get_data_dir, settings
 from memanto.app.routes.auth_deps import clear_session_cookie, set_session_cookie
 from memanto.app.utils.validation import validate_safe_id
 from memanto.cli.client.direct_client import DirectClient
@@ -479,7 +479,7 @@ async def list_conflict_scans(
         agent_id = aid
     _validate_agent_id(str(agent_id))
 
-    conflicts_dir = Path.home() / ".memanto" / "conflicts"
+    conflicts_dir = get_data_dir() / "conflicts"
     scans: dict[str, dict] = {}
     if conflicts_dir.exists():
         suffix = "_conflicts.json"
@@ -523,8 +523,6 @@ async def read_daily_summary(
     Response: {exists, agent_id, date, path, content}
     """
     from datetime import datetime as dt
-
-    from memanto.app.config import get_data_dir
 
     if not agent_id:
         aid, _session_token = _config_manager.get_active_session()

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
+from memanto.app.config import get_data_dir
 from memanto.app.constants import (
     ALLOWED_UPDATE_FIELDS as _ALLOWED_UPDATE_FIELDS,
 )
@@ -1274,7 +1275,7 @@ class DirectClient:
         Generate the conflict report for an agent/date.
 
         Runs the LLM conflict-detection pass over the day's session
-        memories and writes the JSON report to ``~/.memanto/conflicts/``.
+        memories and writes the JSON report under the active backend's data dir.
 
         Args:
             agent_id: Target agent.
@@ -1315,9 +1316,7 @@ class DirectClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
 
         if not json_path.exists():
             return []
@@ -1359,9 +1358,7 @@ class DirectClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
+from memanto.app.config import get_data_dir
 from memanto.app.constants import (
     ALLOWED_UPDATE_FIELDS as _ALLOWED_UPDATE_FIELDS,
 )
@@ -1147,7 +1148,7 @@ class SdkClient:
         Generate the conflict report for an agent/date.
 
         Runs the LLM conflict-detection pass over the day's session
-        memories and writes the JSON report to ``~/.memanto/conflicts/``.
+        memories and writes the JSON report under the active backend's data dir.
 
         Args:
             agent_id: Target agent.
@@ -1187,9 +1188,7 @@ class SdkClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
 
         if not json_path.exists():
             return []
@@ -1230,9 +1229,7 @@ class SdkClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import typer
 from rich.panel import Panel
 
+from memanto.app.config import get_data_dir
 from memanto.cli.commands._shared import (
     BOLD_PRIMARY,
     BRIGHT,
@@ -971,9 +972,7 @@ def conflicts(
 
     # Load full conflict list to get original indices
 
-    json_path = (
-        Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-    )
+    json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
     with open(json_path, encoding="utf-8") as f:
         all_conflicts = json.load(f)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1866,6 +1866,29 @@ class TestCWE200ApiKeyLeak:
         assert resp.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_conflict_scans_uses_active_backend_data_dir(
+        self, client, _mock_ui_config_manager, tmp_path, monkeypatch
+    ):
+        """The UI must not expose cloud conflict scans while on-prem is active."""
+        from memanto.app import config as app_config
+
+        monkeypatch.setattr(app_config.settings, "MEMANTO_BACKEND", "on-prem")
+        monkeypatch.setattr(app_config.Path, "home", classmethod(lambda cls: tmp_path))
+        conflicts_dir = tmp_path / ".memanto" / "on-prem" / "conflicts"
+        conflicts_dir.mkdir(parents=True)
+        (conflicts_dir / "agent-1_2026-06-27_conflicts.json").write_text(
+            "[]", encoding="utf-8"
+        )
+
+        resp = await client.get(
+            "/api/ui/conflict-scans",
+            params={"agent_id": "agent-1"},
+        )
+
+        assert resp.status_code == 200
+        assert "2026-06-27" in resp.json()["scans"]
+
+    @pytest.mark.asyncio
     async def test_generate_conflict_report_rejects_traversal_date(
         self, client, _mock_ui_config_manager
     ):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -176,3 +176,27 @@ class TestDataDirRouting:
         result = app_config.get_data_dir()
         assert result == tmp_path / ".memanto" / "on-prem"
         assert result.exists()
+
+
+class TestConflictReportDataDirRouting:
+    def test_clients_read_conflicts_from_active_backend(self, tmp_path, monkeypatch):
+        import json
+
+        from memanto.app import config as app_config
+        from memanto.cli.client.direct_client import DirectClient
+        from memanto.cli.client.sdk_client import SdkClient
+
+        monkeypatch.setattr(app_config.settings, "MEMANTO_BACKEND", "on-prem")
+        monkeypatch.setattr(app_config.Path, "home", classmethod(lambda cls: tmp_path))
+        conflicts_dir = tmp_path / ".memanto" / "on-prem" / "conflicts"
+        conflicts_dir.mkdir(parents=True)
+        report = conflicts_dir / "agent-1_2026-06-28_conflicts.json"
+        report.write_text(
+            json.dumps([{"title": "on-prem conflict", "resolved": False}]),
+            encoding="utf-8",
+        )
+
+        for client_cls in (DirectClient, SdkClient):
+            client = client_cls.__new__(client_cls)
+            conflicts = client.list_conflicts("agent-1", "2026-06-28")
+            assert [item["title"] for item in conflicts] == ["on-prem conflict"]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -191,12 +191,34 @@ class TestConflictReportDataDirRouting:
         conflicts_dir = tmp_path / ".memanto" / "on-prem" / "conflicts"
         conflicts_dir.mkdir(parents=True)
         report = conflicts_dir / "agent-1_2026-06-28_conflicts.json"
-        report.write_text(
-            json.dumps([{"title": "on-prem conflict", "resolved": False}]),
+        on_prem_conflicts = [{"title": "on-prem conflict", "resolved": False}]
+        report.write_text(json.dumps(on_prem_conflicts), encoding="utf-8")
+
+        cloud_dir = tmp_path / ".memanto" / "conflicts"
+        cloud_dir.mkdir(parents=True)
+        cloud_report = cloud_dir / report.name
+        cloud_conflicts = [{"title": "cloud conflict", "resolved": False}]
+        cloud_report.write_text(
+            json.dumps(cloud_conflicts),
             encoding="utf-8",
         )
 
         for client_cls in (DirectClient, SdkClient):
-            client = client_cls.__new__(client_cls)
+            report.write_text(json.dumps(on_prem_conflicts), encoding="utf-8")
+            client = client_cls(api_key="dummy-key")
             conflicts = client.list_conflicts("agent-1", "2026-06-28")
             assert [item["title"] for item in conflicts] == ["on-prem conflict"]
+
+            monkeypatch.setattr(client, "_get_write_service", lambda: object())
+            client.resolve_conflict("agent-1", "2026-06-28", 0, "keep_both")
+
+            assert json.loads(report.read_text(encoding="utf-8")) == [
+                {
+                    "title": "on-prem conflict",
+                    "resolved": True,
+                    "resolution": "keep_both",
+                }
+            ]
+            assert (
+                json.loads(cloud_report.read_text(encoding="utf-8")) == cloud_conflicts
+            )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -683,6 +683,48 @@ def test_conflict_report_handles_non_object_json_items(tmp_path, monkeypatch):
     assert conflicts[0]["description"] == '["not an object", 1]'
 
 
+def test_conflict_report_uses_active_backend_data_dir(tmp_path, monkeypatch):
+    """On-prem conflict reports must not overwrite cloud conflict state."""
+    from unittest.mock import MagicMock
+
+    from memanto.app.config import settings
+    from memanto.app.services import daily_analysis_service as module
+
+    sessions_dir = tmp_path / "sessions"
+    summaries_dir = tmp_path / "summaries"
+    sessions_dir.mkdir()
+    (sessions_dir / "agent-1_2026-06-28_001_summary.md").write_text(
+        "# Session\n\nNo conflicts.", encoding="utf-8"
+    )
+
+    client = MagicMock()
+    client.answer.generate.return_value = {"answer": "[]"}
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: "test-model")
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=summaries_dir,
+    )
+    result = service.generate_conflict_report("agent-1", "2026-06-28")
+
+    expected = (
+        tmp_path
+        / ".memanto"
+        / "on-prem"
+        / "conflicts"
+        / "agent-1_2026-06-28_conflicts.json"
+    )
+    cloud_path = (
+        tmp_path / ".memanto" / "conflicts" / "agent-1_2026-06-28_conflicts.json"
+    )
+    assert result["json_path"] == str(expected)
+    assert expected.exists()
+    assert not cloud_path.exists()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])
 


### PR DESCRIPTION
## Summary

Memanto intentionally isolates on-prem state under `~/.memanto/on-prem/`, but conflict-report storage bypassed `get_data_dir()` across every write and read path. Both cloud and on-prem used `~/.memanto/conflicts/`, so switching backends could expose, resolve, or overwrite the other backend's conflict state for the same agent and date.

This fixes the backend-boundary violation by routing conflict report generation, DirectClient/SdkClient listing and resolution, the interactive CLI, and the UI conflict-scan endpoint through the active backend data directory.

Refs #770

## Reproduction

1. Run Memanto with the cloud backend and generate a conflict report for `agent-1` on `2026-06-28`.
2. Switch to the on-prem backend, which otherwise stores agents, sessions, summaries, and exports under `~/.memanto/on-prem/`.
3. Generate or inspect conflicts for the same agent/date.
4. Before this fix, both backends address `~/.memanto/conflicts/agent-1_2026-06-28_conflicts.json`; the on-prem scan can overwrite the cloud report, and CLI/UI readers cannot distinguish them.
5. After this fix, cloud continues using `~/.memanto/conflicts/`, while on-prem consistently uses `~/.memanto/on-prem/conflicts/`.

The added regressions prove that:

- on-prem report generation writes only under the on-prem data directory;
- DirectClient and SdkClient read and resolve the on-prem report while leaving the cloud report unchanged;
- the UI conflict-scan endpoint lists the active backend's reports.

## Fix

- Replace hard-coded `Path.home() / .memanto / conflicts` paths with `get_data_dir() / conflicts` across all conflict-report surfaces.
- Preserve the existing cloud path unchanged.
- Add writer, client read/write isolation, and UI regression coverage.

## Related work

PR #647 introduced the conflict-scan surfaces but retained or added the hard-coded cloud conflict directory. It does not address backend isolation; this PR fixes the remaining paths on current `main`.

## Validation

- `uv run pytest` - **276 passed, 24 skipped** (live Moorcheh E2E tests require an API key)
- `uv run ruff check .` - passed
- `uv run ruff format --check .` - passed
- `uv run mypy .` - passed
- `git diff --check` - passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conflict reports, listings, and resolutions now store and read from the active backend’s configured data directory (including UI conflict-scan results).
  * Prevents on-prem conflict data from being written to or exposed via the default cloud directory.
  * Memory CLI conflict operations were updated to match the same storage location.

* **Tests**
  * Added API/UI and client routing tests to confirm conflict data is correctly isolated per active backend.
  * Added unit coverage for conflict report output path selection by backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
