### PR TITLE
Fix: Ambiguity Guard bypassed by common auxiliary verbs (is/are/was/were)

### DIFF
--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -41,7 +41,6 @@ class MemoryParsingService:
         for pattern in [
             r"https?://[^\s<>()\[\]{},;:\"']*[^\s<>()\[\]{},;:\"'.,!?]",
             r"\b(?:endpoint|url|api key|path|email|phone|address)\b",
-            r"\b(?:is|are|was|were)\b",
         ]
     ]
 

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -190,3 +190,14 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
     parser.parse_memory(memory)
 
     assert memory.type == "fact"
+
+
+def test_ambiguity_guard_not_bypassed_by_auxiliary_verbs():
+    parser = MemoryParsingService()
+
+    # Contains 'is' alongside a typo for a decision term
+    memory = make_memory("The project uses Django and it is maintained, and we decded on Postgres")
+
+    parser.parse_memory(memory)
+
+    assert memory.type == "decision"


### PR DESCRIPTION
This PR resolves the issue where the `MemoryParsingService` ambiguity guard is bypassed for most English sentences due to standalone auxiliary verbs (`is`, `are`, `was`, `were`) being present in `STRONG_FACT_PATTERNS`.

Standalone auxiliary verbs are too common and weak to bypass the ambiguity check. More specific structures are already mapped to correct confidence scores under classification rules.

Closes #1375
Part of Bug Challenge #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory classification for ambiguous statements containing auxiliary verbs and misspelled decision terms.
  * Reduced incorrect “fact” classifications for generic phrasing such as “is,” “are,” “was,” and “were.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->