### PR TITLE
Reject failed uploads when storing memories

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -97,6 +97,12 @@ class MemoryWriteService:
             result = self.client.documents.upload(
                 namespace_name=namespace, documents=[document]
             )
+            upload_status = str(result.get("status", "unknown")).lower()
+            if upload_status not in SUCCESSFUL_UPLOAD_STATUSES:
+                raise MemoryError(
+                    f"Failed to store memory {memory.id}: "
+                    f"backend returned status {result.get('status', 'unknown')!r}"
+                )
 
             return {
                 "id": memory.id,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -500,6 +500,24 @@ class TestMemoryReadServiceFormatting:
 
 
 class TestMemoryWriteServiceBatch:
+    def test_store_memory_rejects_failed_upload_status(self):
+        from memanto.app.core import MemoryRecord
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "failed"}
+        memory = MemoryRecord(
+            title="Failed write",
+            content="This memory should not be reported as stored.",
+            agent_id="test-agent",
+            actor_id="tester",
+            source="manual",
+        )
+
+        with pytest.raises(MemoryError, match="backend returned status 'failed'"):
+            MemoryWriteService(client).store_memory(memory)
+
     def test_batch_store_counts_ok_upload_status_as_success(self):
         from memanto.app.core import MemoryRecord
         from memanto.app.services.memory_write_service import MemoryWriteService


### PR DESCRIPTION
## Summary
- Reject store_memory() calls when the backend upload response is not a successful status.
- Prevent memory writes from being reported as stored when the upload returns ailed or an unknown status.
- Add regression coverage for failed upload status handling.

## Bounty
Relevant to #770: memory write integrity and inconsistent state reporting.

## Tests
- .venv\\Scripts\\python.exe -m pytest tests\\test_unit.py::TestMemoryWriteServiceBatch tests\\test_unit.py::TestMemoryWriteServiceDelete -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory saving reliability by detecting failed backend upload statuses.
  * Prevented unsuccessful uploads from being treated as completed successfully.
  * Added clearer error reporting when an upload fails.

* **Tests**
  * Added coverage for failed upload responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->