### PR TITLE
fix: keep busy-day summaries within embedding context

### DIFF
--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -27,6 +27,12 @@ class DailyAnalysisService:
     daily AI summary and the conflict report.
     """
 
+    # ``answer.generate`` embeds the query before retrieval. Keep the daily
+    # session digest below the default on-prem embedding model's 2048-token
+    # context window while passing the complete source text to the LLM through
+    # ``header_prompt``.
+    _MAX_SUMMARY_QUERY_CHARS = 6_000
+
     def __init__(
         self,
         sessions_dir: Path | None = None,
@@ -80,13 +86,15 @@ class DailyAnalysisService:
         client = get_moorcheh_client()
         namespace = agent_namespace(agent_id)
 
-        summary_prompt = f"""
+        header_prompt = f"""
 Summarize the following session memories from {date} into a concise natural language daily summary.
 Focus on key themes, accomplishments, and high-level activities.
 
 Sessions Content:
 {full_text}
+"""
 
+        footer_prompt = f"""
 Format the output as a Markdown report:
 # Daily Summary for {agent_id} - {date}
 **Generated at:** {format_current_local_time()}
@@ -96,11 +104,14 @@ Format the output as a Markdown report:
 ## Key Themes & Activities
 ...
 """
+        retrieval_query = full_text[: self._MAX_SUMMARY_QUERY_CHARS]
         try:
             generate_kwargs: dict[str, Any] = {
                 "namespace": namespace,
-                "query": summary_prompt,
+                "query": retrieval_query,
                 "top_k": 50,
+                "header_prompt": header_prompt,
+                "footer_prompt": footer_prompt,
             }
             ai_model = get_active_llm_model(settings.SUMMARY_MODEL)
             if ai_model is not None:

--- a/tests/test_daily_summary_query_length.py
+++ b/tests/test_daily_summary_query_length.py
@@ -58,8 +58,9 @@ def test_short_day_summary_preserves_session_text_as_retrieval_query(
     short_content = "Decision: ship the authentication change on Friday."
     service, client = _make_summary_service(tmp_path, monkeypatch, short_content)
 
-    service.generate_summary("agent-1", "2026-06-28")
+    result = service.generate_summary("agent-1", "2026-06-28")
 
+    assert result["status"] == "success"
     call_kwargs = client.answer.generate.call_args.kwargs
     assert call_kwargs["query"] == short_content
     assert call_kwargs["ai_model"] == "test-model"

--- a/tests/test_daily_summary_query_length.py
+++ b/tests/test_daily_summary_query_length.py
@@ -1,0 +1,65 @@
+"""Regression coverage for daily-summary embedding context overflow."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from memanto.app.services import daily_analysis_service as module
+
+
+def _make_summary_service(tmp_path, monkeypatch, session_content: str):
+    sessions_dir = tmp_path / "sessions"
+    summaries_dir = tmp_path / "summaries"
+    sessions_dir.mkdir()
+    (sessions_dir / "agent-1_2026-06-28_001_summary.md").write_text(
+        session_content,
+        encoding="utf-8",
+    )
+
+    client = MagicMock()
+
+    def reject_oversized_embedding_query(**kwargs):
+        query = kwargs["query"]
+        if len(query) > 6_000:
+            raise RuntimeError("embedding input exceeds context length")
+        return {"answer": "# Daily Summary"}
+
+    client.answer.generate.side_effect = reject_oversized_embedding_query
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: "test-model")
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=summaries_dir,
+    )
+    return service, client
+
+
+def test_busy_day_summary_keeps_embedded_query_within_context_window(
+    tmp_path, monkeypatch
+):
+    """Long session content must not be sent as an oversized embedding query."""
+    long_content = "Important decision: use PostgreSQL for the project. " * 300
+    service, client = _make_summary_service(tmp_path, monkeypatch, long_content)
+
+    result = service.generate_summary("agent-1", "2026-06-28")
+
+    assert result["status"] == "success"
+    call_kwargs = client.answer.generate.call_args.kwargs
+    assert len(call_kwargs["query"]) <= 6_000
+    assert long_content in call_kwargs["header_prompt"]
+    assert "Format the output as a Markdown report" in call_kwargs["footer_prompt"]
+
+
+def test_short_day_summary_preserves_session_text_as_retrieval_query(
+    tmp_path, monkeypatch
+):
+    """Short inputs should retain their full content for relevant retrieval."""
+    short_content = "Decision: ship the authentication change on Friday."
+    service, client = _make_summary_service(tmp_path, monkeypatch, short_content)
+
+    service.generate_summary("agent-1", "2026-06-28")
+
+    call_kwargs = client.answer.generate.call_args.kwargs
+    assert call_kwargs["query"] == short_content
+    assert call_kwargs["ai_model"] == "test-model"


### PR DESCRIPTION
## Summary

Prevent busy-day daily summaries from failing when the session text exceeds the embedding model's context window.

## Flaw and impact

`DailyAnalysisService.generate_summary()` concatenates every session summary for the requested day, the summarization instructions, and the Markdown output scaffold into `answer.generate(query=...)`. Moorcheh embeds `query` before retrieval, so a sufficiently active day exceeds the default on-prem `nomic-embed-text` 2,048-token context window and the summary endpoint fails before the LLM can summarize anything.

This is the same backend constraint documented for conflict detection in #1329, but it affects the independent daily-summary path. PR #1539 changes conflict detection only; it leaves `generate_summary()` unchanged.

The regression uses a deterministic fake backend that rejects embedded queries over 6,000 characters. Current `main` raises:

```text
MemoryError: AI summarization failed: embedding input exceeds context length
```

## Fix

- Keep the embedded retrieval query to a conservative 6,000-character session digest.
- Move the complete session text and summarization instructions to `header_prompt`, which reaches the LLM without being embedded.
- Move the Markdown output contract to `footer_prompt`.
- Preserve the full session content for the LLM and preserve short-day retrieval behavior exactly.

## Verification

- New regressions prove a busy day completes without an oversized embedding query.
- New regressions prove the complete session text remains in the LLM prompt.
- New regressions prove short session text remains the exact retrieval query.
- Full pytest suite passes; only the 24 live Moorcheh E2Es requiring a real API key are skipped.
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `git diff --check`

Refs #770. Related to #1329.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily summary generation for days with lengthy session content.
  * Limited the size of retrieval/query text to avoid context-length issues while still including full source content in the prompts.
  * Kept Markdown report formatting instructions intact and preserved session text correctly for shorter days.
* **Tests**
  * Added regression coverage to ensure the retrieval query is capped (long days) and matches the original session text (short days).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Social field report

https://x.com/TurboNexic/status/2079433707669139619
