### PR TITLE
fix(claudecode): distill only the current Stop turn

### DIFF
--- a/integrations/claudecode/hooks/_common.py
+++ b/integrations/claudecode/hooks/_common.py
@@ -130,52 +130,71 @@ def read_transcript_text(
     find (string content, or content blocks carrying a ``text`` field),
     labelling it by role when available. Returns the trailing ``max_chars``.
     """
-    _, rendered = _read_transcript_full(
-        transcript_path, max_messages=max_messages, max_chars=max_chars
-    )
-    return rendered
+    messages = _read_transcript_messages(transcript_path)
+    return _render_messages(messages, max_messages=max_messages, max_chars=max_chars)
 
 
 def read_transcript_for_distillation(
     transcript_path: str | None,
+    last_assistant_message: str | None = None,
     max_messages: int = 40,
     max_chars: int = 8000,
 ) -> tuple[str | None, str]:
-    """Return ``(skill, tail_text)`` from a single pass over the transcript.
+    """Return ``(skill, current_turn_text)`` for one Stop-hook invocation.
 
-    Long sessions truncate to the tail for the LLM (the latest discussion is
-    where decisions usually crystallise), but the user's original ``/tdd`` or
-    ``/grill-with-docs`` invocation typically sits at the very start of the
-    conversation and would fall outside that tail. We scan the entire
-    transcript for the first skill token, then return it alongside the
-    truncated text so ``distill_and_store`` can tag memories correctly even
-    on long sessions.
+    Claude Code fires ``Stop`` once per turn, not once per session. Re-sending
+    the cumulative transcript on every invocation makes earlier decisions get
+    extracted and stored repeatedly. Scope distillation to the latest user
+    turn instead, while retaining the most recent skill invocation for tags.
+
+    Async hooks can read the transcript after a newer turn has already been
+    appended. ``last_assistant_message`` anchors the snapshot to the turn that
+    triggered this hook so two overlapping hook processes cannot both ingest
+    the newest turn.
     """
-    return _read_transcript_full(
-        transcript_path, max_messages=max_messages, max_chars=max_chars
-    )
-
-
-def _read_transcript_full(
-    transcript_path: str | None,
-    max_messages: int,
-    max_chars: int,
-) -> tuple[str | None, str]:
-    """Read the transcript once and return (first-skill-seen, tail-text)."""
-    if not transcript_path:
+    messages = _read_transcript_messages(transcript_path)
+    if not messages:
         return None, ""
+
+    end = _anchored_end(messages, last_assistant_message)
+    scoped = messages[:end]
+
+    skill: str | None = None
+    for role, text in scoped:
+        if _is_user_role(role):
+            found = detect_skill(text)
+            if found:
+                skill = found
+
+    turn_start = 0
+    for index in range(len(scoped) - 1, -1, -1):
+        if _is_user_role(scoped[index][0]):
+            turn_start = index
+            break
+
+    rendered = _render_messages(
+        scoped[turn_start:], max_messages=max_messages, max_chars=max_chars
+    )
+    return skill, rendered
+
+
+def _read_transcript_messages(
+    transcript_path: str | None,
+) -> list[tuple[str | None, str]]:
+    """Read parseable prose messages from a Claude Code transcript."""
+    if not transcript_path:
+        return []
     path = Path(transcript_path)
     if not path.exists():
-        return None, ""
+        return []
 
     try:
         with path.open(encoding="utf-8") as fh:
             lines = fh.readlines()
     except Exception:
-        return None, ""
+        return []
 
-    pieces: list[str] = []
-    skill: str | None = None
+    messages: list[tuple[str | None, str]] = []
     for line in lines:
         line = line.strip()
         if not line:
@@ -187,15 +206,48 @@ def _read_transcript_full(
         role, text = _extract_role_text(entry)
         if not text:
             continue
-        # First skill mention wins — typically the opening user prompt.
-        if skill is None:
-            found = detect_skill(text)
-            if found:
-                skill = found
-        pieces.append(f"{role}: {text}" if role else text)
+        messages.append((str(role) if role is not None else None, text))
 
+    return messages
+
+
+def _render_messages(
+    messages: list[tuple[str | None, str]],
+    *,
+    max_messages: int,
+    max_chars: int,
+) -> str:
+    """Render a bounded transcript slice for LLM distillation."""
+    pieces = [f"{role}: {text}" if role else text for role, text in messages]
     rendered = "\n".join(pieces[-max_messages:])
-    return skill, rendered[-max_chars:]
+    return rendered[-max_chars:]
+
+
+def _is_user_role(role: str | None) -> bool:
+    """Recognise user roles across the common transcript variants."""
+    return bool(role and role.strip().lower() in {"user", "human"})
+
+
+def _is_assistant_role(role: str | None) -> bool:
+    """Recognise assistant roles across the common transcript variants."""
+    return bool(role and role.strip().lower() in {"assistant", "ai"})
+
+
+def _anchored_end(
+    messages: list[tuple[str | None, str]],
+    last_assistant_message: str | None,
+) -> int:
+    """Return the exclusive end index for the Stop event's own turn."""
+    if not last_assistant_message or not last_assistant_message.strip():
+        return len(messages)
+
+    needle = " ".join(last_assistant_message.split())
+    for index in range(len(messages) - 1, -1, -1):
+        role, text = messages[index]
+        if _is_assistant_role(role) and " ".join(text.split()) == needle:
+            return index + 1
+
+    return len(messages)
 
 
 def _extract_role_text(entry: Any) -> tuple[str | None, str]:

--- a/integrations/claudecode/hooks/on_stop.py
+++ b/integrations/claudecode/hooks/on_stop.py
@@ -28,10 +28,10 @@ from _common import (  # noqa: E402
 
 
 def main() -> int:
-    """Read the finished transcript and distill it into typed memories.
+    """Read the finished turn and distill it into typed memories.
 
-    Skips when ``stop_hook_active`` is set so the same session is never
-    distilled twice on re-fires. Runs asynchronously and silently — failure
+    Skips when ``stop_hook_active`` is set to avoid hook-induced continuation
+    loops. Runs asynchronously and silently — failure
     paths exit 0 instead of surfacing errors to the developer.
     """
     if not memory_enabled():
@@ -44,11 +44,12 @@ def main() -> int:
     if data.get("stop_hook_active"):
         return 0
 
-    # Single pass: finds the original /skill across the FULL transcript,
-    # then returns only the tail for LLM distillation. This avoids tagging
-    # long sessions as skill:unknown when the opening prompt has fallen
-    # outside the truncation window.
-    skill, transcript = read_transcript_for_distillation(data.get("transcript_path"))
+    # Stop fires once per turn. Scope distillation to this event's user turn,
+    # while scanning the transcript up to that turn for the active /skill tag.
+    skill, transcript = read_transcript_for_distillation(
+        data.get("transcript_path"),
+        last_assistant_message=data.get("last_assistant_message"),
+    )
     if not transcript:
         return 0
 

--- a/integrations/claudecode/tests/test_hooks.py
+++ b/integrations/claudecode/tests/test_hooks.py
@@ -172,3 +172,57 @@ class TestReadTranscriptForDistillation:
         skill, text = common.read_transcript_for_distillation(str(f))
         assert skill is None
         assert "just a chat" in text
+
+    def test_distills_only_the_latest_turn(self, tmp_path: Path) -> None:
+        """A later Stop event must not re-submit an earlier turn."""
+        f = tmp_path / "t.jsonl"
+        lines = [
+            {"message": {"role": "user", "content": "/tdd use unittest"}},
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Old decision: use unittest.",
+                }
+            },
+            {"message": {"role": "user", "content": "/diagnose inspect auth"}},
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Current finding: tokens expire early.",
+                }
+            },
+        ]
+        f.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+
+        skill, text = common.read_transcript_for_distillation(str(f))
+
+        assert skill == "diagnose"
+        assert "tokens expire early" in text
+        assert "Old decision" not in text
+        assert "use unittest" not in text
+
+    def test_assistant_anchor_excludes_a_later_appended_turn(
+        self, tmp_path: Path
+    ) -> None:
+        """An async Stop hook must ingest the turn that spawned it."""
+        f = tmp_path / "t.jsonl"
+        lines = [
+            {"message": {"role": "user", "content": "/tdd first task"}},
+            {"message": {"role": "assistant", "content": "First answer."}},
+            {"message": {"role": "user", "content": "second task"}},
+            {"message": {"role": "assistant", "content": "Second answer."}},
+            {"message": {"role": "user", "content": "/diagnose third task"}},
+            {"message": {"role": "assistant", "content": "Third answer."}},
+        ]
+        f.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+
+        skill, text = common.read_transcript_for_distillation(
+            str(f), last_assistant_message="Second answer."
+        )
+
+        assert skill == "tdd"
+        assert "second task" in text
+        assert "Second answer" in text
+        assert "first task" not in text
+        assert "third task" not in text
+        assert "Third answer" not in text


### PR DESCRIPTION
## Summary

Claude Code invokes the configured `Stop` hook whenever Claude finishes a response. The integration previously sent the cumulative transcript tail to Memanto on every turn, so durable decisions from earlier turns were repeatedly extracted and stored until they aged out of the tail.

This change distills only the user turn associated with the current `Stop` event. It also anchors asynchronous hook reads with `last_assistant_message`, preventing a delayed hook from ingesting a newer turn appended after the hook started.

Bounty submission for #770.

## Root cause and impact

The hook treated `Stop` as a once-per-session event, but Claude Code documents it as an event that runs when the agent finishes responding. The existing `stop_hook_active` guard only identifies continuation caused by a Stop hook; it does not suppress normal Stop events on later user turns.

As a session grew, each turn re-submitted earlier user and assistant messages to `distill_and_store()`. That could:

- create duplicate or near-duplicate durable memories;
- make retrieval noisier by overweighting old decisions;
- repeatedly spend LLM tokens and backend writes on unchanged history; and
- let an async hook accidentally process a later turn instead of the turn that spawned it.

Official hook semantics:

- https://code.claude.com/docs/en/hooks
- https://code.claude.com/docs/en/hooks-guide

## Reproduction

1. Create a Claude Code transcript with two completed user/assistant turns.
2. Run the existing Stop-hook transcript reader after the second turn.
3. Observe that the returned text contains both the first turn's durable decision and the second turn, so the first decision is submitted again.
4. For the async race, append a third turn before the second turn's hook reads the file. The old reader consumes the third turn even though it belongs to a later Stop event.

The added regression tests model both cases. Before this fix, the first case includes `Old decision: use unittest`, and there is no way to anchor the second Stop event before the appended third turn.

## Fix

- Parse transcript messages once into role/text pairs.
- Anchor the readable snapshot to the Stop event's `last_assistant_message`.
- Slice from the latest user message before that anchor through the anchored assistant response.
- Retain the most recent user-invoked `/skill` up to the anchor for memory tagging.
- Preserve `read_transcript_text()` behavior for callers that intentionally need a bounded cumulative tail.

## Validation

- `python -m pytest integrations/claudecode/tests -q --disable-warnings` — 70 passed
- `python -m pytest -q --disable-warnings` — full non-live suite passed; 24 live-key E2E tests skipped as expected
- `python -m ruff check integrations/claudecode/hooks/_common.py integrations/claudecode/hooks/on_stop.py integrations/claudecode/tests/test_hooks.py`
- `python -m ruff format --check integrations/claudecode/hooks/_common.py integrations/claudecode/hooks/on_stop.py integrations/claudecode/tests/test_hooks.py`
- `python -m mypy integrations/claudecode/hooks/_common.py integrations/claudecode/hooks/on_stop.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript handling for varied message formats and role labels.
  * Distillation now focuses on the specific conversation turn that triggered the stop hook.
  * Skill detection is limited to the relevant turn, preventing older or unrelated commands from being selected.
  * Added safeguards to exclude content from earlier and later turns.

* **Tests**
  * Added regression coverage for turn scoping and assistant-message anchoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->