### PR TITLE
fix(langgraph): prevent cross-query results on rate-limit fallback

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -106,7 +106,7 @@ class MemantoStore(BaseStore):
         # (namespace, query, limit, type, min_sim) -> (timestamp, list[SearchItem])
         self._search_cache: dict[tuple, tuple[float, list[SearchItem]]] = {}
         # Survives 429s without flashing the UI panel to zero.
-        self._last_good: dict[tuple[str, ...], list[SearchItem]] = {}
+        self._last_good: dict[tuple, list[SearchItem]] = {}
 
     def _ensure_client(self, namespace: tuple[str, ...]) -> tuple[SdkClient, str]:
         ns_str = "_".join(namespace) or "default"
@@ -355,16 +355,16 @@ class MemantoStore(BaseStore):
         out = out[: op.limit]
 
         with self._lock:
-            if not out and rate_limited and op.namespace_prefix in self._last_good:
+            if not out and rate_limited and cache_key in self._last_good:
                 logger.info(
                     "MemantoStore: rate-limited, returning last-good for %r",
                     op.namespace_prefix,
                 )
-                return self._last_good[op.namespace_prefix]
+                return self._last_good[cache_key]
 
             if out and not rate_limited:
                 self._search_cache[cache_key] = (time.time(), out)
-                self._last_good[op.namespace_prefix] = out
+                self._last_good[cache_key] = out
 
         return out
 

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -96,6 +96,7 @@ class MemantoStore(BaseStore):
     # Cache TTL keeps short-interval polls (Streamlit reruns, multiple graph
     # nodes) from burning rate-limit budget on identical queries.
     _CACHE_TTL_S = 30.0
+    _CACHE_MAX_ENTRIES = 1000
 
     def __init__(self, api_key: str) -> None:
         """Initialize MemantoStore with an API key."""
@@ -365,6 +366,10 @@ class MemantoStore(BaseStore):
             if out and not rate_limited:
                 self._search_cache[cache_key] = (time.time(), out)
                 self._last_good[cache_key] = out
+                if len(self._search_cache) > self._CACHE_MAX_ENTRIES:
+                    self._search_cache.pop(next(iter(self._search_cache)))
+                if len(self._last_good) > self._CACHE_MAX_ENTRIES:
+                    self._last_good.pop(next(iter(self._last_good)))
 
         return out
 

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -235,6 +235,72 @@ def test_do_search_semantic(mock_sdk_client):
     )
 
 
+def test_do_search_rate_limit_does_not_reuse_different_query(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall.side_effect = [
+        {
+            "memories": [
+                {
+                    "id": "mem-private",
+                    "tags": ["lg:key:salary", "private"],
+                    "type": "fact",
+                    "content": "Salary is 100000",
+                }
+            ]
+        },
+        RuntimeError("429 Limit Exceeded"),
+    ]
+
+    private_items = store._do_search(
+        SearchOp(
+            namespace_prefix=("my_ns",),
+            query="salary",
+            filter={"tags": ["private"]},
+        )
+    )
+    store._search_cache.clear()
+    public_items = store._do_search(
+        SearchOp(
+            namespace_prefix=("my_ns",),
+            query="weather",
+            filter={"tags": ["public"]},
+        )
+    )
+
+    assert private_items[0].value["content"] == "Salary is 100000"
+    assert public_items == []
+
+
+def test_do_search_rate_limit_reuses_identical_last_good(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall.side_effect = [
+        {
+            "memories": [
+                {
+                    "id": "mem-456",
+                    "tags": ["lg:key:key2"],
+                    "type": "observation",
+                    "content": "observed",
+                }
+            ]
+        },
+        RuntimeError("429 Limit Exceeded"),
+    ]
+    op = SearchOp(namespace_prefix=("my_ns",), query="test query")
+
+    first_items = store._do_search(op)
+    store._search_cache.clear()
+    fallback_items = store._do_search(op)
+
+    assert fallback_items == first_items
+
+
 def test_batch_execution(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -301,6 +301,29 @@ def test_do_search_rate_limit_reuses_identical_last_good(mock_sdk_client):
     assert fallback_items == first_items
 
 
+def test_do_search_caches_evict_oldest_entries(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    store._CACHE_MAX_ENTRIES = 2
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+    client_instance.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-456",
+                "tags": ["lg:key:key2"],
+                "type": "observation",
+                "content": "observed",
+            }
+        ]
+    }
+
+    for query in ("query-1", "query-2", "query-3"):
+        store._do_search(SearchOp(namespace_prefix=("my_ns",), query=query))
+
+    assert [key[1] for key in store._search_cache] == ["query-2", "query-3"]
+    assert [key[1] for key in store._last_good] == ["query-2", "query-3"]
+
+
 def test_batch_execution(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()


### PR DESCRIPTION
## Bounty submission

Addresses #770.

## Flaw

`MemantoStore` kept its 429 `last-good` fallback by namespace alone. Every successful search in a namespace replaced that entry. If a later, different search in the same namespace hit a backend rate limit, the store returned the previous search result without checking the new query, tag filter, type filter, similarity threshold, or limit.

That makes retrieval nondeterministically wrong under realistic rate pressure: an unrelated memory can be presented as if it matched the current semantic query, and results excluded by the current filters can reappear. The backend does not need to return bad data; the contamination happens locally after the 429.

## Reproduction

The regression test performs two searches in one namespace:

1. A `salary` query with tag `private` succeeds and seeds the fallback.
2. The short-lived search cache is cleared (equivalent to waiting past its TTL).
3. A `weather` query with tag `public` receives `429 Limit Exceeded`.

Before this patch, step 3 returns the salary memory:

```text
FAILED test_do_search_rate_limit_does_not_reuse_different_query
assert public_items == []
Left contains Item(... content='Salary is 100000' ...)
```

## Fix

Key last-good results by the existing complete search signature instead of only `namespace_prefix`. A 429 now falls back only when namespace, query, limit, tags, type, and similarity threshold all match the successful request. The companion regression confirms that identical requests still receive the intended fallback. Both search caches are capped at 1,000 entries with FIFO eviction to keep unique queries from causing unbounded process memory growth.

## Verification

- `.venv/bin/python -m pytest -q integrations/langgraph/tests` -> 39 passed
- `.venv/bin/python -m pytest -q` -> passed; 24 live-backend E2E tests skipped without an API key
- `.venv/bin/python -m ruff check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py` -> passed
- `.venv/bin/python -m ruff format --check integrations/langgraph/langgraph_memanto/store.py integrations/langgraph/tests/test_store.py` -> passed
- `git diff --check` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search “last good” fallback so rate-limited results only reuse entries for the exact query and filter combination.
  * Ensured fallback and normal search results share consistent cache eviction behavior with a capped in-memory size.
* **Tests**
  * Updated search tests to reflect the new recall limit used during searches.
  * Added unit tests verifying rate-limit fallback behavior for matching vs. non-matching query/filter identity and cache eviction under a reduced cache size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->