### PR TITLE
Reject cross-site requests to local UI endpoints

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -12,6 +12,7 @@ import signal
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import (
     APIRouter,
@@ -73,6 +74,17 @@ def _is_loopback(host: str | None) -> bool:
         return False
 
 
+def _is_loopback_origin(origin: str | None) -> bool:
+    """Return True when a browser Origin header points at localhost."""
+    if not origin:
+        return False
+    parsed = urlparse(origin)
+    hostname = parsed.hostname
+    if hostname == "localhost":
+        return True
+    return _is_loopback(hostname)
+
+
 async def _require_local(request: Request) -> None:
     """Reject requests that do not originate from the loopback interface.
 
@@ -89,6 +101,22 @@ async def _require_local(request: Request) -> None:
                 "UI management endpoints are only accessible from localhost. "
                 f"Request origin: {client_host}"
             ),
+        )
+
+    origin = request.headers.get("origin")
+    origin = origin if isinstance(origin, str) else None
+    if origin and not _is_loopback_origin(origin):
+        raise HTTPException(
+            status_code=403,
+            detail="UI management endpoints reject cross-site browser requests.",
+        )
+
+    sec_fetch_site = request.headers.get("sec-fetch-site")
+    sec_fetch_site = sec_fetch_site.lower() if isinstance(sec_fetch_site, str) else ""
+    if sec_fetch_site in {"cross-site", "same-site"}:
+        raise HTTPException(
+            status_code=403,
+            detail="UI management endpoints reject cross-site browser requests.",
         )
 
 

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -78,11 +78,8 @@ def _is_loopback_origin(origin: str | None) -> bool:
     """Return True when a browser Origin header points at localhost."""
     if not origin:
         return False
-    parsed = urlparse(origin)
-    hostname = parsed.hostname
-    if hostname == "localhost":
-        return True
-    return _is_loopback(hostname)
+    hostname = urlparse(origin).hostname
+    return hostname == "localhost" or _is_loopback(hostname)
 
 
 async def _require_local(request: Request) -> None:
@@ -111,8 +108,7 @@ async def _require_local(request: Request) -> None:
             detail="UI management endpoints reject cross-site browser requests.",
         )
 
-    sec_fetch_site = request.headers.get("sec-fetch-site")
-    sec_fetch_site = sec_fetch_site.lower() if isinstance(sec_fetch_site, str) else ""
+    sec_fetch_site = request.headers.get("sec-fetch-site", "").lower()
     if sec_fetch_site in {"cross-site", "same-site"}:
         raise HTTPException(
             status_code=403,

--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -24,6 +24,23 @@ def _make_app():
     return app
 
 
+class _LoopbackClient:
+    """ASGI wrapper that makes TestClient requests look like loopback traffic."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            scope = dict(scope)
+            scope["client"] = ("127.0.0.1", 50000)
+        await self.app(scope, receive, send)
+
+
+def _make_loopback_client(app):
+    return TestClient(_LoopbackClient(app), raise_server_exceptions=False)
+
+
 class TestUnauthenticatedUIEndpoints:
     """Unauthenticated requests from non-localhost must be refused with HTTP 403.
 
@@ -64,6 +81,32 @@ class TestUnauthenticatedUIEndpoints:
         resp = client.put("/api/ui/api-key", json={"api_key": "stolen"})
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
 
+    def test_loopback_cross_site_origin_rejected(self):
+        """Local browser requests from another website must not reach UI endpoints."""
+        app = _make_app()
+        client = _make_loopback_client(app)
+        resp = client.post(
+            "/api/ui/shutdown",
+            headers={"Origin": "https://evil.example"},
+        )
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+        assert resp.json()["detail"] == (
+            "UI management endpoints reject cross-site browser requests."
+        )
+
+    def test_loopback_cross_site_fetch_metadata_rejected(self):
+        """Fetch Metadata blocks no-cors style cross-site POSTs without Origin."""
+        app = _make_app()
+        client = _make_loopback_client(app)
+        resp = client.post(
+            "/api/ui/shutdown",
+            headers={"Sec-Fetch-Site": "cross-site"},
+        )
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+        assert resp.json()["detail"] == (
+            "UI management endpoints reject cross-site browser requests."
+        )
+
 
 class TestLoopbackDetection:
     """Unit tests for the _is_loopback helper used by _require_local.
@@ -103,6 +146,19 @@ class TestLoopbackDetection:
         from memanto.app.ui.routes.ui_router import _is_loopback
 
         assert _is_loopback("testclient") is False
+
+    def test_loopback_origin_accepted(self):
+        """Same-origin UI requests from localhost must be allowed."""
+        from memanto.app.ui.routes.ui_router import _is_loopback_origin
+
+        assert _is_loopback_origin("http://localhost:8000") is True
+        assert _is_loopback_origin("http://127.0.0.1:8000") is True
+        assert _is_loopback_origin("http://[::1]:8000") is True
+
+    def test_remote_origin_rejected(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback_origin
+
+        assert _is_loopback_origin("https://evil.example") is False
 
     def test_require_local_allows_loopback(self):
         """_require_local must not raise for a 127.0.0.1 caller."""


### PR DESCRIPTION
## Summary
- Harden local-only UI management endpoints against cross-site browser requests.
- Allow same-origin localhost UI calls and non-browser local tooling, while rejecting remote Origin and cross-site Fetch Metadata headers.
- Add regression coverage for Origin, Sec-Fetch-Site, and loopback origin handling.

## Reproduction
1. Start the Memanto UI locally with the default wildcard CORS setting.
2. From another website, send a browser request to a local UI management endpoint such as /api/ui/shutdown.
3. Before this change, the endpoint only checked the TCP client address, so a browser-originated localhost request could pass the local guard.
4. After this change, cross-site browser requests are rejected with 403 while localhost same-origin requests still pass.

## Tests
- HOME=/private/tmp/memanto-test-home .venv/bin/python -m pytest tests/test_ui_auth.py tests/test_cors_fix.py -q
- HOME=/private/tmp/memanto-test-home .venv/bin/python -m pytest tests/test_remaining_ui_auth.py -q

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened protection for local UI management endpoints by rejecting cross-site browser requests and non-local `Origin` headers with HTTP 403.
  * Improved loopback detection by accepting `localhost` and common loopback/IP `Origin` formats, including IPv4-mapped IPv6.

* **Tests**
  * Added regression tests ensuring cross-site `Origin`/`Sec-Fetch-Site` scenarios are denied.
  * Added coverage verifying loopback `Origin` forms are accepted and remote origins are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->