### PR TITLE
fix(okf): preserve memory lifecycle status

### DIFF
--- a/memanto/app/constants.py
+++ b/memanto/app/constants.py
@@ -68,6 +68,13 @@ VALID_PROVENANCE_TYPES = {
     "imported",
 }
 
+VALID_STATUS_TYPES = {
+    "active",
+    "superseded",
+    "deleted",
+    "provisional",
+}
+
 ALLOWED_UPDATE_FIELDS = {
     "title",
     "content",

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -743,7 +743,7 @@ class DirectClient:
                 "source": item.get("source") or "user",
                 "provenance": provenance,
             }
-            for opt_key in ("source_ref", "created_at", "updated_at"):
+            for opt_key in ("source_ref", "created_at", "updated_at", "status"):
                 val = item.get(opt_key)
                 if val is not None:
                     kwargs[opt_key] = val

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -572,7 +572,7 @@ class SdkClient:
                 "source": item.get("source") or "user",
                 "provenance": provenance,
             }
-            for opt_key in ("source_ref", "created_at", "updated_at"):
+            for opt_key in ("source_ref", "created_at", "updated_at", "status"):
                 val = item.get(opt_key)
                 if val is not None:
                     kwargs[opt_key] = val

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -35,7 +35,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
-from memanto.app.constants import VALID_MEMORY_TYPES
+from memanto.app.constants import VALID_MEMORY_TYPES, VALID_STATUS_TYPES
 
 # Mem0 ships category labels per memory. Map the common ones to Memanto's
 # typed primitives; everything else falls through to None (auto-classify).
@@ -71,6 +71,14 @@ def _coerce_type(raw: str | None) -> str | None:
         return None
     t = raw.strip().lower()
     return t if t in VALID_MEMORY_TYPES else None
+
+
+def _coerce_status(raw: Any) -> str | None:
+    """Return a supported Memanto status or ignore malformed extensions."""
+    if not isinstance(raw, str):
+        return None
+    status = raw.strip().lower()
+    return status if status in VALID_STATUS_TYPES else None
 
 
 def _scope_tag(scope: dict[str, Any] | None) -> str | None:
@@ -452,6 +460,7 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
         confidence = min(1.0, max(0.0, confidence))
 
         source = x_memanto.get("source") or "okf"
+        status = _coerce_status(x_memanto.get("status"))
         created_at = _parse_dt(entry.get("timestamp"))
 
         footer_items: list[tuple[str, Any]] = [
@@ -470,20 +479,25 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
         elif len(content) > _MAX_CONTENT_CHARS:
             content = content[: _MAX_CONTENT_CHARS - 4] + "\n..."
 
-        rows.append(
-            {
-                "title": title or _title_from(content),
-                "content": content,
-                "type": memory_type,
-                "tags": tags,
-                "confidence": confidence,
-                "source": source,
-                "source_ref": str(resource) if resource else None,
-                "provenance": "imported",
-                "created_at": created_at,
-                "updated_at": migrated_at,
-            }
-        )
+        row = {
+            "title": title or _title_from(content),
+            "content": content,
+            "type": memory_type,
+            "tags": tags,
+            "confidence": confidence,
+            "source": source,
+            "source_ref": str(resource) if resource else None,
+            "provenance": "imported",
+            "created_at": created_at,
+            "updated_at": migrated_at,
+        }
+        # A Memanto export carries lifecycle state in its namespaced extension.
+        # Preserve it so superseded/deleted memories do not become active again
+        # after a supported export/import round trip. Foreign or malformed OKF
+        # data omits the field and keeps MemoryRecord's safe active default.
+        if status is not None:
+            row["status"] = status
+        rows.append(row)
     return rows
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -510,6 +510,47 @@ class TestMEMANTOCLI:
 
         mock_write_service.batch_store_memories.assert_not_called()
 
+    @pytest.mark.parametrize("client_path", ["direct_client", "sdk_client"])
+    def test_batch_import_preserves_memory_status(self, mock_all_clients, client_path):
+        """Migration clients must forward lifecycle state into MemoryRecord."""
+        from importlib import import_module
+        from unittest.mock import MagicMock, patch
+
+        module = import_module(f"memanto.cli.client.{client_path}")
+        client_cls = (
+            module.DirectClient if client_path == "direct_client" else module.SdkClient
+        )
+        mock_write_service = MagicMock()
+        mock_write_service.batch_store_memories.return_value = {"results": []}
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+
+        with (
+            patch.object(
+                client_cls, "_get_write_service", return_value=mock_write_service
+            ),
+            patch.object(
+                client_cls,
+                "_get_validated_session_for_agent",
+                return_value=mock_session,
+            ),
+        ):
+            client = client_cls.__new__(client_cls)
+            client.api_key = "test-api-key"
+            client.session_token = None
+            client.batch_remember(
+                agent_id="test-agent",
+                memories=[
+                    {
+                        "content": "An obsolete deployment instruction.",
+                        "status": "superseded",
+                    }
+                ],
+            )
+
+        records = mock_write_service.batch_store_memories.call_args.args[0]
+        assert records[0].status == "superseded"
+
     def test_edit_sdk_normalizes_confidence_and_accepts_valid_payload(
         self, mock_all_clients
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -852,8 +852,10 @@ class TestMEMANTOCLI:
         self, client_class_path, method_name, args, bad_limit
     ):
         """Temporal recall paths must not forward invalid limits to storage."""
+        from importlib import import_module
+
         module_name, class_name = client_class_path.rsplit(".", 1)
-        module = __import__(module_name, fromlist=[class_name])
+        module = import_module(module_name)
         client_class = getattr(module, class_name)
         client = client_class.__new__(client_class)
         read_service = MagicMock()

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -108,7 +108,7 @@ def test_memanto_round_trip_preserves_extras(tmp_path):
                 confidence=0.9,
                 provenance="explicit_statement",
                 source="user",
-                status="active",
+                status="superseded",
                 created_at="2026-05-28T14:30:00Z",
                 source_ref="https://example.com/db",
             )
@@ -125,6 +125,7 @@ def test_memanto_round_trip_preserves_extras(tmp_path):
     pg = by_title["Postgres is the DB"]
     assert pg["type"] == "fact"  # x_memanto.type round-trips
     assert pg["confidence"] == 0.9  # x_memanto.confidence round-trips
+    assert pg["status"] == "superseded"  # lifecycle state round-trips
     assert pg["source_ref"] == "https://example.com/db"  # resource -> source_ref
     assert pg["provenance"] == "imported"
     assert set(pg["tags"]) == {"infra", "db"}
@@ -186,3 +187,21 @@ def test_loader_splits_stacked_file(tmp_path):
     assert {m["title"] for m in export["memories"]} == {
         f"Standup {i}" for i in range(5)
     }
+
+
+def test_okf_mapper_ignores_invalid_memanto_status(tmp_path):
+    """Malformed extension data must not break foreign OKF imports."""
+    (tmp_path / "memory.md").write_text(
+        "---\n"
+        "type: fact\n"
+        "title: A fact\n"
+        "x_memanto:\n"
+        "  status: archived\n"
+        "---\n\n"
+        "A useful fact.\n",
+        encoding="utf-8",
+    )
+
+    row = map_okf(load_okf_bundle(tmp_path))[0]
+
+    assert "status" not in row


### PR DESCRIPTION
## Summary

- preserve valid `x_memanto.status` values during Memanto -> OKF -> Memanto imports
- forward imported lifecycle status through both CLI client implementations
- fall back safely for foreign or malformed OKF status values

## Root cause and impact

`OkfExportService` writes lifecycle state (`active`, `superseded`, `deleted`, or `provisional`) into the namespaced `x_memanto` block, but `map_okf()` discarded it and both migration clients omitted it when creating `MemoryRecord`s. Every round-tripped record therefore fell back to `status="active"`.

A superseded or deleted memory could be reactivated by the supported export/import flow, resurrecting obsolete knowledge and allowing it to influence future recall.

## Reproduction

1. Export a memory with `status="superseded"` through `OkfExportService`.
2. Load the bundle with `load_okf_bundle()`.
3. Map it with `map_okf()`.
4. Before this fix, the exported extension contains `superseded`, but the mapped row has no status and is stored as active.

## Validation

- `pytest -q` - 306 passed, 24 live E2E tests skipped without a Moorcheh API key
- `ruff check .`
- `ruff format --check .`
- `mypy memanto`
- `git diff --check`

Refs #770

Bounty: https://www.bountyhub.dev/bounty/view/a7d4cc29-f927-4939-bc77-d7b8bb36c3da

/claim #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch imports can now preserve each memory’s lifecycle status (e.g., superseded) for both client interfaces.
  * OKF imports now recognize and map supported lifecycle statuses: active, superseded, deleted, and provisional.
* **Bug Fixes**
  * Unsupported lifecycle status values from OKF imports are ignored and not written to records.
* **Tests**
  * Added/updated integration and round-trip tests to verify status preservation across batch import paths and proper handling of invalid statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->