### PR TITLE
fix(security): rate limiter fail-closed for unknown operations (issue #1438)

### DIFF
--- a/memanto/app/utils/rate_limiting.py
+++ b/memanto/app/utils/rate_limiting.py
@@ -38,6 +38,11 @@ class RateLimiter:
             "health": RateLimit(300, 60),  # 300/min
         }
 
+        # Fail-closed default: any operation not explicitly configured is still
+        # rate-limited instead of silently allowed (prevents bypass via typos /
+        # unknown operation names). Chosen conservatively strict.
+        self.default_limit = RateLimit(30, 60)
+
     def _get_key(self, operation: str, agent_id: str) -> str:
         """Generate rate limit key"""
         return f"{operation}:{agent_id}"
@@ -49,10 +54,9 @@ class RateLimiter:
         Check if request is within rate limit
         Returns: (allowed, retry_after_seconds)
         """
-        if operation not in self.limits:
-            return True, None
-
-        limit = self.limits[operation]
+        # Fail-closed: unknown operations fall back to a safe default limit
+        # rather than being silently allowed (was a fail-open bypass).
+        limit = self.limits.get(operation, self.default_limit)
         key = self._get_key(operation, agent_id)
         now = time.time()
 
@@ -96,7 +100,7 @@ class RateLimiter:
                     "error": "rate_limit_exceeded",
                     "message": f"Rate limit exceeded for {operation}",
                     "retry_after": retry_after,
-                    "limit": f"{self.limits[operation].requests}/{self.limits[operation].window}s",
+                    "limit": f"{limit.requests}/{limit.window}s",
                 },
                 headers={"Retry-After": str(retry_after)},
             )

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,66 @@
+"""
+Regression tests for fail-closed rate limiting (issue #1438).
+
+Previously, `check_rate_limit` returned `True` for any operation not present
+in `self.limits` (fail-open), letting unknown/typo'd operations bypass all
+rate limiting. Now unknown operations fall back to a conservative default
+limit instead of being silently allowed.
+"""
+import time
+
+from memanto.app.utils.rate_limiting import RateLimiter
+
+
+def test_unknown_operation_is_rate_limited_fail_closed():
+    """An unconfigured operation must be limited (not silently allowed).
+
+    Fail-closed means unknown ops are capped by the conservative default
+    (30/60s) instead of being unlimited. After exhausting the default
+    window the request is denied.
+    """
+    rl = RateLimiter()
+    allowed_count = 0
+    for _ in range(35):
+        allowed, _ = rl.check_rate_limit("totally_unknown_op", "agent-x")
+        if allowed:
+            allowed_count += 1
+    assert allowed_count == 30
+
+
+def test_unknown_operation_returns_retry_after_when_exhausted():
+    rl = RateLimiter()
+    for _ in range(30):
+        rl.check_rate_limit("totally_unknown_op", "agent-y")
+    allowed, retry_after = rl.check_rate_limit("totally_unknown_op", "agent-y")
+    assert allowed is False
+    assert isinstance(retry_after, int) and retry_after > 0
+
+
+def test_known_operation_still_works():
+    rl = RateLimiter()
+    # health allows 300/60s, so a single call is allowed
+    allowed, retry_after = rl.check_rate_limit("health", "agent-z")
+    assert allowed is True
+    assert retry_after is None
+
+
+def test_known_operation_enforces_limit():
+    rl = RateLimiter()
+    op = "memory_answer"  # 30 requests / 60s
+    allowed_count = 0
+    for _ in range(35):
+        allowed, _ = rl.check_rate_limit(op, "agent-limit")
+        if allowed:
+            allowed_count += 1
+    assert allowed_count == 30
+
+
+def test_unknown_operation_enforces_default_limit():
+    """Unknown ops use the conservative default (30/60s), not unlimited."""
+    rl = RateLimiter()
+    allowed_count = 0
+    for _ in range(35):
+        allowed, _ = rl.check_rate_limit("weird_op", "agent-def")
+        if allowed:
+            allowed_count += 1
+    assert allowed_count == 30


### PR DESCRIPTION
## Summary
- Fixes #1438: `RateLimiter.check_rate_limit()` was **fail-open** — any operation not present in `self.limits` (typos, unknown ops, newly added routes) was silently allowed with no rate limiting at all.
- Now unknown operations fall back to a conservative default limit (`30 req / 60s`) instead of being allowed unlimited.
- `enforce_rate_limit()` detail message now references the resolved `limit` to avoid a `KeyError` for unknown operations.

## Test plan
```bash
python -m pytest tests/test_rate_limiting.py -q
```
Added regression tests:
- unknown op is capped by the default limit (not unlimited)
- unknown op returns a positive `retry_after` once the window is exhausted
- known ops (`health`, `memory_answer`) still behave correctly

## Impact
Closes a rate-limit bypass that let unrecognized operations evade throttling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit enforcement for previously unconfigured operations.
  * Requests now receive a conservative default limit instead of bypassing rate limiting.
  * Rate-limit responses provide accurate retry timing and limit details.
  * Existing configured operations continue to enforce their specified limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->