### PR TITLE
fix(plugin/onprem): fix 403 error on profile startup (issue #1478)

### DIFF
--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -296,13 +296,58 @@ class _MemantoClient:
         self._auto_create = auto_create
         self._session_duration_hours = session_duration_hours
         self._client = SdkClient(api_key=api_key)
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._ready = False
         self._retry_after = 0.0
+        self._profile_path: Path | None = None
+        self._token_file: Path | None = None
+        self._last_refresh = 0.0
 
     @property
     def agent_id(self) -> str:
         return self._agent_id
+
+    def set_profile_path(self, profile_path: str) -> None:
+        self._profile_path = Path(profile_path)
+        self._token_file = self._profile_path / ".memanto_session_token"
+
+        # Load any existing persisted token on startup
+        token = self.load_token()
+        if token:
+            self._client.session_token = token
+            self._client.agent_id = self._agent_id
+            self._ready = True
+
+    def save_token(self, token: str) -> None:
+        if self._token_file:
+            try:
+                self._token_file.parent.mkdir(parents=True, exist_ok=True)
+                self._token_file.write_text(token, encoding="utf-8")
+            except Exception:
+                logger.debug("Failed to save token to file", exc_info=True)
+
+    def load_token(self) -> str | None:
+        if self._token_file and self._token_file.exists():
+            try:
+                return self._token_file.read_text(encoding="utf-8").strip()
+            except Exception:
+                logger.debug("Failed to load token from file", exc_info=True)
+        return None
+
+    def auto_refresh(self) -> bool:
+        now = time.monotonic()
+        if now - self._last_refresh < 5.0:
+            return False
+        self._last_refresh = now
+        try:
+            with self._lock:
+                self._ready = False
+                self._retry_after = 0.0
+                self.ensure_session()
+            return True
+        except Exception:
+            logger.debug("Auto-refresh activation failed", exc_info=True)
+            return False
 
     def ensure_session(self) -> None:
         if self._ready:
@@ -333,10 +378,14 @@ class _MemantoClient:
                         )
                     except AgentAlreadyExistsError:
                         pass  # race: another caller created it
-                self._client.activate_agent(
+                res = self._client.activate_agent(
                     self._agent_id,
                     duration_hours=self._session_duration_hours,
                 )
+                if isinstance(res, dict):
+                    token = res.get("session_token")
+                    if token:
+                        self.save_token(token)
                 self._ready = True
                 self._retry_after = 0.0
             except Exception:
@@ -354,17 +403,34 @@ class _MemantoClient:
         source: str = "hermes",
         provenance: str = "explicit_statement",
     ) -> dict:
-        self.ensure_session()
-        return self._client.remember(
-            agent_id=self._agent_id,
-            memory_type=memory_type,
-            title=title,
-            content=content,
-            confidence=confidence,
-            tags=tags or [],
-            source=source,
-            provenance=provenance,
-        )
+        try:
+            self.ensure_session()
+            return self._client.remember(
+                agent_id=self._agent_id,
+                memory_type=memory_type,
+                title=title,
+                content=content,
+                confidence=confidence,
+                tags=tags or [],
+                source=source,
+                provenance=provenance,
+            )
+        except Exception as e:
+            msg = str(e).lower()
+            if "expired" in msg or "invalid" in msg or "401" in msg or "403" in msg:
+                logger.debug("Token expired or invalid during remember, attempting auto-refresh")
+                if self.auto_refresh():
+                    return self._client.remember(
+                        agent_id=self._agent_id,
+                        memory_type=memory_type,
+                        title=title,
+                        content=content,
+                        confidence=confidence,
+                        tags=tags or [],
+                        source=source,
+                        provenance=provenance,
+                    )
+            raise
 
     def recall(
         self,
@@ -374,23 +440,50 @@ class _MemantoClient:
         type: list[str] | None = None,
         min_confidence: float | None = None,
     ) -> list[dict]:
-        self.ensure_session()
-        result = self._client.recall(
-            agent_id=self._agent_id,
-            query=query,
-            limit=limit,
-            type=type,
-            min_confidence=min_confidence,
-        )
-        return result.get("memories", [])
+        try:
+            self.ensure_session()
+            result = self._client.recall(
+                agent_id=self._agent_id,
+                query=query,
+                limit=limit,
+                type=type,
+                min_confidence=min_confidence,
+            )
+            return result.get("memories", [])
+        except Exception as e:
+            msg = str(e).lower()
+            if "expired" in msg or "invalid" in msg or "401" in msg or "403" in msg:
+                logger.debug("Token expired or invalid during recall, attempting auto-refresh")
+                if self.auto_refresh():
+                    result = self._client.recall(
+                        agent_id=self._agent_id,
+                        query=query,
+                        limit=limit,
+                        type=type,
+                        min_confidence=min_confidence,
+                    )
+                    return result.get("memories", [])
+            raise
 
     def answer(self, question: str, *, limit: int | None = None) -> dict:
-        self.ensure_session()
-        return self._client.answer(
-            agent_id=self._agent_id,
-            question=question,
-            limit=limit,
-        )
+        try:
+            self.ensure_session()
+            return self._client.answer(
+                agent_id=self._agent_id,
+                question=question,
+                limit=limit,
+            )
+        except Exception as e:
+            msg = str(e).lower()
+            if "expired" in msg or "invalid" in msg or "401" in msg or "403" in msg:
+                logger.debug("Token expired or invalid during answer, attempting auto-refresh")
+                if self.auto_refresh():
+                    return self._client.answer(
+                        agent_id=self._agent_id,
+                        question=question,
+                        limit=limit,
+                    )
+            raise
 
 
 # -- Tool schemas -------------------------------------------------------------
@@ -565,6 +658,9 @@ class MemantoMemoryProvider(MemoryProvider):
                 auto_create=self._config["auto_create"],
                 session_duration_hours=self._config["session_duration_hours"],
             )
+            profile_dir = Path(self._hermes_home) / "profiles" / identity
+            if hasattr(self._client, "set_profile_path"):
+                self._client.set_profile_path(str(profile_dir))
             self._active = True
         except Exception:
             logger.warning("Memanto initialization failed", exc_info=True)

--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -33,8 +33,9 @@ import os
 import re
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 try:  # resolved against the host Hermes at runtime
     from agent.memory_provider import MemoryProvider
@@ -110,6 +111,10 @@ _RECALL_TAG_RE = re.compile(
     rf"{_MEMORY_OPEN_TAG}|{_MEMORY_CLOSE_TAG}",
     re.IGNORECASE,
 )
+_REFRESH_THROTTLE_SECONDS = 5.0
+_TOKEN_FILE_NAME = ".memanto_session_token"
+
+_T = TypeVar("_T")
 
 
 def _resolve_hermes_home() -> str:
@@ -309,7 +314,7 @@ class _MemantoClient:
 
     def set_profile_path(self, profile_path: str) -> None:
         self._profile_path = Path(profile_path)
-        self._token_file = self._profile_path / ".memanto_session_token"
+        self._token_file = self._profile_path / _TOKEN_FILE_NAME
 
         # Load any existing persisted token on startup
         token = self.load_token()
@@ -322,7 +327,15 @@ class _MemantoClient:
         if self._token_file:
             try:
                 self._token_file.parent.mkdir(parents=True, exist_ok=True)
-                self._token_file.write_text(token, encoding="utf-8")
+                fd = os.open(
+                    str(self._token_file),
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                    0o600,
+                )
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(token)
+                if os.name != "nt":
+                    os.chmod(self._token_file, 0o600)
             except Exception:
                 logger.debug("Failed to save token to file", exc_info=True)
 
@@ -335,19 +348,55 @@ class _MemantoClient:
         return None
 
     def auto_refresh(self) -> bool:
-        now = time.monotonic()
-        if now - self._last_refresh < 5.0:
-            return False
-        self._last_refresh = now
         try:
             with self._lock:
+                now = time.monotonic()
+                if now - self._last_refresh < _REFRESH_THROTTLE_SECONDS:
+                    return self._ready
+                self._last_refresh = now
                 self._ready = False
                 self._retry_after = 0.0
                 self.ensure_session()
-            return True
+                return self._ready
         except Exception:
             logger.debug("Auto-refresh activation failed", exc_info=True)
             return False
+
+    def _is_refreshable_auth_error(self, error: Exception) -> bool:
+        try:
+            from memanto.app.utils.errors import (
+                AuthenticationError,
+                AuthorizationError,
+                InvalidSessionTokenError,
+                SessionExpiredError,
+            )
+
+            return isinstance(
+                error,
+                (
+                    AuthenticationError,
+                    AuthorizationError,
+                    SessionExpiredError,
+                    InvalidSessionTokenError,
+                ),
+            )
+        except Exception:
+            return False
+
+    def _call_with_auth_retry(self, operation: str, call: Callable[[], _T]) -> _T:
+        self.ensure_session()
+        try:
+            return call()
+        except Exception as error:
+            if not self._is_refreshable_auth_error(error):
+                raise
+            logger.debug(
+                "Auth failure during %s, attempting auto-refresh", operation,
+                exc_info=True,
+            )
+            if not self.auto_refresh():
+                raise
+            return call()
 
     def ensure_session(self) -> None:
         if self._ready:
@@ -403,9 +452,9 @@ class _MemantoClient:
         source: str = "hermes",
         provenance: str = "explicit_statement",
     ) -> dict:
-        try:
-            self.ensure_session()
-            return self._client.remember(
+        return self._call_with_auth_retry(
+            "remember",
+            lambda: self._client.remember(
                 agent_id=self._agent_id,
                 memory_type=memory_type,
                 title=title,
@@ -414,23 +463,8 @@ class _MemantoClient:
                 tags=tags or [],
                 source=source,
                 provenance=provenance,
-            )
-        except Exception as e:
-            msg = str(e).lower()
-            if "expired" in msg or "invalid" in msg or "401" in msg or "403" in msg:
-                logger.debug("Token expired or invalid during remember, attempting auto-refresh")
-                if self.auto_refresh():
-                    return self._client.remember(
-                        agent_id=self._agent_id,
-                        memory_type=memory_type,
-                        title=title,
-                        content=content,
-                        confidence=confidence,
-                        tags=tags or [],
-                        source=source,
-                        provenance=provenance,
-                    )
-            raise
+            ),
+        )
 
     def recall(
         self,
@@ -440,50 +474,27 @@ class _MemantoClient:
         type: list[str] | None = None,
         min_confidence: float | None = None,
     ) -> list[dict]:
-        try:
-            self.ensure_session()
-            result = self._client.recall(
+        result = self._call_with_auth_retry(
+            "recall",
+            lambda: self._client.recall(
                 agent_id=self._agent_id,
                 query=query,
                 limit=limit,
                 type=type,
                 min_confidence=min_confidence,
-            )
-            return result.get("memories", [])
-        except Exception as e:
-            msg = str(e).lower()
-            if "expired" in msg or "invalid" in msg or "401" in msg or "403" in msg:
-                logger.debug("Token expired or invalid during recall, attempting auto-refresh")
-                if self.auto_refresh():
-                    result = self._client.recall(
-                        agent_id=self._agent_id,
-                        query=query,
-                        limit=limit,
-                        type=type,
-                        min_confidence=min_confidence,
-                    )
-                    return result.get("memories", [])
-            raise
+            ),
+        )
+        return result.get("memories", [])
 
     def answer(self, question: str, *, limit: int | None = None) -> dict:
-        try:
-            self.ensure_session()
-            return self._client.answer(
+        return self._call_with_auth_retry(
+            "answer",
+            lambda: self._client.answer(
                 agent_id=self._agent_id,
                 question=question,
                 limit=limit,
-            )
-        except Exception as e:
-            msg = str(e).lower()
-            if "expired" in msg or "invalid" in msg or "401" in msg or "403" in msg:
-                logger.debug("Token expired or invalid during answer, attempting auto-refresh")
-                if self.auto_refresh():
-                    return self._client.answer(
-                        agent_id=self._agent_id,
-                        question=question,
-                        limit=limit,
-                    )
-            raise
+            ),
+        )
 
 
 # -- Tool schemas -------------------------------------------------------------
@@ -632,6 +643,7 @@ class MemantoMemoryProvider(MemoryProvider):
 
         # Resolve the agent id: env override > config, with {identity} template.
         identity = kwargs.get("agent_identity", "default") or "default"
+        safe_identity = _sanitize_agent_id(str(identity))
         raw_id = (
             os.environ.get("MEMANTO_AGENT_ID", "").strip() or self._config["agent_id"]
         )
@@ -658,7 +670,7 @@ class MemantoMemoryProvider(MemoryProvider):
                 auto_create=self._config["auto_create"],
                 session_duration_hours=self._config["session_duration_hours"],
             )
-            profile_dir = Path(self._hermes_home) / "profiles" / identity
+            profile_dir = Path(self._hermes_home) / "profiles" / safe_identity
             if hasattr(self._client, "set_profile_path"):
                 self._client.set_profile_path(str(profile_dir))
             self._active = True

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -565,3 +565,99 @@ def test_installer_refuses_overwrite_without_force(tmp_path):
         install(tmp_path, force=False)
     # force=True overwrites cleanly
     assert install(tmp_path, force=True).exists()
+
+
+# -- _MemantoClient Tests -----------------------------------------------------
+
+
+class DummySdk:
+    def __init__(self, token=""):
+        self.session_token = token
+        self.agent_id = None
+        self.remember_calls = []
+        self.recall_calls = []
+        self.answer_calls = []
+        self.raise_err = None
+
+    def get_agent(self, agent_id):
+        return {"id": agent_id}
+
+    def activate_agent(self, agent_id, duration_hours=None):
+        self.agent_id = agent_id
+        return {"session_token": "new-session-token"}
+
+    def remember(self, **kwargs):
+        if self.raise_err:
+            err = self.raise_err
+            self.raise_err = None  # Clear so retry succeeds
+            raise err
+        self.remember_calls.append(kwargs)
+        return {"memory_id": "m1"}
+
+    def recall(self, **kwargs):
+        if self.raise_err:
+            err = self.raise_err
+            self.raise_err = None
+            raise err
+        self.recall_calls.append(kwargs)
+        return {"memories": []}
+
+    def answer(self, **kwargs):
+        if self.raise_err:
+            err = self.raise_err
+            self.raise_err = None
+            raise err
+        self.answer_calls.append(kwargs)
+        return {"answer": "grounded answer"}
+
+
+def test_memanto_client_token_persistence(tmp_path):
+    from hermes_memanto.provider import _MemantoClient
+
+    client = _MemantoClient("api-key", "agent-1")
+    # Stub the internal SDK client
+    sdk = DummySdk()
+    client._client = sdk
+
+    # Set profile path
+    client.set_profile_path(str(tmp_path))
+    assert client._token_file == tmp_path / ".memanto_session_token"
+
+    # Save token
+    client.save_token("token-abc")
+    assert (tmp_path / ".memanto_session_token").read_text() == "token-abc"
+
+    # Loading profile path again loads the token
+    client2 = _MemantoClient("api-key2", "agent-1")
+    client2._client = DummySdk()
+    client2.set_profile_path(str(tmp_path))
+    assert client2._ready is True
+    assert client2._client.session_token == "token-abc"
+
+
+def test_memanto_client_auto_refresh_on_expiration(tmp_path):
+    from hermes_memanto.provider import _MemantoClient
+
+    client = _MemantoClient("api-key", "agent-1")
+    sdk = DummySdk()
+    client._client = sdk
+    client.set_profile_path(str(tmp_path))
+
+    # Force ready with an expired token
+    client._client.session_token = "expired-token"
+    client._ready = True
+
+    # Configure remember to raise an expired error first
+    sdk.raise_err = RuntimeError("Token is expired or invalid")
+
+    res = client.remember(
+        memory_type="fact",
+        title="Title",
+        content="Some content",
+        confidence=0.9,
+    )
+    assert res == {"memory_id": "m1"}
+    # Verify that activate_agent was called to get a new token
+    assert sdk.agent_id == "agent-1"
+    assert (tmp_path / ".memanto_session_token").read_text() == "new-session-token"
+

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -6,8 +6,11 @@ monkeypatched with an in-memory fake.
 """
 
 import json
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from memanto.app.utils.errors import InvalidSessionTokenError
 
 from hermes_memanto.provider import (
     MemantoMemoryProvider,
@@ -43,6 +46,7 @@ class FakeClient:
         self.answer_calls = []
         self.recall_results = []
         self.answer_response = {"answer": "", "sources": []}
+        self.profile_path: str | None = None
 
     @property
     def agent_id(self):
@@ -81,6 +85,9 @@ class FakeClient:
     def answer(self, question, *, limit=None):
         self.answer_calls.append({"question": question, "limit": limit})
         return self.answer_response
+
+    def set_profile_path(self, profile_path: str):
+        self.profile_path = profile_path
 
 
 @pytest.fixture
@@ -570,54 +577,12 @@ def test_installer_refuses_overwrite_without_force(tmp_path):
 # -- _MemantoClient Tests -----------------------------------------------------
 
 
-class DummySdk:
-    def __init__(self, token=""):
-        self.session_token = token
-        self.agent_id = None
-        self.remember_calls = []
-        self.recall_calls = []
-        self.answer_calls = []
-        self.raise_err = None
-
-    def get_agent(self, agent_id):
-        return {"id": agent_id}
-
-    def activate_agent(self, agent_id, duration_hours=None):
-        self.agent_id = agent_id
-        return {"session_token": "new-session-token"}
-
-    def remember(self, **kwargs):
-        if self.raise_err:
-            err = self.raise_err
-            self.raise_err = None  # Clear so retry succeeds
-            raise err
-        self.remember_calls.append(kwargs)
-        return {"memory_id": "m1"}
-
-    def recall(self, **kwargs):
-        if self.raise_err:
-            err = self.raise_err
-            self.raise_err = None
-            raise err
-        self.recall_calls.append(kwargs)
-        return {"memories": []}
-
-    def answer(self, **kwargs):
-        if self.raise_err:
-            err = self.raise_err
-            self.raise_err = None
-            raise err
-        self.answer_calls.append(kwargs)
-        return {"answer": "grounded answer"}
-
-
 def test_memanto_client_token_persistence(tmp_path):
     from hermes_memanto.provider import _MemantoClient
 
     client = _MemantoClient("api-key", "agent-1")
     # Stub the internal SDK client
-    sdk = DummySdk()
-    client._client = sdk
+    client._client = MagicMock()
 
     # Set profile path
     client.set_profile_path(str(tmp_path))
@@ -629,7 +594,7 @@ def test_memanto_client_token_persistence(tmp_path):
 
     # Loading profile path again loads the token
     client2 = _MemantoClient("api-key2", "agent-1")
-    client2._client = DummySdk()
+    client2._client = MagicMock()
     client2.set_profile_path(str(tmp_path))
     assert client2._ready is True
     assert client2._client.session_token == "token-abc"
@@ -639,16 +604,18 @@ def test_memanto_client_auto_refresh_on_expiration(tmp_path):
     from hermes_memanto.provider import _MemantoClient
 
     client = _MemantoClient("api-key", "agent-1")
-    sdk = DummySdk()
+    sdk = MagicMock()
+    sdk.activate_agent.return_value = {"session_token": "new-session-token"}
+    sdk.remember.side_effect = [
+        InvalidSessionTokenError("expired"),
+        {"memory_id": "m1"},
+    ]
     client._client = sdk
     client.set_profile_path(str(tmp_path))
 
     # Force ready with an expired token
     client._client.session_token = "expired-token"
     client._ready = True
-
-    # Configure remember to raise an expired error first
-    sdk.raise_err = RuntimeError("Token is expired or invalid")
 
     res = client.remember(
         memory_type="fact",
@@ -658,6 +625,6 @@ def test_memanto_client_auto_refresh_on_expiration(tmp_path):
     )
     assert res == {"memory_id": "m1"}
     # Verify that activate_agent was called to get a new token
-    assert sdk.agent_id == "agent-1"
+    sdk.activate_agent.assert_called_once_with("agent-1", duration_hours=None)
     assert (tmp_path / ".memanto_session_token").read_text() == "new-session-token"
 


### PR DESCRIPTION
Resolves #1478.

### Summary of Changes:
1. **Token Persistence**: Added `set_profile_path`, `save_token`, and `load_token` to `_MemantoClient` to automatically persist/load the session token in the Hermes profile directory (`.memanto_session_token`).
2. **Auto Token Refresh**: Added `auto_refresh` method to handle token expiration/invalid errors.
3. **Automatic Cooldown and Retries**: Wrapped `remember`, `recall`, and `answer` to catch 401/403/invalid/expired token errors, automatically refresh the token, and retry the operation once.
4. **Deadlock Prevention**: Changed `_lock` from `threading.Lock` to `threading.RLock` to allow recursive acquisition of the lock when `auto_refresh` calls `ensure_session` from the same thread.
5. **Mock/Defensive Improvements**: Added defensive check for `set_profile_path` in initialization to remain backwards compatible with tests.
6. **Unit Tests**: Added comprehensive test cases in `test_provider.py` validating token loading, token persistence, and auto-refresh retry execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling for Memanto integrations by preserving authentication state between sessions.
  * Automatically refreshes expired or invalid sessions and retries affected requests once.
  * Saves newly issued session tokens for more reliable future access.

* **Tests**
  * Added coverage for session-token persistence and automatic refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->