### PR TITLE
fix(okf): preserve literal entry delimiters during round trips

### DIFF
--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -21,6 +21,7 @@ Memanto -> OKF -> Memanto round-trips keep them. OKF consumers ignore unknown
 frontmatter keys.
 """
 
+import html
 import re
 import shutil
 from datetime import datetime
@@ -36,6 +37,7 @@ from memanto.app.utils.validation import validate_output_path, validate_safe_id
 # the loader can split them back apart without colliding with ``---`` that may
 # appear inside a document body (e.g. the migrate ``[Supporting data]`` footer).
 ENTRY_DELIMITER = "<!-- okf-entry -->"
+CONTENT_ENCODING_HTML_ESCAPED = "html-escaped-v1"
 
 # Default: collapse a type into a single stacked file once it exceeds this many
 # memories (see the ``auto`` split mode).
@@ -275,6 +277,7 @@ class OkfExportService:
     def _render_okf_doc(self, mem: dict[str, Any], mem_type: str) -> str:
         """Render a single memory dict as one OKF markdown document."""
         content = (mem.get("content") or "").strip()
+        rendered_content = content
         title = mem.get("title") or "Untitled"
 
         frontmatter: dict[str, Any] = {"type": mem_type, "title": title}
@@ -300,6 +303,12 @@ class OkfExportService:
             val = mem.get(key)
             if val not in (None, ""):
                 x_memanto[key] = val
+        if ENTRY_DELIMITER in content:
+            # Stacked exports use ENTRY_DELIMITER as record framing. Escape the
+            # complete body so a literal marker in user content cannot create a
+            # phantom record; the loader reverses this encoding after splitting.
+            rendered_content = html.escape(content, quote=False)
+            x_memanto["content_encoding"] = CONTENT_ENCODING_HTML_ESCAPED
         x_memanto["type"] = mem_type
         frontmatter["x_memanto"] = x_memanto
 
@@ -309,7 +318,7 @@ class OkfExportService:
             allow_unicode=True,
             default_flow_style=False,
         ).strip()
-        return f"---\n{front}\n---\n\n{content}\n"
+        return f"---\n{front}\n---\n\n{rendered_content}\n"
 
     def _first_line(self, content: str) -> str:
         """First non-empty line of content (heading marks stripped), for the

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -51,6 +51,30 @@ def _as_float(value: Any, default: float) -> float:
         return default
 
 
+def _contains_entry_delimiter(value: Any) -> bool:
+    """Return whether a nested frontmatter value contains record framing."""
+    if isinstance(value, str):
+        return ENTRY_DELIMITER in value
+    if isinstance(value, dict):
+        return any(_contains_entry_delimiter(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_entry_delimiter(item) for item in value)
+    return False
+
+
+def _escape_strings(value: Any) -> Any:
+    """HTML-escape nested strings while preserving their container types."""
+    if isinstance(value, str):
+        return html.escape(value, quote=False)
+    if isinstance(value, dict):
+        return {key: _escape_strings(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_escape_strings(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_escape_strings(item) for item in value)
+    return value
+
+
 class OkfExportService:
     """Formats and writes an OKF bundle for an agent."""
 
@@ -303,14 +327,16 @@ class OkfExportService:
             val = mem.get(key)
             if val not in (None, ""):
                 x_memanto[key] = val
-        if ENTRY_DELIMITER in content:
-            # Stacked exports use ENTRY_DELIMITER as record framing. Escape the
-            # complete body so a literal marker in user content cannot create a
-            # phantom record; the loader reverses this encoding after splitting.
-            rendered_content = html.escape(content, quote=False)
-            x_memanto["content_encoding"] = CONTENT_ENCODING_HTML_ESCAPED
         x_memanto["type"] = mem_type
         frontmatter["x_memanto"] = x_memanto
+
+        if ENTRY_DELIMITER in content or _contains_entry_delimiter(frontmatter):
+            # Stacked exports use ENTRY_DELIMITER as record framing. Escape every
+            # string in the document so a literal marker in body or frontmatter
+            # cannot create a phantom record; the loader reverses this encoding.
+            rendered_content = html.escape(content, quote=False)
+            frontmatter = _escape_strings(frontmatter)
+            frontmatter["x_memanto"]["content_encoding"] = CONTENT_ENCODING_HTML_ESCAPED
 
         front = yaml.safe_dump(
             frontmatter,

--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -13,13 +13,17 @@ are skipped.
 
 from __future__ import annotations
 
+import html
 import re
 from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 
-from memanto.app.services.okf_export_service import ENTRY_DELIMITER
+from memanto.app.services.okf_export_service import (
+    CONTENT_ENCODING_HTML_ESCAPED,
+    ENTRY_DELIMITER,
+)
 
 # Frontmatter must open at the very start of a (stripped) document. ``.*?`` is
 # non-greedy so the first ``\n---`` closes the block even when the body below
@@ -107,6 +111,8 @@ def _parse_entry(chunk: str, file_path: Path, rel_base: Path) -> dict[str, Any] 
     x_memanto = frontmatter.get("x_memanto")
     if not isinstance(x_memanto, dict):
         x_memanto = {}
+    if x_memanto.get("content_encoding") == CONTENT_ENCODING_HTML_ESCAPED:
+        body = html.unescape(body)
 
     extra = {k: v for k, v in frontmatter.items() if k not in _KNOWN_FIELDS}
     links = [f"{text} -> {target}" for text, target in _LINK_RE.findall(body)]

--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -45,6 +45,17 @@ _KNOWN_FIELDS = {
 }
 
 
+def _unescape_strings(value: Any) -> Any:
+    """Reverse the exporter's recursive HTML escaping of string values."""
+    if isinstance(value, str):
+        return html.unescape(value)
+    if isinstance(value, dict):
+        return {key: _unescape_strings(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_unescape_strings(item) for item in value]
+    return value
+
+
 def load_okf_bundle(path: str | Path) -> dict[str, Any]:
     """Load an OKF bundle directory (or a single ``.md`` file) into an export dict."""
     root = Path(path)
@@ -102,17 +113,19 @@ def _parse_entry(chunk: str, file_path: Path, rel_base: Path) -> dict[str, Any] 
     if not body and not frontmatter.get("title"):
         return None
 
+    x_memanto = frontmatter.get("x_memanto")
+    if not isinstance(x_memanto, dict):
+        x_memanto = {}
+    if x_memanto.get("content_encoding") == CONTENT_ENCODING_HTML_ESCAPED:
+        frontmatter = _unescape_strings(frontmatter)
+        body = html.unescape(body)
+        x_memanto = frontmatter["x_memanto"]
+
     tags = frontmatter.get("tags")
     if isinstance(tags, str):
         tags = [tags]
     elif not isinstance(tags, list):
         tags = []
-
-    x_memanto = frontmatter.get("x_memanto")
-    if not isinstance(x_memanto, dict):
-        x_memanto = {}
-    if x_memanto.get("content_encoding") == CONTENT_ENCODING_HTML_ESCAPED:
-        body = html.unescape(body)
 
     extra = {k: v for k, v in frontmatter.items() if k not in _KNOWN_FIELDS}
     links = [f"{text} -> {target}" for text, target in _LINK_RE.findall(body)]

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -186,3 +186,27 @@ def test_loader_splits_stacked_file(tmp_path):
     assert {m["title"] for m in export["memories"]} == {
         f"Standup {i}" for i in range(5)
     }
+
+
+def test_round_trip_preserves_literal_entry_delimiter_in_memory_content(tmp_path):
+    """User content must never be interpreted as the stacked-file framing."""
+    content = (
+        "Document the literal internal marker & keep &amp; and <tags> unchanged:\n"
+        "<!-- okf-entry -->\n"
+        "It is part of the memory, not a record boundary."
+    )
+    memories_by_type = {
+        "fact": [
+            _mem("f1", "Delimiter documentation", content),
+            _mem("f2", "Neighboring fact", "This memory must remain separate."),
+        ]
+    }
+
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    result = svc.write_okf_bundle("agent1", memories_by_type, split="type")
+
+    export = load_okf_bundle(result["output_path"])
+    assert len(export["memories"]) == 2
+    by_title = {memory["title"]: memory for memory in export["memories"]}
+    assert by_title["Delimiter documentation"]["body"] == content
+    assert by_title["Neighboring fact"]["body"] == "This memory must remain separate."

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -197,7 +197,13 @@ def test_round_trip_preserves_literal_entry_delimiter_in_memory_content(tmp_path
     )
     memories_by_type = {
         "fact": [
-            _mem("f1", "Delimiter documentation", content),
+            _mem(
+                "f1",
+                "Delimiter <!-- okf-entry --> documentation &amp;",
+                content,
+                tags=["format <!-- okf-entry -->", "entity &amp;"],
+                source_ref="https://example.test/<!-- okf-entry -->?x=&amp;",
+            ),
             _mem("f2", "Neighboring fact", "This memory must remain separate."),
         ]
     }
@@ -208,5 +214,13 @@ def test_round_trip_preserves_literal_entry_delimiter_in_memory_content(tmp_path
     export = load_okf_bundle(result["output_path"])
     assert len(export["memories"]) == 2
     by_title = {memory["title"]: memory for memory in export["memories"]}
-    assert by_title["Delimiter documentation"]["body"] == content
+    title = "Delimiter <!-- okf-entry --> documentation &amp;"
+    assert by_title[title]["body"] == content
+    assert by_title[title]["tags"] == [
+        "format <!-- okf-entry -->",
+        "entity &amp;",
+    ]
+    assert (
+        by_title[title]["resource"] == "https://example.test/<!-- okf-entry -->?x=&amp;"
+    )
     assert by_title["Neighboring fact"]["body"] == "This memory must remain separate."


### PR DESCRIPTION
## Summary

- prevent literal `<!-- okf-entry -->` text in memory bodies or YAML metadata from becoming stacked-file framing
- reversibly HTML-escape every string in only affected documents and record the encoding in `x_memanto`
- decode affected bodies and frontmatter after the loader has safely split real records
- add a deterministic two-memory regression covering body, title, tags, resource, and pre-existing HTML entities

Refs #770

## Root cause and impact

OKF uses the literal HTML comment `<!-- okf-entry -->` to separate records in stacked files. The exporter writes memory content and metadata into each document, and the loader calls `text.split(ENTRY_DELIMITER)` over the complete Markdown text before parsing either frontmatter or body.

A user memory containing that ordinary text is therefore treated as multiple records during the supported Memanto → OKF → Memanto flow. In the regression, two exported memories become three imported memories: the affected memory is truncated at the marker, its remaining content becomes a phantom untyped record, and its metadata no longer describes the complete memory. The same collision affects both stacked and per-memory files because the loader splits every file.

This is realistic for memories that preserve documentation, templates, source snippets, or discussions of the OKF format itself. More generally, user-controlled memory text must not be able to alter the export framing.

## Reproduction

The added test exports two facts with `split="type"`. One body contains:

```text
Document the literal internal marker & keep &amp; and <tags> unchanged:
<!-- okf-entry -->
It is part of the memory, not a record boundary.
```

Before the fix:

```text
FAILED tests/test_okf.py::test_round_trip_preserves_literal_entry_delimiter_in_memory_content
AssertionError: assert 3 == 2
```

The first memory is truncated and a third phantom memory is created.

## Fix

When a document body or any nested frontmatter string contains the framing sentinel, the exporter applies reversible `html.escape(..., quote=False)` encoding to every string in that document and records `x_memanto.content_encoding = "html-escaped-v1"`. Encoding the complete affected document also prevents collisions in title, description, tags, resource, and Memanto metadata while preserving pre-existing entities such as `&amp;` exactly. The loader reverses body and frontmatter encoding only after real entries have been separated. Unaffected exports remain byte-for-byte unchanged and human-readable.

## Validation

- `python -m pytest tests/test_okf.py -q` — 6 passed
- `python -m pytest -q` — 363 passed, 24 skipped (live API key tests)
- `python -m ruff check memanto/app/services/okf_export_service.py memanto/cli/migrate/okf_loader.py tests/test_okf.py`
- `python -m ruff format --check memanto/app/services/okf_export_service.py memanto/cli/migrate/okf_loader.py tests/test_okf.py`
- `python -m mypy memanto/app/services/okf_export_service.py memanto/cli/migrate/okf_loader.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved literal stacked-entry delimiter text in exported and re-imported content.
  * Prevented delimiter-like text in document content and metadata from corrupting OKF imports.
  * Preserved nested metadata, tags, resources, and HTML entities during round trips.
* **Tests**
  * Added coverage confirming neighboring entries remain correctly separated while content is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->