### PR TITLE
fix: classify negated preferences as preferences

### DIFF
--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -56,6 +56,20 @@ class MemoryParsingService:
             MemoryRule(re.compile(pattern, re.IGNORECASE), score)
             for pattern, score in [
                 (
+                    r"\b(?:i|we|they|he|she|user|client|customer)\s+"
+                    r"(?:really\s+)?"
+                    r"(?:(?:do|does|did)\s+not|don['’]t|doesn['’]t|didn['’]t|"
+                    r"no longer|never)\s+(?:really\s+)?"
+                    r"(?:like(?:d)?|love(?:d)?|prefer(?:red)?|enjoy(?:ed)?|favou?r(?:ed)?)\b",
+                    6,
+                ),
+                (
+                    r"\b(?:i|we|they|he|she|user|client|customer)\s+"
+                    r"(?:can['’]t|cannot)\s+stand\b",
+                    6,
+                ),
+                (r"\b(?:prefer|prefers)\s+not\s+to\b", 5),
+                (
                     r"\b(?:i|we|they|he|she|user|client|customer)\s+(?:really\s+)?(?:like|likes|love|loves|prefer|prefers|enjoy|enjoys|favor|favors)\b",
                     4,
                 ),

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -31,6 +31,39 @@ def test_detect_preference():
     assert memory.type == "preference"
 
 
+def test_detect_negated_preferences_instead_of_instructions():
+    parser = MemoryParsingService()
+
+    cases = [
+        "I don't like Python",
+        "I really don't like JavaScript",
+        "I do not like dark mode",
+        "We don’t enjoy weekly meetings",
+        "She doesn't prefer email",
+        "I no longer like Vim",
+        "I never liked Vim",
+        "They can't stand noisy notifications",
+        "The client prefers not to receive phone calls",
+    ]
+
+    for content in cases:
+        memory = make_memory(content)
+
+        parser.parse_memory(memory)
+
+        assert memory.type == "preference", content
+
+
+def test_negative_imperative_remains_an_instruction():
+    parser = MemoryParsingService()
+
+    memory = make_memory("Don't deploy unpinned dependencies in production")
+
+    parser.parse_memory(memory)
+
+    assert memory.type == "instruction"
+
+
 # 2 Do NOT override existing type
 def test_no_override_existing_type():
     parser = MemoryParsingService()


### PR DESCRIPTION
## Summary

Fix auto-classification of negated user preferences so they remain retrievable as `preference` memories instead of being mislabeled as `instruction` or falling back to `fact`.

## Flaw and impact

The generic instruction rule treats `do not` / `don't` as an instruction signal. The preference rules only recognized affirmative wording, so common durable preferences were classified incorrectly:

| Input | Before | After |
| --- | --- | --- |
| `I don't like Python` | `instruction` | `preference` |
| `I do not like dark mode` | `instruction` | `preference` |
| `I no longer like Vim` | `fact` | `preference` |

Because memory type is embedded at write time, these records disappear from preference-filtered recall and downstream preference views even though their meaning is unambiguously a user preference.

## Reproduction

```python
from typing import Any, cast

from memanto.app.core import MemoryRecord
from memanto.app.services.memory_parsing_service import MemoryParsingService

memory = MemoryRecord(
    content="I don't like Python",
    type="fact",
    title="preference",
    actor_id="user",
    source="test",
    agent_id="agent",
)
cast(Any, memory).type = None

MemoryParsingService().parse_memory(memory)
print(memory.type)  # before: instruction; after: preference
```

## Fix

- Add high-confidence negated-preference rules for `do/does/did not`, straight and curly apostrophe contractions, `no longer`, `never`, `can't stand`, and `prefer not to`.
- Let those specific subject-plus-preference signals outrank the generic negative-instruction keyword.
- Keep true imperatives such as `Don't deploy unpinned dependencies in production` classified as `instruction`.

## Verification

- Full pytest suite passes; only the 24 live Moorcheh tests requiring a real API key are skipped.
- `ruff check .`
- `ruff format --check .`
- `mypy memanto`
- `git diff --check`

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of negative preference statements, including ?don?t like,? ?prefer not,? and ?can?t stand.?
  * Prevented negative commands, such as ?Don?t deploy,? from being incorrectly classified as preferences.

* **Tests**
  * Added coverage for distinguishing negated preferences from instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Public field report

- X: https://x.com/TurboNexic/status/2079429190462349702
