### PR TITLE
fix(ts): authenticate remote management requests

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -91,6 +91,10 @@ The spawned `memanto serve` inherits the on-prem config from `~/.memanto/`, and 
 | `healthTimeoutMs` | `number` | `60000` | Health-check timeout. |
 | `verbose` | `boolean` | `false` | Stream server logs to the parent process. |
 
+When `baseUrl` points to an existing server, `apiKey` is sent as `X-Api-Key`
+on agent-management and activation requests. Session-scoped memory requests
+continue to use the server-issued session token.
+
 ### Methods
 
 **Memory writes**

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -137,6 +137,7 @@ export class Memanto {
   private readonly agentId: string;
   private readonly encodedAgentId: string;
   private readonly autoCreate: boolean;
+  private readonly apiKey?: string;
   private sessionToken: string | null = null;
   private starting: Promise<void> | null = null;
 
@@ -145,6 +146,7 @@ export class Memanto {
     this.agentId = opts.agentId;
     this.encodedAgentId = encodeURIComponent(opts.agentId);
     this.autoCreate = opts.autoCreate ?? true;
+    this.apiKey = opts.apiKey;
     this.lifecycle = new ServerLifecycle(opts);
   }
 
@@ -325,7 +327,7 @@ export class Memanto {
     const baseUrl = this.lifecycle.baseUrl;
     const res = await fetch(`${baseUrl}/api/v2/agents`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.managementHeaders(),
       body: JSON.stringify({
         agent_id: this.agentId,
         pattern: input.pattern,
@@ -398,14 +400,16 @@ export class Memanto {
 
   private async createAgentIfMissing(): Promise<void> {
     const baseUrl = this.lifecycle.baseUrl;
-    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}`);
+    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}`, {
+      headers: this.managementHeaders(),
+    });
     if (res.ok) return;
     if (res.status !== 404) {
       throw await asError(res, "Failed to look up agent");
     }
     const create = await fetch(`${baseUrl}/api/v2/agents`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.managementHeaders(),
       body: JSON.stringify({ agent_id: this.agentId }),
     });
     if (!create.ok && create.status !== 409) {
@@ -417,6 +421,7 @@ export class Memanto {
     const baseUrl = this.lifecycle.baseUrl;
     const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}/activate`, {
       method: "POST",
+      headers: this.managementHeaders(),
     });
     if (!res.ok) throw await asError(res, "Failed to activate agent");
     const session = (await res.json()) as SessionRecord;
@@ -441,6 +446,8 @@ export class Memanto {
     };
     if (requireSession) {
       headers["X-Session-Token"] = this.sessionToken ?? "";
+    } else if (this.apiKey) {
+      headers["X-Api-Key"] = this.apiKey;
     }
     const res = await fetch(`${baseUrl}${path}`, {
       method,
@@ -450,6 +457,14 @@ export class Memanto {
     if (!res.ok) throw await asError(res, `${method} ${path} failed`);
     if (res.status === 204) return undefined as T;
     return (await res.json()) as T;
+  }
+
+  private managementHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.apiKey) headers["X-Api-Key"] = this.apiKey;
+    return headers;
   }
 
   private async requestMultipart<T = unknown>(

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -10,7 +10,7 @@ interface Recorded {
   body: string;
 }
 
-function startFakeApi(agentId = "test-agent"): Promise<{
+function startFakeApi(agentId = "test-agent", requiredApiKey?: string): Promise<{
   url: string;
   recorded: Recorded[];
   close: () => void;
@@ -34,6 +34,19 @@ function startFakeApi(agentId = "test-agent"): Promise<{
         };
 
         if (url === "/health") return reply(200, { status: "ok" });
+        const agentUrl = `/api/v2/agents/${encodedAgentId}`;
+        const isManagementRequest =
+          url === "/api/v2/status" ||
+          url === "/api/v2/agents" ||
+          (url === agentUrl && ["GET", "DELETE"].includes(req.method ?? "")) ||
+          url === `${agentUrl}/activate`;
+        if (
+          requiredApiKey &&
+          isManagementRequest &&
+          req.headers["x-api-key"] !== requiredApiKey
+        ) {
+          return reply(401, { detail: "invalid API key" });
+        }
         if (url === "/api/v2/status" && req.method === "GET")
           return reply(200, {
             session_id: "existing-session",
@@ -175,6 +188,36 @@ describe("Memanto", () => {
       "GET /api/v2/status",
     ]);
     expect(api.recorded[0]?.headers["x-session-token"]).toBeUndefined();
+  });
+
+  it("authenticates remote management endpoints with apiKey", async () => {
+    const apiKey = "mch_remote_test_key";
+    const api = await startFakeApi("test-agent", apiKey);
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url, apiKey });
+    cleanupFns.push(() => m.close());
+
+    await m.remember({ content: "Remote servers require management auth" });
+    await m.status();
+
+    const managementUrls = new Set([
+      "/api/v2/agents/test-agent",
+      "/api/v2/agents",
+      "/api/v2/agents/test-agent/activate",
+      "/api/v2/status",
+    ]);
+    const managementRequests = api.recorded.filter((r) =>
+      managementUrls.has(r.url),
+    );
+    expect(managementRequests).toHaveLength(4);
+    expect(managementRequests.every((r) => r.headers["x-api-key"] === apiKey)).toBe(
+      true,
+    );
+
+    const remember = api.recorded.find((r) => r.url.endsWith("/remember"));
+    expect(remember?.headers["x-session-token"]).toBe("fake-token");
+    expect(remember?.headers["x-api-key"]).toBeUndefined();
   });
 
   it("rejects empty agentId", () => {


### PR DESCRIPTION
## Summary

- authenticate TypeScript SDK management requests when `baseUrl` points to an existing Memanto server
- keep session-scoped memory requests on the narrower `X-Session-Token` credential
- add a regression server that rejects unauthenticated management requests

## Flaw and impact

The TypeScript SDK accepts both `baseUrl` and `apiKey`, but it previously used
`apiKey` only when spawning a local `uvx` server. When `baseUrl` pointed to a
remote or network-accessible Memanto server, agent lookup, creation, activation,
deletion, listing, and status requests omitted the required management
credential.

As a result, the documented existing-server setup fails during bootstrap with
`401 Unauthorized` as soon as management access is protected. The SDK cannot
reach the session-token stage, so all memory operations are blocked. This is a
realistic deployment path for containers, shared development servers, and
remote/on-prem installations.

## Reproduction

1. Start an existing Memanto server with a configured management API key.
2. Construct the TypeScript client with that server URL and the matching key:

   ```ts
   const memanto = new Memanto({
     agentId: "remote-agent",
     baseUrl: "https://memanto.example.com",
     apiKey: process.env.MOORCHEH_API_KEY,
   });
   ```

3. Call `remember()` or another session-scoped method.
4. Before this fix, the initial agent lookup/activation has no
   `Authorization` or `X-Api-Key` header and fails with 401.

The added test reproduces the behavior using a fake server that returns 401 for
management endpoints unless the expected `X-Api-Key` is present.

## Fix

- retain the configured API key in the TypeScript client
- attach it as `X-Api-Key` to management and activation requests
- do not attach it to memory operations after a session is active; those calls
  continue to use `X-Session-Token`
- document the existing-server credential behavior

## Validation

- `npm test` — 38 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed

Refs #770



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional API key authentication for management and administrative requests when connecting to an existing server.
  - API keys are automatically sent for agent management, activation, and status operations.
  - Session-based memory operations continue using session tokens and do not send the API key.

- **Documentation**
  - Updated TypeScript SDK documentation to explain authentication behavior when using an existing server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->