### PR TITLE
fix(read): normalize tags before filtering

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -684,12 +684,18 @@ class MemoryReadService:
                 return metadata[field_name]
             return item.get(flat_name)
 
-        # Parse tags - can be comma-separated string or array
+        # Parse tags - can be comma-separated string or array. External imports
+        # and older documents may include spaces after commas, so normalize
+        # before exact tag filters run.
         tags_value = get_field("tags")
         if isinstance(tags_value, str):
-            tags = tags_value.split(",") if tags_value else []
+            tags = [tag.strip() for tag in tags_value.split(",") if tag.strip()]
         elif isinstance(tags_value, list):
-            tags = tags_value
+            tags = [
+                str(tag).strip()
+                for tag in tags_value
+                if str(tag).strip()
+            ]
         else:
             tags = []
 

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -689,12 +689,12 @@ class MemoryReadService:
         # before exact tag filters run.
         tags_value = get_field("tags")
         if isinstance(tags_value, str):
-            tags = [tag.strip() for tag in tags_value.split(",") if tag.strip()]
+            tags = [tag_value for tag in tags_value.split(",") if (tag_value := tag.strip())]
         elif isinstance(tags_value, list):
             tags = [
-                str(tag).strip()
+                tag_value
                 for tag in tags_value
-                if str(tag).strip()
+                if tag is not None and (tag_value := str(tag).strip())
             ]
         else:
             tags = []

--- a/tests/test_memory_read_confidence.py
+++ b/tests/test_memory_read_confidence.py
@@ -105,6 +105,20 @@ def test_format_memory_item_normalizes_comma_separated_tag_whitespace():
     assert formatted["tags"] == ["alpha", "beta", "gamma"]
 
 
+def test_format_memory_item_ignores_empty_and_none_list_tags():
+    service = MemoryReadService(None)
+
+    formatted = service._format_memory_item(
+        {
+            "id": "mem-1",
+            "text": "[FACT] List tag cleanup\n\ncontent",
+            "tags": ["alpha", None, " beta ", ""],
+        }
+    )
+
+    assert formatted["tags"] == ["alpha", "beta"]
+
+
 def test_fetch_all_memories_tag_filter_matches_trimmed_list_tags():
     class _FakeDocuments:
         def fetch_text_data(self, **kwargs):

--- a/tests/test_memory_read_confidence.py
+++ b/tests/test_memory_read_confidence.py
@@ -89,3 +89,41 @@ def test_zero_min_confidence_preserves_results_without_confidence_field():
     )
 
     assert [memory["id"] for memory in result["results"]] == ["legacy"]
+
+
+def test_format_memory_item_normalizes_comma_separated_tag_whitespace():
+    service = MemoryReadService(None)
+
+    formatted = service._format_memory_item(
+        {
+            "id": "mem-1",
+            "text": "[FACT] Tag spacing\n\ncontent",
+            "tags": "alpha, beta,  gamma,",
+        }
+    )
+
+    assert formatted["tags"] == ["alpha", "beta", "gamma"]
+
+
+def test_fetch_all_memories_tag_filter_matches_trimmed_list_tags():
+    class _FakeDocuments:
+        def fetch_text_data(self, **kwargs):
+            return {
+                "items": [
+                    {
+                        "id": "mem-1",
+                        "text": "[FACT] Spaced list tags\n\ncontent",
+                        "tags": ["alpha", " beta", ""],
+                    }
+                ],
+                "pagination": {"has_more": False},
+            }
+
+    class _Client:
+        documents = _FakeDocuments()
+
+    service = MemoryReadService(_Client())
+
+    memories = service._fetch_all_memories(["memanto_agent_demo"], tags=["beta"])
+
+    assert [memory["id"] for memory in memories] == ["mem-1"]


### PR DESCRIPTION
## Summary
Bounty submission for #770.

Fixes a retrieval-integrity bug where imported or backend-provided tags with whitespace after commas, or list entries like `" beta"`, were preserved literally. That made exact tag filters skip memories that visibly carried the requested tag.

## Reproduction
A memory formatted from `tags: "alpha, beta"` became `["alpha", " beta"]`, and `_fetch_all_memories(..., tags=["beta"])` could skip it even though the memory carried `beta`.

## Fix
Normalize tags in `MemoryReadService._format_memory_item()` for both comma-separated strings and list-like values by trimming whitespace and dropping empty entries before filtering.

## Validation
- `uv run --extra all python -m pytest tests\test_memory_read_confidence.py -q`
- `uv run --extra all python -m ruff check memanto\app\services\memory_read_service.py tests\test_memory_read_confidence.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory tag formatting by trimming whitespace, splitting comma-separated tag strings more cleanly, and removing empty/invalid entries.
  * Tag-based filtering now matches memories correctly even when stored tags have inconsistent leading/trailing spaces.
* **Tests**
  * Expanded unit tests to verify comma-separated tag normalization, cleanup of list-form tags (ignoring `None`/empty values), and correct behavior of tag filtering with trimmed comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->