### PR TITLE
fix: return union for multi-type recall

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -113,17 +113,31 @@ class MemoryReadService:
             if not namespaces:
                 return {"results": [], "total_found": 0, "execution_time": 0}
 
-            # Build enhanced query with Moorcheh metadata filters
-            enhanced_query = self._build_filtered_query(
-                query=query,
-                type=type,
-                tags=tags,
-                min_confidence=min_confidence,
-                status_filter=status_filter,
-                created_after=created_after,
-                created_before=created_before,
-                metadata_filters=metadata_filters,
+            # Moorcheh combines repeated exact-match filters. A document cannot
+            # satisfy both ``#memory_type:fact`` and
+            # ``#memory_type:preference``, so a list of requested types must be
+            # issued as one search per type and merged as a union. Build every
+            # query before dispatch so an invalid later type cannot trigger a
+            # partial set of backend calls.
+            distinct_types = list(dict.fromkeys(type or []))
+            type_variants: list[list[str] | None] = (
+                [[memory_type] for memory_type in distinct_types]
+                if len(distinct_types) > 1
+                else [distinct_types or None]
             )
+            enhanced_queries = [
+                self._build_filtered_query(
+                    query=query,
+                    type=type_variant,
+                    tags=tags,
+                    min_confidence=min_confidence,
+                    status_filter=status_filter,
+                    created_after=created_after,
+                    created_before=created_before,
+                    metadata_filters=metadata_filters,
+                )
+                for type_variant in type_variants
+            ]
 
             # Build query parameters
             # Request extra results to handle offset (Moorcheh doesn't have native offset support)
@@ -150,18 +164,50 @@ class MemoryReadService:
             # threshold; min_similarity=0.0 means "no filter", but on-prem
             # kiosk_mode + threshold=0.0 still filters everything out.
             use_kiosk = min_similarity_score is not None and min_similarity_score > 0
-            search_result = self.client.similarity_search.query(
-                query=enhanced_query,
-                namespaces=namespaces,
-                top_k=top_k,
-                threshold=min_similarity_score if use_kiosk else None,
-                kiosk_mode=use_kiosk,
-            )
-
-            search_items = search_result.get("results", [])
+            search_items: list[Any] = []
+            execution_time = 0.0
+            for enhanced_query in enhanced_queries:
+                search_result = self.client.similarity_search.query(
+                    query=enhanced_query,
+                    namespaces=namespaces,
+                    top_k=top_k,
+                    threshold=min_similarity_score if use_kiosk else None,
+                    kiosk_mode=use_kiosk,
+                )
+                search_items.extend(search_result.get("results", []))
+                try:
+                    execution_time += float(search_result.get("execution_time", 0))
+                except (TypeError, ValueError):
+                    pass
 
             # Format results
             all_results = [self._format_memory_item(item) for item in search_items]
+
+            if len(enhanced_queries) > 1:
+                # Scores from the per-type searches share the same backend
+                # scale. Re-rank the union before applying offset/limit and
+                # de-duplicate defensively in case malformed metadata causes a
+                # row to be returned by more than one variant.
+                def _score(memory: dict[str, Any]) -> float:
+                    raw_score = memory.get("score")
+                    if raw_score is None:
+                        return float("-inf")
+                    try:
+                        return float(raw_score)
+                    except (TypeError, ValueError):
+                        return float("-inf")
+
+                all_results.sort(key=_score, reverse=True)
+                unique_results: list[dict[str, Any]] = []
+                seen_ids: set[Any] = set()
+                for memory in all_results:
+                    memory_id = memory.get("id")
+                    if memory_id is not None and memory_id in seen_ids:
+                        continue
+                    if memory_id is not None:
+                        seen_ids.add(memory_id)
+                    unique_results.append(memory)
+                all_results = unique_results
 
             # Apply temporal filtering (post-processing since Moorcheh metadata filters are string-based)
             if created_after or created_before:
@@ -191,8 +237,8 @@ class MemoryReadService:
                 "limit": limit,
                 "has_more": has_more,
                 "query": query,
-                "enhanced_query": enhanced_query,
-                "execution_time": search_result.get("execution_time", 0),
+                "enhanced_query": " OR ".join(enhanced_queries),
+                "execution_time": execution_time,
             }
 
         except Exception as e:

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -3,6 +3,7 @@ Memory Read Service
 """
 
 import re
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
@@ -164,16 +165,36 @@ class MemoryReadService:
             # threshold; min_similarity=0.0 means "no filter", but on-prem
             # kiosk_mode + threshold=0.0 still filters everything out.
             use_kiosk = min_similarity_score is not None and min_similarity_score > 0
+
+            def _dispatch(enhanced_query: str) -> dict[str, Any]:
+                """Run one exact-filter search with the shared request options."""
+                return cast(
+                    dict[str, Any],
+                    self.client.similarity_search.query(
+                        query=enhanced_query,
+                        namespaces=namespaces,
+                        top_k=top_k,
+                        threshold=min_similarity_score if use_kiosk else None,
+                        kiosk_mode=use_kiosk,
+                    ),
+                )
+
+            if len(enhanced_queries) == 1:
+                search_results = [_dispatch(enhanced_queries[0])]
+            else:
+                # The variants are independent network calls. Dispatch them in
+                # parallel so the latency of a multi-type union is bounded by
+                # the slowest search rather than the sum of every round trip.
+                # pool.map preserves enhanced-query order for deterministic
+                # result aggregation while capping concurrency for direct
+                # service callers that pass every supported type.
+                max_workers = min(len(enhanced_queries), 8)
+                with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                    search_results = list(pool.map(_dispatch, enhanced_queries))
+
             search_items: list[Any] = []
             execution_time = 0.0
-            for enhanced_query in enhanced_queries:
-                search_result = self.client.similarity_search.query(
-                    query=enhanced_query,
-                    namespaces=namespaces,
-                    top_k=top_k,
-                    threshold=min_similarity_score if use_kiosk else None,
-                    kiosk_mode=use_kiosk,
-                )
+            for search_result in search_results:
                 search_items.extend(search_result.get("results", []))
                 try:
                     execution_time += float(search_result.get("execution_time", 0))
@@ -189,6 +210,7 @@ class MemoryReadService:
                 # de-duplicate defensively in case malformed metadata causes a
                 # row to be returned by more than one variant.
                 def _score(memory: dict[str, Any]) -> float:
+                    """Return a sortable backend score, placing missing values last."""
                     raw_score = memory.get("score")
                     if raw_score is None:
                         return float("-inf")

--- a/tests/test_memory_read_multi_type.py
+++ b/tests/test_memory_read_multi_type.py
@@ -1,0 +1,105 @@
+"""Regression coverage for union semantics in multi-type recall."""
+
+import re
+
+import pytest
+
+from memanto.app.services.memory_read_service import MemoryReadService
+from memanto.app.utils.errors import MemoryError
+
+
+def _memory(memory_id: str, memory_type: str, score: float) -> dict:
+    return {
+        "id": memory_id,
+        "text": f"[{memory_type.upper()}] {memory_id}\n\n{memory_id} content",
+        "memory_type": memory_type,
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "active",
+        "created_at": "2026-07-20T00:00:00Z",
+        "updated_at": "2026-07-20T00:00:00Z",
+        "score": score,
+    }
+
+
+class _ExactFilterSearch:
+    """Minimal Moorcheh filter semantics: repeated clauses are conjunctive."""
+
+    def __init__(self, rows: list[dict]):
+        self.rows = rows
+        self.queries: list[str] = []
+
+    def query(self, **kwargs):
+        query = kwargs["query"]
+        self.queries.append(query)
+        requested_types = re.findall(r"#memory_type:([A-Za-z0-9_.-]+)", query)
+        results = [
+            row
+            for row in self.rows
+            if all(row["memory_type"] == value for value in requested_types)
+        ]
+        return {"results": results[: kwargs["top_k"]], "execution_time": 0.01}
+
+
+class _Client:
+    def __init__(self, rows: list[dict]):
+        self.similarity_search = _ExactFilterSearch(rows)
+
+
+def test_multi_type_recall_queries_each_type_and_returns_ranked_union():
+    client = _Client(
+        [
+            _memory("fact-low", "fact", 0.70),
+            _memory("preference-high", "preference", 0.95),
+            _memory("instruction-excluded", "instruction", 0.99),
+        ]
+    )
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="project context",
+        agent_id="agent-1",
+        type=["fact", "preference"],
+        limit=10,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == [
+        "preference-high",
+        "fact-low",
+    ]
+    assert client.similarity_search.queries == [
+        "project context #memory_type:fact",
+        "project context #memory_type:preference",
+    ]
+
+
+def test_duplicate_type_does_not_issue_duplicate_backend_search():
+    client = _Client([_memory("fact", "fact", 0.8)])
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="project context",
+        agent_id="agent-1",
+        type=["fact", "fact"],
+        limit=10,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["fact"]
+    assert client.similarity_search.queries == ["project context #memory_type:fact"]
+
+
+def test_invalid_later_type_is_rejected_before_any_backend_search():
+    client = _Client([_memory("fact", "fact", 0.8)])
+    service = MemoryReadService(client)
+
+    with pytest.raises(MemoryError, match="Invalid memory_type"):
+        service.search_memories(
+            query="project context",
+            agent_id="agent-1",
+            type=["fact", "not-a-type"],
+            limit=10,
+        )
+
+    assert client.similarity_search.queries == []

--- a/tests/test_memory_read_multi_type.py
+++ b/tests/test_memory_read_multi_type.py
@@ -1,6 +1,7 @@
 """Regression coverage for union semantics in multi-type recall."""
 
 import re
+import threading
 
 import pytest
 
@@ -9,6 +10,7 @@ from memanto.app.utils.errors import MemoryError
 
 
 def _memory(memory_id: str, memory_type: str, score: float) -> dict:
+    """Build one formatted backend row for a memory type."""
     return {
         "id": memory_id,
         "text": f"[{memory_type.upper()}] {memory_id}\n\n{memory_id} content",
@@ -28,10 +30,12 @@ class _ExactFilterSearch:
     """Minimal Moorcheh filter semantics: repeated clauses are conjunctive."""
 
     def __init__(self, rows: list[dict]):
+        """Retain candidate rows and a trace of dispatched queries."""
         self.rows = rows
         self.queries: list[str] = []
 
     def query(self, **kwargs):
+        """Apply every exact type filter to the in-memory rows."""
         query = kwargs["query"]
         self.queries.append(query)
         requested_types = re.findall(r"#memory_type:([A-Za-z0-9_.-]+)", query)
@@ -44,11 +48,34 @@ class _ExactFilterSearch:
 
 
 class _Client:
+    """Expose the fake search surface expected by MemoryReadService."""
+
     def __init__(self, rows: list[dict]):
+        """Initialize a client with exact-filter search behavior."""
         self.similarity_search = _ExactFilterSearch(rows)
 
 
+class _BarrierSearch:
+    """Require two type searches to overlap before either can complete."""
+
+    def __init__(self, rows: list[dict]):
+        """Initialize candidate rows and a two-party synchronization barrier."""
+        self.rows = rows
+        self.barrier = threading.Barrier(2)
+
+    def query(self, **kwargs):
+        """Fail deterministically if the two searches run sequentially."""
+        requested_type = re.search(r"#memory_type:([A-Za-z0-9_.-]+)", kwargs["query"])
+        assert requested_type is not None
+        self.barrier.wait(timeout=5)
+        results = [
+            row for row in self.rows if row["memory_type"] == requested_type.group(1)
+        ]
+        return {"results": results, "execution_time": 0.01}
+
+
 def test_multi_type_recall_queries_each_type_and_returns_ranked_union():
+    """Multi-type recall returns the score-ranked union of requested types."""
     client = _Client(
         [
             _memory("fact-low", "fact", 0.70),
@@ -69,13 +96,40 @@ def test_multi_type_recall_queries_each_type_and_returns_ranked_union():
         "preference-high",
         "fact-low",
     ]
-    assert client.similarity_search.queries == [
-        "project context #memory_type:fact",
-        "project context #memory_type:preference",
-    ]
+    assert sorted(client.similarity_search.queries) == sorted(
+        [
+            "project context #memory_type:fact",
+            "project context #memory_type:preference",
+        ]
+    )
+
+
+def test_multi_type_searches_run_concurrently():
+    """Independent exact-type searches overlap instead of adding their latency."""
+    client = _Client([])
+    client.similarity_search = _BarrierSearch(
+        [
+            _memory("fact", "fact", 0.8),
+            _memory("preference", "preference", 0.9),
+        ]
+    )
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="project context",
+        agent_id="agent-1",
+        type=["fact", "preference"],
+        limit=10,
+    )
+
+    assert {memory["id"] for memory in result["results"]} == {
+        "fact",
+        "preference",
+    }
 
 
 def test_duplicate_type_does_not_issue_duplicate_backend_search():
+    """Repeated input types collapse to one backend query."""
     client = _Client([_memory("fact", "fact", 0.8)])
     service = MemoryReadService(client)
 
@@ -91,6 +145,7 @@ def test_duplicate_type_does_not_issue_duplicate_backend_search():
 
 
 def test_invalid_later_type_is_rejected_before_any_backend_search():
+    """Validation completes before any query is dispatched."""
     client = _Client([_memory("fact", "fact", 0.8)])
     service = MemoryReadService(client)
 


### PR DESCRIPTION
## Summary  Fixes a recall-accuracy bug in the multi-type filter accepted by the v2 recall API. A request such as `type=[fact, preference]` was serialized into one Moorcheh query containing both `#memory_type:fact` and `#memory_type:preference`. Exact metadata filters are combined, so no single memory can satisfy the mutually exclusive clauses and relevant memories disappear from recall.  Addresses #770.  ## Reproduction  The new deterministic regression uses a minimal backend fake with Moorcheh's conjunctive exact-filter semantics:  1. Store one `fact`, one `preference`, and one higher-scoring excluded `instruction` result. 2. Call `search_memories(..., type=[fact, preference])`. 3. Before this fix, Memanto emits one impossible query:     ```text    project context #memory_type:fact #memory_type:preference    ```     The result is empty even though both requested types are available. 4. With the fix, Memanto issues one exact query per requested type, merges the two result sets, re-ranks them by backend score, de-duplicates IDs, and returns both requested memories while excluding the instruction.  The tests also prove that duplicate type values do not cause duplicate backend work and that an invalid later type is rejected before any partial search is sent.  ## Impact  The public request schema intentionally accepts a list of memory types, but multi-type semantic recall could silently omit all requested memories. This is timeline/context amnesia in a core read path and can make agents answer without facts or preferences that are present in storage.  ## Fix  - Validate and de-duplicate all requested types before dispatch. - Preserve the existing single-query path for zero or one type. - For multiple types, run one filtered search per type. - Merge, score-sort, and de-duplicate the union before existing temporal, TTL, confidence, and pagination processing. - Aggregate backend execution timing and retain a readable enhanced-query trace.  ## Validation  - Full suite: all non-live tests passed; 24 live Moorcheh E2E tests skipped because no real API key is configured. - Focused regression and read-filter suites passed. - Ruff lint passed. - Ruff format check passed. - MyPy passed for `memory_read_service.py`. - `git diff --check` passed.    <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
* **Bug Fixes**
  * Improved memory recall when multiple memory types are requested by running type-specific searches and merging results.
  * Preserved relevance ranking by re-ranking combined results and removing duplicates.
  * Prevented duplicate backend searches when the same memory type is requested multiple times.
  * Added validation so invalid memory types are rejected before any search is executed.
* **Tests**
  * Added regression coverage for multi-type recall, deduplication, validation, and concurrent execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

## Social field report

https://x.com/TurboNexic/status/2079420719004291469
