### PR TITLE
Reject failed uploads during memory updates

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -30,6 +30,36 @@ _REMOVED_TRUST_FIELDS = frozenset(
     }
 )
 
+# Fields owned by the current MemoryRecord/document schema. They must not be
+# copied from the old document after an update because an omitted optional field
+# (for example, tags=[] or source_ref=None) represents an intentional clear.
+_MEMORY_SCHEMA_FIELDS = frozenset(
+    {
+        "id",
+        "text",
+        "memory_type",
+        "type",
+        "title",
+        "content",
+        "agent_id",
+        "actor_id",
+        "source",
+        "source_ref",
+        "confidence",
+        "status",
+        "tags",
+        "provenance",
+        "created_at",
+        "updated_at",
+        "expires_at",
+        "ttl_seconds",
+        "score",
+        "metadata",
+        "scope_type",
+        "scope_id",
+    }
+)
+
 
 class MemoryWriteService:
     """Persist memory records to Moorcheh-backed namespaces."""
@@ -405,29 +435,47 @@ class MemoryWriteService:
                 extra_original_document = cast(dict[str, Any], original_document)
                 for key in existing_meta:
                     if (
-                        key not in document
-                        and key != "text"
+                        key not in _MEMORY_SCHEMA_FIELDS
                         and key not in _REMOVED_TRUST_FIELDS
                     ):
                         extra_document[key] = existing_meta[key]
                     if (
-                        key not in original_document
-                        and key != "text"
+                        key not in _MEMORY_SCHEMA_FIELDS
                         and key not in _REMOVED_TRUST_FIELDS
                     ):
                         extra_original_document[key] = existing_meta[key]
 
-            upload_result = self.client.documents.upload(
-                namespace_name=namespace, documents=[document]
-            )
-            upload_status = str(upload_result.get("status", "unknown")).lower()
-            if upload_status not in SUCCESSFUL_UPLOAD_STATUSES:
-                restore_result = self.client.documents.upload(
-                    namespace_name=namespace, documents=[original_document]
+            try:
+                upload_result = self.client.documents.upload(
+                    namespace_name=namespace, documents=[document]
                 )
-                restore_status = str(
-                    restore_result.get("status", "unknown")
-                ).lower()
+                upload_status = str(upload_result.get("status", "unknown")).lower()
+                if upload_status in SUCCESSFUL_UPLOAD_STATUSES:
+                    upload_error = None
+                else:
+                    upload_error = (
+                        "backend returned status "
+                        f"{upload_result.get('status', 'unknown')!r}"
+                    )
+            except Exception as exc:
+                upload_result = None
+                upload_error = f"upload raised {type(exc).__name__}: {exc}"
+
+            if upload_error is not None:
+                try:
+                    restore_result = self.client.documents.upload(
+                        namespace_name=namespace, documents=[original_document]
+                    )
+                    restore_status = str(
+                        restore_result.get("status", "unknown")
+                    ).lower()
+                except Exception as restore_exc:
+                    raise MemoryError(
+                        f"Failed to upload updated memory {memory_id} and failed "
+                        f"to restore the original: {type(restore_exc).__name__}: "
+                        f"{restore_exc}"
+                    )
+
                 if restore_status not in SUCCESSFUL_UPLOAD_STATUSES:
                     raise MemoryError(
                         f"Failed to upload updated memory {memory_id} and failed "
@@ -435,8 +483,7 @@ class MemoryWriteService:
                         f"backend returned status {restore_result.get('status', 'unknown')!r}"
                     )
                 raise MemoryError(
-                    f"Failed to upload updated memory {memory_id}: "
-                    f"backend returned status {upload_result.get('status', 'unknown')!r}"
+                    f"Failed to upload updated memory {memory_id}: {upload_error}"
                 )
 
             return {

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -381,6 +381,12 @@ class MemoryWriteService:
             upload_result = self.client.documents.upload(
                 namespace_name=namespace, documents=[document]
             )
+            upload_status = str(upload_result.get("status", "unknown")).lower()
+            if upload_status not in SUCCESSFUL_UPLOAD_STATUSES:
+                raise MemoryError(
+                    f"Failed to upload updated memory {memory_id}: "
+                    f"backend returned status {upload_result.get('status', 'unknown')!r}"
+                )
 
             return {
                 "id": memory_id,

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -304,6 +304,35 @@ class MemoryWriteService:
                     f"in namespace {namespace}"
                 )
 
+            # Keep a restorable snapshot before deleting the existing document.
+            original_memory = MemoryRecord(
+                id=memory_id,
+                type=metadata.get("type", "fact"),
+                title=existing_memory_data.get("title", "Updated Memory"),
+                content=existing_memory_data.get("content", ""),
+                agent_id=agent_id,
+                actor_id=metadata.get("actor_id", "unknown"),
+                source=metadata.get("source", "system"),
+                source_ref=metadata.get("source_ref"),
+                confidence=metadata.get("confidence", 0.8),
+                status=metadata.get("status", "active"),
+                tags=metadata.get("tags", []),
+                provenance=metadata.get("provenance", "explicit_statement"),
+            )
+
+            for field_name in ("created_at", "updated_at", "expires_at"):
+                raw_value = metadata.get(field_name)
+                if isinstance(raw_value, str):
+                    try:
+                        raw_value = datetime.fromisoformat(
+                            raw_value.replace("Z", "+00:00")
+                        )
+                    except (ValueError, AttributeError):
+                        raw_value = None
+                if raw_value is not None:
+                    setattr(original_memory, field_name, raw_value)
+            original_memory.ttl_seconds = metadata.get("ttl_seconds")
+
             # Build updated memory record
             updated_memory = MemoryRecord(
                 id=memory_id,  # Keep same ID
@@ -362,6 +391,9 @@ class MemoryWriteService:
             from moorcheh_sdk.types.document import Document
 
             document = cast(Document, updated_memory.to_moorcheh_document())
+            original_document = cast(
+                Document, original_memory.to_moorcheh_document()
+            )
 
             # Preserve extra metadata fields from the existing record (e.g. original_id
             # in on-prem data_store.json) that aren't part of the MemoryRecord schema.
@@ -370,6 +402,7 @@ class MemoryWriteService:
                 # ``document`` is a TypedDict; cast to a plain dict to attach
                 # extra schema-external keys (e.g. original_id) dynamically.
                 extra_document = cast(dict[str, Any], document)
+                extra_original_document = cast(dict[str, Any], original_document)
                 for key in existing_meta:
                     if (
                         key not in document
@@ -377,12 +410,30 @@ class MemoryWriteService:
                         and key not in _REMOVED_TRUST_FIELDS
                     ):
                         extra_document[key] = existing_meta[key]
+                    if (
+                        key not in original_document
+                        and key != "text"
+                        and key not in _REMOVED_TRUST_FIELDS
+                    ):
+                        extra_original_document[key] = existing_meta[key]
 
             upload_result = self.client.documents.upload(
                 namespace_name=namespace, documents=[document]
             )
             upload_status = str(upload_result.get("status", "unknown")).lower()
             if upload_status not in SUCCESSFUL_UPLOAD_STATUSES:
+                restore_result = self.client.documents.upload(
+                    namespace_name=namespace, documents=[original_document]
+                )
+                restore_status = str(
+                    restore_result.get("status", "unknown")
+                ).lower()
+                if restore_status not in SUCCESSFUL_UPLOAD_STATUSES:
+                    raise MemoryError(
+                        f"Failed to upload updated memory {memory_id} and failed "
+                        "to restore the original: "
+                        f"backend returned status {restore_result.get('status', 'unknown')!r}"
+                    )
                 raise MemoryError(
                     f"Failed to upload updated memory {memory_id}: "
                     f"backend returned status {upload_result.get('status', 'unknown')!r}"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -476,34 +476,65 @@ class TestMemoryWriteServiceDelete:
         assert "validation_count" not in uploaded
 
     def test_update_memory_rejects_failed_upload_status(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
         from memanto.app.services.memory_write_service import MemoryWriteService
         from memanto.app.utils.errors import MemoryError
 
         client = MagicMock()
-        client.documents.delete.return_value = {"status": "success"}
-        client.documents.upload.return_value = {"status": "failed"}
-        existing_memory = {
+        namespace = "memanto_agent_test-agent"
+        original_document = {
             "id": "mem-1",
-            "type": "fact",
-            "title": "Original title",
-            "content": "Original content",
+            "text": "[FACT] Original title\n\nOriginal content",
+            "memory_type": "fact",
+            "agent_id": "test-agent",
             "actor_id": "tester",
             "source": "manual",
             "confidence": 0.8,
             "status": "active",
-            "tags": [],
+            "provenance": "explicit_statement",
+            "created_at": "2026-07-01T00:00:00",
+            "updated_at": "2026-07-01T00:00:00",
         }
+        stored_documents = {"mem-1": original_document}
+        upload_attempt = 0
 
-        with patch(
-            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
-            return_value=existing_memory,
-        ):
-            with pytest.raises(MemoryError, match="backend returned status 'failed'"):
-                MemoryWriteService(client).update_memory(
-                    "mem-1",
-                    "memanto_agent_test-agent",
-                    {"content": "Updated content"},
-                )
+        def get_documents(**kwargs):
+            return {
+                "items": [
+                    stored_documents[memory_id]
+                    for memory_id in kwargs["ids"]
+                    if memory_id in stored_documents
+                ]
+            }
+
+        def delete_documents(**kwargs):
+            for memory_id in kwargs["ids"]:
+                stored_documents.pop(memory_id, None)
+            return {"status": "success"}
+
+        def upload_documents(**kwargs):
+            nonlocal upload_attempt
+            upload_attempt += 1
+            if upload_attempt == 1:
+                return {"status": "failed"}
+            for document in kwargs["documents"]:
+                stored_documents[document["id"]] = document
+            return {"status": "success"}
+
+        client.documents.get.side_effect = get_documents
+        client.documents.delete.side_effect = delete_documents
+        client.documents.upload.side_effect = upload_documents
+
+        with pytest.raises(MemoryError, match="backend returned status 'failed'"):
+            MemoryWriteService(client).update_memory(
+                "mem-1", namespace, {"content": "Updated content"}
+            )
+
+        restored = MemoryReadService(client).get_memory("mem-1", namespace)
+        assert restored is not None
+        assert restored["title"] == "Original title"
+        assert restored["content"] == "Original content"
+        assert client.documents.upload.call_count == 2
 
 
 class TestMemoryReadServiceFormatting:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -452,9 +452,10 @@ class TestMemoryWriteServiceDelete:
             "content": "Original content",
             "actor_id": "tester",
             "source": "manual",
+            "source_ref": "original-source",
             "confidence": 0.8,
             "status": "active",
-            "tags": [],
+            "tags": ["old-tag"],
             # Extra field not in the MemoryRecord schema (e.g. on-prem data_store.json).
             "original_id": "orig-123",
             # Trust field removed 2026-06-29; must not be resurrected on update.
@@ -468,12 +469,18 @@ class TestMemoryWriteServiceDelete:
             MemoryWriteService(client).update_memory(
                 "mem-1",
                 "memanto_agent_test-agent",
-                {"content": "Updated content"},
+                {
+                    "content": "Updated content",
+                    "tags": [],
+                    "source_ref": None,
+                },
             )
 
         uploaded = client.documents.upload.call_args.kwargs["documents"][0]
         assert uploaded.get("original_id") == "orig-123"
         assert "validation_count" not in uploaded
+        assert "tags" not in uploaded
+        assert "source_ref" not in uploaded
 
     def test_update_memory_rejects_failed_upload_status(self):
         from memanto.app.services.memory_read_service import MemoryReadService
@@ -526,6 +533,67 @@ class TestMemoryWriteServiceDelete:
         client.documents.upload.side_effect = upload_documents
 
         with pytest.raises(MemoryError, match="backend returned status 'failed'"):
+            MemoryWriteService(client).update_memory(
+                "mem-1", namespace, {"content": "Updated content"}
+            )
+
+        restored = MemoryReadService(client).get_memory("mem-1", namespace)
+        assert restored is not None
+        assert restored["title"] == "Original title"
+        assert restored["content"] == "Original content"
+        assert client.documents.upload.call_count == 2
+
+    def test_update_memory_restores_original_when_upload_raises(self):
+        from memanto.app.services.memory_read_service import MemoryReadService
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        client = MagicMock()
+        namespace = "memanto_agent_test-agent"
+        original_document = {
+            "id": "mem-1",
+            "text": "[FACT] Original title\n\nOriginal content",
+            "memory_type": "fact",
+            "agent_id": "test-agent",
+            "actor_id": "tester",
+            "source": "manual",
+            "confidence": 0.8,
+            "status": "active",
+            "provenance": "explicit_statement",
+            "created_at": "2026-07-01T00:00:00",
+            "updated_at": "2026-07-01T00:00:00",
+        }
+        stored_documents = {"mem-1": original_document}
+        upload_attempt = 0
+
+        def get_documents(**kwargs):
+            return {
+                "items": [
+                    stored_documents[memory_id]
+                    for memory_id in kwargs["ids"]
+                    if memory_id in stored_documents
+                ]
+            }
+
+        def delete_documents(**kwargs):
+            for memory_id in kwargs["ids"]:
+                stored_documents.pop(memory_id, None)
+            return {"status": "success"}
+
+        def upload_documents(**kwargs):
+            nonlocal upload_attempt
+            upload_attempt += 1
+            if upload_attempt == 1:
+                raise TimeoutError("backend unavailable")
+            for document in kwargs["documents"]:
+                stored_documents[document["id"]] = document
+            return {"status": "success"}
+
+        client.documents.get.side_effect = get_documents
+        client.documents.delete.side_effect = delete_documents
+        client.documents.upload.side_effect = upload_documents
+
+        with pytest.raises(MemoryError, match="upload raised TimeoutError"):
             MemoryWriteService(client).update_memory(
                 "mem-1", namespace, {"content": "Updated content"}
             )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -475,6 +475,36 @@ class TestMemoryWriteServiceDelete:
         assert uploaded.get("original_id") == "orig-123"
         assert "validation_count" not in uploaded
 
+    def test_update_memory_rejects_failed_upload_status(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        client = MagicMock()
+        client.documents.delete.return_value = {"status": "success"}
+        client.documents.upload.return_value = {"status": "failed"}
+        existing_memory = {
+            "id": "mem-1",
+            "type": "fact",
+            "title": "Original title",
+            "content": "Original content",
+            "actor_id": "tester",
+            "source": "manual",
+            "confidence": 0.8,
+            "status": "active",
+            "tags": [],
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            with pytest.raises(MemoryError, match="backend returned status 'failed'"):
+                MemoryWriteService(client).update_memory(
+                    "mem-1",
+                    "memanto_agent_test-agent",
+                    {"content": "Updated content"},
+                )
+
 
 class TestMemoryReadServiceFormatting:
     def test_format_memory_item_preserves_falsey_metadata_values(self):


### PR DESCRIPTION
## Summary
- Reject memory updates when the backend upload step returns a non-success status.
- Prevent update_memory() from reporting ction: updated after a failed replacement upload.
- Add regression coverage for failed upload responses during delete-and-recreate updates.

## Bounty
Relevant to #770: memory update integrity and inconsistent state reporting.

## Tests
- .venv\\Scripts\\python.exe -m pytest tests\\test_unit.py::TestMemoryWriteServiceDelete -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Memory updates now preserve a restorable snapshot of the prior memory/document before replacing content.
  - Updates correctly carry forward schema-external “extra” fields while omitting removed trust-related fields.
  - Upload results are validated; on failure, the original document is automatically restored and errors include the backend status.

- **Tests**
  - Extended coverage to confirm extra fields are preserved while removed trust fields are dropped.
  - Added a unit test for rejected failed backend upload statuses, verifying restore behavior and retry upload attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->