### PR TITLE
fix(voltagent): validate configured default limit

### DIFF
--- a/sdks/typescript/src/integrations/voltagent.ts
+++ b/sdks/typescript/src/integrations/voltagent.ts
@@ -52,6 +52,17 @@ export function createMemantoVoltAgentTools(
 ) {
   const { include, defaultLimit } = options;
 
+  // A configured default bypasses the Zod parameter schemas below because it
+  // is applied only after VoltAgent has validated the model's arguments. Keep
+  // it inside the stricter recallMemory contract so an omitted model limit
+  // cannot silently send an invalid value to the Memanto API.
+  if (
+    defaultLimit !== undefined &&
+    (!Number.isInteger(defaultLimit) || defaultLimit < 1 || defaultLimit > 50)
+  ) {
+    throw new RangeError("defaultLimit must be an integer between 1 and 50");
+  }
+
   const all = {
     recallMemory: createTool({
       name: "recallMemory",

--- a/sdks/typescript/test/integrations/voltagent.test.ts
+++ b/sdks/typescript/test/integrations/voltagent.test.ts
@@ -98,6 +98,35 @@ describe("createMemantoVoltAgentTools", () => {
     });
   });
 
+  it.each([0, -1, 1.5, 51, Number.NaN])(
+    "rejects invalid defaultLimit %s before creating tools",
+    (defaultLimit) => {
+      expect(() =>
+        createMemantoVoltAgentTools(fakeMemanto() as unknown as Memanto, {
+          defaultLimit,
+        }),
+      ).toThrow("defaultLimit must be an integer between 1 and 50");
+    },
+  );
+
+  it("accepts the maximum recall-compatible defaultLimit", async () => {
+    const m = fakeMemanto();
+    const tools = createMemantoVoltAgentTools(m as unknown as Memanto, {
+      defaultLimit: 50,
+    });
+
+    await byName(tools, "recallMemory").execute!(
+      { query: "what milk?" },
+      execOpts,
+    );
+
+    expect(m.recall).toHaveBeenCalledWith({
+      query: "what milk?",
+      limit: 50,
+      type: undefined,
+    });
+  });
+
   it("exposes the server memory-type contract", () => {
     expect(MEMORY_TYPES).toContain("fact");
     expect(MEMORY_TYPES).toContain("preference");


### PR DESCRIPTION
## Summary

The new VoltAgent integration applies `defaultLimit` after VoltAgent/Zod validates the model's arguments. That means a host configuration such as `defaultLimit: 0`, `51`, `1.5`, or `NaN` bypasses the tool schema and is forwarded to the Memanto client whenever the model omits `limit`.

This change validates the configured default at tool-construction time against the stricter shared recall contract (`1..50`, integer), producing a clear `RangeError` instead of a later backend validation failure.

## Reproduction

```ts
const tools = createMemantoVoltAgentTools(memanto, { defaultLimit: 0 });
await tools.find((tool) => tool.name === "recallMemory")!.execute!(
  { query: "what changed?" },
  context,
);
```

Before this patch, `memanto.recall()` receives `limit: 0` even though the `recallMemory` schema declares `.min(1)`. The same bypass applies to non-integers and values above the schema maximum.

## Fix

- Reject configured defaults that are not integers in the inclusive range `1..50`.
- Add regression cases for `0`, `-1`, `1.5`, `51`, and `NaN`.
- Verify the maximum valid value is still forwarded when the model omits `limit`.

## Validation

From `sdks/typescript`:

- `npm test` ? 7 files, 43 tests passed
- `npm run typecheck` ? passed
- `npm run build` ? passed
- `git diff --check` ? passed

The first Windows `npm ci` omitted Rolldown's optional native binding (the npm optional-dependency issue reported by Rolldown). Installing `@rolldown/binding-win32-x64-msvc` locally without saving it allowed the unchanged test suite to run; no dependency or lockfile changes are included.

Bounty submission for #770. This is a focused setup/reliability flaw in the newly merged VoltAgent integration; it does not claim a security vulnerability or production data loss.
