### PR TITLE
Fix temporal filters for malformed memory timestamps

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -499,14 +499,23 @@ class MemoryReadService:
 
         filtered = results
 
+        def _parse_created_at(result: dict[str, Any]):
+            created_at = result.get("created_at")
+            if not created_at:
+                return None
+            try:
+                return parse_iso_timestamp(str(created_at))
+            except (ValueError, AttributeError, TypeError):
+                return None
+
         if created_after:
             try:
                 after_dt = parse_iso_timestamp(created_after)
                 filtered = [
                     r
                     for r in filtered
-                    if r.get("created_at")
-                    and parse_iso_timestamp(r["created_at"]) >= after_dt
+                    if (created_at := _parse_created_at(r)) is not None
+                    and created_at >= after_dt
                 ]
             except (ValueError, AttributeError):
                 pass  # Skip invalid timestamps
@@ -517,8 +526,8 @@ class MemoryReadService:
                 filtered = [
                     r
                     for r in filtered
-                    if r.get("created_at")
-                    and parse_iso_timestamp(r["created_at"]) <= before_dt
+                    if (created_at := _parse_created_at(r)) is not None
+                    and created_at <= before_dt
                 ]
             except (ValueError, AttributeError):
                 pass  # Skip invalid timestamps

--- a/tests/test_memory_read_filter_sanitization.py
+++ b/tests/test_memory_read_filter_sanitization.py
@@ -43,3 +43,35 @@ def test_build_filtered_query_rejects_unknown_memory_type():
 
     with pytest.raises(ValueError, match="Invalid memory_type"):
         service._build_filtered_query(query="deployment notes", type=["not-a-type"])
+
+
+def test_temporal_filter_skips_malformed_result_timestamps():
+    service = MemoryReadService(MagicMock())
+
+    results = [
+        {"id": "old", "created_at": "2024-01-01T00:00:00Z"},
+        {"id": "malformed", "created_at": "not-a-timestamp"},
+        {"id": "new", "created_at": "2026-01-01T00:00:00Z"},
+    ]
+
+    filtered = service._apply_temporal_filter(
+        results, created_after="2025-01-01T00:00:00Z"
+    )
+
+    assert [result["id"] for result in filtered] == ["new"]
+
+
+def test_temporal_filter_skips_malformed_result_timestamps_before_boundary():
+    service = MemoryReadService(MagicMock())
+
+    results = [
+        {"id": "malformed", "created_at": "not-a-timestamp"},
+        {"id": "old", "created_at": "2024-01-01T00:00:00Z"},
+        {"id": "new", "created_at": "2026-01-01T00:00:00Z"},
+    ]
+
+    filtered = service._apply_temporal_filter(
+        results, created_before="2025-01-01T00:00:00Z"
+    )
+
+    assert [result["id"] for result in filtered] == ["old"]


### PR DESCRIPTION
## Summary
- Fix temporal memory filtering so a single malformed result timestamp no longer disables the whole created_after/created_before filter.
- Skip malformed result timestamps during temporal comparisons instead of returning unfiltered results.
- Add regression coverage for both after and before boundaries.

## Bounty
Addresses memory retrieval/integrity behavior relevant to #770.

## Tests
- .venv\\Scripts\\python.exe -m pytest tests\\test_memory_read_filter_sanitization.py tests\\test_temporal_helpers.py -q
- With USERPROFILE/HOME/TMP/TEMP redirected inside the repo sandbox: .venv\\Scripts\\python.exe -m pytest tests -q -k " temporal or memory_read or recall\


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-based filtering by safely handling records with missing or invalid timestamps.
  * Ensured malformed timestamp records are excluded when filtering results by dates.

* **Tests**
  * Added coverage for invalid timestamps in both “after” and “before” date filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->