### PR TITLE
fix: add re.DOTALL to title regex to prevent multi-line title corruption

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -715,9 +715,9 @@ class MemoryReadService:
 
             # Extract title: strip the "[TYPE] " prefix from first line
 
-            title_match = re.match(r"^\[.*?\]\s*(.*)$", first_line)
+            title_match = re.match(r"^\[.*?\]\s*(.*)$", first_line, re.DOTALL)
             if title_match:
-                title = title_match.group(1).strip()
+                title = title_match.group(1).strip()[:100]
                 # Content is the rest after the first line (skip tags section)
                 if len(lines) > 1:
                     # Check if last part is tags


### PR DESCRIPTION
## Summary

Fixes #1493 — multi-line memory titles corrupt on recall and compound [FACT] prefixes.

## Root Cause

The title extraction regex in `_format_memory_item` used `.*?` without `re.DOTALL`, so it could not match newlines in titles:

```python
# Before (broken)
title_match = re.match(r"^\[.*?\]\s*(.*)$", first_line)

# After (fixed)  
title_match = re.match(r"^\[.*?\]\s*(.*)$", first_line, re.DOTALL)
```

Without `re.DOTALL`, when a title contained a newline (e.g. `"Deploy checklist\n(staging first)"`), the regex failed to match the `[TYPE]` prefix. The entire first block — prefix included — was returned as the title: `"[FACT] Deploy checklist\n(staging first)"`.

## Failure Chain

1. **Recall leaks storage internals** — `[TYPE]` prefix appears in the title
2. **Every update compounds corruption** — each `update_memory` re-reads the corrupted title and adds another `[FACT] ` prefix
3. **Memory becomes permanently un-updatable** — accumulated prefixes push title past 100-char `MemoryRecord` limit, causing `ValidationError`

## Fix

1. Add `re.DOTALL` to the regex so `.` matches newlines
2. Truncate extracted title to 100 chars to prevent `MemoryRecord` validation errors

## Testing

The fix can be verified with:

```python
from unittest.mock import MagicMock
from memanto.app.core import MemoryRecord
from memanto.app.services.memory_read_service import MemoryReadService

svc = MemoryReadService(MagicMock())

# Create a memory with a multi-line title
record = MemoryRecord(
    id="test-1",
    memory_type="fact",
    title="Deploy checklist\n(staging first)",
    content="Step 1: deploy to staging",
    status="active",
    confidence=0.9,
)

# Before fix: title would be "[FACT] Deploy checklist\n(staging first)"
# After fix: title is "Deploy checklist\n(staging first)"
doc = record.to_moorcheh_document()
result = svc._format_memory_item({"id": record.id, "text": doc["text"]})
assert result["title"] == "Deploy checklist\n(staging first)"
assert "[FACT]" not in result["title"]
```

This is a Bug Challenge submission for #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of long memory titles by limiting extracted titles to 100 characters.
  * Enhanced title extraction for content spanning multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->