### PR TITLE
fix: protect persisted session credentials

### DIFF
--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -54,6 +54,9 @@ def get_session_service() -> "SessionService":
 class SessionService:
     """Service for managing sessions"""
 
+    _PRIVATE_FILE_MODE = 0o600
+    _PRIVATE_DIR_MODE = 0o700
+
     def __init__(self, secret_key: str | None = None, sessions_dir: Path | None = None):
         """
         Initialize session service
@@ -63,13 +66,55 @@ class SessionService:
             sessions_dir: Directory for session storage (defaults to ~/.memanto/sessions/)
         """
         self.sessions_dir = sessions_dir or get_data_dir() / "sessions"
-        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        self.sessions_dir.mkdir(
+            parents=True, exist_ok=True, mode=self._PRIVATE_DIR_MODE
+        )
+        self._harden_session_storage()
         resolved_secret_key = (
             secret_key
             or settings.MEMANTO_SECRET_KEY
             or self._generate_secure_secret_key()
         )
         self.secret_key: str = resolved_secret_key
+
+    @staticmethod
+    def _set_private_permissions(path: Path, mode: int) -> None:
+        """Best-effort owner-only permissions for persisted session state."""
+        try:
+            path.chmod(mode)
+        except OSError:
+            # Windows ACLs are not represented by POSIX mode bits. Creation and
+            # access still follow the owning user's ACL in that environment.
+            pass
+
+    def _harden_session_storage(self) -> None:
+        """Protect both newly-created and pre-existing session artifacts.
+
+        Session JSON files contain live bearer tokens, while summary files can
+        contain private memory content. A normal ``mkdir``/``open`` sequence on
+        POSIX inherits the process umask and commonly creates these as 0755 and
+        0644, allowing other local accounts to traverse and read them.
+        """
+        self._set_private_permissions(self.sessions_dir, self._PRIVATE_DIR_MODE)
+        for path in self.sessions_dir.iterdir():
+            if path.is_symlink() or not path.is_file():
+                continue
+            self._set_private_permissions(path, self._PRIVATE_FILE_MODE)
+
+    def _open_private_text(self, path: Path, flags: int, mode: str, **kwargs):
+        """Open a text file with owner-only permissions from first creation."""
+        fd = os.open(str(path), flags, self._PRIVATE_FILE_MODE)
+        try:
+            try:
+                fchmod = getattr(os, "fchmod", None)
+                if fchmod is not None:
+                    fchmod(fd, self._PRIVATE_FILE_MODE)
+            except OSError:
+                pass
+            return os.fdopen(fd, mode, **kwargs)
+        except Exception:
+            os.close(fd)
+            raise
 
     def _generate_secure_secret_key(self) -> str:
         """Generate (or reuse) a persisted fallback secret for JWT signing.
@@ -385,7 +430,8 @@ class SessionService:
         """Save session to file"""
         validate_safe_id(session.agent_id, "agent_id")
         session_file = self.sessions_dir / f"{session.agent_id}.json"
-        with open(session_file, "w") as f:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        with self._open_private_text(session_file, flags, "w") as f:
             json.dump(session.model_dump(mode="json"), f, indent=2)
 
     def _load_session_file(self, session_file: Path) -> Session | None:
@@ -443,7 +489,8 @@ class SessionService:
         status = getattr(memory_record, "status", None)
         tags = getattr(memory_record, "tags", None)
 
-        with open(summary_file, "a", encoding="utf-8") as f:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        with self._open_private_text(summary_file, flags, "a", encoding="utf-8") as f:
             if write_header:
                 f.write(f"# Session Summary for {agent_id}\n")
                 f.write(f"**Session ID:** `{session_id}`\n\n")
@@ -492,7 +539,8 @@ class SessionService:
 
         write_header = not summary_file.exists()
 
-        with open(summary_file, "a", encoding="utf-8") as f:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        with self._open_private_text(summary_file, flags, "a", encoding="utf-8") as f:
             if write_header:
                 f.write(f"# Session Summary for {agent_id}\n")
                 f.write(f"**Session ID:** `{session_id}`\n\n")
@@ -518,7 +566,8 @@ class SessionService:
             active_link.symlink_to(f"{agent_id}.json")
         except (OSError, NotImplementedError):
             # Fallback for Windows or systems without symlink support
-            with open(active_link, "w") as f:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            with self._open_private_text(active_link, flags, "w") as f:
                 f.write(agent_id)
 
     def _clear_active_session(self) -> None:

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -116,6 +116,31 @@ class SessionService:
             os.close(fd)
             raise
 
+    def _write_private_json_atomic(self, path: Path, data: Any) -> None:
+        """Atomically replace a private JSON file after a complete durable write.
+
+        Writing directly to the live path with ``O_TRUNC`` can destroy the only
+        valid session record if serialization or the process fails mid-write.
+        A sibling temporary file keeps readers on the previous complete record
+        until the replacement is ready.
+        """
+        tmp_path = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        try:
+            with self._open_private_text(
+                tmp_path, flags, "w", encoding="utf-8"
+            ) as tmp_file:
+                json.dump(data, tmp_file, indent=2)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+            os.replace(tmp_path, path)
+            self._set_private_permissions(path, self._PRIVATE_FILE_MODE)
+        finally:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
+
     def _generate_secure_secret_key(self) -> str:
         """Generate (or reuse) a persisted fallback secret for JWT signing.
 
@@ -430,9 +455,7 @@ class SessionService:
         """Save session to file"""
         validate_safe_id(session.agent_id, "agent_id")
         session_file = self.sessions_dir / f"{session.agent_id}.json"
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-        with self._open_private_text(session_file, flags, "w") as f:
-            json.dump(session.model_dump(mode="json"), f, indent=2)
+        self._write_private_json_atomic(session_file, session.model_dump(mode="json"))
 
     def _load_session_file(self, session_file: Path) -> Session | None:
         """Load one session file, treating corrupt local state as absent."""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -120,6 +120,31 @@ class TestSessionService:
         assert stat.S_IMODE(session_file.stat().st_mode) == 0o600
         assert stat.S_IMODE(summary_file.stat().st_mode) == 0o600
 
+    def test_interrupted_session_save_preserves_previous_record(self, session_service):
+        """A failed replacement must not truncate the live bearer-token record."""
+        session = session_service.create_session(
+            agent_id="test-agent", duration_hours=1
+        )
+        session_file = session_service.sessions_dir / "test-agent.json"
+        original_contents = session_file.read_text(encoding="utf-8")
+        replacement = session.model_copy(update={"session_id": "sess-replacement"})
+
+        def interrupted_dump(data, file_obj, **kwargs):
+            file_obj.write('{"session_id":')
+            file_obj.flush()
+            raise OSError("simulated interrupted write")
+
+        with patch(
+            "memanto.app.services.session_service.json.dump",
+            side_effect=interrupted_dump,
+        ):
+            with pytest.raises(OSError, match="simulated interrupted write"):
+                session_service._save_session(replacement)
+
+        assert session_file.read_text(encoding="utf-8") == original_contents
+        assert session_service.get_session("test-agent") == session
+        assert not list(session_service.sessions_dir.glob(".*.tmp"))
+
     def test_validate_session(self, session_service):
         """Test session validation"""
         # Create session

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,6 +4,8 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
+import os
+import stat
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
@@ -67,6 +69,56 @@ class TestSessionService:
         print(f"   Session ID: {session.session_id}")
         print(f"   Namespace: {session.namespace}")
         print(f"   Expires in: {time_diff / 3600:.2f} hours")
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits required")
+    def test_session_token_storage_is_owner_only(self, temp_dir):
+        """Persisted bearer tokens must not be readable by other local users."""
+        sessions_dir = temp_dir / "sessions"
+        service = SessionService(
+            secret_key="test-secret-key-min-32-bytes-1234",
+            sessions_dir=sessions_dir,
+        )
+
+        session = service.create_session(agent_id="private-agent", duration_hours=1)
+        record = MemoryRecord(
+            type="fact",
+            title="Private fact",
+            content="Private memory content",
+            agent_id="private-agent",
+            actor_id="user",
+            source="user",
+        )
+        service.log_memory_to_session_summary(
+            "private-agent", session.session_id, record
+        )
+
+        session_file = sessions_dir / "private-agent.json"
+        summary_file = next(sessions_dir.glob("*_summary.md"))
+        assert stat.S_IMODE(sessions_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(session_file.stat().st_mode) == 0o600
+        assert stat.S_IMODE(summary_file.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits required")
+    def test_initialization_hardens_existing_session_artifacts(self, temp_dir):
+        """Upgrades must close exposure of files created by older versions."""
+        sessions_dir = temp_dir / "sessions"
+        sessions_dir.mkdir(mode=0o777)
+        session_file = sessions_dir / "existing.json"
+        summary_file = sessions_dir / "existing_summary.md"
+        session_file.write_text('{"session_token": "live-bearer-token"}')
+        summary_file.write_text("private memory content")
+        sessions_dir.chmod(0o777)
+        session_file.chmod(0o666)
+        summary_file.chmod(0o666)
+
+        SessionService(
+            secret_key="test-secret-key-min-32-bytes-1234",
+            sessions_dir=sessions_dir,
+        )
+
+        assert stat.S_IMODE(sessions_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(session_file.stat().st_mode) == 0o600
+        assert stat.S_IMODE(summary_file.stat().st_mode) == 0o600
 
     def test_validate_session(self, session_service):
         """Test session validation"""


### PR DESCRIPTION
## Summary

Challenge submission for #770.

Memanto persists each live JWT bearer token in `~/.memanto/sessions/<agent>.json` and writes private memory content to session summary files. Two storage flaws put that state at risk:

1. On POSIX, the existing plain `mkdir` / `open` calls inherit the normal `022` umask, producing a traversable `0755` sessions directory and commonly readable `0644` files. Another local account can read a victim's active `session_token` and call the session-authenticated memory API as that agent, including recall, write, update, upload, and delete operations. Summary Markdown is also directly disclosed.
2. Session JSON was overwritten in place with `O_TRUNC`. A serialization error, process termination, or storage failure after truncation destroys the only valid session record. Subsequent validation treats the bearer token as inactive, and the session disappears from status/list operations even though the previous record was complete before the attempted update.

These are CWE-732 (Incorrect Permission Assignment for Critical Resource) and CWE-459/CWE-664 style lifecycle failures around critical persisted state.

## Reproduction

### Local credential disclosure

On an affected Linux/macOS install with the normal `umask 022`:

1. Activate an agent so Memanto writes `~/.memanto/sessions/<agent>.json`.
2. Inspect the modes from another local account:

```console
$ namei -l ~/.memanto/sessions/<agent>.json
drwxr-xr-x ... .memanto
drwxr-xr-x ... sessions
-rw-r--r-- ... <agent>.json
```

3. Read `session_token` from that JSON file and present it in `X-Session-Token` to the local Memanto API. The request is accepted within that agent's memory namespace.

### Interrupted session save

1. Create an active session and retain the valid JSON file.
2. Begin a replacement save and interrupt `json.dump` after it emits only `{"session_id":`.
3. Before this fix, the live file is left truncated and `get_session()` returns `None`, invalidating the existing token through the persisted-state check.

The included regression test injects this exact failure and verifies that the original session remains byte-for-byte intact.

## Fix

- Create and enforce the sessions directory as owner-only (`0700`).
- Create session JSON, summary Markdown, and fallback active-marker files as owner-only (`0600`) from first creation.
- Use descriptor-level permission tightening before writing sensitive content.
- Harden pre-existing regular session artifacts during service initialization so upgrades close the exposure.
- Leave the active-session symlink untouched while protecting its containing directory and target.
- Save session JSON to a private, exclusive sibling temporary file, flush and `fsync` it, then publish it with atomic `os.replace`.
- Remove an incomplete temporary file on every failure path, preserving the prior valid session record.
- Add regression tests for POSIX permissions, upgrade hardening, and interrupted writes.

## Validation

- Full local suite: **363 passed, 26 skipped**
  - 24 live Moorcheh E2E tests skipped without a real API key
  - 2 POSIX-mode assertions skipped on Windows and available to run in Linux CI
- Focused session unit suite: passed
- Ruff lint: passed
- Ruff format check: passed
- Mypy on the changed service: passed
- `git diff --check`: passed

