### PR TITLE
fix(ts): clean up lifecycle signal listeners

### DIFF
--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -163,11 +163,11 @@ export class ServerLifecycle {
     };
     const sigint = () => {
       cleanup();
-      process.exit(130);
+      process.exitCode ??= 130;
     };
     const sigterm = () => {
       cleanup();
-      process.exit(143);
+      process.exitCode ??= 143;
     };
     this.cleanupHandlers = { exit: cleanup, sigint, sigterm };
     process.once("exit", cleanup);

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -92,8 +92,13 @@ export class ServerLifecycle {
     });
 
     try {
+      const healthPromise = this.waitForHealth(
+        baseUrl,
+        this.opts.healthTimeoutMs ?? 60_000,
+      );
+      void healthPromise.catch(() => {});
       await Promise.race([
-        this.waitForHealth(baseUrl, this.opts.healthTimeoutMs ?? 60_000),
+        healthPromise,
         spawnError,
       ]);
     } catch (err) {
@@ -126,6 +131,7 @@ export class ServerLifecycle {
     const deadline = Date.now() + timeoutMs;
     let lastErr: unknown = null;
     while (Date.now() < deadline) {
+      if (!this.process) return;
       if (this.process && this.process.exitCode !== null) {
         throw new Error(
           `memanto server exited with code ${this.process.exitCode} before becoming healthy.`,
@@ -139,6 +145,7 @@ export class ServerLifecycle {
       }
       await sleep(250);
     }
+    if (!this.process) return;
     await this.stop();
     throw new Error(
       `memanto server at ${baseUrl} did not become healthy within ${timeoutMs}ms${

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -120,7 +120,11 @@ export class ServerLifecycle {
     this.process = null;
     this.url = null;
     this.unregisterCleanup();
-    if (!child || child.killed) return;
+    if (
+      !child ||
+      child.exitCode !== null ||
+      child.signalCode !== null
+    ) return;
 
     let exited = false;
     await new Promise<void>((resolve) => {
@@ -142,31 +146,45 @@ export class ServerLifecycle {
   }
 
   private async waitForHealth(baseUrl: string, timeoutMs: number): Promise<void> {
+    const child = this.process;
+    if (!child) {
+      throw new Error("Server lifecycle stopped before becoming healthy.");
+    }
+
+    const assertActive = () => {
+      if (this.process !== child) {
+        throw new Error("Server lifecycle stopped before becoming healthy.");
+      }
+      if (child.exitCode !== null || child.signalCode !== null) {
+        throw new Error(
+          `memanto server exited before becoming healthy (code: ${child.exitCode}, signal: ${child.signalCode}).`,
+        );
+      }
+    };
+
     const deadline = Date.now() + timeoutMs;
     let lastErr: unknown = null;
     while (Date.now() < deadline) {
-      if (!this.process) {
-        throw new Error("Server lifecycle stopped before becoming healthy.");
-      }
-      if (
-        this.process.exitCode !== null ||
-        this.process.signalCode !== null
-      ) {
-        throw new Error(
-          `memanto server exited before becoming healthy (code: ${this.process.exitCode}, signal: ${this.process.signalCode}).`,
-        );
-      }
+      assertActive();
+      let res: Response | null = null;
       try {
-        const res = await fetch(`${baseUrl}/health`);
-        if (res.ok) return;
+        const attemptTimeoutMs = Math.max(
+          1,
+          Math.min(2_000, deadline - Date.now()),
+        );
+        res = await fetch(`${baseUrl}/health`, {
+          signal: AbortSignal.timeout(attemptTimeoutMs),
+        });
       } catch (err) {
         lastErr = err;
       }
-      await sleep(250);
+      assertActive();
+      if (res?.ok) return;
+
+      const remainingMs = deadline - Date.now();
+      if (remainingMs > 0) await sleep(Math.min(250, remainingMs));
     }
-    if (!this.process) {
-      throw new Error("Server lifecycle stopped before becoming healthy.");
-    }
+    assertActive();
     await this.stop();
     throw new Error(
       `memanto server at ${baseUrl} did not become healthy within ${timeoutMs}ms${

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -32,7 +32,11 @@ export interface ServerOptions {
 export class ServerLifecycle {
   private process: ChildProcess | null = null;
   private url: string | null = null;
-  private cleanupRegistered = false;
+  private cleanupHandlers: {
+    exit: () => void;
+    sigint: () => void;
+    sigterm: () => void;
+  } | null = null;
 
   constructor(private readonly opts: ServerOptions = {}) {}
 
@@ -67,6 +71,9 @@ export class ServerLifecycle {
 
     this.process = child;
     this.registerCleanup();
+    child.once("exit", () => {
+      if (this.process === child) this.unregisterCleanup();
+    });
 
     const baseUrl = `http://${host}:${port}`;
 
@@ -84,10 +91,16 @@ export class ServerLifecycle {
       });
     });
 
-    await Promise.race([
-      this.waitForHealth(baseUrl, this.opts.healthTimeoutMs ?? 60_000),
-      spawnError,
-    ]);
+    try {
+      await Promise.race([
+        this.waitForHealth(baseUrl, this.opts.healthTimeoutMs ?? 60_000),
+        spawnError,
+      ]);
+    } catch (err) {
+      this.unregisterCleanup();
+      if (this.process === child) this.process = null;
+      throw err;
+    }
     this.url = baseUrl;
     return baseUrl;
   }
@@ -96,6 +109,7 @@ export class ServerLifecycle {
     const child = this.process;
     this.process = null;
     this.url = null;
+    this.unregisterCleanup();
     if (!child || child.killed) return;
 
     let exited = false;
@@ -134,22 +148,33 @@ export class ServerLifecycle {
   }
 
   private registerCleanup(): void {
-    if (this.cleanupRegistered) return;
-    this.cleanupRegistered = true;
+    if (this.cleanupHandlers) return;
     const cleanup = () => {
       if (this.process && !this.process.killed) {
         this.process.kill("SIGTERM");
       }
     };
-    process.once("exit", cleanup);
-    process.once("SIGINT", () => {
+    const sigint = () => {
       cleanup();
       process.exit(130);
-    });
-    process.once("SIGTERM", () => {
+    };
+    const sigterm = () => {
       cleanup();
       process.exit(143);
-    });
+    };
+    this.cleanupHandlers = { exit: cleanup, sigint, sigterm };
+    process.once("exit", cleanup);
+    process.once("SIGINT", sigint);
+    process.once("SIGTERM", sigterm);
+  }
+
+  private unregisterCleanup(): void {
+    const handlers = this.cleanupHandlers;
+    if (!handlers) return;
+    process.removeListener("exit", handlers.exit);
+    process.removeListener("SIGINT", handlers.sigint);
+    process.removeListener("SIGTERM", handlers.sigterm);
+    this.cleanupHandlers = null;
   }
 }
 

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -72,7 +72,11 @@ export class ServerLifecycle {
     this.process = child;
     this.registerCleanup();
     child.once("exit", () => {
-      if (this.process === child) this.unregisterCleanup();
+      if (this.process === child) {
+        this.unregisterCleanup();
+        this.process = null;
+        this.url = null;
+      }
     });
 
     const baseUrl = `http://${host}:${port}`;
@@ -118,12 +122,16 @@ export class ServerLifecycle {
     if (!child || child.killed) return;
 
     let exited = false;
-    await new Promise<void>((resolve, reject) => {
-      child.once("exit", () => { exited = true; resolve(); });
-      child.kill("SIGTERM");
-      setTimeout(() => {
+    await new Promise<void>((resolve) => {
+      const forceKillTimer = setTimeout(() => {
         if (!exited) child.kill("SIGKILL");
       }, 5_000);
+      child.once("exit", () => {
+        exited = true;
+        clearTimeout(forceKillTimer);
+        resolve();
+      });
+      child.kill("SIGTERM");
     });
   }
 
@@ -131,10 +139,15 @@ export class ServerLifecycle {
     const deadline = Date.now() + timeoutMs;
     let lastErr: unknown = null;
     while (Date.now() < deadline) {
-      if (!this.process) return;
-      if (this.process && this.process.exitCode !== null) {
+      if (!this.process) {
+        throw new Error("Server lifecycle stopped before becoming healthy.");
+      }
+      if (
+        this.process.exitCode !== null ||
+        this.process.signalCode !== null
+      ) {
         throw new Error(
-          `memanto server exited with code ${this.process.exitCode} before becoming healthy.`,
+          `memanto server exited before becoming healthy (code: ${this.process.exitCode}, signal: ${this.process.signalCode}).`,
         );
       }
       try {
@@ -145,7 +158,9 @@ export class ServerLifecycle {
       }
       await sleep(250);
     }
-    if (!this.process) return;
+    if (!this.process) {
+      throw new Error("Server lifecycle stopped before becoming healthy.");
+    }
     await this.stop();
     throw new Error(
       `memanto server at ${baseUrl} did not become healthy within ${timeoutMs}ms${
@@ -164,10 +179,12 @@ export class ServerLifecycle {
     const sigint = () => {
       cleanup();
       process.exitCode ??= 130;
+      if (process.listenerCount("SIGINT") === 0) process.exit();
     };
     const sigterm = () => {
       cleanup();
       process.exitCode ??= 143;
+      if (process.listenerCount("SIGTERM") === 0) process.exit();
     };
     this.cleanupHandlers = { exit: cleanup, sigint, sigterm };
     process.once("exit", cleanup);

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -152,13 +152,13 @@ export class ServerLifecycle {
     }
 
     const assertActive = () => {
-      if (this.process !== child) {
-        throw new Error("Server lifecycle stopped before becoming healthy.");
-      }
       if (child.exitCode !== null || child.signalCode !== null) {
         throw new Error(
           `memanto server exited before becoming healthy (code: ${child.exitCode}, signal: ${child.signalCode}).`,
         );
+      }
+      if (this.process !== child) {
+        throw new Error("Server lifecycle stopped before becoming healthy.");
       }
     };
 
@@ -175,6 +175,7 @@ export class ServerLifecycle {
         res = await fetch(`${baseUrl}/health`, {
           signal: AbortSignal.timeout(attemptTimeoutMs),
         });
+        await res.arrayBuffer();
       } catch (err) {
         lastErr = err;
       }

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -94,6 +94,7 @@ export class ServerLifecycle {
         }
       });
     });
+    void spawnError.catch(() => {});
 
     try {
       const healthPromise = this.waitForHealth(
@@ -126,11 +127,16 @@ export class ServerLifecycle {
       const forceKillTimer = setTimeout(() => {
         if (!exited) child.kill("SIGKILL");
       }, 5_000);
-      child.once("exit", () => {
+      const onEnd = () => {
+        if (exited) return;
         exited = true;
         clearTimeout(forceKillTimer);
+        child.removeListener("exit", onEnd);
+        child.removeListener("error", onEnd);
         resolve();
-      });
+      };
+      child.once("exit", onEnd);
+      child.once("error", onEnd);
       child.kill("SIGTERM");
     });
   }

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -95,9 +95,12 @@ describe("ServerLifecycle", () => {
     const exitSpy = vi
       .spyOn(process, "exit")
       .mockImplementation((() => undefined) as never);
+    const originalListenerCount = process.listenerCount.bind(process);
     const listenerCountSpy = vi
       .spyOn(process, "listenerCount")
-      .mockReturnValue(1);
+      .mockImplementation((event) =>
+        event === "SIGINT" ? 1 : originalListenerCount(event),
+      );
     cleanupFns.push(() => {
       exitSpy.mockRestore();
       listenerCountSpy.mockRestore();
@@ -120,7 +123,9 @@ describe("ServerLifecycle", () => {
     expect(exitSpy).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(130);
 
-    listenerCountSpy.mockReturnValue(0);
+    listenerCountSpy.mockImplementation((event) =>
+      event === "SIGTERM" ? 0 : originalListenerCount(event),
+    );
     process.exitCode = undefined;
     life.cleanupHandlers?.sigterm();
 
@@ -149,6 +154,28 @@ describe("ServerLifecycle", () => {
     child.emit("exit", 0, null);
     await stopped;
 
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("settles shutdown when the child emits an error", async () => {
+    vi.useFakeTimers();
+    cleanupFns.push(() => vi.useRealTimers());
+    const child = Object.assign(new EventEmitter(), {
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      stop(): Promise<void>;
+    };
+    life.process = child;
+
+    const stopped = life.stop();
+    child.emit("error", new Error("signal delivery failed"));
+
+    await expect(stopped).resolves.toBeUndefined();
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -65,4 +65,26 @@ describe("ServerLifecycle", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
   });
+
+  it("removes process cleanup listeners when stopped", async () => {
+    const eventNames = ["exit", "SIGINT", "SIGTERM"] as const;
+    const before = Object.fromEntries(
+      eventNames.map((event) => [event, process.listenerCount(event)]),
+    );
+    const life = new ServerLifecycle() as unknown as {
+      registerCleanup(): void;
+      stop(): Promise<void>;
+    };
+    cleanupFns.push(() => life.stop());
+
+    life.registerCleanup();
+    for (const event of eventNames) {
+      expect(process.listenerCount(event)).toBe(before[event] + 1);
+    }
+
+    await life.stop();
+    for (const event of eventNames) {
+      expect(process.listenerCount(event)).toBe(before[event]);
+    }
+  });
 });

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -179,6 +179,43 @@ describe("ServerLifecycle", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("returns immediately when the child has already exited", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      killed: false,
+      exitCode: 0,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      stop(): Promise<void>;
+    };
+    life.process = child;
+
+    await expect(life.stop()).resolves.toBeUndefined();
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("waits for exit when a kill signal was sent but the child is still alive", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      killed: true,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      stop(): Promise<void>;
+    };
+    life.process = child;
+
+    const stopped = life.stop();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    child.emit("exit", 0, null);
+
+    await expect(stopped).resolves.toBeUndefined();
+  });
+
   it("rejects health polling after a concurrent stop", async () => {
     const life = new ServerLifecycle() as unknown as {
       waitForHealth(baseUrl: string, timeoutMs: number): Promise<void>;
@@ -205,6 +242,71 @@ describe("ServerLifecycle", () => {
     await expect(
       life.waitForHealth("http://127.0.0.1:9999", 100),
     ).rejects.toThrow(/signal: SIGKILL/);
+  });
+
+  it("does not let an old health poll observe a replacement child", async () => {
+    const originalChild = Object.assign(new EventEmitter(), {
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const replacementChild = Object.assign(new EventEmitter(), {
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      waitForHealth(baseUrl: string, timeoutMs: number): Promise<void>;
+    };
+    life.process = originalChild;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      life.process = replacementChild;
+      return new Response(null, { status: 503 });
+    });
+    cleanupFns.push(() => fetchSpy.mockRestore());
+
+    await expect(
+      life.waitForHealth("http://127.0.0.1:9999", 100),
+    ).rejects.toThrow(/stopped before becoming healthy/);
+    expect(replacementChild.kill).not.toHaveBeenCalled();
+  });
+
+  it("bounds each health request by the configured deadline", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      stop(): Promise<void>;
+      waitForHealth(baseUrl: string, timeoutMs: number): Promise<void>;
+    };
+    life.process = child;
+    const stopSpy = vi.spyOn(life, "stop").mockResolvedValue();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          signal?.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
+    cleanupFns.push(() => {
+      fetchSpy.mockRestore();
+      stopSpy.mockRestore();
+    });
+
+    await expect(
+      life.waitForHealth("http://127.0.0.1:9999", 30),
+    ).rejects.toThrow(/did not become healthy within 30ms/);
+    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(stopSpy).toHaveBeenCalledOnce();
   });
 
   it("stops health polling after the server process fails to spawn", async () => {

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { createServer, type Server } from "node:http";
 import { AddressInfo } from "node:net";
 import { ServerLifecycle } from "../src/lifecycle.js";
@@ -93,8 +95,12 @@ describe("ServerLifecycle", () => {
     const exitSpy = vi
       .spyOn(process, "exit")
       .mockImplementation((() => undefined) as never);
+    const listenerCountSpy = vi
+      .spyOn(process, "listenerCount")
+      .mockReturnValue(1);
     cleanupFns.push(() => {
       exitSpy.mockRestore();
+      listenerCountSpy.mockRestore();
       process.exitCode = originalExitCode;
     });
     const life = new ServerLifecycle() as unknown as {
@@ -108,16 +114,70 @@ describe("ServerLifecycle", () => {
     cleanupFns.push(() => life.stop());
 
     life.registerCleanup();
+    process.exitCode = undefined;
     life.cleanupHandlers?.sigint();
 
     expect(exitSpy).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(originalExitCode ?? 130);
+    expect(process.exitCode).toBe(130);
 
+    listenerCountSpy.mockReturnValue(0);
     process.exitCode = undefined;
     life.cleanupHandlers?.sigterm();
 
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledOnce();
     expect(process.exitCode).toBe(143);
+  });
+
+  it("clears the force-kill timer when the child exits", async () => {
+    vi.useFakeTimers();
+    cleanupFns.push(() => vi.useRealTimers());
+    const child = Object.assign(new EventEmitter(), {
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      url: string | null;
+      stop(): Promise<void>;
+    };
+    life.process = child;
+    life.url = "http://127.0.0.1:9999";
+
+    const stopped = life.stop();
+    child.emit("exit", 0, null);
+    await stopped;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects health polling after a concurrent stop", async () => {
+    const life = new ServerLifecycle() as unknown as {
+      waitForHealth(baseUrl: string, timeoutMs: number): Promise<void>;
+    };
+
+    await expect(
+      life.waitForHealth("http://127.0.0.1:9999", 100),
+    ).rejects.toThrow(/stopped before becoming healthy/);
+  });
+
+  it("fails health polling immediately after signal termination", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      killed: true,
+      exitCode: null,
+      signalCode: "SIGKILL",
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      waitForHealth(baseUrl: string, timeoutMs: number): Promise<void>;
+    };
+    life.process = child;
+
+    await expect(
+      life.waitForHealth("http://127.0.0.1:9999", 100),
+    ).rejects.toThrow(/signal: SIGKILL/);
   });
 
   it("stops health polling after the server process fails to spawn", async () => {

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -244,6 +244,60 @@ describe("ServerLifecycle", () => {
     ).rejects.toThrow(/signal: SIGKILL/);
   });
 
+  it("preserves exit diagnostics after child-exit cleanup clears state", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      killed: false,
+      exitCode: null as number | null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      waitForHealth(baseUrl: string, timeoutMs: number): Promise<void>;
+    };
+    life.process = child;
+    let resolveFetch!: (response: Response) => void;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    cleanupFns.push(() => fetchSpy.mockRestore());
+
+    const polling = life.waitForHealth("http://127.0.0.1:9999", 100);
+    child.exitCode = 1;
+    life.process = null;
+    resolveFetch(new Response(null, { status: 503 }));
+
+    await expect(polling).rejects.toThrow(/code: 1, signal: null/);
+  });
+
+  it("consumes health-check response bodies", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const life = new ServerLifecycle() as unknown as {
+      process: ChildProcess | null;
+      waitForHealth(baseUrl: string, timeoutMs: number): Promise<void>;
+    };
+    life.process = child;
+    const response = new Response("healthy");
+    const bodySpy = vi.spyOn(response, "arrayBuffer");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    cleanupFns.push(() => {
+      bodySpy.mockRestore();
+      fetchSpy.mockRestore();
+    });
+
+    await expect(
+      life.waitForHealth("http://127.0.0.1:9999", 100),
+    ).resolves.toBeUndefined();
+    expect(bodySpy).toHaveBeenCalledOnce();
+  });
+
   it("does not let an old health poll observe a replacement child", async () => {
     const originalChild = Object.assign(new EventEmitter(), {
       killed: false,

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -90,6 +90,7 @@ describe("ServerLifecycle", () => {
 
   it("stops health polling after the server process fails to spawn", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
+    cleanupFns.push(() => fetchSpy.mockRestore());
     const life = new ServerLifecycle({
       uvxPath: `missing-uvx-${Date.now()}`,
       healthTimeoutMs: 2_000,
@@ -102,6 +103,5 @@ describe("ServerLifecycle", () => {
     await new Promise((resolve) => setTimeout(resolve, 350));
 
     expect(fetchSpy).toHaveBeenCalledTimes(callsAfterFailure);
-    fetchSpy.mockRestore();
   });
 });

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -88,6 +88,38 @@ describe("ServerLifecycle", () => {
     }
   });
 
+  it("does not force the host process to exit on signals", async () => {
+    const originalExitCode = process.exitCode;
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    cleanupFns.push(() => {
+      exitSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    });
+    const life = new ServerLifecycle() as unknown as {
+      cleanupHandlers: {
+        sigint: () => void;
+        sigterm: () => void;
+      } | null;
+      registerCleanup(): void;
+      stop(): Promise<void>;
+    };
+    cleanupFns.push(() => life.stop());
+
+    life.registerCleanup();
+    life.cleanupHandlers?.sigint();
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(originalExitCode ?? 130);
+
+    process.exitCode = undefined;
+    life.cleanupHandlers?.sigterm();
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(143);
+  });
+
   it("stops health polling after the server process fails to spawn", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     cleanupFns.push(() => fetchSpy.mockRestore());

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -87,4 +87,21 @@ describe("ServerLifecycle", () => {
       expect(process.listenerCount(event)).toBe(before[event]);
     }
   });
+
+  it("stops health polling after the server process fails to spawn", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const life = new ServerLifecycle({
+      uvxPath: `missing-uvx-${Date.now()}`,
+      healthTimeoutMs: 2_000,
+    });
+    cleanupFns.push(() => life.stop());
+
+    await expect(life.start()).rejects.toThrow(/Could not find `uvx`/);
+    const callsAfterFailure = fetchSpy.mock.calls.length;
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(callsAfterFailure);
+    fetchSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

`ServerLifecycle.start()` installs process-level `exit`, `SIGINT`, and `SIGTERM` listeners, but the previous implementation never removed them. Every lifecycle instance therefore remained retained after `stop()`, and applications that repeatedly create and close SDK clients eventually emitted `MaxListenersExceededWarning`.

This change retains the exact handler references and unregisters them when the lifecycle stops, startup fails, or the child process exits. It also stops the in-flight health polling loop when a spawn failure clears the child process. Signal handlers now allow an embedding application with its own signal listener to finish graceful shutdown while preserving normal process termination when the SDK is the only listener.

## Reproduction

The regression tests record the baseline listener counts, register one lifecycle's cleanup hooks, call `stop()`, and assert all three counts return to baseline. They also verify graceful host signal handling, default termination without a host listener, timer cleanup, shutdown error handling, concurrent-stop rejection, and signal-terminated child detection:

```bash
cd sdks/typescript
npm test -- lifecycle.test.ts
```

Against the previous implementation, each stopped lifecycle leaves one listener behind for each of `exit`, `SIGINT`, and `SIGTERM`. Repeating the lifecycle more than ten times triggers Node's listener-leak warning and retains otherwise-dead `ServerLifecycle` instances. A signal also called `process.exit()` synchronously, which could abort cleanup owned by the embedding application.

## Root cause and fix

The old `cleanupRegistered` boolean prevented duplicate registration on one instance but did not preserve handler references, so `stop()` could not remove the listeners. Anonymous signal wrappers made removal impossible.

The fix:

- stores the three registered handler references;
- removes them during `stop()`;
- removes them after startup failure or child exit and clears stale process/URL state;
- stops abandoned health polling after a spawn failure;
- rejects health polling after a concurrent stop or signal-terminated child;
- clears the delayed SIGKILL timer when graceful child shutdown succeeds;
- settles shutdown if signaling produces a child-process error;
- distinguishes a sent kill signal from a fully terminated child;
- keeps health polling bound to the child instance that initiated it;
- aborts unresponsive health requests within the configured deadline;
- drains health response bodies so polling releases connections promptly;
- preserves child exit codes and signals in startup failure diagnostics;
- prevents late child errors from creating unhandled promise rejections;
- preserves graceful host signal handling without swallowing default termination; and
- keeps cleanup idempotent across repeated lifecycle operations.

## Validation

- `npm run typecheck`
- `npm test -- lifecycle.test.ts` (17 tests passed)
- `npm test` (50 tests passed across 7 files)
- `npm run build`
- `git diff --check`

## Human QA

This is an AI-assisted submission, not an undisclosed fully autonomous claim. Account owner Sajid manually ran the host-shutdown harness in a visible PowerShell session, pressed Ctrl+C, and reported: `PASS: the host application's cleanup handler ran after Ctrl+C.` This directly verifies that an embedding application's signal cleanup remains reachable.

Candidate fix for #770. BountyHub claim `cadc1350-d5c1-4362-a68c-ef401d7a2349` is active under GitHub account `SajidAhmed619`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown reliability by ensuring exit, SIGINT, and SIGTERM cleanup callbacks are managed correctly and removed when no longer needed.
  * Made health checks stop immediately when shutdown starts, preventing stale polling during stop/termination scenarios.
  * Improved behavior for concurrent spawn/health failures and for children exiting due to signals.
* **Tests**
  * Added extensive coverage for listener registration/unregistration, signal-specific exit-code behavior, and multiple child lifecycle/health edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



