### PR TITLE
fix: serialize persisted JWT secret creation

### DIFF
--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -9,6 +9,8 @@ import json
 import logging
 import os
 import secrets
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -76,36 +78,65 @@ class SessionService:
 
         Persisted alongside the sessions directory so sessions survive
         process restarts instead of every new process invalidating all
-        existing session tokens. Created atomically (O_CREAT | O_EXCL) with
-        restrictive permissions from the moment of creation, so concurrent
-        first-start processes can't race each other into using divergent
-        secrets and there's no window where the file is world-readable. An
+        existing session tokens. A cross-process lock serializes the initial
+        read/write so concurrent first-start workers cannot return divergent
+        secrets. The file has restrictive permissions from creation, and an
         existing-but-empty file (e.g. left behind by a crash mid-write) is
-        treated as absent and rewritten.
+        safely rewritten by the lock holder.
         """
         secret_file = self.sessions_dir.parent / "secret_key"
-        existing = self._read_persisted_secret(secret_file)
-        if existing is not None:
-            return existing
-
-        secret = secrets.token_hex(32)
-        try:
-            fd = os.open(str(secret_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        except FileExistsError:
-            # Lost a race to another process, or the file is a stale empty stub.
+        lock_file = secret_file.with_name(f"{secret_file.name}.lock")
+        with self._exclusive_file_lock(lock_file):
             existing = self._read_persisted_secret(secret_file)
             if existing is not None:
                 return existing
-            fd = os.open(str(secret_file), os.O_WRONLY | os.O_TRUNC, 0o600)
+
+            secret = secrets.token_hex(32)
+            fd = os.open(str(secret_file), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as file_handle:
+                file_handle.write(secret)
+                file_handle.flush()
+                os.fsync(file_handle.fileno())
+            try:
+                secret_file.chmod(0o600)
+            except OSError:
+                pass  # Windows may not support chmod
+            return secret
+
+    @staticmethod
+    @contextmanager
+    def _exclusive_file_lock(lock_file: Path) -> Iterator[None]:
+        """Hold an advisory cross-process lock on one byte of ``lock_file``."""
+        fd = os.open(str(lock_file), os.O_CREAT | os.O_RDWR, 0o600)
+        locked = False
         try:
-            os.write(fd, secret.encode())
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+                os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_EX)  # type: ignore[attr-defined]
+            locked = True
+            yield
         finally:
+            if locked:
+                os.lseek(fd, 0, os.SEEK_SET)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)  # type: ignore[attr-defined]
             os.close(fd)
-        try:
-            secret_file.chmod(0o600)
-        except OSError:
-            pass  # Windows may not support chmod
-        return secret
 
     @staticmethod
     def _read_persisted_secret(secret_file: Path) -> str | None:

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -5,10 +5,13 @@ Handles session creation, validation, and management.
 Uses JWT tokens for stateless authentication.
 """
 
+import errno
 import json
 import logging
 import os
 import secrets
+import tempfile
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import timedelta
@@ -92,15 +95,22 @@ class SessionService:
                 return existing
 
             secret = secrets.token_hex(32)
-            fd = os.open(str(secret_file), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-            with os.fdopen(fd, "w", encoding="utf-8") as file_handle:
-                file_handle.write(secret)
-                file_handle.flush()
-                os.fsync(file_handle.fileno())
+            fd, temp_name = tempfile.mkstemp(
+                prefix=f".{secret_file.name}.", dir=secret_file.parent
+            )
+            temp_file = Path(temp_name)
             try:
-                secret_file.chmod(0o600)
-            except OSError:
-                pass  # Windows may not support chmod
+                with os.fdopen(fd, "w", encoding="utf-8") as file_handle:
+                    file_handle.write(secret)
+                    file_handle.flush()
+                    os.fsync(file_handle.fileno())
+                os.replace(temp_file, secret_file)
+                try:
+                    secret_file.chmod(0o600)
+                except OSError:
+                    pass  # Windows may not support chmod
+            finally:
+                temp_file.unlink(missing_ok=True)
             return secret
 
     @staticmethod
@@ -118,7 +128,19 @@ class SessionService:
             if os.name == "nt":
                 import msvcrt
 
-                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                while True:
+                    try:
+                        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                        break
+                    except OSError as exc:
+                        if exc.errno not in {
+                            errno.EACCES,
+                            errno.EAGAIN,
+                            errno.EDEADLK,
+                        }:
+                            raise
+                        os.lseek(fd, 0, os.SEEK_SET)
+                        time.sleep(0.05)
             else:
                 import fcntl
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -249,6 +249,7 @@ class TestSessionService:
         thread_role = threading.local()
         real_open = os.open
         real_fdopen = os.fdopen
+        real_write = os.write
 
         def observed_open(path, flags, mode=0o777):
             if (
@@ -258,6 +259,11 @@ class TestSessionService:
             ):
                 second_truncated_secret.set()
             return real_open(path, flags, mode)
+
+        def delayed_write(fd, data):
+            if getattr(thread_role, "value", None) == "first" and len(data) == 64:
+                assert release_first_writer.wait(timeout=5)
+            return real_write(fd, data)
 
         def delayed_fdopen(fd, *args, **kwargs):
             file_handle = real_fdopen(fd, *args, **kwargs)
@@ -286,6 +292,7 @@ class TestSessionService:
 
         monkeypatch.setattr(os, "open", observed_open)
         monkeypatch.setattr(os, "fdopen", delayed_fdopen)
+        monkeypatch.setattr(os, "write", delayed_write)
 
         with ThreadPoolExecutor(max_workers=2) as pool:
             first = pool.submit(create_service, "first")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,7 +4,11 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import jwt
@@ -231,6 +235,67 @@ class TestSessionService:
             sessions_dir=temp_dir / "other-install" / "sessions"
         )
         assert other_root.secret_key != first.secret_key
+
+    def test_concurrent_first_start_uses_one_persisted_secret(
+        self, temp_dir, monkeypatch
+    ):
+        """Concurrent service starts must agree on the JWT signing secret."""
+        monkeypatch.delenv("MEMANTO_SECRET_KEY", raising=False)
+        monkeypatch.setattr(settings, "MEMANTO_SECRET_KEY", "")
+
+        sessions_dir = temp_dir / "sessions"
+        second_truncated_secret = threading.Event()
+        release_first_writer = threading.Event()
+        thread_role = threading.local()
+        real_open = os.open
+        real_fdopen = os.fdopen
+
+        def observed_open(path, flags, mode=0o777):
+            if (
+                getattr(thread_role, "value", None) == "second"
+                and Path(path).name == "secret_key"
+                and flags & os.O_TRUNC
+            ):
+                second_truncated_secret.set()
+            return real_open(path, flags, mode)
+
+        def delayed_fdopen(fd, *args, **kwargs):
+            file_handle = real_fdopen(fd, *args, **kwargs)
+            if getattr(thread_role, "value", None) != "first":
+                return file_handle
+
+            class DelayedWriter:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc_value, traceback):
+                    return file_handle.__exit__(exc_type, exc_value, traceback)
+
+                def write(self, data):
+                    assert release_first_writer.wait(timeout=5)
+                    return file_handle.write(data)
+
+                def __getattr__(self, name):
+                    return getattr(file_handle, name)
+
+            return DelayedWriter()
+
+        def create_service(role):
+            thread_role.value = role
+            return SessionService(sessions_dir=sessions_dir).secret_key
+
+        monkeypatch.setattr(os, "open", observed_open)
+        monkeypatch.setattr(os, "fdopen", delayed_fdopen)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(create_service, "first")
+            second = pool.submit(create_service, "second")
+            second_truncated_secret.wait(timeout=0.1)
+            release_first_writer.set()
+            returned_secrets = [first.result(timeout=5), second.result(timeout=5)]
+
+        persisted_secret = (temp_dir / "secret_key").read_text()
+        assert returned_secrets == [persisted_secret, persisted_secret]
 
     def test_get_active_session_ignores_invalid_session_file(self, session_service):
         """A corrupt active session file should not crash status checks."""


### PR DESCRIPTION
## Summary

Challenge submission for #770.

When `MEMANTO_SECRET_KEY` is unset, concurrent first-start workers can return different fallback JWT signing secrets even though they share the same data directory. The existing `O_CREAT | O_EXCL` path creates the final file before writing it; another worker can observe that empty file, treat it as stale, open it with `O_TRUNC`, and generate a competing secret.

That creates split-brain authentication: tokens minted by one worker can be rejected by another, and only one of the returned secrets survives on disk after restart.

## Reproduction

A deterministic two-worker harness pauses the first writer after it creates the empty `secret_key` file, then starts the second service. Before this fix it produced:

```text
returned_secrets: [secret_A, secret_B]
persisted_secret: secret_A
all_equal: False
```

The included regression test forces that interleaving and asserts both workers return the one persisted value.

## Fix

- Serialize fallback-secret initialization with a cross-process byte-range lock.
- Use `msvcrt.locking` on Windows and `fcntl.flock` on POSIX.
- Re-read the persisted secret only after acquiring the lock.
- Write, flush, and `fsync` the generated value before releasing the lock.
- Preserve restrictive creation permissions and recovery from an empty file.

## Validation

- Full local suite: **364 passed, 24 skipped** (only live Moorcheh E2E tests without an API key)
- Focused regression + existing persisted-secret test: **2 passed**
- Real 12-process simultaneous first-start check: **1 unique secret, all 12 matched the persisted value, no errors**
- Ruff lint: passed
- Ruff format check: passed
- Mypy on the changed service: passed
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session security initialization to prevent conflicting secret keys when multiple processes start simultaneously.
  * Ensured generated session secrets are safely persisted and protected with restrictive file permissions.
  * Added cross-platform safeguards for reliable secret storage and locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->