### PR TITLE
fix(temporal): one malformed created_at must not disable the entire temporal filter boundary (#770)

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -500,28 +500,28 @@ class MemoryReadService:
         filtered = results
 
         if created_after:
-            try:
-                after_dt = parse_iso_timestamp(created_after)
-                filtered = [
-                    r
-                    for r in filtered
-                    if r.get("created_at")
-                    and parse_iso_timestamp(r["created_at"]) >= after_dt
-                ]
-            except (ValueError, AttributeError):
-                pass  # Skip invalid timestamps
+            after_dt = parse_iso_timestamp(created_after)
+
+            def _after(item: dict[str, Any]) -> bool:
+                try:
+                    raw = item.get("created_at")
+                    return bool(raw) and parse_iso_timestamp(raw) >= after_dt
+                except (ValueError, AttributeError):
+                    return False
+
+            filtered = [r for r in filtered if _after(r)]
 
         if created_before:
-            try:
-                before_dt = parse_iso_timestamp(created_before)
-                filtered = [
-                    r
-                    for r in filtered
-                    if r.get("created_at")
-                    and parse_iso_timestamp(r["created_at"]) <= before_dt
-                ]
-            except (ValueError, AttributeError):
-                pass  # Skip invalid timestamps
+            before_dt = parse_iso_timestamp(created_before)
+
+            def _before(item: dict[str, Any]) -> bool:
+                try:
+                    raw = item.get("created_at")
+                    return bool(raw) and parse_iso_timestamp(raw) <= before_dt
+                except (ValueError, AttributeError):
+                    return False
+
+            filtered = [r for r in filtered if _before(r)]
 
         return filtered
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -498,6 +498,23 @@ class TestMemoryReadServiceFormatting:
         assert formatted["confidence"] == 0.0
         assert formatted["tags"] == []
 
+    def test_temporal_filter_excludes_bad_timestamp_without_disabling_boundary(self):
+        """One corrupt record must not make an as-of boundary fail open."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        results = [
+            {"id": "bad", "created_at": "not-a-timestamp"},
+            {"id": "past", "created_at": "2024-12-31T23:59:59Z"},
+            {"id": "future", "created_at": "2025-01-01T00:00:01Z"},
+        ]
+
+        filtered = MemoryReadService(MagicMock())._apply_temporal_filter(
+            results,
+            created_before="2025-01-01T00:00:00Z",
+        )
+
+        assert [item["id"] for item in filtered] == ["past"]
+
 
 class TestMemoryWriteServiceBatch:
     def test_batch_store_counts_ok_upload_status_as_success(self):


### PR DESCRIPTION
## Summary

Fixes a **fail-open temporal filter boundary bug** in `MemoryReadService._apply_temporal_filter()`.

When any single memory record has a malformed `created_at` string (e.g. `"not-a-timestamp"`), `parse_iso_timestamp()` raises `ValueError` inside the list comprehension. The outer `try/except` catches this and silently returns the **entire unfiltered list** — one corrupt record disables `created_after` / `created_before` filtering for ALL records.

## Root Cause

The per-item timestamp parsing happened inside a list comprehension without per-item error handling. An exception from any single record propagated to the outer `except ValueError: pass`, which left `filtered` unchanged (no filtering applied at all).

## Fix

Move timestamp parsing into per-item helper functions that catch `ValueError`/`AttributeError` at the record level. A bad record is excluded from results, while the rest of the filter boundary continues to work correctly.

## Reproduction

```bash
python -m pytest tests/test_unit.py::TestMemoryReadServiceFormatting::test_temporal_filter_excludes_bad_timestamp_without_disabling_boundary -q
```

On `main`, this test fails — all 3 records pass the `created_before` filter. On this branch, only the record with a valid past timestamp passes.

## Validation

- `python -m pytest -q`: all non-E2E tests pass
- `python -m ruff check memanto/app/services/memory_read_service.py tests/test_unit.py`: pass
- `git diff --check`: pass

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory retrieval when individual records contain invalid timestamps.
  * Invalid memory timestamps are now excluded without interrupting other results or boundary-based filtering.
  * Added stricter validation when formatting retrieved memory records.

* **Tests**
  * Added coverage for temporal filtering with malformed timestamps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->