### PR TITLE
fix: serialize session renewal and logout

### DIFF
--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import secrets
+import threading
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -70,6 +71,13 @@ class SessionService:
             or self._generate_secure_secret_key()
         )
         self.secret_key: str = resolved_secret_key
+        self._auto_renew_locks: dict[str, threading.RLock] = {}
+        self._auto_renew_locks_guard = threading.Lock()
+
+    def _get_auto_renew_lock(self, agent_id: str) -> threading.RLock:
+        """Return the per-agent lock that serializes token rotation."""
+        with self._auto_renew_locks_guard:
+            return self._auto_renew_locks.setdefault(agent_id, threading.RLock())
 
     def _generate_secure_secret_key(self) -> str:
         """Generate (or reuse) a persisted fallback secret for JWT signing.
@@ -365,19 +373,24 @@ class SessionService:
         if not settings.SESSION_AUTO_RENEW_ENABLED:
             return None
 
-        session = self.get_session(agent_id)
-        if not session or not session.is_active():
-            return None
+        # Validation and renewal must be one operation. Without a per-agent
+        # single-flight lock, parallel requests can all observe the same
+        # near-expiry session, mint competing tokens, and immediately
+        # invalidate every replacement except the last file write.
+        with self._get_auto_renew_lock(agent_id):
+            session = self.get_session(agent_id)
+            if not session or not session.is_active():
+                return None
 
-        remaining = session.time_remaining()
-        threshold = timedelta(minutes=settings.SESSION_EXTEND_THRESHOLD_MINUTES)
+            remaining = session.time_remaining()
+            threshold = timedelta(minutes=settings.SESSION_EXTEND_THRESHOLD_MINUTES)
 
-        if remaining <= threshold:
-            # Renew with a fresh session
-            return self.renew_session(
-                agent_id=agent_id,
-                pattern=session.pattern,
-            )
+            if remaining <= threshold:
+                # Renew with a fresh session
+                return self.renew_session(
+                    agent_id=agent_id,
+                    pattern=session.pattern,
+                )
 
         return None
 

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -71,10 +71,23 @@ class SessionService:
             or self._generate_secure_secret_key()
         )
         self.secret_key: str = resolved_secret_key
-        # Session rotation, termination, and the global active-session marker
-        # form one lifecycle. Serialize them so a concurrent renewal cannot
-        # publish a fresh bearer token after logout has completed.
-        self._session_lifecycle_lock = threading.RLock()
+        # Serialize lifecycle operations for the same agent so renewal cannot
+        # publish a fresh bearer token after logout has completed. Keep the
+        # process-wide active marker on its own narrower lock so unrelated
+        # agents can create, renew, and terminate sessions concurrently.
+        self._agent_locks: dict[str, threading.RLock] = {}
+        self._agent_locks_guard = threading.Lock()
+        self._active_marker_lock = threading.RLock()
+
+    def _lock_for_agent(self, agent_id: str) -> threading.RLock:
+        """Return the stable lifecycle lock for one agent."""
+        validate_safe_id(agent_id, "agent_id")
+        with self._agent_locks_guard:
+            lock = self._agent_locks.get(agent_id)
+            if lock is None:
+                lock = threading.RLock()
+                self._agent_locks[agent_id] = lock
+            return lock
 
     def _generate_secure_secret_key(self) -> str:
         """Generate (or reuse) a persisted fallback secret for JWT signing.
@@ -150,7 +163,7 @@ class SessionService:
         Returns:
             Session object with JWT token
         """
-        with self._session_lifecycle_lock:
+        with self._lock_for_agent(agent_id):
             return self._create_session(agent_id, pattern, duration_hours)
 
     def _create_session(
@@ -159,7 +172,7 @@ class SessionService:
         pattern: AgentPattern | None,
         duration_hours: int | None,
     ) -> Session:
-        """Create and publish a session while the lifecycle lock is held."""
+        """Create and publish a session while the agent lifecycle lock is held."""
         # Use config default if not explicitly provided
         if duration_hours is None:
             duration_hours = settings.SESSION_DEFAULT_DURATION_HOURS
@@ -271,28 +284,30 @@ class SessionService:
         Returns:
             Session object or None if no active session or session is expired
         """
-        active_link = self.sessions_dir / "active"
-        if not active_link.exists():
-            return None
+        with self._active_marker_lock:
+            active_link = self.sessions_dir / "active"
+            if not active_link.exists():
+                return None
 
-        # Read symlink (or file on Windows)
-        if active_link.is_symlink():
-            target = active_link.readlink()
-            agent_id = target.stem
-        else:
-            with open(active_link) as f:
-                agent_id = f.read().strip()
+            # Read symlink (or file on Windows)
+            if active_link.is_symlink():
+                target = active_link.readlink()
+                agent_id = target.stem
+            else:
+                with open(active_link) as f:
+                    agent_id = f.read().strip()
 
-        session = self.get_session(agent_id)
-        if not session:
-            return None
+            session = self.get_session(agent_id)
+            if not session:
+                return None
 
-        # If session is expired, clear the stale active marker and return None
-        if not session.is_active():
-            self._clear_active_session()
-            return None
+            # If session is expired, clear the stale marker and return None.
+            # The marker lock is re-entrant for this cleanup path.
+            if not session.is_active():
+                self._clear_active_session()
+                return None
 
-        return session
+            return session
 
     def end_session(self, agent_id: str) -> SessionSummary:
         """
@@ -307,7 +322,7 @@ class SessionService:
         Raises:
             SessionNotFoundError: If session doesn't exist
         """
-        with self._session_lifecycle_lock:
+        with self._lock_for_agent(agent_id):
             return self._end_session(agent_id)
 
     def _end_session(self, agent_id: str) -> SessionSummary:
@@ -385,12 +400,12 @@ class SessionService:
         if not settings.SESSION_AUTO_RENEW_ENABLED:
             return None
 
-        # Validation and renewal must be one operation. Without the lifecycle
-        # lock, parallel requests can all observe the same
+        # Validation and renewal must be one operation. Without the per-agent
+        # lifecycle lock, parallel requests can all observe the same
         # near-expiry session, mint competing tokens, and immediately
         # invalidate every replacement except the last file write. The same
         # lock also makes logout authoritative over an in-flight renewal.
-        with self._session_lifecycle_lock:
+        with self._lock_for_agent(agent_id):
             session = self.get_session(agent_id)
             if not session or not session.is_active():
                 return None
@@ -532,26 +547,28 @@ class SessionService:
     def _set_active_session(self, agent_id: str) -> None:
         """Mark session as active"""
         validate_safe_id(agent_id, "agent_id")
-        active_link = self.sessions_dir / "active"
+        with self._active_marker_lock:
+            active_link = self.sessions_dir / "active"
 
-        # Remove existing active link
-        if active_link.exists() or active_link.is_symlink():
-            active_link.unlink()
+            # Remove existing active link
+            if active_link.exists() or active_link.is_symlink():
+                active_link.unlink()
 
-        # Create new active marker
-        # On Windows, write agent_id to file instead of symlink
-        try:
-            active_link.symlink_to(f"{agent_id}.json")
-        except (OSError, NotImplementedError):
-            # Fallback for Windows or systems without symlink support
-            with open(active_link, "w") as f:
-                f.write(agent_id)
+            # Create new active marker
+            # On Windows, write agent_id to file instead of symlink
+            try:
+                active_link.symlink_to(f"{agent_id}.json")
+            except (OSError, NotImplementedError):
+                # Fallback for Windows or systems without symlink support
+                with open(active_link, "w") as f:
+                    f.write(agent_id)
 
     def _clear_active_session(self) -> None:
         """Clear active session marker"""
-        active_link = self.sessions_dir / "active"
-        if active_link.exists() or active_link.is_symlink():
-            active_link.unlink()
+        with self._active_marker_lock:
+            active_link = self.sessions_dir / "active"
+            if active_link.exists() or active_link.is_symlink():
+                active_link.unlink()
 
     def clear_active_session(self) -> None:
         """Public alias: clear the active-session marker without ending the session."""
@@ -564,24 +581,25 @@ class SessionService:
         Used when an agent is deleted: the agent metadata is gone, so a saved
         session for that agent must not remain usable through X-Session-Token.
         """
-        active_link = self.sessions_dir / "active"
-        active_agent_id: str | None = None
+        with self._lock_for_agent(agent_id), self._active_marker_lock:
+            active_link = self.sessions_dir / "active"
+            active_agent_id: str | None = None
 
-        if active_link.is_symlink():
-            active_agent_id = active_link.readlink().stem
-        elif active_link.exists():
-            with open(active_link) as f:
-                active_agent_id = f.read().strip()
+            if active_link.is_symlink():
+                active_agent_id = active_link.readlink().stem
+            elif active_link.exists():
+                with open(active_link) as f:
+                    active_agent_id = f.read().strip()
 
-        session_file = self.sessions_dir / f"{agent_id}.json"
-        deleted = session_file.exists()
-        if deleted:
-            session_file.unlink()
+            session_file = self.sessions_dir / f"{agent_id}.json"
+            deleted = session_file.exists()
+            if deleted:
+                session_file.unlink()
 
-        if active_agent_id == agent_id:
-            self._clear_active_session()
+            if active_agent_id == agent_id:
+                self._clear_active_session()
 
-        return deleted
+            return deleted
 
     def list_sessions(self) -> list[Session]:
         """

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -71,13 +71,10 @@ class SessionService:
             or self._generate_secure_secret_key()
         )
         self.secret_key: str = resolved_secret_key
-        self._auto_renew_locks: dict[str, threading.RLock] = {}
-        self._auto_renew_locks_guard = threading.Lock()
-
-    def _get_auto_renew_lock(self, agent_id: str) -> threading.RLock:
-        """Return the per-agent lock that serializes token rotation."""
-        with self._auto_renew_locks_guard:
-            return self._auto_renew_locks.setdefault(agent_id, threading.RLock())
+        # Session rotation, termination, and the global active-session marker
+        # form one lifecycle. Serialize them so a concurrent renewal cannot
+        # publish a fresh bearer token after logout has completed.
+        self._session_lifecycle_lock = threading.RLock()
 
     def _generate_secure_secret_key(self) -> str:
         """Generate (or reuse) a persisted fallback secret for JWT signing.
@@ -153,6 +150,16 @@ class SessionService:
         Returns:
             Session object with JWT token
         """
+        with self._session_lifecycle_lock:
+            return self._create_session(agent_id, pattern, duration_hours)
+
+    def _create_session(
+        self,
+        agent_id: str,
+        pattern: AgentPattern | None,
+        duration_hours: int | None,
+    ) -> Session:
+        """Create and publish a session while the lifecycle lock is held."""
         # Use config default if not explicitly provided
         if duration_hours is None:
             duration_hours = settings.SESSION_DEFAULT_DURATION_HOURS
@@ -300,6 +307,11 @@ class SessionService:
         Raises:
             SessionNotFoundError: If session doesn't exist
         """
+        with self._session_lifecycle_lock:
+            return self._end_session(agent_id)
+
+    def _end_session(self, agent_id: str) -> SessionSummary:
+        """Terminate a session while excluding concurrent token rotation."""
         session = self.get_session(agent_id)
         if not session:
             raise SessionNotFoundError(f"No session found for agent {agent_id}")
@@ -373,11 +385,12 @@ class SessionService:
         if not settings.SESSION_AUTO_RENEW_ENABLED:
             return None
 
-        # Validation and renewal must be one operation. Without a per-agent
-        # single-flight lock, parallel requests can all observe the same
+        # Validation and renewal must be one operation. Without the lifecycle
+        # lock, parallel requests can all observe the same
         # near-expiry session, mint competing tokens, and immediately
-        # invalidate every replacement except the last file write.
-        with self._get_auto_renew_lock(agent_id):
+        # invalidate every replacement except the last file write. The same
+        # lock also makes logout authoritative over an in-flight renewal.
+        with self._session_lifecycle_lock:
             session = self.get_session(agent_id)
             if not session or not session.is_active():
                 return None

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -286,16 +286,18 @@ class SessionService:
         """
         with self._active_marker_lock:
             active_link = self.sessions_dir / "active"
-            if not active_link.exists():
-                return None
 
-            # Read symlink (or file on Windows)
-            if active_link.is_symlink():
-                target = active_link.readlink()
-                agent_id = target.stem
-            else:
-                with open(active_link) as f:
-                    agent_id = f.read().strip()
+            try:
+                # Read symlink (or file on Windows). Another process can replace
+                # or remove the marker while this process holds its local lock.
+                if active_link.is_symlink():
+                    target = active_link.readlink()
+                    agent_id = target.stem
+                else:
+                    with open(active_link) as f:
+                        agent_id = f.read().strip()
+            except OSError:
+                return None
 
             session = self.get_session(agent_id)
             if not session:
@@ -551,8 +553,7 @@ class SessionService:
             active_link = self.sessions_dir / "active"
 
             # Remove existing active link
-            if active_link.exists() or active_link.is_symlink():
-                active_link.unlink()
+            active_link.unlink(missing_ok=True)
 
             # Create new active marker
             # On Windows, write agent_id to file instead of symlink
@@ -567,8 +568,7 @@ class SessionService:
         """Clear active session marker"""
         with self._active_marker_lock:
             active_link = self.sessions_dir / "active"
-            if active_link.exists() or active_link.is_symlink():
-                active_link.unlink()
+            active_link.unlink(missing_ok=True)
 
     def clear_active_session(self) -> None:
         """Public alias: clear the active-session marker without ending the session."""
@@ -585,16 +585,18 @@ class SessionService:
             active_link = self.sessions_dir / "active"
             active_agent_id: str | None = None
 
-            if active_link.is_symlink():
-                active_agent_id = active_link.readlink().stem
-            elif active_link.exists():
-                with open(active_link) as f:
-                    active_agent_id = f.read().strip()
+            try:
+                if active_link.is_symlink():
+                    active_agent_id = active_link.readlink().stem
+                else:
+                    with open(active_link) as f:
+                        active_agent_id = f.read().strip()
+            except OSError:
+                pass
 
             session_file = self.sessions_dir / f"{agent_id}.json"
             deleted = session_file.exists()
-            if deleted:
-                session_file.unlink()
+            session_file.unlink(missing_ok=True)
 
             if active_agent_id == agent_id:
                 self._clear_active_session()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,6 +4,8 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
@@ -180,6 +182,44 @@ class TestSessionService:
         # Note: We can't easily test this without manipulating time
         # Just verify the logic exists
         print("✅ Session expiration logic exists")
+
+    def test_auto_renew_is_single_flight_per_agent(self, session_service, monkeypatch):
+        """Parallel near-expiry requests must not mint competing tokens."""
+        session_service.create_session(agent_id="test-agent", duration_hours=1)
+        monkeypatch.setattr(settings, "SESSION_EXTEND_THRESHOLD_MINUTES", 120)
+
+        original_renew = session_service.renew_session
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        release_first = threading.Event()
+        counter_lock = threading.Lock()
+        call_count = 0
+
+        def controlled_renew(agent_id, pattern=None):
+            nonlocal call_count
+            with counter_lock:
+                call_count += 1
+                call_number = call_count
+            if call_number == 1:
+                first_entered.set()
+                assert release_first.wait(timeout=2)
+            elif call_number == 2:
+                second_entered.set()
+            return original_renew(agent_id=agent_id, pattern=pattern)
+
+        monkeypatch.setattr(session_service, "renew_session", controlled_renew)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(session_service.check_and_auto_renew, "test-agent")
+            assert first_entered.wait(timeout=2)
+            second = pool.submit(session_service.check_and_auto_renew, "test-agent")
+            second_entered.wait(timeout=0.25)
+            release_first.set()
+            results = [first.result(timeout=2), second.result(timeout=2)]
+
+        renewed = [session for session in results if session is not None]
+        assert len(renewed) == 1
+        session_service.validate_session(renewed[0].session_token)
 
     def test_end_session(self, session_service):
         """Test ending session"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -17,6 +17,7 @@ from memanto.app.core import MemoryRecord
 from memanto.app.models.session import AgentCreate, AgentPattern, Session, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
+from memanto.app.utils.errors import InvalidSessionTokenError
 
 
 class TestSessionService:
@@ -220,6 +221,52 @@ class TestSessionService:
         renewed = [session for session in results if session is not None]
         assert len(renewed) == 1
         session_service.validate_session(renewed[0].session_token)
+
+    def test_end_session_revokes_concurrent_auto_renewal(
+        self, session_service, monkeypatch
+    ):
+        """Logout must terminate a renewal that was already in flight."""
+        original = session_service.create_session(
+            agent_id="test-agent", duration_hours=1
+        )
+        monkeypatch.setattr(settings, "SESSION_EXTEND_THRESHOLD_MINUTES", 120)
+
+        original_renew = session_service.renew_session
+        renewal_entered = threading.Event()
+        release_renewal = threading.Event()
+        termination_saved = threading.Event()
+        original_save = session_service._save_session
+
+        def controlled_renew(agent_id, pattern=None):
+            renewal_entered.set()
+            assert release_renewal.wait(timeout=2)
+            return original_renew(agent_id=agent_id, pattern=pattern)
+
+        def observed_save(session):
+            original_save(session)
+            if session.status == SessionStatus.TERMINATED:
+                termination_saved.set()
+
+        monkeypatch.setattr(session_service, "renew_session", controlled_renew)
+        monkeypatch.setattr(session_service, "_save_session", observed_save)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            renewing = pool.submit(session_service.check_and_auto_renew, "test-agent")
+            assert renewal_entered.wait(timeout=2)
+            ending = pool.submit(session_service.end_session, "test-agent")
+
+            # Logout cannot persist a stale termination while renewal owns the
+            # lifecycle. It proceeds immediately after the fresh token exists.
+            assert not termination_saved.wait(timeout=0.25)
+            release_renewal.set()
+            renewed = renewing.result(timeout=2)
+            summary = ending.result(timeout=2)
+
+        assert renewed is not None
+        assert renewed.session_id != original.session_id
+        assert summary.session_id == renewed.session_id
+        with pytest.raises(InvalidSessionTokenError):
+            session_service.validate_session(renewed.session_token)
 
     def test_end_session(self, session_service):
         """Test ending session"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7,6 +7,7 @@ Tests the session and agent services directly without HTTP layer.
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import jwt
@@ -375,6 +376,64 @@ class TestSessionService:
         (session_service.sessions_dir / "broken-agent.json").write_text("{")
 
         assert session_service.get_active_session() is None
+
+    def test_get_active_session_tolerates_external_marker_removal(
+        self, session_service, monkeypatch
+    ):
+        """A marker removed by another process during its read is treated as absent."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.write_text("test-agent")
+        original_open = open
+
+        def disappearing_marker(file, *args, **kwargs):
+            if Path(file) == active_marker:
+                active_marker.unlink(missing_ok=True)
+                raise FileNotFoundError(active_marker)
+            return original_open(file, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", disappearing_marker)
+
+        assert session_service.get_active_session() is None
+
+    def test_clear_active_session_tolerates_external_marker_removal(
+        self, session_service, monkeypatch
+    ):
+        """A marker removed after an existence check does not crash cleanup."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.write_text("test-agent")
+        original_exists = Path.exists
+
+        def disappearing_marker(path):
+            exists = original_exists(path)
+            if path == active_marker and exists:
+                path.unlink()
+                return True
+            return exists
+
+        monkeypatch.setattr(Path, "exists", disappearing_marker)
+
+        session_service.clear_active_session()
+
+        assert not original_exists(active_marker)
+
+    def test_delete_session_tolerates_external_marker_removal(
+        self, session_service, monkeypatch
+    ):
+        """Deleting session state succeeds if another process removes the marker."""
+        session_service.create_session("test-agent")
+        active_marker = session_service.sessions_dir / "active"
+        original_open = open
+
+        def disappearing_marker(file, *args, **kwargs):
+            if Path(file) == active_marker:
+                active_marker.unlink(missing_ok=True)
+                raise FileNotFoundError(active_marker)
+            return original_open(file, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", disappearing_marker)
+
+        assert session_service.delete_session("test-agent") is True
+        assert not (session_service.sessions_dir / "test-agent.json").exists()
 
     def test_list_sessions_skips_invalid_session_files(self, session_service):
         """One corrupt session record must not hide all valid sessions."""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -222,6 +222,55 @@ class TestSessionService:
         assert len(renewed) == 1
         session_service.validate_session(renewed[0].session_token)
 
+    def test_lifecycle_operations_for_different_agents_can_overlap(
+        self, session_service, monkeypatch
+    ):
+        """One agent's session file I/O must not block another agent."""
+        original_save = session_service._save_session
+        first_save_entered = threading.Event()
+        release_first_save = threading.Event()
+
+        def controlled_save(session):
+            if session.agent_id == "agent-a":
+                first_save_entered.set()
+                assert release_first_save.wait(timeout=2)
+            original_save(session)
+
+        monkeypatch.setattr(session_service, "_save_session", controlled_save)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(session_service.create_session, "agent-a")
+            assert first_save_entered.wait(timeout=2)
+            second = pool.submit(session_service.create_session, "agent-b")
+            second_session = second.result(timeout=1)
+            release_first_save.set()
+            first_session = first.result(timeout=2)
+
+        assert first_session.agent_id == "agent-a"
+        assert second_session.agent_id == "agent-b"
+
+    def test_active_session_read_waits_for_marker_update(self, session_service):
+        """Readers must not observe an active marker during its replacement."""
+        session = session_service.create_session("test-agent")
+        read_started = threading.Event()
+
+        def read_active_session():
+            read_started.set()
+            return session_service.get_active_session()
+
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            with session_service._active_marker_lock:
+                pending_read = pool.submit(read_active_session)
+                assert read_started.wait(timeout=2)
+                assert not pending_read.done()
+            active_session = pending_read.result(timeout=2)
+        finally:
+            pool.shutdown(wait=True)
+
+        assert active_session is not None
+        assert active_session.session_id == session.session_id
+
     def test_end_session_revokes_concurrent_auto_renewal(
         self, session_service, monkeypatch
     ):


### PR DESCRIPTION
## Summary

Serializes each agent's session lifecycle so parallel auto-renewals cannot mint competing replacement tokens and a renewal already in flight cannot publish a fresh bearer token after logout, while unrelated agents remain concurrent.

Addresses #770.

## Flaw and impact

Session validation, renewal, creation, termination, and publication of the global active-session marker were separate unsynchronized operations.

### Competing renewals

When two requests for the same agent arrived inside the renewal window, both could observe the same near-expiry session and both call `renew_session()`. Each renewal creates a different JWT and overwrites the same session JSON and global active-session marker. Only the last token written remains valid. This can:

- return an already-invalid replacement token or cookie to one caller;
- intermittently lock a browser or parallel SDK client out on its next request; and
- raise `FileNotFoundError` when renewals race while unlinking the shared `active` marker.

### Logout bypass race

`end_session()` did not share the renewal lock. If logout overlapped a request already inside `check_and_auto_renew()`, this ordering was possible:

1. Renewal reads the old active session and passes the near-expiry check.
2. Logout marks that old session terminated and returns successfully.
3. The in-flight renewal creates a new session, persists a new JWT, and marks it active.

The result is a fresh, valid bearer token created after logout completed. An already authenticated/stolen client racing the victim's logout can therefore retain access. The opposite write order can also return a token that is invalid immediately.

This is a concurrent execution / time-of-check-to-time-of-use failure (CWE-362/CWE-367) at the session-revocation boundary.

## Reproduction

Four deterministic regression tests cover the lifecycle guarantees:

- `test_auto_renew_is_single_flight_per_agent` forces two requests into the near-expiry path together and verifies exactly one replacement token is issued.
- `test_end_session_revokes_concurrent_auto_renewal` pauses a renewal after eligibility is established, starts logout, then releases renewal. Logout must wait, terminate the newly issued session, and make that fresh JWT fail validation.
- `test_lifecycle_operations_for_different_agents_can_overlap` pauses one agent's session write and verifies another agent can complete session creation independently.
- `test_active_session_read_waits_for_marker_update` verifies readers cannot inspect the process-wide active marker while it is being replaced.

Before the lifecycle fix, logout completes against the old session while renewal is paused; release then publishes a new active token and the revocation assertion fails.

## Fix

- Use one reentrant lifecycle lock per agent for session creation, termination, and the read/check/renew sequence.
- Use a separate narrow reentrant lock for every read, replacement, and deletion of the process-wide active-session marker.
- Keep token rotation reentrant so `check_and_auto_renew()` can call the normal `renew_session()` / `create_session()` path without deadlock, without blocking unrelated agents during session file I/O.
- Ensure a concurrent logout is authoritative: if renewal started first, logout terminates the replacement; if logout started first, renewal observes the terminated session and does nothing.

## Validation

- Full local suite: **366 passed, 24 skipped** (**390 collected**)
  - All skips are live Moorcheh E2E tests gated on a real `MOORCHEH_API_KEY`
- All four focused concurrency regressions: passed
- Ruff lint: passed
- Ruff format check: passed
- Mypy on the changed service: passed
- `git diff --check`: passed

## Checklist

- [x] Deterministic regression tests added
- [x] Existing unit and API tests pass
- [x] Ruff lint and formatting checks pass
- [x] Mypy passes for the changed service
- [x] No credentials or secrets added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session lifecycle reliability during simultaneous creation, renewal, termination, and deletion.
  - Prevented conflicting operations from producing invalid or inconsistent active-session and token states.
  - Ensured automatic renewal is single-flight per agent under concurrent checks.
  - Improved consistency of the active-session marker, avoiding partial/mid-update reads.

- **Tests**
  - Expanded concurrency test coverage across same and different agents.
  - Added assertions verifying concurrent lifecycle actions correctly invalidate and revoke tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->