### PR TITLE
fix(okf): preserve provenance during round-trip imports

### DIFF
--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -35,7 +35,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
-from memanto.app.constants import VALID_MEMORY_TYPES
+from memanto.app.constants import VALID_MEMORY_TYPES, VALID_PROVENANCE_TYPES
 
 # Mem0 ships category labels per memory. Map the common ones to Memanto's
 # typed primitives; everything else falls through to None (auto-classify).
@@ -71,6 +71,13 @@ def _coerce_type(raw: str | None) -> str | None:
         return None
     t = raw.strip().lower()
     return t if t in VALID_MEMORY_TYPES else None
+
+
+def _coerce_provenance(raw: Any) -> str:
+    if not isinstance(raw, str):
+        return "imported"
+    provenance = raw.strip().lower()
+    return provenance if provenance in VALID_PROVENANCE_TYPES else "imported"
 
 
 def _scope_tag(scope: dict[str, Any] | None) -> str | None:
@@ -452,6 +459,7 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
         confidence = min(1.0, max(0.0, confidence))
 
         source = x_memanto.get("source") or "okf"
+        provenance = _coerce_provenance(x_memanto.get("provenance"))
         created_at = _parse_dt(entry.get("timestamp"))
 
         footer_items: list[tuple[str, Any]] = [
@@ -479,7 +487,7 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
                 "confidence": confidence,
                 "source": source,
                 "source_ref": str(resource) if resource else None,
-                "provenance": "imported",
+                "provenance": provenance,
                 "created_at": created_at,
                 "updated_at": migrated_at,
             }

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -96,8 +96,7 @@ def test_context_sections_and_import_scope(tmp_path):
 
 
 def test_memanto_round_trip_preserves_extras(tmp_path):
-    """Memanto -> OKF -> Memanto keeps type/confidence/source_ref/tags/body via
-    the ``x_memanto`` block, and always marks provenance as imported."""
+    """Memanto -> OKF -> Memanto keeps schema fields from ``x_memanto``."""
     memories_by_type = {
         "fact": [
             _mem(
@@ -126,11 +125,26 @@ def test_memanto_round_trip_preserves_extras(tmp_path):
     assert pg["type"] == "fact"  # x_memanto.type round-trips
     assert pg["confidence"] == 0.9  # x_memanto.confidence round-trips
     assert pg["source_ref"] == "https://example.com/db"  # resource -> source_ref
-    assert pg["provenance"] == "imported"
+    assert pg["provenance"] == "explicit_statement"
     assert set(pg["tags"]) == {"infra", "db"}
     assert pg["created_at"] is not None
     assert "PostgreSQL 16" in pg["content"]
     assert by_title["Chose Redis"]["type"] == "decision"
+
+
+def test_okf_invalid_provenance_falls_back_to_imported():
+    """Foreign or malformed provenance must not reach batch validation."""
+    export = {
+        "memories": [
+            {
+                "title": "Foreign memory",
+                "body": "Imported from another OKF producer.",
+                "x_memanto": {"provenance": "untrusted-value"},
+            }
+        ]
+    }
+
+    assert map_okf(export)[0]["provenance"] == "imported"
 
 
 def test_foreign_okf_bundle_is_lossless(tmp_path):


### PR DESCRIPTION
## Problem

`OkfExportService` stores Memanto provenance under the namespaced `x_memanto` block and documents that Memanto -> OKF -> Memanto round-trips preserve it. However, `map_okf` discarded that value and hard-coded every imported row to `provenance="imported"`.

A memory marked `explicit_statement`, `inferred`, `corrected`, `validated`, or `observed` therefore lost its trust/source semantics after a supported export/import round-trip. This is especially damaging for corrected or inferred memories because downstream consumers can no longer distinguish how the memory was established.

Reproduction before this change:

1. Export a memory with `provenance="explicit_statement"` using `OkfExportService`.
2. Load the generated bundle with `load_okf_bundle`.
3. Map it with `map_okf`.
4. Observe that the mapped row reports `provenance="imported"` instead of the exported value.

## Fix

- Restore valid `x_memanto.provenance` values during OKF mapping.
- Validate against `VALID_PROVENANCE_TYPES` before passing the value to `SdkClient.batch_remember`.
- Keep the existing safe `imported` fallback for foreign, missing, non-string, or malformed values.
- Add regression coverage for both the round-trip and malformed-value fallback.

## Validation

- `pytest -q`: all non-live tests pass; 24 live Moorcheh E2E tests are skipped because no real API key is configured.
- `pytest tests/test_okf.py -q`: 6 passed.
- `ruff check .`: passed.
- `ruff format --check .`: passed.
- `mypy memanto`: passed.

Refs #770

/claim #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OKF imports now preserve valid provenance values from source data.
  * Invalid or unsupported provenance values safely default to “imported.”
  * Imported memories continue to retain related metadata, tags, timestamps, source content, and automatically mapped types.

* **Tests**
  * Added coverage for provenance preservation and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

BountyHub: https://www.bountyhub.dev/bounty/view/a7d4cc29-f927-4939-bc77-d7b8bb36c3da
