### PR TITLE
fix(recall): include full day in date-only as-of queries

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -179,9 +179,12 @@ class MemoryReadService:
             limit: Max results
         """
         try:
-            from memanto.app.utils.temporal_helpers import parse_iso_timestamp
+            from memanto.app.utils.temporal_helpers import (
+                parse_as_of_timestamp,
+                parse_iso_timestamp,
+            )
 
-            as_of_dt = parse_iso_timestamp(as_of_date)
+            as_of_dt = parse_as_of_timestamp(as_of_date)
 
             namespaces = self._get_search_namespaces(agent_id)
             if not namespaces:
@@ -194,7 +197,7 @@ class MemoryReadService:
 
             all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
             all_memories = self._apply_temporal_filter(
-                all_memories, created_before=as_of_date
+                all_memories, created_before=as_of_dt.isoformat()
             )
 
             # Filter to only include memories valid at as_of_date

--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -4,7 +4,7 @@ Temporal Query Helpers
 Utility functions to make temporal queries easier for agents.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 
@@ -34,6 +34,26 @@ def parse_iso_timestamp(ts_str: str) -> datetime:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
+
+
+def parse_as_of_timestamp(ts_str: str) -> datetime:
+    """Parse a point-in-time cutoff, treating a date as the end of that day.
+
+    ``recall_as_of`` is exposed through REST, the Python clients, CLI, and MCP.
+    The REST request model already documents date-only values as end-of-day,
+    while the lower-level clients pass strings directly to the read service.
+    Normalizing at the service boundary keeps every caller consistent without
+    changing the meaning of full ISO timestamps.
+    """
+    if len(ts_str) == 10 and ts_str[4] == "-" and ts_str[7] == "-":
+        try:
+            return datetime.combine(
+                date.fromisoformat(ts_str), time.max, tzinfo=timezone.utc
+            )
+        except ValueError:
+            pass
+
+    return parse_iso_timestamp(ts_str)
 
 
 def format_local_time(ts) -> str:

--- a/tests/test_memory_read_as_of.py
+++ b/tests/test_memory_read_as_of.py
@@ -1,0 +1,59 @@
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _memory(memory_id: str, created_at: str) -> dict:
+    return {
+        "id": memory_id,
+        "text": f"[FACT] {memory_id}\n\nStored memory",
+        "memory_type": "fact",
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+
+
+class _FakeDocuments:
+    def fetch_text_data(self, **kwargs):
+        return {
+            "items": [
+                _memory("morning", "2026-01-15T09:00:00Z"),
+                _memory("evening", "2026-01-15T18:00:00Z"),
+                _memory("next-day", "2026-01-16T00:00:00Z"),
+            ],
+            "pagination": {"has_more": False},
+        }
+
+
+class _FakeClient:
+    documents = _FakeDocuments()
+
+
+def test_search_as_of_date_only_includes_the_whole_day():
+    service = MemoryReadService(_FakeClient())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15",
+        agent_id="agent-1",
+        limit=None,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == [
+        "morning",
+        "evening",
+    ]
+
+
+def test_search_as_of_full_timestamp_keeps_exact_cutoff():
+    service = MemoryReadService(_FakeClient())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15T12:00:00Z",
+        agent_id="agent-1",
+        limit=None,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["morning"]

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -1,6 +1,9 @@
 from datetime import timezone
 
-from memanto.app.utils.temporal_helpers import parse_iso_timestamp
+from memanto.app.utils.temporal_helpers import (
+    parse_as_of_timestamp,
+    parse_iso_timestamp,
+)
 
 
 def test_parse_iso_timestamp_normalizes_offset_to_utc():
@@ -14,4 +17,17 @@ def test_parse_iso_timestamp_assumes_naive_values_are_utc():
     parsed = parse_iso_timestamp("2026-01-15T13:30:00")
 
     assert parsed.tzinfo == timezone.utc
+    assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"
+
+
+def test_parse_as_of_timestamp_treats_date_only_as_end_of_day():
+    parsed = parse_as_of_timestamp("2026-01-15")
+
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.isoformat() == "2026-01-15T23:59:59.999999+00:00"
+
+
+def test_parse_as_of_timestamp_preserves_explicit_time():
+    parsed = parse_as_of_timestamp("2026-01-15T13:30:00Z")
+
     assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"


### PR DESCRIPTION
## Summary

Date-only point-in-time queries are documented as an end-of-day snapshot, and the CLI/MCP examples encourage inputs such as `2026-01-15`. The lower-level clients pass that value directly to `MemoryReadService`, where `datetime.fromisoformat()` interpreted it as midnight. As a result, CLI, Python SDK, DirectClient, and MCP users silently lost every memory created later on the requested date.

This is a bug-challenge submission for #770.

## Reproduction

With three memories created at:

- `2026-01-15T09:00:00Z`
- `2026-01-15T18:00:00Z`
- `2026-01-16T00:00:00Z`

calling `search_as_of(as_of_date="2026-01-15", ...)` previously used `2026-01-15T00:00:00Z` as its cutoff and returned none of the January 15 memories. The date-only contract expects the first two memories and excludes the next-day memory.

The REST request model already normalized date-only values, which masked the inconsistency in API tests. The CLI, SDK, DirectClient, and MCP paths all reach the service without that model.

## Fix

- Add a point-in-time parser that maps an exact `YYYY-MM-DD` value to `23:59:59.999999Z`.
- Preserve the exact meaning of full ISO timestamps, including timezone normalization.
- Use the normalized cutoff for both creation-time filtering and expiration checks.
- Add deterministic, backend-free service regression tests for date-only and full-timestamp cutoffs, plus parser unit tests.

## Verification

- `pytest`: **277 passed, 24 skipped**
- `ruff check .`: **All checks passed**
- `ruff format --check .`: **200 files already formatted**
- `python -m compileall`: passed

No API key or external Moorcheh service is required by the new tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved point-in-time searches using date-only filters.
  * Date-only values now include the entire specified day.
  * Full timestamps continue to apply precise cutoff times.
* **Tests**
  * Added coverage for date-only and timestamp-based temporal searches.
  * Added validation for UTC timestamp normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->