### PR TITLE
fix: return renewed tokens to header-authenticated clients

### DIFF
--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -97,6 +97,7 @@ app.add_middleware(
     allow_credentials=settings.CORS_ALLOW_CREDENTIALS,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-Session-Token"],
 )
 
 # Include routers

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -226,6 +226,11 @@ def get_current_session(
             # fails signature/session_id validation.
             if session_cookie:
                 set_session_cookie(response, renewed.session_token, request)
+            # API clients authenticate with the request header instead of a
+            # cookie. Return the replacement token on the response so they can
+            # use it after auto-renewal invalidates the presented token.
+            if x_session_token:
+                response.headers["X-Session-Token"] = renewed.session_token
 
         return session
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2134,6 +2134,58 @@ class TestCWE200ApiKeyLeak:
         assert fresh_response.status_code == 200
 
     @pytest.mark.asyncio
+    async def test_header_session_auto_renewal_returns_replacement_token(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Header clients must receive the token created by auto-renewal.
+
+        Renewing a session replaces its persisted session ID, so the token in
+        the triggering request becomes invalid immediately.  Unlike browser
+        callers, API clients do not have a cookie jar for the server to
+        refresh; the replacement must therefore be returned in a response
+        header so the next request can authenticate.
+        """
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        assert activate_resp.status_code == 200
+        old_token = activate_resp.json()["session_token"]
+
+        # Remove the activation cookie to exercise only X-Session-Token auth.
+        client.cookies = Cookies()
+        session_headers = {**auth_headers, "X-Session-Token": old_token}
+        with patch.object(settings, "SESSION_EXTEND_THRESHOLD_MINUTES", 10**9):
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                headers=session_headers,
+                json={},
+            )
+        assert response.status_code == 200
+
+        new_token = response.headers.get("x-session-token")
+        assert new_token
+        assert new_token != old_token
+
+        stale_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers=session_headers,
+            json={},
+        )
+        assert stale_response.status_code == 401
+
+        fresh_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers={**auth_headers, "X-Session-Token": new_token},
+            json={},
+        )
+        assert fresh_response.status_code == 200
+
+    @pytest.mark.asyncio
     async def test_traversal_filename_is_sanitized(
         self, client, auth_headers, mock_moorcheh
     ):

--- a/tests/test_cors_fix.py
+++ b/tests/test_cors_fix.py
@@ -7,6 +7,7 @@ Verifies that:
     when wildcard origins and allow_credentials are combined.
 3.  Wildcard origins + credentials=False does NOT send
     Access-Control-Allow-Credentials: true in responses.
+4.  Browser API clients can read replacement X-Session-Token response headers.
 """
 
 import pytest
@@ -110,3 +111,28 @@ class TestCorsHeaderBehavior:
             f"Expected '*' or absent, got '{origin_header}' — "
             "reflected origin means credentials mode is still on"
         )
+
+    async def test_replacement_session_token_header_is_exposed(self):
+        """Cross-origin header clients must be able to read renewed tokens."""
+        from unittest.mock import patch
+
+        import httpx
+
+        with patch(
+            "memanto.app.main._validate_startup_dependencies", return_value=None
+        ):
+            from memanto.app.main import app
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as ac:
+            resp = await ac.get("/health", headers={"Origin": "https://app.example"})
+
+        exposed = {
+            header.strip().lower()
+            for header in resp.headers.get("access-control-expose-headers", "").split(
+                ","
+            )
+        }
+        assert "x-session-token" in exposed


### PR DESCRIPTION
## Summary

Header-authenticated API clients are silently disconnected when a near-expiry session auto-renews.

`get_current_session()` replaces the persisted session and JWT during the request, immediately invalidating the `X-Session-Token` that triggered renewal. Browser-cookie callers receive the replacement through `Set-Cookie`, but header clients receive no replacement and their next request always fails with 401. Cross-origin browser clients also need the replacement response header exposed through CORS.

## Reproduction

1. Create and activate an agent.
2. Authenticate a memory request with `X-Session-Token`.
3. Make the session fall within `SESSION_EXTEND_THRESHOLD_MINUTES`.
4. The triggering request succeeds and auto-renews the session.
5. The response contains no replacement usable by a header-only client.
6. Reusing the original header returns 401 because the persisted session ID changed.

The regression test forces the threshold deterministically and proves both the stale-token failure and replacement-token success path.

## Fix

- Return the newly issued token in the response's `X-Session-Token` header when renewal was triggered by header authentication.
- Expose `X-Session-Token` through CORS so allowed cross-origin browser clients can read it.
- Preserve the existing HttpOnly `Set-Cookie` refresh for cookie callers.

## Validation

- Full pytest suite passes (24 live Moorcheh E2E tests skipped without a real API key)
- Ruff check and format check pass
- mypy passes for all 77 source files
- Regression coverage verifies:
  - replacement token is returned
  - old token becomes unauthorized
  - new token authenticates the next request
  - CORS exposes the replacement header
  - existing cookie auto-renewal remains green

Refs #770

Bounty: https://www.bountyhub.dev/en/bounty/a7d4cc29-f927-4939-bc77-d7b8bb36c3da


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API clients using the `X-Session-Token` header now receive refreshed session tokens automatically when sessions renew.
  * Browser-based clients can read refreshed session tokens from responses across origins.

* **Bug Fixes**
  * Prevented header-authenticated clients from losing access when their session token is renewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->