### PR TITLE
Fix noisy LLM memory JSON extraction

### DIFF
--- a/integrations/claudecode/claudecode_memanto/extractor.py
+++ b/integrations/claudecode/claudecode_memanto/extractor.py
@@ -18,11 +18,11 @@ Why ``answer()`` for extraction?
 
 from __future__ import annotations
 
-import json
 import re
 from typing import Any
 
 from memanto.app.constants import VALID_MEMORY_TYPES
+from memanto.app.utils.json_extraction import iter_json_arrays
 from memanto.app.utils.validation import InputLimits
 
 # Sourced from the SDK so this never drifts if Memanto adds a 14th type.
@@ -78,23 +78,15 @@ def parse_llm_memories(answer_text: str) -> list[dict[str, Any]]:
     if not answer_text:
         return []
 
-    payload = _extract_json_array(answer_text)
-    if payload is None:
-        return []
-
-    try:
-        raw = json.loads(payload)
-    except (json.JSONDecodeError, ValueError):
-        return []
-    if not isinstance(raw, list):
-        return []
-
-    out: list[dict[str, Any]] = []
-    for item in raw:
-        mem = _coerce_memory(item)
-        if mem is not None:
-            out.append(mem)
-    return out
+    for raw in iter_json_arrays(answer_text):
+        out: list[dict[str, Any]] = []
+        for item in raw:
+            mem = _coerce_memory(item)
+            if mem is not None:
+                out.append(mem)
+        if out:
+            return out
+    return []
 
 
 def heuristic_memories(summary: str) -> list[dict[str, Any]]:
@@ -137,17 +129,6 @@ def heuristic_memories(summary: str) -> list[dict[str, Any]]:
 # --------------------------------------------------------------------------- #
 # Internals
 # --------------------------------------------------------------------------- #
-
-_FENCE_RE = re.compile(r"```(?:json)?", re.IGNORECASE)
-
-
-def _extract_json_array(text: str) -> str | None:
-    cleaned = _FENCE_RE.sub("", text).strip()
-    start = cleaned.find("[")
-    end = cleaned.rfind("]")
-    if start == -1 or end == -1 or end <= start:
-        return None
-    return cleaned[start : end + 1]
 
 
 def _coerce_memory(item: Any) -> dict[str, Any] | None:

--- a/integrations/claudecode/tests/test_extractor.py
+++ b/integrations/claudecode/tests/test_extractor.py
@@ -22,6 +22,16 @@ class TestParseLlmMemories:
         assert len(mems) == 1
         assert mems[0]["type"] == "fact"
 
+    def test_ignores_non_json_brackets_before_memory_array(self) -> None:
+        text = (
+            "Extraction status [draft]: found durable memories.\n"
+            '[{"type":"instruction","title":"Tests","content":"Always run the '
+            'focused regression tests before pushing.","confidence":0.9}]'
+        )
+        mems = extractor.parse_llm_memories(text)
+        assert len(mems) == 1
+        assert mems[0]["type"] == "instruction"
+
     def test_invalid_type_coerced_to_learning(self) -> None:
         mems = extractor.parse_llm_memories(
             '[{"type":"nonsense","content":"something durable"}]'

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -7,12 +7,12 @@ Moorcheh answer-generation path used by the RAG answer endpoint.
 
 from __future__ import annotations
 
-import json
 import re
 from typing import Any
 
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.constants import VALID_MEMORY_TYPES
+from memanto.app.utils.json_extraction import iter_json_arrays
 
 
 class ConversationMemoryExtractionService:
@@ -114,18 +114,9 @@ class ConversationMemoryExtractionService:
         if not text:
             raise ValueError("Memory extraction returned an empty response")
 
-        fenced = re.search(r"```(?:json)?\s*(.*?)```", text, flags=re.DOTALL)
-        if fenced:
-            text = fenced.group(1).strip()
-
-        try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            start = text.find("[")
-            end = text.rfind("]")
-            if start != -1 and end != -1 and end > start:
-                return json.loads(text[start : end + 1])
-            raise ValueError("Memory extraction did not return valid JSON")
+        for parsed in iter_json_arrays(text):
+            return parsed
+        raise ValueError("Memory extraction did not return valid JSON")
 
     def _normalize_candidates(
         self, parsed: Any, *, max_memories: int

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -60,8 +60,24 @@ class ConversationMemoryExtractionService:
         response = self.client.answer.generate(**generate_kwargs)
 
         raw_answer = response.get("answer", "")
-        parsed = self._parse_json_answer(raw_answer)
-        return self._normalize_candidates(parsed, max_memories=max_memories)
+        text = raw_answer.strip()
+        if not text:
+            raise ValueError("Memory extraction returned an empty response")
+
+        has_any_array = False
+        for parsed in iter_json_arrays(text):
+            has_any_array = True
+            try:
+                normalized = self._normalize_candidates(parsed, max_memories=max_memories)
+                if normalized:
+                    return normalized
+            except ValueError:
+                continue
+
+        if has_any_array:
+            return []
+
+        raise ValueError("Memory extraction did not return valid JSON")
 
     def _validate_messages(self, messages: list[dict[str, str]]) -> None:
         if not messages:
@@ -108,15 +124,6 @@ class ConversationMemoryExtractionService:
             "Return only JSON. The JSON must be an array of objects with keys: "
             "type, title, content, confidence. Confidence must be 0.0 to 1.0."
         )
-
-    def _parse_json_answer(self, answer: str) -> Any:
-        text = answer.strip()
-        if not text:
-            raise ValueError("Memory extraction returned an empty response")
-
-        for parsed in iter_json_arrays(text):
-            return parsed
-        raise ValueError("Memory extraction did not return valid JSON")
 
     def _normalize_candidates(
         self, parsed: Any, *, max_memories: int

--- a/memanto/app/utils/json_extraction.py
+++ b/memanto/app/utils/json_extraction.py
@@ -1,0 +1,45 @@
+"""Helpers for extracting structured JSON from LLM responses."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator
+from typing import Any
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
+
+
+def iter_json_arrays(text: str) -> Iterator[list[Any]]:
+    """Yield JSON arrays embedded in a possibly noisy LLM response.
+
+    LLMs often return valid JSON with short prose, labels, or markdown fences.
+    A naive first-``[``/last-``]`` slice fails when that prose contains its own
+    brackets. Scanning each candidate ``[`` with JSONDecoder keeps extraction
+    tolerant without accepting malformed JSON.
+    """
+    if not text:
+        return
+
+    candidates = [match.group(1).strip() for match in _FENCE_RE.finditer(text)]
+    candidates.append(_FENCE_RE.sub("", text).strip())
+
+    decoder = json.JSONDecoder()
+    seen: set[str] = set()
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        for match in re.finditer(r"\[", candidate):
+            fragment = candidate[match.start() :]
+            try:
+                parsed, end = decoder.raw_decode(fragment)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed, list):
+                continue
+            raw = fragment[:end]
+            if raw in seen:
+                continue
+            seen.add(raw)
+            yield parsed

--- a/memanto/app/utils/json_extraction.py
+++ b/memanto/app/utils/json_extraction.py
@@ -21,24 +21,26 @@ def iter_json_arrays(text: str) -> Iterator[list[Any]]:
     if not text:
         return
 
-    candidates = [match.group(1).strip() for match in _FENCE_RE.finditer(text)]
-    candidates.append(_FENCE_RE.sub("", text).strip())
-
     decoder = json.JSONDecoder()
     seen: set[str] = set()
+    last_end = 0
 
-    for candidate in candidates:
-        if not candidate:
+    for match in re.finditer(r"\[", text):
+        if match.start() < last_end:
             continue
-        for match in re.finditer(r"\[", candidate):
-            try:
-                parsed, end = decoder.raw_decode(candidate, match.start())
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(parsed, list):
-                continue
-            raw = candidate[match.start() : end]
-            if raw in seen:
-                continue
-            seen.add(raw)
-            yield parsed
+            
+        try:
+            parsed, end = decoder.raw_decode(text, match.start())
+        except json.JSONDecodeError:
+            continue
+            
+        if not isinstance(parsed, list):
+            continue
+            
+        last_end = end
+        
+        raw = text[match.start() : end]
+        if raw in seen:
+            continue
+        seen.add(raw)
+        yield parsed

--- a/memanto/app/utils/json_extraction.py
+++ b/memanto/app/utils/json_extraction.py
@@ -31,14 +31,13 @@ def iter_json_arrays(text: str) -> Iterator[list[Any]]:
         if not candidate:
             continue
         for match in re.finditer(r"\[", candidate):
-            fragment = candidate[match.start() :]
             try:
-                parsed, end = decoder.raw_decode(fragment)
+                parsed, end = decoder.raw_decode(candidate, match.start())
             except json.JSONDecodeError:
                 continue
             if not isinstance(parsed, list):
                 continue
-            raw = fragment[:end]
+            raw = candidate[match.start() : end]
             if raw in seen:
                 continue
             seen.add(raw)

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -80,6 +80,30 @@ def test_extract_conversation_memories_normalizes_candidates():
     assert "user:" in client.answer.call_kwargs["query"]
 
 
+def test_extract_ignores_non_json_brackets_before_memory_array():
+    client = FakeClient(
+        "I checked the transcript [notes] and extracted this:\n"
+        '[{"type":"learning","title":"Regression tests","content":"Run focused '
+        'regression tests before pushing memory extraction fixes.","confidence":0.88}]'
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Remember to test extraction fixes."}],
+    )
+
+    assert candidates == [
+        {
+            "type": "learning",
+            "title": "Regression tests",
+            "content": "Run focused regression tests before pushing memory extraction fixes.",
+            "confidence": 0.88,
+            "source": "conversation",
+            "provenance": "inferred",
+        }
+    ]
+
 def test_extract_omits_unset_active_ai_model(monkeypatch):
     """On-prem fallback should let answer.generate use its configured model."""
     from memanto.app.services import conversation_memory_extraction_service as module

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -99,7 +99,7 @@ def test_extract_ignores_non_json_brackets_before_memory_array():
             "title": "Regression tests",
             "content": "Run focused regression tests before pushing memory extraction fixes.",
             "confidence": 0.88,
-            "source": "conversation",
+            "source": "system",
             "provenance": "inferred",
         }
     ]

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -104,6 +104,52 @@ def test_extract_ignores_non_json_brackets_before_memory_array():
         }
     ]
 
+def test_extract_skips_invalid_json_arrays():
+    client = FakeClient(
+        "Dummy array first: [1, 2]\n"
+        "Real array second:\n"
+        '[{"type":"fact","title":"Validation","content":"Iterate arrays.","confidence":0.95}]'
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Iterate arrays."}],
+    )
+
+    assert candidates == [
+        {
+            "type": "fact",
+            "title": "Validation",
+            "content": "Iterate arrays.",
+            "confidence": 0.95,
+            "source": "system",
+            "provenance": "inferred",
+        }
+    ]
+
+def test_extract_ignores_brackets_in_strings():
+    client = FakeClient(
+        '[{"type":"fact","title":"Nested brackets","content":"Like this [1, 2].","confidence":0.95}]'
+    )
+
+    service = ConversationMemoryExtractionService(client)
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Like this [1, 2]."}],
+    )
+
+    assert candidates == [
+        {
+            "type": "fact",
+            "title": "Nested brackets",
+            "content": "Like this [1, 2].",
+            "confidence": 0.95,
+            "source": "system",
+            "provenance": "inferred",
+        }
+    ]
+
 def test_extract_omits_unset_active_ai_model(monkeypatch):
     """On-prem fallback should let answer.generate use its configured model."""
     from memanto.app.services import conversation_memory_extraction_service as module


### PR DESCRIPTION
## Summary

Bounty submission for #770.

This fixes a memory-extraction robustness bug in the LLM JSON parsing path used by:

- `ConversationMemoryExtractionService` behind `/remember/extract`
- the Claude Code Memanto integration session distiller

Both parsers attempted to recover from noisy LLM output by slicing from the first `[` to the last `]`. That fails when the model includes bracketed prose before the actual JSON array, for example: `I checked the transcript [notes] and extracted this: [{"type":"learning","content":"Run focused regression tests before pushing."}]`.

The valid memory array is present, but the parser tries to decode `[notes] ... ]`, fails, and drops the extracted memories. In the Claude Code hook path this can make the agent forget durable session learnings even though the backend returned a usable JSON array.

## Fix

- Add a shared `iter_json_arrays()` helper that scans candidate `[` positions with `json.JSONDecoder.raw_decode`.
- Preserve support for fenced JSON arrays and prose-wrapped JSON.
- Use the helper in both core conversation extraction and Claude Code session distillation.
- Add regression coverage for bracketed non-JSON prose before the memory array.

## Validation

- `python -m pytest -c pyproject.toml tests\\test_conversation_memory_extraction.py -q` -> 5 passed
- `PYTHONPATH=.;integrations/claudecode python -m pytest -c integrations\\claudecode\\pyproject.toml integrations\\claudecode\\tests -q` -> 69 passed
- `python -m ruff check memanto\\app\\utils\\json_extraction.py memanto\\app\\services\\conversation_memory_extraction_service.py integrations\\claudecode\\claudecode_memanto\\extractor.py tests\\test_conversation_memory_extraction.py integrations\\claudecode\\tests\\test_extractor.py` -> all checks passed
- `python -m py_compile memanto\\app\\utils\\json_extraction.py memanto\\app\\services\\conversation_memory_extraction_service.py integrations\\claudecode\\claudecode_memanto\\extractor.py` -> passed
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory extraction from noisy LLM responses that include unrelated bracketed text.
  * More reliably identifies and parses the first valid JSON array in the response.
  * Invalid extracted entries are ignored; candidates are normalized with `source: "system"`.

* **New Features**
  * Added a shared JSON-array extraction utility to standardize parsing across the integration and memory extraction service.

* **Tests**
  * Added coverage to ensure extraction succeeds when non-JSON bracket text appears before the memory array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->