### PR TITLE
fix: block cross-site management token theft

### DIFF
--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -118,14 +118,25 @@ def _is_loopback_origin(origin: str | None) -> bool:
     return parsed.hostname == "localhost" or _is_loopback_host(parsed.hostname)
 
 
+def _is_loopback_host_header(host: str | None) -> bool:
+    """Return True when an HTTP Host header names a loopback interface."""
+    if not host:
+        return False
+    try:
+        hostname = urlsplit(f"//{host}").hostname
+    except ValueError:
+        return False
+    return hostname == "localhost" or _is_loopback_host(hostname)
+
+
 def _is_cross_site_browser_request(request: Request) -> bool:
     """Detect browser requests that must not inherit loopback trust."""
-    fetch_site = request.headers.get("sec-fetch-site", "").strip().lower()
-    if fetch_site in {"cross-site", "same-site"}:
-        return True
-
     origin = request.headers.get("origin")
-    return origin is not None and not _is_loopback_origin(origin)
+    if origin is not None:
+        return not _is_loopback_origin(origin)
+
+    fetch_site = request.headers.get("sec-fetch-site", "").strip().lower()
+    return fetch_site in {"cross-site", "same-site"}
 
 
 def require_management_access(
@@ -175,7 +186,11 @@ def require_management_access(
         return server_key
 
     client_host = request.client.host if request.client else None
-    if _is_loopback_host(client_host) and not _is_cross_site_browser_request(request):
+    if (
+        _is_loopback_host(client_host)
+        and _is_loopback_host_header(request.headers.get("host"))
+        and not _is_cross_site_browser_request(request)
+    ):
         return server_key
 
     raise HTTPException(

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,6 +4,8 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
+from urllib.parse import urlsplit
+
 from fastapi import Cookie, Header, HTTPException, Request, Response
 
 from memanto.app.models.session import Session
@@ -103,6 +105,29 @@ def _is_loopback_host(host: str | None) -> bool:
     return ipv4_mapped is not None and ipv4_mapped.is_loopback
 
 
+def _is_loopback_origin(origin: str | None) -> bool:
+    """Return True when a browser Origin points at the local Memanto host."""
+    if not origin:
+        return False
+    try:
+        parsed = urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    return parsed.hostname == "localhost" or _is_loopback_host(parsed.hostname)
+
+
+def _is_cross_site_browser_request(request: Request) -> bool:
+    """Detect browser requests that must not inherit loopback trust."""
+    fetch_site = request.headers.get("sec-fetch-site", "").strip().lower()
+    if fetch_site in {"cross-site", "same-site"}:
+        return True
+
+    origin = request.headers.get("origin")
+    return origin is not None and not _is_loopback_origin(origin)
+
+
 def require_management_access(
     request: Request,
     authorization: str | None = Header(None),
@@ -150,7 +175,7 @@ def require_management_access(
         return server_key
 
     client_host = request.client.host if request.client else None
-    if _is_loopback_host(client_host):
+    if _is_loopback_host(client_host) and not _is_cross_site_browser_request(request):
         return server_key
 
     raise HTTPException(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -179,6 +179,53 @@ class TestMEMANTOAPI:
             assert response.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_cross_site_loopback_cannot_create_agent(self, client):
+        """A website cannot use the loopback exemption to manage agents."""
+        response = await client.post(
+            "/api/v2/agents",
+            headers={
+                "Origin": "https://evil.example",
+                "Sec-Fetch-Site": "cross-site",
+            },
+            json={"agent_id": "cross-site-agent", "pattern": "support"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_cross_site_loopback_cannot_activate_agent(
+        self, client, auth_headers
+    ):
+        """A website cannot mint a session token for an existing agent."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": "cross-site-activate", "pattern": "support"},
+        )
+
+        response = await client.post(
+            "/api/v2/agents/cross-site-activate/activate",
+            headers={"Sec-Fetch-Site": "cross-site"},
+        )
+
+        assert response.status_code == 401
+        assert "session_token" not in response.text
+
+    @pytest.mark.asyncio
+    async def test_loopback_origin_keeps_local_management_access(self, client):
+        """The localhost browser UI keeps the intentional loopback exemption."""
+        response = await client.post(
+            "/api/v2/agents",
+            headers={
+                "Origin": "http://localhost:8000",
+                "Sec-Fetch-Site": "same-origin",
+            },
+            json={"agent_id": "localhost-origin-agent", "pattern": "support"},
+        )
+
+        assert response.status_code == 201
+
+    @pytest.mark.asyncio
     async def test_create_agent_fails_when_server_key_missing(self, client):
         """Test failure when server API key is not configured"""
         payload = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -217,6 +217,7 @@ class TestMEMANTOAPI:
         response = await client.post(
             "/api/v2/agents",
             headers={
+                "Host": "localhost:8000",
                 "Origin": "http://localhost:8000",
                 "Sec-Fetch-Site": "same-origin",
             },
@@ -224,6 +225,35 @@ class TestMEMANTOAPI:
         )
 
         assert response.status_code == 201
+
+    @pytest.mark.asyncio
+    async def test_loopback_cross_port_origin_keeps_local_access(self, client):
+        """An explicit local Origin wins over the same-site fetch fallback."""
+        response = await client.post(
+            "/api/v2/agents",
+            headers={
+                "Host": "127.0.0.1:8000",
+                "Origin": "http://localhost:3000",
+                "Sec-Fetch-Site": "same-site",
+            },
+            json={"agent_id": "localhost-cross-port", "pattern": "support"},
+        )
+
+        assert response.status_code == 201
+
+    @pytest.mark.asyncio
+    async def test_dns_rebinding_host_cannot_inherit_loopback_access(self, client):
+        """A remote Host header cannot turn a loopback socket into trust."""
+        response = await client.post(
+            "/api/v2/agents",
+            headers={
+                "Host": "attacker.example",
+                "Sec-Fetch-Site": "same-origin",
+            },
+            json={"agent_id": "dns-rebinding-agent", "pattern": "support"},
+        )
+
+        assert response.status_code == 401
 
     @pytest.mark.asyncio
     async def test_create_agent_fails_when_server_key_missing(self, client):


### PR DESCRIPTION
## Summary

Prevent hostile browser pages and DNS-rebinding domains from inheriting Memanto's passwordless localhost management exemption. Explicitly credentialed management clients and legitimate localhost UI traffic, including cross-port frontends, continue to work.

Refs #770

## Flaw and impact

Memanto intentionally permits unauthenticated management requests from a loopback TCP client so the local CLI and browser UI remain convenient. The server also ships with `ALLOWED_ORIGINS=["*"]` and allows every CORS method and header.

A malicious website opened on the same machine could therefore call the primary `/api/v2` management API through `localhost`. Before this fix, the browser's connection appeared to originate from `127.0.0.1`, so the server trusted it without a management credential. The default CORS policy made the response readable to the attacking origin.

This allowed a site to:

1. create or enumerate agents;
2. activate an agent without a management key;
3. read the returned `session_token`;
4. use that token against the agent's memory read/write/delete endpoints.

The regression reproduced both critical steps before the fix:

- cross-site agent creation returned `201 Created`;
- cross-site activation returned `200 OK` with a live session token.

## Root cause

`require_management_access()` treated the socket peer's loopback address as sufficient authorization. That proves where the browser connection terminates, but not which web origin controls the browser. The exemption also did not validate the HTTP `Host`, so a DNS-rebinding domain could appear same-origin while resolving to the local service.

## Fix

Passwordless local management now requires all of the following:

- a loopback TCP peer;
- a loopback HTTP `Host` (`localhost`, IPv4/IPv6 loopback, with optional port);
- browser provenance that is not cross-site.

An explicit `Origin` is evaluated first. A loopback Origin is allowed even when a cross-port local frontend produces `Sec-Fetch-Site: same-site`; when Origin is absent, Fetch Metadata is used as the fallback. Remote origins, cross-site fetches, and non-loopback Host values are rejected.

Explicit API-key authorization remains available to remote clients and does not depend on the loopback exemption.

## Regression coverage

- rejects cross-site agent creation from a loopback socket;
- rejects cross-site activation and does not expose a session token;
- preserves same-origin localhost management access;
- preserves legitimate cross-port localhost UI access;
- rejects a DNS-rebinding Host header even when Fetch Metadata says `same-origin`.

## Validation

- focused security regressions: 5 passed
- full non-live test suite passed; 24 live Moorcheh E2E tests skipped without an API key
- Ruff check passed
- Ruff format check passed
- mypy passed
- `git diff --check` passed

/claim #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened management access controls for browser requests originating from outside the local environment.
  * Prevented cross-site requests from creating agents or obtaining session tokens through loopback access.
  * Preserved authorized management access for same-origin requests from localhost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
