### PR TITLE
Validate schedule times before enabling jobs

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -189,7 +189,10 @@ async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
         )
 
     if "schedule_time" in updates:
-        _config_manager.set_schedule_time(updates["schedule_time"])
+        try:
+            _config_manager.set_schedule_time(updates["schedule_time"])
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
 
     if "session" in updates and isinstance(updates["session"], dict):
         data = _config_manager.load_yaml()

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from dotenv import load_dotenv, set_key
 
 from memanto.app.clients.backend import Backend, parse_backend
+from memanto.cli.schedule_time import normalize_schedule_time
 
 yaml = importlib.import_module("yaml")
 
@@ -397,7 +398,7 @@ class ConfigManager:
 
     def set_schedule_time(self, time_str: str) -> None:
         """Set daily summary + conflict time."""
-        self.set("schedule_time", time_str)
+        self.set("schedule_time", normalize_schedule_time(time_str))
 
     # Active session tracking — sourced from SessionService (~/.memanto/sessions/).
     # CLI and API server both go through here so they always agree.

--- a/memanto/cli/schedule_manager.py
+++ b/memanto/cli/schedule_manager.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from memanto.cli.schedule_time import normalize_schedule_time, parse_schedule_time
+
 
 class ScheduleManager:
     """Manages OS-level scheduled tasks for MEMANTO."""
@@ -75,6 +77,11 @@ class ScheduleManager:
     # Windows (schtasks)
 
     def _enable_windows(self, time_str: str = "23:55") -> dict[str, Any]:
+        try:
+            schedule_time = normalize_schedule_time(time_str)
+        except ValueError as e:
+            return {"status": "error", "message": str(e)}
+
         command = [
             "schtasks",
             "/create",
@@ -85,14 +92,14 @@ class ScheduleManager:
             "/sc",
             "daily",
             "/st",
-            time_str,
+            schedule_time,
             "/f",
         ]
         try:
             subprocess.run(command, capture_output=True, text=True, check=True)
             return {
                 "status": "success",
-                "message": f"Scheduled task created for {time_str} daily.",
+                "message": f"Scheduled task created for {schedule_time} daily.",
             }
         except subprocess.CalledProcessError as e:
             return {
@@ -132,10 +139,10 @@ class ScheduleManager:
 
     def _enable_unix(self, time_str: str = "23:55") -> dict[str, Any]:
         try:
-            parts = time_str.split(":")
-            hour, minute = int(parts[0]), int(parts[1])
-        except (ValueError, IndexError):
-            hour, minute = 23, 55
+            hour, minute = parse_schedule_time(time_str)
+            schedule_time = f"{hour:02d}:{minute:02d}"
+        except ValueError as e:
+            return {"status": "error", "message": str(e)}
 
         marker = f"# {self.TASK_NAME}"
         cron_entry = f"{minute} {hour} * * * {self._command()}  {marker}"
@@ -149,7 +156,7 @@ class ScheduleManager:
             subprocess.run(["crontab", "-"], input=new_cron, text=True, check=True)
             return {
                 "status": "success",
-                "message": f"Crontab entry added for {time_str} daily.",
+                "message": f"Crontab entry added for {schedule_time} daily.",
             }
         except Exception as e:
             return {"status": "error", "message": f"Failed to update crontab: {str(e)}"}

--- a/memanto/cli/schedule_time.py
+++ b/memanto/cli/schedule_time.py
@@ -1,0 +1,23 @@
+"""Validation helpers for MEMANTO schedule times."""
+
+import re
+
+_SCHEDULE_TIME_RE = re.compile(r"^([01]?\d|2[0-3]):([0-5]\d)$")
+_SCHEDULE_TIME_ERROR = "schedule_time must be in HH:MM 24-hour format (00:00-23:59)"
+
+
+def parse_schedule_time(time_str: str) -> tuple[int, int]:
+    """Parse a schedule time string into ``(hour, minute)``."""
+    if not isinstance(time_str, str):
+        raise ValueError(_SCHEDULE_TIME_ERROR)
+
+    match = _SCHEDULE_TIME_RE.fullmatch(time_str.strip())
+    if not match:
+        raise ValueError(_SCHEDULE_TIME_ERROR)
+    return int(match.group(1)), int(match.group(2))
+
+
+def normalize_schedule_time(time_str: str) -> str:
+    """Return a canonical HH:MM representation for a valid schedule time."""
+    hour, minute = parse_schedule_time(time_str)
+    return f"{hour:02d}:{minute:02d}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1856,6 +1856,20 @@ class TestCWE200ApiKeyLeak:
         assert data["has_active_session"] is True
 
     @pytest.mark.asyncio
+    async def test_config_update_rejects_invalid_schedule_time(
+        self, client, _mock_ui_config_manager
+    ):
+        """Invalid UI schedule updates should be reported as client errors."""
+        _mock_ui_config_manager.set_schedule_time.side_effect = ValueError(
+            "schedule_time must be in HH:MM 24-hour format (00:00-23:59)"
+        )
+
+        resp = await client.patch("/api/ui/config", json={"schedule_time": "25:61"})
+
+        assert resp.status_code == 400
+        assert "HH:MM" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
     async def test_daily_summary_rejects_traversal_agent_id(
         self, client, tmp_path, _mock_ui_config_manager
     ):

--- a/tests/test_schedule_time_validation.py
+++ b/tests/test_schedule_time_validation.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from memanto.cli.config.manager import ConfigManager
+from memanto.cli.schedule_manager import ScheduleManager
+
+
+def test_unix_schedule_rejects_invalid_time_before_crontab_write():
+    manager = ScheduleManager()
+
+    with patch("memanto.cli.schedule_manager.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="")
+
+        result = manager._enable_unix("not-a-time")
+
+    assert result["status"] == "error"
+    assert "HH:MM" in result["message"]
+    assert all(call.args[0] != ["crontab", "-"] for call in mock_run.call_args_list)
+
+
+def test_unix_schedule_accepts_valid_time_and_writes_normalized_cron():
+    manager = ScheduleManager()
+
+    def _run(command, capture_output=False, text=False, check=False, input=None):
+        if command == ["crontab", "-l"]:
+            return MagicMock(stdout="# existing cron\n")
+        if command == ["crontab", "-"]:
+            assert input is not None
+            assert "5 7 * * *" in input
+            assert "07:05" not in input
+            return MagicMock()
+        raise AssertionError(command)
+
+    with patch("memanto.cli.schedule_manager.subprocess.run", side_effect=_run):
+        result = manager._enable_unix("7:05")
+
+    assert result["status"] == "success"
+    assert "07:05" in result["message"]
+
+
+def test_config_manager_rejects_invalid_schedule_time(tmp_path):
+    manager = ConfigManager(config_dir=tmp_path)
+
+    with pytest.raises(ValueError, match="HH:MM"):
+        manager.set_schedule_time("25:61")


### PR DESCRIPTION
## Summary
- Add shared validation for MEMANTO schedule times in HH:MM 24-hour format.
- Reject invalid schedule times before persisting config or writing OS scheduler entries.
- Return a UI 400 response for invalid schedule_time updates instead of surfacing an internal error.

## Reproduction
Before this change, `ConfigManager.set_schedule_time("25:61")` persisted an invalid value. On Unix, `_enable_unix("not-a-time")` silently fell back to `23:55` and wrote a cron entry; on Windows, the invalid string was passed through to `schtasks`.

## Tests
- `../memanto-770-claim-20260712a/.venv/bin/pytest -q tests/test_schedule_time_validation.py tests/test_cli.py -k schedule`
- `../memanto-770-claim-20260712a/.venv/bin/pytest -q tests/test_api.py::TestCWE200ApiKeyLeak`
- `../memanto-770-claim-20260712a/.venv/bin/ruff check memanto/cli/schedule_time.py memanto/cli/config/manager.py memanto/cli/schedule_manager.py memanto/app/ui/routes/ui_router.py tests/test_schedule_time_validation.py tests/test_api.py`
- `../memanto-770-claim-20260712a/.venv/bin/ruff format --check memanto/cli/schedule_time.py memanto/cli/config/manager.py memanto/cli/schedule_manager.py memanto/app/ui/routes/ui_router.py tests/test_schedule_time_validation.py tests/test_api.py`
- `git diff --check`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule times are now validated using the required 24-hour `HH:MM` format.
  * Valid times are normalized consistently across configuration, Windows scheduling, and Unix cron scheduling.
  * Invalid schedule times now return clear errors without creating or updating schedules.
  * API configuration updates now respond with HTTP 400 for invalid schedule times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->