### PR TITLE
fix(conflicts): preserve resolutions and fail closed on delete errors (#770)

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -39,7 +39,10 @@ from memanto.app.services.conversation_memory_extraction_service import (
     ConversationMemoryExtractionService,
 )
 from memanto.app.services.memory_read_service import MemoryReadService
-from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.services.memory_write_service import (
+    SUCCESSFUL_UPLOAD_STATUSES,
+    MemoryWriteService,
+)
 from memanto.app.utils.errors import AuthorizationError, map_error_to_http_exception
 from memanto.app.utils.validation import CostGuard, validate_safe_id
 from memanto.cli.client.direct_client import DirectClient
@@ -285,7 +288,18 @@ async def remember(
         # Store memory in agent's namespace.
         result = await asyncio.to_thread(write_service.store_memory, memory)
 
-        # Log to local session Markdown summary
+        upload_status = str(result.get("status", "unknown")).lower()
+        if upload_status not in SUCCESSFUL_UPLOAD_STATUSES:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "message": "Memory upload to backend did not succeed",
+                    "memory_id": result.get("id"),
+                    "backend_status": result.get("status"),
+                },
+            )
+
+        # Log to local session Markdown summary only after confirmed upload.
         session_service = get_session_service()
         await asyncio.to_thread(
             session_service.log_memory_to_session_summary,
@@ -299,7 +313,7 @@ async def remember(
             "agent_id": agent_id,
             "session_id": session.session_id,
             "namespace": session.namespace,
-            "status": "queued",
+            "status": result.get("status", "unknown"),
             "provenance": request.provenance,
             "confidence": request.confidence,
             # Resolved memory type (auto-parsed when not explicitly provided)
@@ -363,16 +377,22 @@ async def batch_remember(
             write_service.batch_store_memories, memory_records
         )
 
-        # Log each memory to local MD summary
+        # Log each successfully stored memory to local MD summary.
         session_service = get_session_service()
+        successful_ids = {
+            item["id"]
+            for item in result["results"]
+            if str(item.get("status", "")).lower() in SUCCESSFUL_UPLOAD_STATUSES
+        }
 
         for record in memory_records:
-            await asyncio.to_thread(
-                session_service.log_memory_to_session_summary,
-                agent_id=agent_id,
-                session_id=session.session_id,
-                memory_record=record,
-            )
+            if record.id in successful_ids:
+                await asyncio.to_thread(
+                    session_service.log_memory_to_session_summary,
+                    agent_id=agent_id,
+                    session_id=session.session_id,
+                    memory_record=record,
+                )
 
         return {
             "agent_id": agent_id,

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -14,6 +14,7 @@ from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import get_data_dir, settings
 from memanto.app.core import agent_namespace
 from memanto.app.services.session_service import get_session_service
+from memanto.app.utils.conflict_helpers import merge_conflict_reports
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.temporal_helpers import (
     format_current_local_time,
@@ -312,6 +313,20 @@ Example response format:
 
         # Save structured JSON for interactive resolution
         json_path = conflicts_dir / f"{agent_id}_{date}_conflicts.json"
+        existing_conflicts: list[dict[str, Any]] = []
+        if json_path.exists():
+            try:
+                with open(json_path, encoding="utf-8") as f:
+                    loaded = json.load(f)
+                if isinstance(loaded, list):
+                    existing_conflicts = loaded
+            except (json.JSONDecodeError, OSError) as exc:
+                print(
+                    f"Warning: Could not load existing conflict report {json_path}: {exc}"
+                )
+
+        conflicts_data = merge_conflict_reports(existing_conflicts, conflicts_data)
+
         with open(json_path, "w", encoding="utf-8") as f:
             json.dump(conflicts_data, f, indent=2, default=str)
 

--- a/memanto/app/utils/conflict_helpers.py
+++ b/memanto/app/utils/conflict_helpers.py
@@ -1,0 +1,66 @@
+"""Shared helpers for conflict report generation and resolution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def conflict_identity(conflict: dict[str, Any]) -> tuple[Any, ...]:
+    """Stable key for deduplicating conflicts across regenerations."""
+    return (
+        conflict.get("old_memory_id"),
+        conflict.get("new_memory_id"),
+        conflict.get("title"),
+        conflict.get("type"),
+    )
+
+
+def merge_conflict_reports(
+    existing: list[dict[str, Any]], newly_detected: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Preserve resolved conflicts when regenerating a daily conflict report."""
+    resolved = [item for item in existing if item.get("resolved")]
+    resolved_keys = {conflict_identity(item) for item in resolved}
+
+    fresh_unresolved = [
+        item
+        for item in newly_detected
+        if not item.get("resolved") and conflict_identity(item) not in resolved_keys
+    ]
+    return resolved + fresh_unresolved
+
+
+def attempt_conflict_delete(
+    write_service: Any,
+    memory_id: str | None,
+    namespace: str,
+    result_details: dict[str, Any],
+    *,
+    label: str | None = None,
+) -> bool:
+    """Delete a memory for conflict resolution; record warnings on failure."""
+    if not memory_id:
+        return True
+
+    warning_key = f"warning_{label}" if label else "warning"
+    deleted_key = f"deleted_{label}" if label else "deleted"
+
+    try:
+        deleted = write_service.delete_memory(memory_id, namespace)
+    except Exception as exc:
+        result_details[warning_key] = f"Could not delete {label or 'memory'} memory: {exc}"
+        return False
+
+    if not deleted:
+        result_details[warning_key] = (
+            f"Memory '{memory_id}' was not deleted (not found in namespace)"
+        )
+        return False
+
+    result_details[deleted_key] = memory_id
+    return True
+
+
+def resolution_has_failures(result_details: dict[str, Any]) -> bool:
+    """Return True when any conflict-resolution warning was recorded."""
+    return any(key == "warning" or key.startswith("warning_") for key in result_details)

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -32,6 +32,10 @@ from memanto.app.constants import (
 from memanto.app.constants import (
     ProvenanceType as MemoryProvenance,
 )
+from memanto.app.utils.conflict_helpers import (
+    attempt_conflict_delete,
+    resolution_has_failures,
+)
 from memanto.app.utils.errors import (
     AgentNotFoundError,
     InvalidSessionTokenError,
@@ -1386,83 +1390,70 @@ class DirectClient:
         result_details = {"action": action}
 
         if action == "keep_old":
-            # Keep old, delete new
-            if new_id:
-                try:
-                    write_service.delete_memory(new_id, namespace)
-                    result_details["deleted"] = new_id
-                except Exception as e:
-                    result_details["warning"] = f"Could not delete new memory: {e}"
+            attempt_conflict_delete(
+                write_service, new_id, namespace, result_details, label="new"
+            )
 
         elif action == "keep_new":
-            # Keep new, delete old
-            if old_id:
-                try:
-                    write_service.delete_memory(old_id, namespace)
-                    result_details["deleted"] = old_id
-                except Exception as e:
-                    result_details["warning"] = f"Could not delete old memory: {e}"
+            attempt_conflict_delete(
+                write_service, old_id, namespace, result_details, label="old"
+            )
 
         elif action == "keep_both":
-            # No-op — both memories remain active
             result_details["note"] = "Both memories kept as-is"
 
         elif action == "remove_both":
-            # Delete both memories
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                attempt_conflict_delete(
+                    write_service, mem_id, namespace, result_details, label=label
+                )
 
         elif action == "manual":
             if not manual_content:
                 raise ValueError("manual_content is required when action is 'manual'")
 
-            # Delete both, store manual replacement
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                attempt_conflict_delete(
+                    write_service, mem_id, namespace, result_details, label=label
+                )
 
-            # Store the manual replacement
-            mem_type = manual_type or conflict.get("type", "fact")
-            if not isinstance(mem_type, str):
-                mem_type = "fact"
-            # Map conflict types to valid memory types
-            if mem_type not in _VALID_MEMORY_TYPES:
-                mem_type = "fact"
-            resolved_type = cast(MemoryType, mem_type)
+            if not resolution_has_failures(result_details):
+                mem_type = manual_type or conflict.get("type", "fact")
+                if not isinstance(mem_type, str):
+                    mem_type = "fact"
+                if mem_type not in _VALID_MEMORY_TYPES:
+                    mem_type = "fact"
+                resolved_type = cast(MemoryType, mem_type)
 
-            from memanto.app.core import MemoryRecord
+                from memanto.app.core import MemoryRecord
 
-            title = (
-                manual_content[:47] + "..."
-                if len(manual_content) > 50
-                else manual_content
-            )
-            memory = MemoryRecord(
-                type=resolved_type,
-                title=title,
-                content=manual_content,
-                agent_id=agent_id,
-                actor_id=agent_id,
-                confidence=0.9,
-                tags=["conflict-resolution"],
-                source="user",
-                provenance="corrected",
-            )
-            store_result = write_service.store_memory(memory)
-            result_details["new_memory_id"] = store_result.get("id")
+                title = (
+                    manual_content[:47] + "..."
+                    if len(manual_content) > 50
+                    else manual_content
+                )
+                memory = MemoryRecord(
+                    type=resolved_type,
+                    title=title,
+                    content=manual_content,
+                    agent_id=agent_id,
+                    actor_id=agent_id,
+                    confidence=0.9,
+                    tags=["conflict-resolution"],
+                    source="user",
+                    provenance="corrected",
+                )
+                store_result = write_service.store_memory(memory)
+                result_details["new_memory_id"] = store_result.get("id")
+                store_status = str(store_result.get("status", "")).lower()
+                if store_status not in {"queued", "success", "ok"}:
+                    result_details["warning"] = (
+                        f"Manual replacement memory was not stored (status={store_status})"
+                    )
+
+        if resolution_has_failures(result_details):
+            result_details["status"] = "failed"
+            return result_details
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -29,6 +29,10 @@ from memanto.app.constants import (
 from memanto.app.constants import (
     ProvenanceType as MemoryProvenance,
 )
+from memanto.app.utils.conflict_helpers import (
+    attempt_conflict_delete,
+    resolution_has_failures,
+)
 from memanto.app.utils.errors import (
     AgentNotFoundError,
     InvalidSessionTokenError,
@@ -1257,78 +1261,70 @@ class SdkClient:
         result_details: dict[str, Any] = {"action": action}
 
         if action == "keep_old":
-            if new_id:
-                try:
-                    write_service.delete_memory(new_id, namespace)
-                    result_details["deleted"] = new_id
-                except Exception as e:
-                    result_details["warning"] = f"Could not delete new memory: {e}"
+            attempt_conflict_delete(
+                write_service, new_id, namespace, result_details, label="new"
+            )
 
         elif action == "keep_new":
-            if old_id:
-                try:
-                    write_service.delete_memory(old_id, namespace)
-                    result_details["deleted"] = old_id
-                except Exception as e:
-                    result_details["warning"] = f"Could not delete old memory: {e}"
+            attempt_conflict_delete(
+                write_service, old_id, namespace, result_details, label="old"
+            )
 
         elif action == "keep_both":
             result_details["note"] = "Both memories kept as-is"
 
         elif action == "remove_both":
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                attempt_conflict_delete(
+                    write_service, mem_id, namespace, result_details, label=label
+                )
 
         elif action == "manual":
             if not manual_content:
                 raise ValueError("manual_content is required when action is 'manual'")
 
-            # Delete both, store manual replacement
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                attempt_conflict_delete(
+                    write_service, mem_id, namespace, result_details, label=label
+                )
 
-            # Store the manual replacement
-            mem_type = manual_type or conflict.get("type", "fact")
-            if not isinstance(mem_type, str):
-                mem_type = "fact"
-            if mem_type not in _VALID_MEMORY_TYPES:
-                mem_type = "fact"
-            resolved_type = cast(MemoryType, mem_type)
+            if not resolution_has_failures(result_details):
+                mem_type = manual_type or conflict.get("type", "fact")
+                if not isinstance(mem_type, str):
+                    mem_type = "fact"
+                if mem_type not in _VALID_MEMORY_TYPES:
+                    mem_type = "fact"
+                resolved_type = cast(MemoryType, mem_type)
 
-            from memanto.app.core import MemoryRecord
+                from memanto.app.core import MemoryRecord
 
-            title = (
-                manual_content[:47] + "..."
-                if len(manual_content) > 50
-                else manual_content
-            )
-            memory = MemoryRecord(
-                type=resolved_type,
-                title=title,
-                content=manual_content,
-                agent_id=agent_id,
-                actor_id=agent_id,
-                confidence=0.9,
-                tags=["conflict-resolution"],
-                source="user",
-                provenance="corrected",
-            )
-            store_result = write_service.store_memory(memory)
-            result_details["new_memory_id"] = store_result.get("id")
+                title = (
+                    manual_content[:47] + "..."
+                    if len(manual_content) > 50
+                    else manual_content
+                )
+                memory = MemoryRecord(
+                    type=resolved_type,
+                    title=title,
+                    content=manual_content,
+                    agent_id=agent_id,
+                    actor_id=agent_id,
+                    confidence=0.9,
+                    tags=["conflict-resolution"],
+                    source="user",
+                    provenance="corrected",
+                )
+                store_result = write_service.store_memory(memory)
+                result_details["new_memory_id"] = store_result.get("id")
+                store_status = str(store_result.get("status", "")).lower()
+                if store_status not in {"queued", "success", "ok"}:
+                    result_details["warning"] = (
+                        f"Manual replacement memory was not stored (status={store_status})"
+                    )
+
+        if resolution_has_failures(result_details):
+            result_details["status"] = "failed"
+            return result_details
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/tests/test_conflict_integrity.py
+++ b/tests/test_conflict_integrity.py
@@ -1,0 +1,187 @@
+"""Regression tests for conflict report integrity and resolution safety."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from memanto.app.utils.conflict_helpers import merge_conflict_reports
+
+
+class TestMergeConflictReports:
+    def test_preserves_resolved_conflicts(self):
+        existing = [
+            {
+                "type": "contradiction",
+                "title": "Database preference changed",
+                "old_memory_id": "old-1",
+                "new_memory_id": "new-1",
+                "resolved": True,
+                "resolution": "keep_new",
+            }
+        ]
+        fresh = [
+            {
+                "type": "contradiction",
+                "title": "Database preference changed",
+                "old_memory_id": "old-1",
+                "new_memory_id": "new-1",
+                "resolved": False,
+            },
+            {
+                "type": "duplicate",
+                "title": "Repeated deployment note",
+                "old_memory_id": "old-2",
+                "new_memory_id": "new-2",
+                "resolved": False,
+            },
+        ]
+
+        merged = merge_conflict_reports(existing, fresh)
+
+        assert len(merged) == 2
+        assert merged[0]["resolved"] is True
+        assert merged[0]["resolution"] == "keep_new"
+        assert merged[1]["title"] == "Repeated deployment note"
+
+
+def test_conflict_regeneration_preserves_resolved_entries(tmp_path, monkeypatch):
+    """Re-running conflict detection must not erase prior user resolutions."""
+    from memanto.app.services import daily_analysis_service as module
+
+    sessions_dir = tmp_path / "sessions"
+    summaries_dir = tmp_path / "summaries"
+    conflicts_dir = tmp_path / ".memanto" / "conflicts"
+    sessions_dir.mkdir()
+    conflicts_dir.mkdir(parents=True)
+
+    (sessions_dir / "agent-1_2026-07-15_001_summary.md").write_text(
+        "# Session\n\nUser switched from PostgreSQL to MongoDB.",
+        encoding="utf-8",
+    )
+
+    existing_report = [
+        {
+            "type": "contradiction",
+            "title": "Database preference changed",
+            "old_memory_id": "old-db",
+            "new_memory_id": "new-db",
+            "resolved": True,
+            "resolution": "keep_new",
+        },
+        {
+            "type": "duplicate",
+            "title": "Repeated deploy note",
+            "old_memory_id": "old-dup",
+            "new_memory_id": "new-dup",
+            "resolved": False,
+        },
+    ]
+    json_path = conflicts_dir / "agent-1_2026-07-15_conflicts.json"
+    json_path.write_text(json.dumps(existing_report), encoding="utf-8")
+
+    client = MagicMock()
+    client.answer.generate.return_value = {
+        "answer": json.dumps(
+            [
+                {
+                    "type": "contradiction",
+                    "title": "Database preference changed",
+                    "old_memory_id": "old-db",
+                    "new_memory_id": "new-db",
+                    "description": "Re-detected contradiction",
+                    "recommendation": "keep_new",
+                }
+            ]
+        )
+    }
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: "test-model")
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=summaries_dir,
+    )
+    result = service.generate_conflict_report("agent-1", "2026-07-15")
+
+    assert result["status"] == "success"
+    saved = json.loads(json_path.read_text(encoding="utf-8"))
+    assert saved[0]["resolved"] is True
+    assert saved[0]["resolution"] == "keep_new"
+    assert any(item.get("title") == "Database preference changed" for item in saved)
+
+
+@pytest.fixture
+def conflict_report_file(tmp_path: Path) -> Path:
+    conflicts_dir = tmp_path / ".memanto" / "conflicts"
+    conflicts_dir.mkdir(parents=True)
+    report = [
+        {
+            "type": "contradiction",
+            "title": "Conflicting preference",
+            "old_memory_id": "old-1",
+            "new_memory_id": "new-1",
+            "resolved": False,
+        }
+    ]
+    json_path = conflicts_dir / "agent-1_2026-07-15_conflicts.json"
+    json_path.write_text(json.dumps(report), encoding="utf-8")
+    return json_path
+
+
+def test_resolve_conflict_fails_when_delete_returns_false(
+    tmp_path, monkeypatch, conflict_report_file
+):
+    """Resolution must stay unresolved when target memories were not deleted."""
+    from memanto.cli.client.direct_client import DirectClient
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    client = DirectClient(api_key="test-key")
+    write_service = MagicMock()
+    write_service.delete_memory.return_value = False
+
+    with patch.object(client, "_get_write_service", return_value=write_service):
+        with patch.object(client, "get_agent", return_value={"agent_id": "agent-1"}):
+            result = client.resolve_conflict(
+                agent_id="agent-1",
+                date="2026-07-15",
+                conflict_index=0,
+                action="keep_new",
+            )
+
+    assert result["status"] == "failed"
+    assert "warning_old" in result
+
+    saved = json.loads(conflict_report_file.read_text(encoding="utf-8"))
+    assert saved[0]["resolved"] is False
+
+
+def test_resolve_conflict_marks_resolved_when_delete_succeeds(
+    tmp_path, monkeypatch, conflict_report_file
+):
+    from memanto.cli.client.direct_client import DirectClient
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    client = DirectClient(api_key="test-key")
+    write_service = MagicMock()
+    write_service.delete_memory.return_value = True
+
+    with patch.object(client, "_get_write_service", return_value=write_service):
+        with patch.object(client, "get_agent", return_value={"agent_id": "agent-1"}):
+            result = client.resolve_conflict(
+                agent_id="agent-1",
+                date="2026-07-15",
+                conflict_index=0,
+                action="keep_new",
+            )
+
+    assert result["status"] == "resolved"
+    saved = json.loads(conflict_report_file.read_text(encoding="utf-8"))
+    assert saved[0]["resolved"] is True
+    assert saved[0]["resolution"] == "keep_new"


### PR DESCRIPTION
## Summary
Fixes three chained memory-integrity bugs for bounty #770:

1. **Conflict regeneration data loss** — re-running detect-conflicts or the nightly schedule overwrote ~/.memanto/conflicts/*.json and erased user resolutions (resolved: true).
2. **False-positive conflict resolution** — resolve_conflict() marked conflicts resolved even when delete_memory() returned False (memories still present).
3. **Phantom session summaries** — POST /{agent_id}/remember hardcoded status: queued and logged failed backend uploads into session Markdown, corrupting daily summaries and conflict detection.

## Reproduction

### Bug 1 — resolution wipe
1. Create a conflict report with one entry and set resolved: true.
2. Run generate_conflict_report() again for the same agent/date.
3. Before: resolved entry gone. After: resolution preserved.

### Bug 2 — false resolution
1. Mock delete_memory() to return False.
2. Call resolve_conflict(..., action=keep_new).
3. Before: status resolved in JSON. After: status failed, resolved false.

### Bug 3 — phantom summary
1. Mock store_memory() to return {status: failed, id: m1}.
2. POST to /remember.
3. Before: HTTP 200 + status queued + session MD updated. After: HTTP 502, no phantom log.

## Validation
- python -m pytest tests/test_conflict_integrity.py -q → 4 passed
- python -m ruff check on touched files → clean

/claim #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Memory entries are now logged locally only after successful backend uploads.
  - Upload failures return clearer error responses, and reported statuses reflect backend results.
  - Regenerating conflict reports now preserves previously resolved conflicts.
  - Conflict resolution stops safely when deletion fails and reports the failure instead of marking conflicts resolved.
  - Manual replacements are created only after earlier resolution steps succeed.

- **Tests**
  - Added coverage for conflict report preservation and successful or failed conflict resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->