### PR TITLE
fix(okf): replace stale bundle content on re-export

### DIFF
--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -107,6 +107,7 @@ class OkfExportService:
             assert validated is not None
             base = validated
         base.mkdir(parents=True, exist_ok=True)
+        self._clear_managed_output(base)
 
         # Section order mirrors how an agent would read the bundle.
         sections: dict[str, str] = {}
@@ -144,6 +145,28 @@ class OkfExportService:
             "per_type_counts": per_type_counts,
             "sections": list(sections),
         }
+
+    @staticmethod
+    def _clear_managed_output(base: Path) -> None:
+        """Remove files owned by a previous export before rebuilding the bundle.
+
+        Reusing an output directory must produce a snapshot of the current
+        agent state.  Without clearing managed sections first, deleted memories
+        and context documents remain on disk and are imported again later.
+        Unknown files at the bundle root are intentionally left untouched.
+        """
+        managed_paths = (
+            base / "index.md",
+            base / "memories",
+            base / "daily-summaries",
+            base / "sessions",
+            base / "metrics",
+        )
+        for path in managed_paths:
+            if path.is_symlink() or path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                shutil.rmtree(path)
 
     # Section writers
     def _write_memories_section(

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -95,6 +95,52 @@ def test_context_sections_and_import_scope(tmp_path):
     assert export["memories"][0]["title"] == "A fact"
 
 
+def test_reexport_replaces_stale_managed_content(tmp_path):
+    """Reusing a bundle path reflects current state instead of resurrecting
+    deleted memories or retaining context files from an earlier export."""
+    summary = tmp_path / "summary.md"
+    summary.write_text("# Old summary\n", encoding="utf-8")
+    session = tmp_path / "session.md"
+    session.write_text("# Old session\n", encoding="utf-8")
+
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    svc.write_okf_bundle(
+        "agent1",
+        {
+            "fact": [
+                _mem("f1", "Keep", "Still current."),
+                _mem("f2", "Deleted", "No longer current."),
+            ]
+        },
+        split="file",
+        summaries=[summary],
+        sessions=[session],
+    )
+    base = svc.exports_dir / "agent1_okf"
+    assert (base / "memories" / "fact" / "deleted.md").exists()
+    assert (base / "daily-summaries" / "summary.md").exists()
+    assert (base / "sessions" / "session.md").exists()
+
+    second = svc.write_okf_bundle(
+        "agent1",
+        {"fact": [_mem("f1", "Keep", "Still current.")]},
+        split="type",
+    )
+
+    reloaded = load_okf_bundle(second["output_path"])
+    assert [entry["title"] for entry in reloaded["memories"]] == ["Keep"]
+    assert (base / "memories" / "fact" / "fact.md").exists()
+    assert not (base / "memories" / "fact" / "deleted.md").exists()
+    assert not (base / "daily-summaries").exists()
+    assert not (base / "sessions").exists()
+
+    empty = svc.write_okf_bundle("agent1", {}, split="file")
+    assert empty["sections"] == []
+    assert load_okf_bundle(empty["output_path"])["memories"] == []
+    assert not (base / "memories").exists()
+    assert not (base / "metrics").exists()
+
+
 def test_memanto_round_trip_preserves_extras(tmp_path):
     """Memanto -> OKF -> Memanto keeps type/confidence/source_ref/tags/body via
     the ``x_memanto`` block, and always marks provenance as imported."""


### PR DESCRIPTION
## Summary

- make each OKF re-export a snapshot of current agent state
- remove only Memanto-managed bundle sections before rebuilding them
- prevent deleted memories, old context documents, and obsolete split layouts from surviving on disk
- add a regression covering memory deletion, file-to-type layout changes, removed context, and an empty final export

Refs #770

## Root cause and impact

`write_okf_bundle` creates the output directory with `exist_ok=True`, then overwrites only paths needed by the current export. It never removes paths produced by an earlier export.

That means deleting a memory and exporting the same agent again leaves its old Markdown file in `memories/`. `load_okf_bundle` recursively imports every Markdown file in that section, so the supposedly deleted memory is resurrected on the next import. Switching from per-file to stacked layout is worse: both layouts remain and the same live memories can be imported twice. Daily summaries, session logs, and metrics can also remain after they no longer exist in current state.

This is a deterministic memory-integrity failure in the supported export/import workflow, not a cosmetic artifact.

## Reproduction

1. Export facts `Keep` and `Deleted` to the default `agent1_okf` path with `split=file`.
2. Re-export the same agent and path with only `Keep`.
3. Load the resulting bundle with `load_okf_bundle`.

Before the fix, the loader returns both records:

~~~text
[(Deleted, memories/fact/deleted.md),
 (Keep, memories/fact/keep.md)]
~~~

The regression also switches the second export to `split=type`, proving obsolete per-memory files do not coexist with the new stacked file.

## Fix

Before writing a bundle, clear only the paths owned by the exporter: the root index plus `memories`, `daily-summaries`, `sessions`, and `metrics`. Symlink and file cases are unlinked without traversal; managed directories are removed and rebuilt. Unknown files at the bundle root are preserved.

The new test verifies that deleted memories and removed context disappear, layout changes do not duplicate data, and an empty re-export leaves no importable memories or stale metrics.

## Validation

- `uv run pytest tests/test_okf.py` — 6 passed
- `uv run pytest` — 363 passed, 24 skipped (live API-key E2E tests)
- `uv run ruff check memanto/app/services/okf_export_service.py tests/test_okf.py`
- `uv run ruff format --check memanto/app/services/okf_export_service.py tests/test_okf.py`
- `uv run mypy memanto/app/services/okf_export_service.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Re-exporting an OKF bundle now removes outdated memories, summaries, sessions, metrics, and index content.
  - Reusing an existing export location now accurately reflects the latest available content.
  - Empty exports no longer retain stale folders or files from previous exports.

- **Tests**
  - Added coverage to verify that re-exported bundles replace removed content correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->