### PR TITLE
fix: serialize concurrent session summary writes

### DIFF
--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -11,6 +11,7 @@ import os
 import secrets
 from datetime import timedelta
 from pathlib import Path
+from threading import Lock
 from typing import Any
 
 import jwt
@@ -64,6 +65,7 @@ class SessionService:
         """
         self.sessions_dir = sessions_dir or get_data_dir() / "sessions"
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        self._summary_lock = Lock()
         resolved_secret_key = (
             secret_key
             or settings.MEMANTO_SECRET_KEY
@@ -428,9 +430,6 @@ class SessionService:
             self.sessions_dir / f"{agent_id}_{date_str}_{session_id}_summary.md"
         )
 
-        # Determine if we need to write the header
-        write_header = not summary_file.exists()
-
         # Format the memory into Markdown
         memory_type = (getattr(memory_record, "type", None) or "unclassified").upper()
         title = getattr(memory_record, "title", "Untitled")
@@ -443,27 +442,25 @@ class SessionService:
         status = getattr(memory_record, "status", None)
         tags = getattr(memory_record, "tags", None)
 
-        with open(summary_file, "a", encoding="utf-8") as f:
-            if write_header:
-                f.write(f"# Session Summary for {agent_id}\n")
-                f.write(f"**Session ID:** `{session_id}`\n\n")
-                f.write("---\n\n")
+        lines = [f"### [{timestamp}] [{memory_type}] {title}\n"]
+        if memory_id:
+            lines.append(f"- **Memory ID**: `{memory_id}`\n")
+        lines.append(f"- **Confidence**: `{confidence}`\n")
+        if status:
+            lines.append(f"- **Status**: `{status}`\n")
+        if source:
+            lines.append(f"- **Source**: `{source}`\n")
+        if provenance:
+            lines.append(f"- **Provenance**: `{provenance}`\n")
+        if tags:
+            lines.append(f"- **Tags**: {', '.join(f'`{t}`' for t in tags)}\n")
+        lines.append("- **Content**:\n")
+        lines.append(f"> {content.replace(chr(10), chr(10) + '> ')}\n\n")
+        lines.append("---\n\n")
 
-            f.write(f"### [{timestamp}] [{memory_type}] {title}\n")
-            if memory_id:
-                f.write(f"- **Memory ID**: `{memory_id}`\n")
-            f.write(f"- **Confidence**: `{confidence}`\n")
-            if status:
-                f.write(f"- **Status**: `{status}`\n")
-            if source:
-                f.write(f"- **Source**: `{source}`\n")
-            if provenance:
-                f.write(f"- **Provenance**: `{provenance}`\n")
-            if tags:
-                f.write(f"- **Tags**: {', '.join(f'`{t}`' for t in tags)}\n")
-            f.write("- **Content**:\n")
-            f.write(f"> {content.replace(chr(10), chr(10) + '> ')}\n\n")
-            f.write("---\n\n")
+        self._append_session_summary(
+            summary_file, agent_id, session_id, "".join(lines)
+        )
 
     def log_memory_deletion_to_session_summary(
         self,
@@ -490,18 +487,33 @@ class SessionService:
             self.sessions_dir / f"{agent_id}_{date_str}_{session_id}_summary.md"
         )
 
-        write_header = not summary_file.exists()
+        entry = (
+            f"### [{timestamp}] [DELETED] Memory Deleted\n"
+            f"- **Memory ID**: `{memory_id}`\n"
+            "- **Confidence**: `1.0`\n"
+            "---\n\n"
+        )
+        self._append_session_summary(summary_file, agent_id, session_id, entry)
 
-        with open(summary_file, "a", encoding="utf-8") as f:
+    def _append_session_summary(
+        self,
+        summary_file: Path,
+        agent_id: str,
+        session_id: str,
+        entry: str,
+    ) -> None:
+        """Append one complete entry without racing header creation or other writes."""
+        with self._summary_lock:
+            write_header = not summary_file.exists()
+            header = ""
             if write_header:
-                f.write(f"# Session Summary for {agent_id}\n")
-                f.write(f"**Session ID:** `{session_id}`\n\n")
-                f.write("---\n\n")
-
-            f.write(f"### [{timestamp}] [DELETED] Memory Deleted\n")
-            f.write(f"- **Memory ID**: `{memory_id}`\n")
-            f.write("- **Confidence**: `1.0`\n")
-            f.write("---\n\n")
+                header = (
+                    f"# Session Summary for {agent_id}\n"
+                    f"**Session ID:** `{session_id}`\n\n"
+                    "---\n\n"
+                )
+            with open(summary_file, "a", encoding="utf-8") as f:
+                f.write(header + entry)
 
     def _set_active_session(self, agent_id: str) -> None:
         """Mark session as active"""

--- a/tests/test_session_summary_concurrency.py
+++ b/tests/test_session_summary_concurrency.py
@@ -1,0 +1,59 @@
+"""Concurrency regressions for local session summaries."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from threading import Barrier, BrokenBarrierError
+
+from memanto.app.core import MemoryRecord
+from memanto.app.services.session_service import SessionService
+
+
+def test_concurrent_summary_writes_create_one_header(monkeypatch, tmp_path):
+    """Concurrent API workers must not race first-write header creation."""
+    service = SessionService(
+        secret_key="test-secret-key-min-32-bytes-1234",
+        sessions_dir=tmp_path / "sessions",
+    )
+    worker_count = 8
+    first_exists_checks = Barrier(worker_count)
+    original_exists = Path.exists
+
+    def synchronize_initial_absence_check(path):
+        exists = original_exists(path)
+        if path.name.endswith("_summary.md") and not exists:
+            try:
+                first_exists_checks.wait(timeout=0.1)
+            except BrokenBarrierError:
+                pass
+        return exists
+
+    monkeypatch.setattr(Path, "exists", synchronize_initial_absence_check)
+
+    def log_memory(index):
+        record = MemoryRecord(
+            type="fact",
+            title=f"concurrent-{index}",
+            content=f"payload-{index}",
+            agent_id="agent-race",
+            actor_id="agent-race",
+            source="agent",
+            created_at=datetime(2026, 7, 20, 12, 0, index),
+        )
+        service.log_memory_to_session_summary(
+            agent_id="agent-race",
+            session_id="sess-race",
+            memory_record=record,
+            memory_id=f"mem-{index}",
+        )
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        list(executor.map(log_memory, range(worker_count)))
+
+    summary_file = service.sessions_dir / "agent-race_2026-07-20_sess-race_summary.md"
+    summary = summary_file.read_text(encoding="utf-8")
+
+    assert summary.count("# Session Summary for agent-race") == 1
+    for index in range(worker_count):
+        assert summary.count(f"### [2026-07-20 12:00:0{index}]") == 1
+        assert summary.count(f"`mem-{index}`") == 1


### PR DESCRIPTION
## Summary
- serialize session-summary header creation and appends through the shared SessionService
- build each memory/deletion entry before entering the critical section and write it as one record
- add a deterministic eight-worker regression for the first-write race

## Bug
Memory API routes dispatch summary logging through asyncio.to_thread. Previously, every worker checked whether the summary existed and then issued many independent append writes. Concurrent first writes could all observe a missing file, duplicate its header, and interleave record fields. These summaries feed daily analysis and conflict detection, so the race can corrupt the local history even when the remote memory writes succeeded.

The regression synchronizes eight concurrent first-existence checks against unpatched main. It fails there with five duplicated headers in the reproduced run; the same test passes with this patch.

## Tests
- uv run ruff check memanto/app/services/session_service.py tests/test_session_summary_concurrency.py
- uv run mypy memanto/app/services/session_service.py
- uv run pytest -q (all tests pass; 24 live E2E tests skipped because no real Moorcheh API key is configured)

## Social field report
- https://x.com/TurboNexic/status/2079352402595995801