### PR TITLE
Feat/okf integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ This means Memanto doesn't need a separate vector DB, embedding pipeline, or rer
 | Grounded QA over memory | `memanto answer` | Generate RAG answers using retrieved memory context. |
 | Daily intelligence workflows | `memanto daily-summary`, `memanto conflicts` | Generate summaries, detect contradictions, and resolve conflicts interactively. |
 | Session and automation controls | `memanto session ...`, `memanto schedule ...` | Inspect sessions and enable scheduled daily summary runs. |
-| Memory file pipelines | `memanto memory export`, `memanto memory sync` | Export structured memory markdown and sync `MEMORY.md` into projects. |
+| Memory file pipelines | `memanto memory export`, `memanto memory sync` | Export structured memory markdown and sync `MEMORY.md` into projects. Add `--okf` to export/sync a portable [Open Knowledge Format](https://docs.memanto.ai/integrations/okf) bundle instead. |
+| Import & migration | `memanto migrate` | Import memories from Mem0, Letta, or Supermemory - or an [OKF](https://docs.memanto.ai/integrations/okf) bundle into an agent. |
 | Configuration inspection | `memanto config show` | Inspect API key status, active agent/session, server settings, and schedule time. |
 | Multi-agent ecosystem integration | `memanto connect ...` | Connect/remove/list integrations for Claude Code, Codex, Cursor, Windsurf, Antigravity, Gemini CLI, Cline, Continue, OpenCode, Goose, Roo, GitHub Copilot, and Augment (local or global). |
 

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -1,0 +1,379 @@
+"""
+OKF (Open Knowledge Format) Export Service
+
+Serializes an agent's memories into an OKF v0.1 bundle — a directory of
+markdown files with YAML frontmatter, one concept per file, grouped into a
+folder per Memanto memory type.
+
+Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf
+
+Layout is controlled by ``split``:
+    - ``auto`` (default): a type with <= ``threshold`` memories is written as
+      one file per memory (``<type>/<slug>.md``); a larger type is collapsed
+      into a single stacked file (``<type>/<type>.md``) to avoid thousands of
+      files for high-volume agents.
+    - ``file``: always one file per memory.
+    - ``type``: always one stacked file per type.
+
+Memanto-only fields (id, confidence, provenance, source, status) are preserved
+under a namespaced ``x_memanto`` frontmatter block so that
+Memanto -> OKF -> Memanto round-trips keep them. OKF consumers ignore unknown
+frontmatter keys.
+"""
+
+import re
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
+from memanto.app.utils.validation import validate_output_path, validate_safe_id
+
+# Stacked files hold multiple OKF documents. This sentinel separates them so
+# the loader can split them back apart without colliding with ``---`` that may
+# appear inside a document body (e.g. the migrate ``[Supporting data]`` footer).
+ENTRY_DELIMITER = "<!-- okf-entry -->"
+
+# Default: collapse a type into a single stacked file once it exceeds this many
+# memories (see the ``auto`` split mode).
+DEFAULT_SPLIT_THRESHOLD = 50
+
+
+def _as_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class OkfExportService:
+    """Formats and writes an OKF bundle for an agent."""
+
+    def __init__(self, exports_dir: Path | None = None):
+        self.exports_dir = exports_dir or (Path.home() / ".memanto" / "exports")
+
+    # Public API
+    def write_okf_bundle(
+        self,
+        agent_id: str,
+        memories_by_type: dict[str, list[dict[str, Any]]],
+        output_dir: Path | None = None,
+        split: str = "auto",
+        threshold: int = DEFAULT_SPLIT_THRESHOLD,
+        summaries: list[Path] | None = None,
+        sessions: list[Path] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Generate and write an OKF bundle to disk.
+
+        The bundle nests memories under ``memories/`` and adds sibling context
+        sections when data is available::
+
+            <bundle>/
+              index.md
+              memories/          # the 13 memory types (from Moorcheh)
+              daily-summaries/   # generated daily-summary MD files
+              sessions/          # per-session logs (adds/deletes + source)
+              metrics/           # aggregate stats & ASCII visualizations
+
+        Args:
+            agent_id: Agent identifier.
+            memories_by_type: Dict mapping memory type -> list of memory dicts.
+            output_dir: Custom bundle directory. Defaults to
+                ``~/.memanto/exports/{agent_id}_okf``.
+            split: Layout mode — ``auto``, ``file``, or ``type``.
+            threshold: Per-type memory count above which ``auto`` collapses to a
+                single stacked file.
+            summaries: Daily-summary MD file paths to copy in (optional).
+            sessions: Session MD file paths to copy in (optional).
+
+        Returns:
+            Dict with ``output_path``, ``total_memories``, ``per_type_counts``,
+            and ``sections`` (the section folders that were written).
+        """
+        validate_safe_id(agent_id, "agent_id")
+        if split not in ("auto", "file", "type"):
+            raise ValueError("split must be one of: auto, file, type")
+
+        if output_dir is None:
+            base = self.exports_dir / f"{agent_id}_okf"
+        else:
+            validated = validate_output_path(
+                str(output_dir), base_dir=self.exports_dir.parent
+            )
+            assert validated is not None
+            base = validated
+        base.mkdir(parents=True, exist_ok=True)
+
+        # Section order mirrors how an agent would read the bundle.
+        sections: dict[str, str] = {}
+
+        type_entries = self._write_memories_section(
+            base / "memories", memories_by_type, split, threshold
+        )
+        per_type_counts = dict(type_entries)
+        total = sum(per_type_counts.values())
+        if type_entries:
+            sections["memories"] = (
+                f"{total} memories across {len(type_entries)} type(s)"
+            )
+
+        n_summaries = self._write_docs_section(
+            base / "daily-summaries", summaries or [], "Daily Summaries"
+        )
+        if n_summaries:
+            sections["daily-summaries"] = f"{n_summaries} daily-summary file(s)"
+
+        n_sessions = self._write_docs_section(
+            base / "sessions", sessions or [], "Sessions"
+        )
+        if n_sessions:
+            sections["sessions"] = f"{n_sessions} session log file(s)"
+
+        if self._write_metrics_section(base / "metrics", memories_by_type):
+            sections["metrics"] = "aggregate stats & visualizations"
+
+        self._write_root_index(base, agent_id, sections)
+
+        return {
+            "output_path": str(base.resolve()),
+            "total_memories": total,
+            "per_type_counts": per_type_counts,
+            "sections": list(sections),
+        }
+
+    # Section writers
+    def _write_memories_section(
+        self,
+        memories_dir: Path,
+        memories_by_type: dict[str, list[dict[str, Any]]],
+        split: str,
+        threshold: int,
+    ) -> list[tuple[str, int]]:
+        """Write the ``memories/`` section (one folder per type). Returns the
+        ``(type, count)`` entries that had memories."""
+        entries: list[tuple[str, int]] = []
+        for mem_type in MEMORY_TYPE_ORDER:
+            memories = memories_by_type.get(mem_type) or []
+            if not memories:
+                continue
+
+            type_dir = memories_dir / mem_type
+            type_dir.mkdir(parents=True, exist_ok=True)
+
+            use_stacked = split == "type" or (
+                split == "auto" and len(memories) > threshold
+            )
+            if use_stacked:
+                docs = [self._render_okf_doc(m, mem_type) for m in memories]
+                stacked = f"\n{ENTRY_DELIMITER}\n".join(docs)
+                (type_dir / f"{mem_type}.md").write_text(stacked, encoding="utf-8")
+                links = [
+                    (m.get("title") or "Untitled", f"{mem_type}.md") for m in memories
+                ]
+            else:
+                used_slugs: set[str] = set()
+                links = []
+                for mem in memories:
+                    slug = self._unique_slug(mem.get("title") or "memory", used_slugs)
+                    (type_dir / f"{slug}.md").write_text(
+                        self._render_okf_doc(mem, mem_type), encoding="utf-8"
+                    )
+                    links.append((mem.get("title") or "Untitled", f"{slug}.md"))
+
+            self._write_index(type_dir, mem_type, f"{mem_type} ({len(links)})", links)
+            entries.append((mem_type, len(memories)))
+
+        if entries:
+            self._write_index(
+                memories_dir,
+                "memories",
+                f"Memories ({sum(count for _, count in entries)})",
+                [(mem_type, f"{mem_type}/index.md") for mem_type, _ in entries],
+            )
+        return entries
+
+    def _write_docs_section(
+        self, section_dir: Path, files: list[Path], title: str
+    ) -> int:
+        """Copy context MD files (daily summaries / session logs) into a section
+        folder verbatim and write an index. Returns the count copied.
+
+        These are export-only context — the loader ignores everything outside
+        ``memories/`` — so they are copied as-is rather than re-wrapped as OKF
+        nodes.
+        """
+        existing = sorted(f for f in files if f.exists())
+        if not existing:
+            return 0
+
+        section_dir.mkdir(parents=True, exist_ok=True)
+        links: list[tuple[str, str]] = []
+        for src in existing:
+            shutil.copy2(str(src), str(section_dir / src.name))
+            links.append((src.name, src.name))
+
+        self._write_index(section_dir, title, f"{title} ({len(links)})", links)
+        return len(links)
+
+    def _write_metrics_section(
+        self, metrics_dir: Path, memories_by_type: dict[str, list[dict[str, Any]]]
+    ) -> bool:
+        """Write a single aggregate metrics overview computed once from the
+        gathered memories (no per-day loop, no LLM). Returns False when there
+        are no memories to chart."""
+        records: list[dict[str, Any]] = []
+        for mem_type, memories in memories_by_type.items():
+            for mem in memories:
+                records.append(
+                    {
+                        "timestamp": self._parse_ts(mem.get("created_at")),
+                        "type": mem_type.upper(),
+                        "title": mem.get("title") or "Untitled",
+                        "confidence": _as_float(mem.get("confidence"), 0.8),
+                    }
+                )
+        if not records:
+            return False
+
+        from memanto.app.services.summary_visualization_service import (
+            SummaryVisualizationService,
+        )
+
+        viz = SummaryVisualizationService().build_visualization_markdown(records)
+        if not viz.strip():
+            return False
+
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        body = f"# Metrics — aggregate\n\n> {len(records)} memories\n{viz}\n"
+        (metrics_dir / "overview.md").write_text(body, encoding="utf-8")
+        self._write_index(
+            metrics_dir, "metrics", "Metrics", [("overview", "overview.md")]
+        )
+        return True
+
+    @staticmethod
+    def _parse_ts(value: Any) -> datetime:
+        """Best-effort parse of a stored ``created_at`` into a datetime; falls
+        back to now so the activity timeline always has an hour bucket."""
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str) and value.strip():
+            text = value.strip()
+            if text.endswith("Z"):
+                text = text[:-1] + "+00:00"
+            try:
+                return datetime.fromisoformat(text)
+            except ValueError:
+                pass
+        return datetime.now()
+
+    # Rendering helpers
+    def _render_okf_doc(self, mem: dict[str, Any], mem_type: str) -> str:
+        """Render a single memory dict as one OKF markdown document."""
+        content = (mem.get("content") or "").strip()
+        title = mem.get("title") or "Untitled"
+
+        frontmatter: dict[str, Any] = {"type": mem_type, "title": title}
+
+        description = self._first_line(content)
+        if description:
+            frontmatter["description"] = description
+
+        tags = mem.get("tags") or []
+        if tags:
+            frontmatter["tags"] = list(tags)
+
+        created_at = mem.get("created_at")
+        if created_at:
+            frontmatter["timestamp"] = str(created_at)
+
+        source_ref = mem.get("source_ref")
+        if source_ref:
+            frontmatter["resource"] = source_ref
+
+        x_memanto: dict[str, Any] = {}
+        for key in ("id", "confidence", "provenance", "source", "status"):
+            val = mem.get(key)
+            if val not in (None, ""):
+                x_memanto[key] = val
+        x_memanto["type"] = mem_type
+        frontmatter["x_memanto"] = x_memanto
+
+        front = yaml.safe_dump(
+            frontmatter,
+            sort_keys=False,
+            allow_unicode=True,
+            default_flow_style=False,
+        ).strip()
+        return f"---\n{front}\n---\n\n{content}\n"
+
+    def _first_line(self, content: str) -> str:
+        """First non-empty line of content (heading marks stripped), for the
+        optional OKF ``description`` field."""
+        for line in content.splitlines():
+            stripped = line.strip().lstrip("#").strip()
+            if stripped:
+                return stripped[:200]
+        return ""
+
+    def _slugify(self, title: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "-", title.lower())
+        slug = re.sub(r"-{2,}", "-", slug).strip("-")
+        return slug[:60].rstrip("-") or "memory"
+
+    def _unique_slug(self, title: str, used: set[str]) -> str:
+        base = self._slugify(title)
+        slug = base
+        counter = 2
+        while slug in used:
+            slug = f"{base}-{counter}"
+            counter += 1
+        used.add(slug)
+        return slug
+
+    def _write_index(
+        self, directory: Path, title: str, heading: str, links: list[tuple[str, str]]
+    ) -> None:
+        """Write a navigational ``index.md`` (skipped on import)."""
+        now = datetime.now().isoformat(timespec="seconds")
+        lines = [
+            "---",
+            "type: index",
+            f"title: {title}",
+            f"timestamp: {now}",
+            "---",
+            "",
+            f"# {heading}",
+            "",
+        ]
+        lines += [f"- [{text}]({rel})" for text, rel in links]
+        lines.append("")
+        (directory / "index.md").write_text("\n".join(lines), encoding="utf-8")
+
+    def _write_root_index(
+        self, base: Path, agent_id: str, sections: dict[str, str]
+    ) -> None:
+        now = datetime.now().isoformat(timespec="seconds")
+        lines = [
+            "---",
+            "type: index",
+            f"title: {agent_id} knowledge bundle",
+            f"timestamp: {now}",
+            "---",
+            "",
+            f"# {agent_id} — OKF bundle",
+            "",
+        ]
+        if sections:
+            lines += [
+                f"- [{name}]({name}/index.md) — {desc}"
+                for name, desc in sections.items()
+            ]
+        else:
+            lines.append("> Empty bundle — no memories found.")
+        lines.append("")
+        (base / "index.md").write_text("\n".join(lines), encoding="utf-8")

--- a/memanto/app/services/summary_visualization_service.py
+++ b/memanto/app/services/summary_visualization_service.py
@@ -46,6 +46,16 @@ class SummaryVisualizationService:
             Markdown string with visual insights (may be empty if no data).
         """
         memories = self._parse_session_files(agent_id, date, sessions_dir)
+        return self.build_visualization_markdown(memories)
+
+    def build_visualization_markdown(self, memories: list[dict]) -> str:
+        """
+        Build the full "Visual Insights" Markdown block from a list of memory
+        records (``{timestamp, type, title, confidence}``).
+
+        Shared by the per-day daily-summary path and aggregate metrics export.
+        Returns an empty string when there are no memories.
+        """
         if not memories:
             return ""
 

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1682,9 +1682,13 @@ class DirectClient:
             total = len(load_okf_bundle(cache)["memories"])
             source = "stale-cache"
 
+        tmp = target.with_suffix(".okf.tmp")
+        if tmp.exists():
+            shutil.rmtree(tmp)
+        shutil.copytree(src, tmp)
         if target.exists():
             shutil.rmtree(target)
-        shutil.copytree(src, target)
+        tmp.rename(target)
 
         return {
             "output_path": str(target.resolve()),

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1499,34 +1499,7 @@ class DirectClient:
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
 
-        from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
-
-        memories_by_type: dict[str, list] = {}
-        failed_types = 0
-
-        for mem_type in MEMORY_TYPE_ORDER:
-            try:
-                result = self.recall(
-                    agent_id=agent_id,
-                    query="*",
-                    limit=limit_per_type,
-                    type=[mem_type],
-                )
-                memories_by_type[mem_type] = result.get("memories", [])
-            except Exception:
-                memories_by_type[mem_type] = []
-                failed_types += 1
-
-        if failed_types == len(MEMORY_TYPE_ORDER):
-            # Every recall failed (e.g. the backend is unreachable) rather
-            # than each type genuinely having zero memories. Raise instead
-            # of writing an empty export — callers may otherwise overwrite
-            # a good cache/MEMORY.md with nothing. See sync_memory_to_project.
-            raise ConnectionError(
-                f"Failed to recall any memories for agent '{agent_id}' — "
-                "the backend appears unreachable. Refusing to write an "
-                "empty export."
-            )
+        memories_by_type = self._gather_memories_by_type(agent_id, limit_per_type)
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None
@@ -1602,6 +1575,121 @@ class DirectClient:
             "output_path": str(target_path.resolve()),
             "total_memories": export_result.get("total_memories", 0),
             "source": "fresh",
+        }
+
+    def _gather_memories_by_type(
+        self, agent_id: str, limit_per_type: int
+    ) -> dict[str, list]:
+        """Recall memories for every type, grouped by type.
+
+        Raises ``ConnectionError`` when *every* type recall fails (backend
+        unreachable) so callers don't overwrite a good export with nothing.
+        """
+        from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
+
+        memories_by_type: dict[str, list] = {}
+        failed_types = 0
+
+        for mem_type in MEMORY_TYPE_ORDER:
+            try:
+                result = self.recall(
+                    agent_id=agent_id,
+                    query="*",
+                    limit=limit_per_type,
+                    type=[mem_type],
+                )
+                memories_by_type[mem_type] = result.get("memories", [])
+            except Exception:
+                memories_by_type[mem_type] = []
+                failed_types += 1
+
+        if failed_types == len(MEMORY_TYPE_ORDER):
+            raise ConnectionError(
+                f"Failed to recall any memories for agent '{agent_id}' — "
+                "the backend appears unreachable. Refusing to write an "
+                "empty export."
+            )
+        return memories_by_type
+
+    def export_okf_bundle(
+        self,
+        agent_id: str,
+        output_dir: str | None = None,
+        split: str = "auto",
+        limit_per_type: int = 25,
+    ) -> dict[str, Any]:
+        """Export all memories for an agent as an OKF bundle directory.
+
+        Args:
+            agent_id: Target agent.
+            output_dir: Bundle directory. Defaults to
+                ``~/.memanto/exports/{agent_id}_okf``.
+            split: OKF layout — ``auto``, ``file``, or ``type``.
+            limit_per_type: Max memories per type (default 25).
+
+        Returns:
+            Dict with ``output_path``, ``total_memories``, ``per_type_counts``.
+        """
+        self._get_validated_session_for_agent(agent_id)
+
+        from memanto.app.config import get_data_dir
+        from memanto.app.services.okf_export_service import OkfExportService
+
+        memories_by_type = self._gather_memories_by_type(agent_id, limit_per_type)
+
+        data_dir = get_data_dir()
+        summaries = sorted((data_dir / "summaries").glob(f"{agent_id}_*.md"))
+        sessions = sorted((data_dir / "sessions").glob(f"{agent_id}_*_summary.md"))
+
+        return OkfExportService().write_okf_bundle(
+            agent_id=agent_id,
+            memories_by_type=memories_by_type,
+            output_dir=Path(output_dir) if output_dir else None,
+            split=split,
+            summaries=summaries,
+            sessions=sessions,
+        )
+
+    def sync_okf_to_project(
+        self,
+        agent_id: str,
+        project_dir: str,
+        split: str = "auto",
+        limit_per_type: int = 25,
+    ) -> dict[str, Any]:
+        """Sync agent memories to a project directory as an OKF bundle (``<project>/okf``).
+
+        Runs a fresh export into the cache, then copies the bundle into the
+        project. Falls back to the previous cached bundle when the backend is
+        unreachable (``source="stale-cache"``).
+        """
+        target = Path(project_dir) / "okf"
+        cache = Path.home() / ".memanto" / "exports" / f"{agent_id}_okf"
+
+        try:
+            result = self.export_okf_bundle(
+                agent_id=agent_id, split=split, limit_per_type=limit_per_type
+            )
+            src = Path(result["output_path"])
+            total = result["total_memories"]
+            source = "fresh"
+        except ConnectionError:
+            if not cache.exists():
+                raise
+            from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+            src = cache
+            total = len(load_okf_bundle(cache)["memories"])
+            source = "stale-cache"
+
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(src, target)
+
+        return {
+            "output_path": str(target.resolve()),
+            "total_memories": total,
+            "source": source,
         }
 
     # Health Check

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1542,9 +1542,13 @@ class SdkClient:
             total = len(load_okf_bundle(cache)["memories"])
             source = "stale-cache"
 
+        tmp = target.with_suffix(".okf.tmp")
+        if tmp.exists():
+            shutil.rmtree(tmp)
+        shutil.copytree(src, tmp)
         if target.exists():
             shutil.rmtree(target)
-        shutil.copytree(src, target)
+        tmp.rename(target)
 
         return {
             "output_path": str(target.resolve()),

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1361,34 +1361,7 @@ class SdkClient:
         # Ensure there is a valid, non-expired session for this agent
         self._get_validated_session_for_agent(agent_id)
 
-        from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
-
-        memories_by_type: dict[str, list] = {}
-        failed_types = 0
-
-        for mem_type in MEMORY_TYPE_ORDER:
-            try:
-                result = self.recall(
-                    agent_id=agent_id,
-                    query="*",
-                    limit=limit_per_type,
-                    type=[mem_type],
-                )
-                memories_by_type[mem_type] = result.get("memories", [])
-            except Exception:
-                memories_by_type[mem_type] = []
-                failed_types += 1
-
-        if failed_types == len(MEMORY_TYPE_ORDER):
-            # Every recall failed (e.g. the backend is unreachable) rather
-            # than each type genuinely having zero memories. Raise instead
-            # of writing an empty export — callers may otherwise overwrite
-            # a good cache/MEMORY.md with nothing. See sync_memory_to_project.
-            raise ConnectionError(
-                f"Failed to recall any memories for agent '{agent_id}' — "
-                "the backend appears unreachable. Refusing to write an "
-                "empty export."
-            )
+        memories_by_type = self._gather_memories_by_type(agent_id, limit_per_type)
 
         export_svc = self._get_export_service()
         out = output_path if output_path else None
@@ -1462,6 +1435,121 @@ class SdkClient:
             "output_path": str(target_path.resolve()),
             "total_memories": 0,
             "source": "fresh",
+        }
+
+    def _gather_memories_by_type(
+        self, agent_id: str, limit_per_type: int
+    ) -> dict[str, list]:
+        """Recall memories for every type, grouped by type.
+
+        Raises ``ConnectionError`` when *every* type recall fails (backend
+        unreachable) so callers don't overwrite a good export with nothing.
+        """
+        from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
+
+        memories_by_type: dict[str, list] = {}
+        failed_types = 0
+
+        for mem_type in MEMORY_TYPE_ORDER:
+            try:
+                result = self.recall(
+                    agent_id=agent_id,
+                    query="*",
+                    limit=limit_per_type,
+                    type=[mem_type],
+                )
+                memories_by_type[mem_type] = result.get("memories", [])
+            except Exception:
+                memories_by_type[mem_type] = []
+                failed_types += 1
+
+        if failed_types == len(MEMORY_TYPE_ORDER):
+            raise ConnectionError(
+                f"Failed to recall any memories for agent '{agent_id}' — "
+                "the backend appears unreachable. Refusing to write an "
+                "empty export."
+            )
+        return memories_by_type
+
+    def export_okf_bundle(
+        self,
+        agent_id: str,
+        output_dir: str | None = None,
+        split: str = "auto",
+        limit_per_type: int = 25,
+    ) -> dict[str, Any]:
+        """Export all memories for an agent as an OKF bundle directory.
+
+        Args:
+            agent_id: Target agent.
+            output_dir: Bundle directory. Defaults to
+                ``~/.memanto/exports/{agent_id}_okf``.
+            split: OKF layout — ``auto``, ``file``, or ``type``.
+            limit_per_type: Max memories per type (default 25).
+
+        Returns:
+            Dict with ``output_path``, ``total_memories``, ``per_type_counts``.
+        """
+        self._get_validated_session_for_agent(agent_id)
+
+        from memanto.app.config import get_data_dir
+        from memanto.app.services.okf_export_service import OkfExportService
+
+        memories_by_type = self._gather_memories_by_type(agent_id, limit_per_type)
+
+        data_dir = get_data_dir()
+        summaries = sorted((data_dir / "summaries").glob(f"{agent_id}_*.md"))
+        sessions = sorted((data_dir / "sessions").glob(f"{agent_id}_*_summary.md"))
+
+        return OkfExportService().write_okf_bundle(
+            agent_id=agent_id,
+            memories_by_type=memories_by_type,
+            output_dir=Path(output_dir) if output_dir else None,
+            split=split,
+            summaries=summaries,
+            sessions=sessions,
+        )
+
+    def sync_okf_to_project(
+        self,
+        agent_id: str,
+        project_dir: str,
+        split: str = "auto",
+        limit_per_type: int = 25,
+    ) -> dict[str, Any]:
+        """Sync agent memories to a project directory as an OKF bundle (``<project>/okf``).
+
+        Runs a fresh export into the cache, then copies the bundle into the
+        project. Falls back to the previous cached bundle when the backend is
+        unreachable (``source="stale-cache"``).
+        """
+        target = Path(project_dir) / "okf"
+        cache = Path.home() / ".memanto" / "exports" / f"{agent_id}_okf"
+
+        try:
+            result = self.export_okf_bundle(
+                agent_id=agent_id, split=split, limit_per_type=limit_per_type
+            )
+            src = Path(result["output_path"])
+            total = result["total_memories"]
+            source = "fresh"
+        except ConnectionError:
+            if not cache.exists():
+                raise
+            from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+            src = cache
+            total = len(load_okf_bundle(cache)["memories"])
+            source = "stale-cache"
+
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(src, target)
+
+        return {
+            "output_path": str(target.resolve()),
+            "total_memories": total,
+            "source": source,
         }
 
     # Health Check

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -262,9 +262,7 @@ def memory_sync(
         if total == 0:
             console.print("\n[yellow]No memories found for this agent.[/yellow]")
         else:
-            console.print(
-                f"\n[green]OK Synced {total} memories to OKF bundle![/green]"
-            )
+            console.print(f"\n[green]OK Synced {total} memories to OKF bundle![/green]")
             console.print(f"[dim]Source: {source_label}[/dim]")
 
         if source == "stale-cache":

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -35,17 +35,29 @@ def memory_export(
     limit: int = typer.Option(
         25, "--limit", "-n", help="Maximum memories per type (default 25)"
     ),
+    okf: bool = typer.Option(
+        False,
+        "--okf",
+        help="Export as an OKF (Open Knowledge Format) bundle directory instead of memory.md",
+    ),
+    split: str = typer.Option(
+        "auto",
+        "--split",
+        help="OKF layout: auto | file | type (only used with --okf)",
+    ),
 ):
     """Export all memories into a structured memory.md file.
 
     Generates a Markdown file with all 13 memory types organized into
-    sections, ready for agent consumption.
+    sections, ready for agent consumption. Pass --okf to instead write an OKF
+    bundle (a directory of markdown files, grouped by type).
 
     Examples:
         memanto memory export
         memanto memory export --agent my-agent
         memanto memory export -o ./memory.md
         memanto memory export -n 50
+        memanto memory export --okf
     """
     start = time.perf_counter()
     active_agent_id, active_session_token = config_manager.get_active_session()
@@ -59,6 +71,60 @@ def memory_export(
         agent_id = active_agent_id
 
     client = get_client()
+
+    if okf:
+        if split not in ("auto", "file", "type"):
+            _error("--split must be one of: auto, file, type")
+
+        console.print(
+            Panel.fit(
+                f"[{BOLD_PRIMARY}]OKF Export[/{BOLD_PRIMARY}]\n"
+                f"Agent: [bold]{agent_id}[/bold]  •  Split: {split}  •  "
+                f"Limit: {limit}/type",
+                border_style=PRIMARY,
+            )
+        )
+
+        with console.status(f"[{PRIMARY}]Building OKF bundle...", spinner="dots"):
+            try:
+                result = client.export_okf_bundle(
+                    agent_id=agent_id,
+                    output_dir=output,
+                    split=split,
+                    limit_per_type=limit,
+                )
+            except Exception as e:
+                _error(f"Failed to export OKF bundle: {e}")
+
+        elapsed = time.perf_counter() - start
+        total = result.get("total_memories", 0)
+        per_type = result.get("per_type_counts", {})
+        out_path = result.get("output_path", "unknown")
+
+        if total == 0:
+            console.print("\n[yellow]No memories found for this agent.[/yellow]")
+        else:
+            table = Table(
+                show_header=True,
+                header_style=BOLD_PRIMARY,
+                title="OKF Bundle Counts",
+            )
+            table.add_column("Type", style=BRIGHT)
+            table.add_column("Count", justify="right", style="white")
+            for mem_type in MEMORY_TYPE_ORDER:
+                count = per_type.get(mem_type, 0)
+                if count > 0:
+                    label, _ = MEMORY_TYPE_META[mem_type]
+                    table.add_row(label, str(count))
+            console.print()
+            console.print(table)
+            console.print(
+                f"\n[green]OK Exported {total} memories to OKF bundle![/green]"
+            )
+
+        console.print(f"[dim]Bundle: {out_path}[/dim]")
+        console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")
+        return
 
     console.print(
         Panel.fit(
@@ -124,16 +190,28 @@ def memory_sync(
         "-n",
         help="Maximum memories per type if fresh export needed (default 25)",
     ),
+    okf: bool = typer.Option(
+        False,
+        "--okf",
+        help="Sync an OKF (Open Knowledge Format) bundle (<project>/okf) instead of MEMORY.md",
+    ),
+    split: str = typer.Option(
+        "auto",
+        "--split",
+        help="OKF layout: auto | file | type (only used with --okf)",
+    ),
 ):
     """Sync agent memories to a project directory's MEMORY.md.
 
     Always performs a fresh export before syncing to ensure the latest
-    memories are captured in the project's MEMORY.md file.
+    memories are captured in the project's MEMORY.md file. Pass --okf to instead
+    sync an OKF bundle into ``<project>/okf``.
 
     Examples:
         memanto memory sync
         memanto memory sync --project-dir ./my-project
         memanto memory sync -p C:\\\\Projects\\\\my-app --agent my-agent
+        memanto memory sync --okf -p ./my-project
     """
     start = time.perf_counter()
     active_agent_id, active_session_token = config_manager.get_active_session()
@@ -147,6 +225,57 @@ def memory_sync(
         agent_id = active_agent_id
 
     client = get_client()
+
+    if okf:
+        if split not in ("auto", "file", "type"):
+            _error("--split must be one of: auto, file, type")
+
+        console.print(
+            Panel.fit(
+                f"[{BOLD_PRIMARY}]OKF Sync[/{BOLD_PRIMARY}]\n"
+                f"Agent: [bold]{agent_id}[/bold]  •  Split: {split}  •  "
+                f"Target_dir: {project_dir}",
+                border_style=PRIMARY,
+            )
+        )
+
+        with console.status(f"[{PRIMARY}]Syncing OKF bundle...", spinner="dots"):
+            try:
+                result = client.sync_okf_to_project(
+                    agent_id=agent_id,
+                    project_dir=project_dir,
+                    split=split,
+                    limit_per_type=limit,
+                )
+            except Exception as e:
+                _error(f"Failed to sync OKF bundle: {e}")
+
+        elapsed = time.perf_counter() - start
+        total = result.get("total_memories", 0)
+        source = result.get("source", "unknown")
+        out_path = result.get("output_path", "unknown")
+        source_label = {
+            "fresh": "fresh export",
+            "stale-cache": "stale cache (backend unreachable)",
+        }.get(source, source)
+
+        if total == 0:
+            console.print("\n[yellow]No memories found for this agent.[/yellow]")
+        else:
+            console.print(
+                f"\n[green]OK Synced {total} memories to OKF bundle![/green]"
+            )
+            console.print(f"[dim]Source: {source_label}[/dim]")
+
+        if source == "stale-cache":
+            console.print(
+                "[yellow]Warning: backend was unreachable; reused the previous "
+                "OKF bundle. Memories may be out of date.[/yellow]"
+            )
+
+        console.print(f"[dim]Output: {out_path}[/dim]")
+        console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")
+        return
 
     console.print(
         Panel.fit(

--- a/memanto/cli/commands/migrate.py
+++ b/memanto/cli/commands/migrate.py
@@ -76,6 +76,7 @@ from memanto.cli.commands._shared import (
     get_client,
     migrate_app,
 )
+from memanto.cli.migrate.okf_loader import load_okf_bundle
 from memanto.cli.migrate.runner import (
     load_export,
     run_migration,
@@ -500,6 +501,121 @@ def migrate_letta(
         agent=agent,
         dry_run=dry_run,
         report=report,
+    )
+
+
+@migrate_app.command("okf")
+def migrate_okf(
+    path: Path = typer.Argument(
+        ...,
+        help="Path to an OKF bundle directory (or a single .md file).",
+    ),
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help="Target Memanto agent id (defaults to the active agent).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the mapping without writing.",
+    ),
+):
+    """Import an OKF (Open Knowledge Format) bundle into the active (or selected) agent.
+
+    Unlike the provider migrations, OKF is a local file bundle — no API key and
+    no savings report. Fields that don't map onto Memanto's schema are preserved
+    in a ``[Supporting data]`` footer, and OKF's free-form ``type`` is
+    auto-classified.
+
+    Examples:
+        memanto migrate okf ./okf-bundle --dry-run
+        memanto migrate okf ./okf-bundle --agent my-agent
+    """
+    if not path.exists():
+        _error(
+            f"OKF bundle not found: {path}",
+            hint="Provide a path to an OKF directory or .md file.",
+        )
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = config_manager.get_migrate_dir("okf") / stamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    mode = "Dry run" if dry_run else "Migrate"
+    console.print(
+        Panel.fit(
+            f"[{BOLD_PRIMARY}]OKF -> Memanto  {mode}[/{BOLD_PRIMARY}]",
+            border_style=PRIMARY,
+        )
+    )
+
+    def progress(msg: str) -> None:
+        console.print(f"  [{BRIGHT}]…[/{BRIGHT}] {msg}")
+
+    target_agent = None if dry_run else _resolve_target_agent(agent)
+
+    progress(f"Loading OKF bundle from {path}")
+    try:
+        export = load_okf_bundle(path)
+    except Exception as exc:
+        _error(f"Failed to load OKF bundle: {exc}")
+
+    progress("Mapping OKF nodes onto Memanto schema...")
+    client = None if dry_run else get_client()
+    summary, rows = run_migration(
+        provider="okf",
+        export=export,
+        client=client,
+        agent_id=target_agent or "",
+        dry_run=dry_run,
+        on_progress=progress,
+    )
+
+    preview_path = write_preview(rows, run_dir / "mapped_preview.json")
+
+    type_lines = (
+        ", ".join(f"{k}: {v}" for k, v in sorted(summary.type_counts.items())) or "—"
+    )
+    body_lines = [
+        f"[dim]OKF nodes:[/dim] {summary.source_count}",
+        f"[dim]Mapped memories:[/dim] {summary.mapped_count}  "
+        f"[dim](skipped {summary.skipped})[/dim]",
+        f"[dim]Type breakdown:[/dim] {type_lines}",
+    ]
+    if dry_run:
+        body_lines.append("")
+        body_lines.append("[yellow]Dry run — no writes performed.[/yellow]")
+    else:
+        body_lines.append(
+            f"[dim]Imported:[/dim] {summary.imported}  "
+            f"[dim]Failed:[/dim] {summary.failed}  "
+            f"[dim]Batches:[/dim] {summary.batches}"
+        )
+        body_lines.append(f"[dim]Target agent:[/dim] {target_agent}")
+
+    body_lines.append("")
+    body_lines.append(f"[dim]Run dir:[/dim] {run_dir}")
+    body_lines.append(f"[dim]Mapped preview:[/dim] {preview_path}")
+    if summary.errors:
+        body_lines.append(
+            f"[red]First error:[/red] {summary.errors[0]}  "
+            "[dim](see run dir for more)[/dim]"
+        )
+
+    border = WARNING if summary.failed else SUCCESS
+    console.print()
+    console.print(
+        Panel(
+            "\n".join(body_lines),
+            title=(
+                "[bold yellow]Dry run complete[/bold yellow]"
+                if dry_run
+                else "[bold green]Import complete[/bold green]"
+            ),
+            border_style=border,
+        )
     )
 
 

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -404,10 +404,94 @@ def map_supermemory(export: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+# --------------------------------------------------------------------------
+# OKF (Open Knowledge Format)
+# --------------------------------------------------------------------------
+
+
+def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map OKF bundle entries (from ``okf_loader.load_okf_bundle``) to Memanto
+    memory payloads.
+
+    OKF's ``type`` is free-form domain vocabulary, so it can't map onto
+    Memanto's fixed types. We use it only when it happens to equal a Memanto
+    type (or when a Memanto ``x_memanto.type`` round-trip value is present);
+    otherwise we leave ``type=None`` for auto-classification and record the
+    original OKF type in the footer. Everything with no schema slot (OKF type,
+    resource, links, unknown frontmatter keys) goes into ``[Supporting data]``.
+    """
+    rows: list[dict[str, Any]] = []
+    migrated_at = _now_utc()
+
+    for entry in export.get("memories", []) or []:
+        body = (entry.get("body") or "").strip()
+        description = (entry.get("description") or "").strip()
+        title = (entry.get("title") or "").strip()
+
+        if description and description not in body:
+            content = f"{description}\n\n{body}".strip()
+        else:
+            content = body
+        if not content:
+            content = title
+        if not content:
+            continue
+
+        x_memanto = entry.get("x_memanto") or {}
+        okf_type = entry.get("type")
+        memory_type = _coerce_type(x_memanto.get("type")) or _coerce_type(okf_type)
+
+        tags = [str(t) for t in (entry.get("tags") or []) if t]
+        resource = entry.get("resource")
+
+        raw_conf = x_memanto.get("confidence")
+        try:
+            confidence = float(raw_conf) if raw_conf is not None else 0.8
+        except (TypeError, ValueError):
+            confidence = 0.8
+        confidence = min(1.0, max(0.0, confidence))
+
+        source = x_memanto.get("source") or "okf"
+        created_at = _parse_dt(entry.get("timestamp"))
+
+        footer_items: list[tuple[str, Any]] = [
+            ("OKF source", entry.get("source_path")),
+            # Only surface the OKF type when we couldn't map it to a slot.
+            ("OKF type", okf_type if not memory_type else None),
+            ("OKF resource", resource),
+            ("Links", entry.get("links")),
+        ]
+        for key, value in (entry.get("extra") or {}).items():
+            footer_items.append((f"OKF {key}", value))
+        footer = _format_supporting_data(footer_items)
+
+        if footer:
+            content = _attach_footer(content, footer)
+        elif len(content) > _MAX_CONTENT_CHARS:
+            content = content[: _MAX_CONTENT_CHARS - 4] + "\n..."
+
+        rows.append(
+            {
+                "title": title or _title_from(content),
+                "content": content,
+                "type": memory_type,
+                "tags": tags,
+                "confidence": confidence,
+                "source": source,
+                "source_ref": str(resource) if resource else None,
+                "provenance": "imported",
+                "created_at": created_at,
+                "updated_at": migrated_at,
+            }
+        )
+    return rows
+
+
 MAPPERS: dict[str, Callable[[dict[str, Any]], list[dict[str, Any]]]] = {
     "mem0": map_mem0,
     "letta": map_letta,
     "supermemory": map_supermemory,
+    "okf": map_okf,
 }
 
 

--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -1,0 +1,133 @@
+"""
+OKF bundle loader.
+
+Reads an OKF (Open Knowledge Format) bundle — a directory of markdown files
+with YAML frontmatter — into the ``{"memories": [...]}`` shape consumed by
+``mappers.map_okf``. Handles both foreign OKF bundles (one concept per file)
+and Memanto's own stacked exports (multiple documents per file, separated by
+the ``okf-entry`` sentinel).
+
+``index.md`` / ``log.md`` navigation files and any document with ``type: index``
+are skipped.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from memanto.app.services.okf_export_service import ENTRY_DELIMITER
+
+# Frontmatter must open at the very start of a (stripped) document. ``.*?`` is
+# non-greedy so the first ``\n---`` closes the block even when the body below
+# contains its own ``---`` rules.
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+_SKIP_FILENAMES = {"index.md", "log.md"}
+# OKF baseline fields + Memanto's namespaced extension block. Anything else in
+# the frontmatter is preserved as "extra" so import stays lossless.
+_KNOWN_FIELDS = {
+    "type",
+    "title",
+    "description",
+    "resource",
+    "tags",
+    "timestamp",
+    "x_memanto",
+}
+
+
+def load_okf_bundle(path: str | Path) -> dict[str, Any]:
+    """Load an OKF bundle directory (or a single ``.md`` file) into an export dict."""
+    root = Path(path)
+    if not root.exists():
+        raise FileNotFoundError(f"OKF bundle not found: {path}")
+
+    if root.is_file():
+        files = [root]
+        rel_base = root.parent
+    else:
+        # Memanto's own bundles nest importable memories under ``memories/``
+        # alongside export-only context (daily-summaries/, sessions/, metrics/).
+        # Scope import to ``memories/`` when present so context logs are never
+        # re-ingested as memories; foreign bundles (no ``memories/``) scan fully.
+        memories_dir = root / "memories"
+        scan_root = memories_dir if memories_dir.is_dir() else root
+        files = sorted(
+            f for f in scan_root.rglob("*.md") if f.name.lower() not in _SKIP_FILENAMES
+        )
+        rel_base = root
+
+    memories: list[dict[str, Any]] = []
+    for file_path in files:
+        text = file_path.read_text(encoding="utf-8")
+        for chunk in text.split(ENTRY_DELIMITER):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            entry = _parse_entry(chunk, file_path, rel_base)
+            if entry is not None:
+                memories.append(entry)
+
+    return {"memories": memories}
+
+
+def _parse_entry(
+    chunk: str, file_path: Path, rel_base: Path
+) -> dict[str, Any] | None:
+    """Parse one OKF document (frontmatter + body) into an entry dict."""
+    match = _FRONTMATTER_RE.match(chunk)
+    if match:
+        raw_frontmatter, body = match.group(1), match.group(2)
+        try:
+            frontmatter = yaml.safe_load(raw_frontmatter) or {}
+        except yaml.YAMLError:
+            frontmatter = {}
+        if not isinstance(frontmatter, dict):
+            frontmatter = {}
+    else:
+        frontmatter, body = {}, chunk
+
+    body = body.strip()
+
+    # Skip navigation index documents.
+    if str(frontmatter.get("type", "")).strip().lower() == "index":
+        return None
+    if not body and not frontmatter.get("title"):
+        return None
+
+    tags = frontmatter.get("tags")
+    if isinstance(tags, str):
+        tags = [tags]
+    elif not isinstance(tags, list):
+        tags = []
+
+    x_memanto = frontmatter.get("x_memanto")
+    if not isinstance(x_memanto, dict):
+        x_memanto = {}
+
+    extra = {k: v for k, v in frontmatter.items() if k not in _KNOWN_FIELDS}
+    links = [f"{text} -> {target}" for text, target in _LINK_RE.findall(body)]
+
+    try:
+        source_path = str(file_path.relative_to(rel_base))
+    except ValueError:
+        source_path = file_path.name
+
+    return {
+        "type": frontmatter.get("type"),
+        "title": frontmatter.get("title"),
+        "description": frontmatter.get("description"),
+        "resource": frontmatter.get("resource"),
+        "tags": tags,
+        "timestamp": frontmatter.get("timestamp"),
+        "body": body,
+        "x_memanto": x_memanto,
+        "links": links,
+        "extra": extra,
+        "source_path": source_path,
+    }

--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -76,9 +76,7 @@ def load_okf_bundle(path: str | Path) -> dict[str, Any]:
     return {"memories": memories}
 
 
-def _parse_entry(
-    chunk: str, file_path: Path, rel_base: Path
-) -> dict[str, Any] | None:
+def _parse_entry(chunk: str, file_path: Path, rel_base: Path) -> dict[str, Any] | None:
     """Parse one OKF document (frontmatter + body) into an entry dict."""
     match = _FRONTMATTER_RE.match(chunk)
     if match:

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -14,7 +14,13 @@ from memanto.cli.migrate.okf_loader import load_okf_bundle
 
 
 def _mem(mem_id, title, content, **extra):
-    base = {"id": mem_id, "title": title, "content": content, "tags": [], "confidence": 0.8}
+    base = {
+        "id": mem_id,
+        "title": title,
+        "content": content,
+        "tags": [],
+        "confidence": 0.8,
+    }
     base.update(extra)
     return base
 
@@ -32,7 +38,9 @@ def test_auto_split_layout(tmp_path):
     }
 
     svc = OkfExportService(exports_dir=tmp_path / "exports")
-    result = svc.write_okf_bundle("agent1", memories_by_type, split="auto", threshold=50)
+    result = svc.write_okf_bundle(
+        "agent1", memories_by_type, split="auto", threshold=50
+    )
     base = svc.exports_dir / "agent1_okf"
     memories = base / "memories"
 
@@ -72,7 +80,12 @@ def test_context_sections_and_import_scope(tmp_path):
     )
     base = svc.exports_dir / "agent1_okf"
 
-    assert set(result["sections"]) == {"memories", "daily-summaries", "sessions", "metrics"}
+    assert set(result["sections"]) == {
+        "memories",
+        "daily-summaries",
+        "sessions",
+        "metrics",
+    }
     assert (base / "daily-summaries" / "agent1_2026-07-01.md").exists()
     assert (base / "sessions" / "agent1_2026-07-01_s1_summary.md").exists()
 
@@ -161,11 +174,15 @@ def test_foreign_okf_bundle_is_lossless(tmp_path):
 def test_loader_splits_stacked_file(tmp_path):
     """A stacked per-type file is split back into one entry per memory."""
     memories_by_type = {
-        "event": [_mem(f"e{i}", f"Standup {i}", f"Standup {i} happened.") for i in range(5)]
+        "event": [
+            _mem(f"e{i}", f"Standup {i}", f"Standup {i} happened.") for i in range(5)
+        ]
     }
     svc = OkfExportService(exports_dir=tmp_path / "exports")
     result = svc.write_okf_bundle("agent1", memories_by_type, split="type")
 
     export = load_okf_bundle(result["output_path"])
     assert len(export["memories"]) == 5
-    assert {m["title"] for m in export["memories"]} == {f"Standup {i}" for i in range(5)}
+    assert {m["title"] for m in export["memories"]} == {
+        f"Standup {i}" for i in range(5)
+    }

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -1,0 +1,171 @@
+"""OKF (Open Knowledge Format) export/import coverage.
+
+Exercises the three pure building blocks — ``OkfExportService`` (Memanto ->
+OKF bundle), ``load_okf_bundle`` (bundle -> entries), and ``map_okf`` (entries
+-> Memanto batch-remember rows) — including the auto-split layout, the
+Memanto <-> OKF round-trip via the ``x_memanto`` frontmatter block, and a
+foreign OKF bundle whose free-form ``type`` and unknown keys must land in the
+``[Supporting data]`` footer without loss.
+"""
+
+from memanto.app.services.okf_export_service import OkfExportService
+from memanto.cli.migrate.mappers import map_okf
+from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+
+def _mem(mem_id, title, content, **extra):
+    base = {"id": mem_id, "title": title, "content": content, "tags": [], "confidence": 0.8}
+    base.update(extra)
+    return base
+
+
+def test_auto_split_layout(tmp_path):
+    """`auto` writes one file per memory for small types and a single stacked
+    file once a type exceeds the threshold; memories live under ``memories/``
+    and index files are always written."""
+    memories_by_type = {
+        "fact": [
+            _mem("f1", "Postgres is the DB", "Uses PostgreSQL 16."),
+            _mem("f2", "API base URL", "Served at https://api.example.com."),
+        ],
+        "event": [_mem(f"e{i}", f"Standup {i}", f"Standup {i}.") for i in range(60)],
+    }
+
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    result = svc.write_okf_bundle("agent1", memories_by_type, split="auto", threshold=50)
+    base = svc.exports_dir / "agent1_okf"
+    memories = base / "memories"
+
+    assert result["total_memories"] == 62
+    assert result["per_type_counts"] == {"fact": 2, "event": 60}
+    assert result["sections"] == ["memories", "metrics"]
+
+    # Small type -> file per memory (+ index); large type -> stacked file.
+    assert (base / "index.md").exists()
+    assert (memories / "index.md").exists()
+    assert (memories / "fact" / "postgres-is-the-db.md").exists()
+    assert (memories / "fact" / "index.md").exists()
+    assert (memories / "event" / "event.md").exists()
+    assert not (memories / "event" / "standup-0.md").exists()
+    # Aggregate metrics generated from the gathered memories.
+    assert (base / "metrics" / "overview.md").exists()
+
+
+def test_context_sections_and_import_scope(tmp_path):
+    """Daily-summary and session files are copied into their sections, and
+    import stays scoped to ``memories/`` so those context logs are never
+    re-ingested as memories."""
+    summary = tmp_path / "agent1_2026-07-01.md"
+    summary.write_text("# Daily summary\nStuff happened.\n", encoding="utf-8")
+    session = tmp_path / "agent1_2026-07-01_s1_summary.md"
+    session.write_text(
+        "# Session Summary for agent1\n### [2026-07-01 10:00:00] [FACT] X\n- **Source**: `user`\n",
+        encoding="utf-8",
+    )
+
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    result = svc.write_okf_bundle(
+        "agent1",
+        {"fact": [_mem("f1", "A fact", "Water is wet.")]},
+        summaries=[summary],
+        sessions=[session],
+    )
+    base = svc.exports_dir / "agent1_okf"
+
+    assert set(result["sections"]) == {"memories", "daily-summaries", "sessions", "metrics"}
+    assert (base / "daily-summaries" / "agent1_2026-07-01.md").exists()
+    assert (base / "sessions" / "agent1_2026-07-01_s1_summary.md").exists()
+
+    # Import must see only the one memory, not the summary/session docs.
+    export = load_okf_bundle(base)
+    assert len(export["memories"]) == 1
+    assert export["memories"][0]["title"] == "A fact"
+
+
+def test_memanto_round_trip_preserves_extras(tmp_path):
+    """Memanto -> OKF -> Memanto keeps type/confidence/source_ref/tags/body via
+    the ``x_memanto`` block, and always marks provenance as imported."""
+    memories_by_type = {
+        "fact": [
+            _mem(
+                "m1",
+                "Postgres is the DB",
+                "The project uses PostgreSQL 16.",
+                tags=["infra", "db"],
+                confidence=0.9,
+                provenance="explicit_statement",
+                source="user",
+                status="active",
+                created_at="2026-05-28T14:30:00Z",
+                source_ref="https://example.com/db",
+            )
+        ],
+        "decision": [_mem("d1", "Chose Redis", "We decided on Redis for cache.")],
+    }
+
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    result = svc.write_okf_bundle("agent1", memories_by_type, split="file")
+
+    rows = map_okf(load_okf_bundle(result["output_path"]))
+    by_title = {r["title"]: r for r in rows}
+
+    pg = by_title["Postgres is the DB"]
+    assert pg["type"] == "fact"  # x_memanto.type round-trips
+    assert pg["confidence"] == 0.9  # x_memanto.confidence round-trips
+    assert pg["source_ref"] == "https://example.com/db"  # resource -> source_ref
+    assert pg["provenance"] == "imported"
+    assert set(pg["tags"]) == {"infra", "db"}
+    assert pg["created_at"] is not None
+    assert "PostgreSQL 16" in pg["content"]
+    assert by_title["Chose Redis"]["type"] == "decision"
+
+
+def test_foreign_okf_bundle_is_lossless(tmp_path):
+    """A foreign OKF doc: free-form ``type`` -> auto-classify (None), and the
+    type, unknown keys, and links are preserved in the footer. ``index.md`` is
+    skipped."""
+    tables = tmp_path / "tables"
+    tables.mkdir()
+    (tables / "orders.md").write_text(
+        "---\n"
+        "type: BigQuery Table\n"
+        "title: Orders\n"
+        "description: One row per completed customer order.\n"
+        "resource: https://console.cloud.google.com/bigquery?t=orders\n"
+        "tags: [sales, revenue]\n"
+        "timestamp: 2026-05-28T14:30:00Z\n"
+        "owner: data-team\n"
+        "---\n\n"
+        "# Schema\nJoined with [customers](/tables/customers.md).\n",
+        encoding="utf-8",
+    )
+    (tables / "index.md").write_text(
+        "---\ntype: index\ntitle: tables\n---\n- [Orders](orders.md)\n",
+        encoding="utf-8",
+    )
+
+    export = load_okf_bundle(tmp_path)
+    assert len(export["memories"]) == 1  # index.md skipped
+
+    row = map_okf(export)[0]
+    assert row["type"] is None  # free-form type -> auto-classify
+    assert row["source"] == "okf"
+    assert row["source_ref"] == "https://console.cloud.google.com/bigquery?t=orders"
+    assert row["provenance"] == "imported"
+    assert "One row per completed customer order." in row["content"]  # description
+    assert "OKF type: BigQuery Table" in row["content"]  # unmapped type -> footer
+    assert "OKF owner: data-team" in row["content"]  # unknown key -> footer
+    assert "customers -> /tables/customers.md" in row["content"]  # link -> footer
+
+
+def test_loader_splits_stacked_file(tmp_path):
+    """A stacked per-type file is split back into one entry per memory."""
+    memories_by_type = {
+        "event": [_mem(f"e{i}", f"Standup {i}", f"Standup {i} happened.") for i in range(5)]
+    }
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    result = svc.write_okf_bundle("agent1", memories_by_type, split="type")
+
+    export = load_okf_bundle(result["output_path"])
+    assert len(export["memories"]) == 5
+    assert {m["title"] for m in export["memories"]} == {f"Standup {i}" for i in range(5)}


### PR DESCRIPTION
- Add okf suppport as export or import formatter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Open Knowledge Format (OKF) bundle export and project synchronization.
  * Added `--okf` and `--split` options for memory export/sync, supporting automatic split into per-type or stacked files.
  * Added `memanto migrate okf` to import memories from OKF bundles.
  * OKF import/export preserves metadata (tags, links, extra fields) and captures context sections (e.g., summaries and sessions) in the bundle.
  * Updated CLI documentation with OKF options and migration notes.
* **Bug Fixes**
  * OKF synchronization falls back to the last cached bundle when the backend is unreachable, with a stale-cache warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->