### PR TITLE
fix: coalesce concurrent TypeScript server starts

### DIFF
--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -122,7 +122,9 @@ export class ServerLifecycle {
     if (this.starting === starting) {
       this.starting = null;
     }
-    if (!child || child.killed) return;
+    if (!child || child.killed || child.pid === undefined || child.exitCode !== null) {
+      return;
+    }
 
     let exited = false;
     await new Promise<void>((resolve, reject) => {
@@ -151,6 +153,8 @@ export class ServerLifecycle {
       }
       await sleep(250);
     }
+    // Avoid waiting on the startup promise that is executing this timeout path.
+    this.starting = null;
     await this.stop();
     throw new Error(
       `memanto server at ${baseUrl} did not become healthy within ${timeoutMs}ms${

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -32,6 +32,7 @@ export interface ServerOptions {
 export class ServerLifecycle {
   private process: ChildProcess | null = null;
   private url: string | null = null;
+  private starting: Promise<string> | null = null;
   private cleanupRegistered = false;
 
   constructor(private readonly opts: ServerOptions = {}) {}
@@ -46,6 +47,18 @@ export class ServerLifecycle {
   async start(): Promise<string> {
     if (this.url) return this.url;
 
+    if (!this.starting) {
+      this.starting = this.startOnce();
+    }
+    try {
+      return await this.starting;
+    } catch (err) {
+      this.starting = null;
+      throw err;
+    }
+  }
+
+  private async startOnce(): Promise<string> {
     if (this.opts.baseUrl) {
       this.url = this.opts.baseUrl.replace(/\/$/, "");
       return this.url;
@@ -96,6 +109,7 @@ export class ServerLifecycle {
     const child = this.process;
     this.process = null;
     this.url = null;
+    this.starting = null;
     if (!child || child.killed) return;
 
     let exited = false;

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -47,13 +47,14 @@ export class ServerLifecycle {
   async start(): Promise<string> {
     if (this.url) return this.url;
 
-    if (!this.starting) {
-      this.starting = this.startOnce();
-    }
+    this.starting ??= this.startOnce();
+    const starting = this.starting;
     try {
-      return await this.starting;
+      return await starting;
     } catch (err) {
-      this.starting = null;
+      if (this.starting === starting) {
+        this.starting = null;
+      }
       throw err;
     }
   }
@@ -106,10 +107,21 @@ export class ServerLifecycle {
   }
 
   async stop(): Promise<void> {
+    const starting = this.starting;
+    if (starting) {
+      try {
+        await starting;
+      } catch {
+        // A failed startup leaves no healthy server to preserve.
+      }
+    }
+
     const child = this.process;
     this.process = null;
     this.url = null;
-    this.starting = null;
+    if (this.starting === starting) {
+      this.starting = null;
+    }
     if (!child || child.killed) return;
 
     let exited = false;

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -78,6 +78,7 @@ describe("ServerLifecycle", () => {
     const child = Object.assign(new EventEmitter(), {
       exitCode: null,
       killed: false,
+      pid: 123,
       kill: vi.fn(),
     });
     child.kill.mockImplementation(() => {
@@ -124,6 +125,7 @@ describe("ServerLifecycle", () => {
     const child = Object.assign(new EventEmitter(), {
       exitCode: null,
       killed: false,
+      pid: 123,
       kill: vi.fn(),
     });
     child.kill.mockImplementation(() => {
@@ -138,11 +140,50 @@ describe("ServerLifecycle", () => {
 
     const life = new ServerLifecycle();
     const starting = life.start();
-    await life.stop();
-    await starting;
+    try {
+      await life.stop();
+      await starting;
+
+      expect(child.kill).toHaveBeenCalledTimes(1);
+      expect(() => life.baseUrl).toThrow(/Server not started/);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("stops the process when startup health checks time out", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null,
+      killed: false,
+      pid: 123,
+      kill: vi.fn(),
+    });
+    child.kill.mockImplementation(() => {
+      child.killed = true;
+      queueMicrotask(() => child.emit("exit", 0));
+      return true;
+    });
+    spawnMock.mockReturnValue(child);
+
+    const life = new ServerLifecycle({ healthTimeoutMs: 0 });
+    await expect(life.start()).rejects.toThrow(/did not become healthy/);
 
     expect(child.kill).toHaveBeenCalledTimes(1);
-    expect(() => life.baseUrl).toThrow(/Server not started/);
-    fetchSpy.mockRestore();
+  });
+
+  it("does not wait for exit from a process that failed to spawn", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null,
+      killed: false,
+      pid: undefined,
+      kill: vi.fn(),
+    });
+    const life = new ServerLifecycle();
+    const internals = life as unknown as { process: typeof child };
+    internals.process = child;
+
+    await life.stop();
+
+    expect(child.kill).not.toHaveBeenCalled();
   });
 });

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
 import { createServer, type Server } from "node:http";
 import { AddressInfo } from "node:net";
 import { ServerLifecycle } from "../src/lifecycle.js";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: spawnMock,
+}));
 
 function startFakeHealthyServer(): Promise<{ url: string; close: () => void }> {
   return new Promise((resolve) => {
@@ -63,6 +71,31 @@ describe("ServerLifecycle", () => {
     await life.start();
 
     expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("coalesces concurrent starts into one server process", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null,
+      killed: false,
+      kill: vi.fn(),
+    });
+    child.kill.mockImplementation(() => {
+      child.killed = true;
+      queueMicrotask(() => child.emit("exit", 0));
+      return true;
+    });
+    spawnMock.mockReturnValue(child);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true } as Response);
+
+    const life = new ServerLifecycle();
+    const [first, second] = await Promise.all([life.start(), life.start()]);
+    cleanupFns.push(() => life.stop());
+
+    expect(first).toBe(second);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
     fetchSpy.mockRestore();
   });
 });

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -98,4 +98,51 @@ describe("ServerLifecycle", () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     fetchSpy.mockRestore();
   });
+
+  it("does not let a stale startup failure clear a newer promise", async () => {
+    const life = new ServerLifecycle();
+    let rejectStartup!: (reason: Error) => void;
+    const stale = new Promise<string>((_, reject) => {
+      rejectStartup = reject;
+    });
+    const internals = life as unknown as {
+      startOnce: () => Promise<string>;
+      starting: Promise<string> | null;
+    };
+    vi.spyOn(internals, "startOnce").mockReturnValue(stale);
+
+    const first = life.start();
+    const replacement = Promise.resolve("http://127.0.0.1:9000");
+    internals.starting = replacement;
+    rejectStartup(new Error("startup failed"));
+
+    await expect(first).rejects.toThrow("startup failed");
+    expect(internals.starting).toBe(replacement);
+  });
+
+  it("waits for an in-flight start before stopping its process", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null,
+      killed: false,
+      kill: vi.fn(),
+    });
+    child.kill.mockImplementation(() => {
+      child.killed = true;
+      queueMicrotask(() => child.emit("exit", 0));
+      return true;
+    });
+    spawnMock.mockReturnValue(child);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true } as Response);
+
+    const life = new ServerLifecycle();
+    const starting = life.start();
+    await life.stop();
+    await starting;
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(() => life.baseUrl).toThrow(/Server not started/);
+    fetchSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
/claim #770

## Summary

Coalesce concurrent `ServerLifecycle.start()` calls so the TypeScript SDK starts only one local Memanto server process.

## Flaw and impact

`start()` checked only the resolved `url`. During first startup, it awaits a free port and the health endpoint before setting that field. Two callers entering during that window therefore each selected a port and spawned a separate `uvx` process. The second spawn overwrote `this.process`, leaving the first process untracked and impossible for `stop()` to terminate.

This can happen when multiple public SDK methods are invoked concurrently on a fresh client, causing leaked local server processes and unnecessary resource usage.

## Reproduction

1. Create one `ServerLifecycle` without `baseUrl`.
2. Call `await Promise.all([life.start(), life.start()])` before either startup resolves.
3. Observe that `spawn()` is called twice on the previous implementation.

The new regression test performs this sequence with a mocked healthy child process and asserts a single spawn.

## Fix

- Cache the in-flight startup promise and return it to concurrent callers.
- Clear the cached promise after a startup failure so a later call can retry.
- Clear it during `stop()` so the lifecycle can start again normally.

## Validation

- `npm test -- --run test/lifecycle.test.ts` — 5 passed
- `npm run typecheck` — passed
- `npm test` — 32 passed
- `npm run build` — passed (ESM, CJS, and declarations)

Refs #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup reliability by coalescing concurrent start requests into a single in-flight startup.
  * Cleared stale startup state after failed attempts to ensure reliable retries.
  * Improved shutdown behavior by coordinating stop with any ongoing startup and avoiding waits on invalid spawn states.
* **Tests**
  * Expanded lifecycle coverage using deterministic mocked process spawning, including concurrency, timeout, and failure-mode scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->