### PR TITLE
fix(migrate): keep OKF batches valid with long titles

### DIFF
--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -55,6 +55,7 @@ _MEM0_CATEGORY_TO_TYPE: dict[str, str] = {
 }
 
 _DEFAULT_TITLE_CHARS = 80
+_MAX_TITLE_CHARS = 100  # MemoryRecord.title max_length
 _MAX_CONTENT_CHARS = 10000  # MemoryRecord.content max_length
 _MAX_FOOTER_CHARS = 800  # cap supporting-data footer so it never dominates
 
@@ -454,7 +455,13 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
         source = x_memanto.get("source") or "okf"
         created_at = _parse_dt(entry.get("timestamp"))
 
+        original_title = None
+        if title and len(title) > _MAX_TITLE_CHARS:
+            original_title = title
+            title = title[: _MAX_TITLE_CHARS - 3].rstrip() + "..."
+
         footer_items: list[tuple[str, Any]] = [
+            ("Original OKF title", original_title),
             ("OKF source", entry.get("source_path")),
             # Only surface the OKF type when we couldn't map it to a slot.
             ("OKF type", okf_type if not memory_type else None),


### PR DESCRIPTION
## Summary

- bound explicit foreign OKF titles to `MemoryRecord`'s 100-character limit
- retain the source title in the supporting-data footer when it must be shortened
- add a regression test that validates both the long-title row and a valid neighboring row against `MemoryRecord`

## Root cause and impact

`map_okf` bounded titles inferred from content, but forwarded explicit OKF titles unchanged. `MemoryRecord.title` rejects values longer than 100 characters, and both batch clients construct every `MemoryRecord` before storage starts.

As a result, one foreign OKF entry with a 101-character title raises a validation error before any write and causes the migration runner to mark the entire batch as failed, including up to 99 otherwise-valid neighboring entries.

The mapper now shortens only the schema-bound title field and records the original value in supporting data, so the batch remains valid without silently discarding the source title.

Submission for #770.

## Validation

- `uv run pytest -q` (full suite passed; 24 live E2E tests skipped because no API key was configured)
- `uv run ruff check .`
- `uv run mypy memanto`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved imported memory title handling by enforcing length limits.
  * Preserved overlong original titles in supporting data while displaying a shortened title.
  * Ensured imports with long foreign titles remain valid and can be processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->