### PR TITLE
fix: enforce Python client query guards

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1191,8 +1191,7 @@ class DirectClient:
         # Ensure there is a valid, non-expired session for this agent
         session = self._get_validated_session_for_agent(agent_id)
 
-        if not question or not question.strip():
-            raise ValueError("Question must be a non-empty string")
+        self._validate_query(question, limit)
 
         # get namespace from session
         namespace = session.namespace
@@ -1755,4 +1754,9 @@ class DirectClient:
         """Validate search parameters."""
         if not query or not query.strip():
             raise ValueError("Search query must be a non-empty string")
+        if len(query) > InputLimits.MAX_QUERY_LENGTH:
+            raise ValueError(
+                f"Query must be at most {InputLimits.MAX_QUERY_LENGTH} characters, "
+                f"got {len(query)}"
+            )
         validate_recall_limit(limit)

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1064,8 +1064,7 @@ class SdkClient:
         # Ensure there is a valid, non-expired session for this agent
         session = self._get_validated_session_for_agent(agent_id)
 
-        if not question or not question.strip():
-            raise ValueError("Question must be a non-empty string")
+        self._validate_query(question, limit)
 
         # get namespace from session
         namespace = session.namespace
@@ -1615,4 +1614,9 @@ class SdkClient:
         """Validate search parameters."""
         if not query or not query.strip():
             raise ValueError("Search query must be a non-empty string")
+        if len(query) > InputLimits.MAX_QUERY_LENGTH:
+            raise ValueError(
+                f"Query must be at most {InputLimits.MAX_QUERY_LENGTH} characters, "
+                f"got {len(query)}"
+            )
         validate_recall_limit(limit)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -802,6 +802,116 @@ class TestMEMANTOCLI:
         read_service.search_as_of.assert_not_called()
         read_service.search_changed_since.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "client_class_path",
+        [
+            "memanto.cli.client.direct_client.DirectClient",
+            "memanto.cli.client.sdk_client.SdkClient",
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("method_name", "query_arg"),
+        [("recall", "query"), ("answer", "question")],
+    )
+    def test_python_query_paths_reject_oversized_input_before_backend(
+        self, client_class_path, method_name, query_arg
+    ):
+        """Python clients must enforce the same query-size guard as REST."""
+        from memanto.app.utils.validation import InputLimits
+
+        module_name, class_name = client_class_path.rsplit(".", 1)
+        module = __import__(module_name, fromlist=[class_name])
+        client_class = getattr(module, class_name)
+        client = client_class.__new__(client_class)
+        read_service = MagicMock()
+        moorcheh = MagicMock()
+        session = MagicMock(namespace="memanto_agent_test-agent")
+
+        answer_config = {
+            "answer_limit": 5,
+            "temperature": 0.7,
+            "model": "test-model",
+            "kiosk_mode": False,
+            "threshold": 0.15,
+        }
+        recall_config = {"limit": 10, "min_similarity": None}
+
+        with (
+            patch.object(
+                client_class,
+                "_get_validated_session_for_agent",
+                return_value=session,
+            ),
+            patch.object(client_class, "_get_read_service", return_value=read_service),
+            patch.object(client_class, "_get_moorcheh", return_value=moorcheh),
+            patch.object(
+                module.ConfigManager,
+                "get_answer_config",
+                return_value=answer_config,
+            ),
+            patch.object(
+                module.ConfigManager,
+                "get_recall_config",
+                return_value=recall_config,
+            ),
+        ):
+            with pytest.raises(ValueError, match="Query must be at most"):
+                getattr(client, method_name)(
+                    agent_id="test-agent",
+                    **{query_arg: "x" * (InputLimits.MAX_QUERY_LENGTH + 1)},
+                )
+
+        read_service.search_memories.assert_not_called()
+        moorcheh.answer.generate.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "client_class_path",
+        [
+            "memanto.cli.client.direct_client.DirectClient",
+            "memanto.cli.client.sdk_client.SdkClient",
+        ],
+    )
+    @pytest.mark.parametrize("bad_limit", [0, 101, 1.5, "10", True])
+    def test_python_answer_rejects_invalid_limit_before_backend(
+        self, client_class_path, bad_limit
+    ):
+        """Answer must not forward malformed or unbounded ``top_k`` values."""
+        module_name, class_name = client_class_path.rsplit(".", 1)
+        module = __import__(module_name, fromlist=[class_name])
+        client_class = getattr(module, class_name)
+        client = client_class.__new__(client_class)
+        moorcheh = MagicMock()
+        session = MagicMock(namespace="memanto_agent_test-agent")
+        answer_config = {
+            "answer_limit": 5,
+            "temperature": 0.7,
+            "model": "test-model",
+            "kiosk_mode": False,
+            "threshold": 0.15,
+        }
+
+        with (
+            patch.object(
+                client_class,
+                "_get_validated_session_for_agent",
+                return_value=session,
+            ),
+            patch.object(client_class, "_get_moorcheh", return_value=moorcheh),
+            patch.object(
+                module.ConfigManager,
+                "get_answer_config",
+                return_value=answer_config,
+            ),
+        ):
+            with pytest.raises(ValueError, match="Limit must be an integer"):
+                client.answer(
+                    agent_id="test-agent",
+                    question="What should I remember?",
+                    limit=bad_limit,
+                )
+
+        moorcheh.answer.generate.assert_not_called()
+
     def test_forget_force(self, mock_all_clients):
         """Test 'memanto forget --force' deletes a memory without prompting."""
         mock_all_clients.delete_memory.return_value = {


### PR DESCRIPTION
## Summary

Enforce Memanto's existing query-size and result-count guards in both Python client implementations.

Addresses #770.

## Flaw and impact

The REST recall and answer endpoints reject questions over 1,000 characters and bound retrieval counts to 1–100. `DirectClient` and `SdkClient` did not enforce the same contract:

- recall accepted and forwarded oversized queries;
- answer accepted and forwarded oversized questions;
- answer accepted malformed or unbounded `limit` values such as `0`, `101`, `1.5`, `"10"`, and `True`.

That bypassed Memanto's local cost guard and allowed invalid `top_k` values or embedding/RAG inputs to cross the backend boundary, producing avoidable backend failures and potentially expensive requests.

## Root cause

Both clients already shared `_validate_query()` for recall, but that helper checked only blank input and the recall limit. The answer paths performed only their own blank-question check and never called the shared limit validator.

## Fix

- Extend `_validate_query()` in both clients to enforce `InputLimits.MAX_QUERY_LENGTH`.
- Route both answer implementations through that same validator.
- Add deterministic coverage for DirectClient and SdkClient across recall and answer.
- Prove that all rejected inputs fail before either storage search or Moorcheh answer generation is called.

## Validation

- Complete non-live test suite passed; 24 live Moorcheh E2E tests skipped because no real API key is configured.
- 14 focused regression cases passed.
- Ruff check passed.
- Ruff format check passed.
- MyPy passed for both client modules.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject queries exceeding the maximum allowed length.
  * Standardized validation for questions and result limits across client implementations.
  * Invalid inputs are now rejected before requests are sent to underlying services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->