### PR TITLE
Fix as-of recall for memories that expired later

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -206,7 +206,12 @@ class MemoryReadService:
                     "temporal_mode": "as_of",
                 }
 
-            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            # Historical queries must evaluate TTL at the requested point in
+            # time. Applying the normal current-time TTL filter here would
+            # discard memories that were valid then but have expired since.
+            all_memories = self._fetch_all_memories(
+                namespaces, type=type, tags=tags, enforce_ttl=False
+            )
             all_memories = self._apply_temporal_filter(
                 all_memories, created_before=as_of_date
             )
@@ -370,6 +375,7 @@ class MemoryReadService:
         namespaces: list[str],
         type: list[str] | None = None,
         tags: list[str] | None = None,
+        enforce_ttl: bool = True,
     ) -> list[dict[str, Any]]:
         """
         List all stored memories across the given namespaces via Moorcheh's
@@ -418,7 +424,9 @@ class MemoryReadService:
 
             memories.append(formatted)
 
-        return self._filter_expired_memories(memories)
+        if enforce_ttl:
+            return self._filter_expired_memories(memories)
+        return memories
 
     def _build_filtered_query(
         self,

--- a/tests/test_memory_read_as_of_ttl.py
+++ b/tests/test_memory_read_as_of_ttl.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _memory(memory_id: str, expires_at: str) -> dict:
+    return {
+        "id": memory_id,
+        "text": "[FACT] Historical fact\n\nThis was true at the requested time.",
+        "metadata": {
+            "memory_type": "fact",
+            "created_at": "2020-01-01T00:00:00Z",
+            "updated_at": "2020-01-01T00:00:00Z",
+            "expires_at": expires_at,
+        },
+    }
+
+
+def test_search_as_of_evaluates_ttl_at_requested_time():
+    client = MagicMock()
+    client.documents.fetch_text_data.return_value = {
+        "items": [
+            _memory("valid-then", "2020-12-31T23:59:59Z"),
+            _memory("expired-then", "2020-05-31T23:59:59Z"),
+        ],
+        "pagination": {"has_more": False},
+    }
+
+    result = MemoryReadService(client).search_as_of(
+        as_of_date="2020-06-01T00:00:00Z",
+        agent_id="test-agent",
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["valid-then"]


### PR DESCRIPTION
## Problem

`search_as_of()` fetches memories through `_fetch_all_memories()`, which applies TTL against the current clock before the historical query can evaluate TTL at `as_of_date`. A memory that was valid at the requested point in time but expired later is therefore missing from historical recall.

Minimal timeline:

- created: `2020-01-01`
- requested as-of: `2020-06-01`
- expires: `2020-12-31`
- queried after expiration

Expected: the memory is returned because it was valid on June 1. Previous behavior: it was filtered out using today's clock.

## Fix

- Allow `_fetch_all_memories()` to skip current-time TTL enforcement when requested.
- Have `search_as_of()` fetch the unpruned records, then retain its existing expiration check against `as_of_date`.
- Keep current-time TTL enforcement unchanged for normal recall, recent recall, and changed-since queries.
- Add a regression test covering both a memory valid at the requested time and one already expired then.

## Validation

- `python -m pytest -q --disable-warnings --maxfail=1`
- `ruff check memanto/app/services/memory_read_service.py tests/test_memory_read_as_of_ttl.py`
- `ruff format --check memanto/app/services/memory_read_service.py tests/test_memory_read_as_of_ttl.py`
- `mypy memanto/app/services/memory_read_service.py`

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected historical memory searches to evaluate expiration times relative to the requested date.
  - Memories that were valid at the selected point in time are now returned accurately, even if their current expiration status differs.

- **Tests**
  - Added coverage verifying point-in-time expiration handling for historical searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->