### PR TITLE
fix: preserve agent when remote purge fails

### DIFF
--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -176,8 +176,6 @@ async def delete_agent(
                 )
             )
         }
-    except AgentNotFoundError as e:
-        raise map_error_to_http_exception(e)
     except Exception as e:
         raise map_error_to_http_exception(e)
 

--- a/memanto/app/routes/sessions.py
+++ b/memanto/app/routes/sessions.py
@@ -158,14 +158,11 @@ async def delete_agent(
             )
 
         if delete_backup_too:
-            # Delete remote namespace only when explicitly requested.
+            # Delete remote namespace only when explicitly requested. This must
+            # succeed before local metadata is removed; otherwise the caller
+            # loses the handle needed to retry a failed purge.
             moorcheh_client = moorcheh_clients.get_moorcheh_client()
-            try:
-                moorcheh_client.namespaces.delete(namespace_name=agent.namespace)
-            except Exception:
-                # If namespace is already gone/unreachable, keep best-effort behavior
-                # and continue removing local metadata.
-                pass
+            moorcheh_client.namespaces.delete(namespace_name=agent.namespace)
 
         agent_service.delete_agent(agent_id)
         get_session_service().delete_session(agent_id)
@@ -180,6 +177,8 @@ async def delete_agent(
             )
         }
     except AgentNotFoundError as e:
+        raise map_error_to_http_exception(e)
+    except Exception as e:
         raise map_error_to_http_exception(e)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -759,6 +759,33 @@ class TestMEMANTOAPI:
         )
 
     @pytest.mark.asyncio
+    async def test_delete_agent_preserves_local_state_when_backup_delete_fails(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """A failed remote purge must remain retryable through the local agent."""
+        agent_id = "retry-delete"
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": agent_id},
+        )
+        mock_moorcheh.namespaces.delete.side_effect = RuntimeError(
+            "remote namespace unavailable"
+        )
+
+        response = await client.delete(
+            f"/api/v2/agents/{agent_id}?delete-backup-too=true",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 500
+        agent_response = await client.get(
+            f"/api/v2/agents/{agent_id}", headers=auth_headers
+        )
+        assert agent_response.status_code == 200
+        assert agent_response.json()["agent_id"] == agent_id
+
+    @pytest.mark.asyncio
     async def test_deactivate_agent(self, client, auth_headers):
         """Test deactivating session"""
         await client.post(


### PR DESCRIPTION
## Summary

DELETE /api/v2/agents/{agent_id}?delete-backup-too=true currently catches every remote namespace deletion error, removes local agent/session state anyway, and returns a success message claiming all memories were deleted.

This changes the operation to fail before local deletion when the requested remote purge fails. The local agent remains available, so the user can retry instead of losing the only normal handle to the retained namespace.

## Reproduction

1. Create an agent.
2. Make namespaces.delete() fail, for example during a temporary backend outage.
3. Delete the agent with delete-backup-too=true.
4. Before this patch, the API returns 200 and the local agent is gone even though its memory namespace remains.

## Validation

- Added an API regression test covering the remote failure and retryable local state.
- uv run pytest -q — 299 passed, 24 skipped because live Moorcheh E2E requires a real key.
- uv run ruff check memanto/app/routes/sessions.py tests/test_api.py
- uv run ruff format --check memanto/app/routes/sessions.py tests/test_api.py

Bounty submission for #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent deletion with “delete backup too” now surfaces remote backup deletion failures instead of silently continuing.
  * Local agent state is preserved when the remote backup purge fails.
  * Unexpected deletion errors now return a consistent server error response, improving clarity for failed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->