### PR TITLE
fix(okf): isolate export caches by backend

### DIFF
--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 
+from memanto.app.config import get_data_dir
 from memanto.app.services.memory_export_service import MEMORY_TYPE_ORDER
 from memanto.app.utils.validation import validate_output_path, validate_safe_id
 
@@ -53,7 +54,7 @@ class OkfExportService:
     """Formats and writes an OKF bundle for an agent."""
 
     def __init__(self, exports_dir: Path | None = None):
-        self.exports_dir = exports_dir or (Path.home() / ".memanto" / "exports")
+        self.exports_dir = exports_dir or (get_data_dir() / "exports")
 
     # Public API
     def write_okf_bundle(
@@ -83,7 +84,7 @@ class OkfExportService:
             agent_id: Agent identifier.
             memories_by_type: Dict mapping memory type -> list of memory dicts.
             output_dir: Custom bundle directory. Defaults to
-                ``~/.memanto/exports/{agent_id}_okf``.
+                the active backend's ``exports/{agent_id}_okf`` directory.
             split: Layout mode — ``auto``, ``file``, or ``type``.
             threshold: Per-type memory count above which ``auto`` collapses to a
                 single stacked file.

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1635,7 +1635,7 @@ class DirectClient:
         Args:
             agent_id: Target agent.
             output_dir: Bundle directory. Defaults to
-                ``~/.memanto/exports/{agent_id}_okf``.
+                the active backend's ``exports/{agent_id}_okf`` directory.
             split: OKF layout — ``auto``, ``file``, or ``type``.
             limit_per_type: Max memories per type (default 25).
 
@@ -1675,8 +1675,10 @@ class DirectClient:
         project. Falls back to the previous cached bundle when the backend is
         unreachable (``source="stale-cache"``).
         """
+        from memanto.app.config import get_data_dir
+
         target = Path(project_dir) / "okf"
-        cache = Path.home() / ".memanto" / "exports" / f"{agent_id}_okf"
+        cache = get_data_dir() / "exports" / f"{agent_id}_okf"
 
         try:
             result = self.export_okf_bundle(

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1495,7 +1495,7 @@ class SdkClient:
         Args:
             agent_id: Target agent.
             output_dir: Bundle directory. Defaults to
-                ``~/.memanto/exports/{agent_id}_okf``.
+                the active backend's ``exports/{agent_id}_okf`` directory.
             split: OKF layout — ``auto``, ``file``, or ``type``.
             limit_per_type: Max memories per type (default 25).
 
@@ -1535,8 +1535,10 @@ class SdkClient:
         project. Falls back to the previous cached bundle when the backend is
         unreachable (``source="stale-cache"``).
         """
+        from memanto.app.config import get_data_dir
+
         target = Path(project_dir) / "okf"
-        cache = Path.home() / ".memanto" / "exports" / f"{agent_id}_okf"
+        cache = get_data_dir() / "exports" / f"{agent_id}_okf"
 
         try:
             result = self.export_okf_bundle(

--- a/tests/test_okf_backend_isolation.py
+++ b/tests/test_okf_backend_isolation.py
@@ -1,0 +1,88 @@
+"""Regression coverage for backend-isolated OKF exports and sync caches."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import memanto.app.config as app_config
+import memanto.cli.client.direct_client as direct_mod
+import memanto.cli.client.sdk_client as sdk_mod
+from memanto.app.services.okf_export_service import OkfExportService
+
+
+def _memory(title: str, content: str) -> dict:
+    return {
+        "id": title.lower().replace(" ", "-"),
+        "title": title,
+        "content": content,
+        "confidence": 0.9,
+        "provenance": "explicit_statement",
+        "source": "user",
+        "status": "active",
+    }
+
+
+def _write_cached_bundle(exports_dir, agent_id: str, title: str, content: str):
+    return OkfExportService(exports_dir=exports_dir).write_okf_bundle(
+        agent_id=agent_id,
+        memories_by_type={"fact": [_memory(title, content)]},
+        split="file",
+    )
+
+
+def test_default_okf_export_uses_active_backend_data_dir(tmp_path, monkeypatch):
+    """On-prem exports must not overwrite the same agent's cloud bundle."""
+    monkeypatch.setattr(app_config.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(app_config.settings, "MEMANTO_BACKEND", "on-prem")
+
+    result = OkfExportService().write_okf_bundle(
+        agent_id="shared-agent",
+        memories_by_type={"fact": [_memory("On-prem fact", "local-only")]},
+        split="file",
+    )
+
+    expected = tmp_path / ".memanto" / "on-prem" / "exports" / "shared-agent_okf"
+    assert result["output_path"] == str(expected.resolve())
+    assert expected.exists()
+    assert not (tmp_path / ".memanto" / "exports" / "shared-agent_okf").exists()
+
+
+@pytest.mark.parametrize(
+    ("client_cls", "client_module"),
+    [
+        (direct_mod.DirectClient, direct_mod),
+        (sdk_mod.SdkClient, sdk_mod),
+    ],
+)
+def test_okf_sync_fallback_reads_only_active_backend_cache(
+    client_cls, client_module, tmp_path, monkeypatch
+):
+    """An on-prem outage must never copy a cloud OKF cache into a project."""
+    monkeypatch.setattr(app_config.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(client_module.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(app_config.settings, "MEMANTO_BACKEND", "on-prem")
+
+    cloud_exports = tmp_path / ".memanto" / "exports"
+    onprem_exports = tmp_path / ".memanto" / "on-prem" / "exports"
+    _write_cached_bundle(cloud_exports, "shared-agent", "Cloud fact", "cloud-secret")
+    _write_cached_bundle(onprem_exports, "shared-agent", "On-prem fact", "local-only")
+
+    client = client_cls(api_key="test-key")
+    monkeypatch.setattr(
+        client,
+        "export_okf_bundle",
+        MagicMock(side_effect=ConnectionError("backend down")),
+    )
+
+    project = tmp_path / f"project-{client_cls.__name__}"
+    result = client.sync_okf_to_project(
+        agent_id="shared-agent", project_dir=str(project)
+    )
+
+    rendered = "\n".join(
+        path.read_text(encoding="utf-8") for path in (project / "okf").rglob("*.md")
+    )
+    assert result["source"] == "stale-cache"
+    assert result["total_memories"] == 1
+    assert "local-only" in rendered
+    assert "cloud-secret" not in rendered


### PR DESCRIPTION
## Summary

- route default OKF bundle exports through the active backend data directory
- make DirectClient and SdkClient stale-cache fallback read only that backend's OKF cache
- add end-to-end regressions for default export placement and outage fallback in both clients

## Flaw and impact

Memanto isolates on-prem state under .memanto/on-prem, but the newer OKF paths bypassed that boundary. OkfExportService always wrote to .memanto/exports, and both Python clients always used that same directory during stale-cache fallback.

A cloud agent and an on-prem agent with the same ID therefore shared one OKF bundle path. A fresh on-prem export could overwrite cloud knowledge. More seriously, if the on-prem backend was unavailable, OKF project sync could copy the cloud agent's cached bundle into the on-prem project and report it as a valid stale-cache recovery. That is a cross-backend confidentiality and memory-integrity failure.

## Reproduction

1. Create a cloud OKF cache for shared-agent containing cloud-only knowledge.
2. Switch to the on-prem backend and use the same agent ID.
3. Leave the on-prem backend unavailable, then run OKF project sync.
4. Before this fix, both clients read .memanto/exports/shared-agent_okf and copy the cloud bundle into the on-prem project.
5. After this fix, the clients read .memanto/on-prem/exports/shared-agent_okf only. If no on-prem cache exists, the outage is surfaced instead of crossing the backend boundary.

The regressions also prove that a normal on-prem OKF export writes only beneath the on-prem data directory.

## Fix

- Make OkfExportService default to get_data_dir() / exports.
- Make DirectClient.sync_okf_to_project and SdkClient.sync_okf_to_project use the same backend-aware cache path.
- Preserve explicit exports_dir and output_dir behavior.
- Keep the existing cloud path unchanged.

## Related work

PR #1460 covers the older MEMORY.md exporter and its cache readers. It does not touch OkfExportService or either OKF sync path, which were added later and remain hard-coded on current main.

## Verification

- Full non-live suite: 363 passed, 24 skipped because no real Moorcheh API key is configured
- Focused OKF suite: 8 passed
- Ruff lint: passed
- Ruff formatting: passed for 250 files
- MyPy: passed for 99 source files
- git diff --check: passed

Refs #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OKF exports now use the active backend’s configured data directory.
  * Synchronization fallback reads only the active backend’s cache, preventing cross-backend data leakage.
  * Direct and SDK clients now consistently follow backend-specific export locations.

* **Tests**
  * Added coverage for backend-isolated export and synchronization behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->