### PR TITLE
fix(mcp): restrict automatic agent creation

### DIFF
--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -123,7 +123,7 @@ All config is via environment variables (load order: process env →
 | `MOORCHEH_API_KEY` | **yes** | — | Moorcheh API key. |
 | `MEMANTO_DEFAULT_AGENT_ID` | recommended | _none_ | Default agent. When set, tool calls may omit `agent_id`. |
 | `MEMANTO_AGENT_PATTERN` | no | `tool` | Pattern (`support`/`project`/`tool`) used when auto-creating the default agent. |
-| `MEMANTO_AGENT_AUTO_CREATE` | no | `true` | Create the default agent on first use if missing. |
+| `MEMANTO_AGENT_AUTO_CREATE` | no | `true` | Create the default agent on first use if missing. Explicit non-default agents must already exist. |
 | `MEMANTO_SESSION_DURATION_HOURS` | no | server default (6) | Session lifetime in hours. |
 | `MEMANTO_EXPOSE_ADMIN` | no | `false` | Register the 4 agent-management tools. |
 | `MEMANTO_MCP_TRANSPORT` | no | `stdio` | `stdio`, `sse`, or `streamable-http`. |

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -122,6 +122,13 @@ class MemantoLifecycle:
                 f"{agent_id}` or via the create_agent tool."
             )
 
+        if agent_id != self._settings.default_agent_id:
+            raise AgentNotFoundError(
+                f"Agent '{agent_id}' does not exist. Only the configured default agent "
+                "may be auto-created; create other agents explicitly with "
+                f"`memanto agent create {agent_id}` or the gated create_agent tool."
+            )
+
         logger.info(
             "Auto-creating agent '%s' with pattern '%s'.",
             agent_id,

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -1,0 +1,53 @@
+"""MCP agent/session lifecycle behavior."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from memanto.app.utils.errors import AgentNotFoundError
+
+from memanto_mcp.config import MCPServerSettings
+from memanto_mcp.lifecycle import MemantoLifecycle
+
+
+def _lifecycle_with_missing_agents(settings: MCPServerSettings):
+    lifecycle = MemantoLifecycle(settings)
+    client = MagicMock()
+    client.get_agent.side_effect = AgentNotFoundError("missing")
+    lifecycle._client = client
+    return lifecycle, client
+
+
+def test_arbitrary_agent_id_cannot_bypass_hidden_admin_tools(
+    fake_api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Auto-create is limited to the configured default agent."""
+    monkeypatch.setenv("MEMANTO_DEFAULT_AGENT_ID", "project-agent")
+    settings = MCPServerSettings()  # type: ignore[call-arg]
+    lifecycle, client = _lifecycle_with_missing_agents(settings)
+
+    with pytest.raises(AgentNotFoundError, match="Only the configured default agent"):
+        lifecycle.ensure_ready("attacker-chosen-agent")
+
+    client.create_agent.assert_not_called()
+    client.activate_agent.assert_not_called()
+
+
+def test_configured_default_agent_is_still_auto_created(
+    fake_api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The documented default-agent convenience remains available."""
+    monkeypatch.setenv("MEMANTO_DEFAULT_AGENT_ID", "project-agent")
+    settings = MCPServerSettings()  # type: ignore[call-arg]
+    lifecycle, client = _lifecycle_with_missing_agents(settings)
+
+    assert lifecycle.ensure_ready("project-agent") == "project-agent"
+
+    client.create_agent.assert_called_once_with(
+        agent_id="project-agent",
+        pattern="tool",
+        description="Auto-created by memanto-mcp",
+    )
+    client.activate_agent.assert_called_once_with(
+        agent_id="project-agent",
+        duration_hours=None,
+    )


### PR DESCRIPTION
## Summary

- restrict MCP automatic agent creation to the configured default agent
- prevent ordinary memory tools from creating attacker-chosen agents when admin tools are hidden
- document the boundary and add regression coverage

## Root cause and impact

`MEMANTO_EXPOSE_ADMIN=false` removes the agent-management tools from the MCP surface, while `MEMANTO_AGENT_AUTO_CREATE` is documented as creating the configured default agent on first use. However, any memory tool call carrying a missing, non-default `agent_id` reached the same auto-create path. A prompt-injected or untrusted tool argument could therefore bypass the hidden administrative surface and create arbitrary agents/namespaces.

The lifecycle now auto-creates only `MEMANTO_DEFAULT_AGENT_ID`. Explicit non-default agents must already exist and otherwise fail with `AgentNotFoundError`.

## Validation

- reproduced the bypass with a regression test that failed before the fix
- MCP test suite: 27 passed
- Ruff check and format check passed
- mypy: success on 12 source files
- `git diff --check` passed

Refs #770

/claim #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic creation of arbitrary agents when they are missing.
  * Missing non-default agents must now be created explicitly.
  * Preserved automatic creation and activation of the configured default agent.

* **Documentation**
  * Clarified the default-agent auto-creation setting and behavior for other agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->