### PR TITLE
fix(mcp): isolate concurrent agent sessions

### DIFF
--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -10,8 +10,9 @@ to call ``recall`` and expects it to "just work". This module owns:
   underlying ``SdkClient._get_validated_session_for_agent`` already auto-renews
   tokens nearing expiry, so each client only has to be activated once.
 
-All operations are guarded by a lock so concurrent tool invocations don't race
-to create the same agent twice.
+The client registry is guarded by a short-lived global lock, while per-agent
+locks serialize setup for the same agent without blocking unrelated agents on
+network calls.
 """
 
 from __future__ import annotations
@@ -44,6 +45,7 @@ class MemantoLifecycle:
         self._settings = settings
         self._client = SdkClient(api_key=settings.api_key_value())
         self._session_clients: dict[str, SdkClient] = {}
+        self._agent_locks: dict[str, threading.Lock] = {}
         self._ensured_agents: set[str] = set()
         self._lock = threading.Lock()
 
@@ -96,15 +98,20 @@ class MemantoLifecycle:
             client = self._session_clients.get(agent_id)
             if client is None:
                 client = SdkClient(api_key=self._settings.api_key_value())
+                self._session_clients[agent_id] = client
+            agent_lock = self._agent_locks.setdefault(agent_id, threading.Lock())
 
-            if agent_id not in self._ensured_agents:
+        with agent_lock:
+            with self._lock:
+                agent_is_ensured = agent_id in self._ensured_agents
+
+            if not agent_is_ensured:
                 self._ensure_agent_exists_locked(client, agent_id)
-                self._ensured_agents.add(agent_id)
+                with self._lock:
+                    self._ensured_agents.add(agent_id)
 
             if client.agent_id != agent_id:
                 self._activate_locked(client, agent_id)
-
-            self._session_clients[agent_id] = client
 
         return client
 

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -6,9 +6,9 @@ to call ``recall`` and expects it to "just work". This module owns:
 * Resolving which Memanto agent_id a given tool call targets (explicit arg
   wins; otherwise the configured default).
 * Lazily creating the default agent on first use (if enabled).
-* Lazily activating a session and keeping it valid across calls. The underlying
-  ``SdkClient._get_validated_session_for_agent`` already auto-renews tokens
-  nearing expiry, so we only have to activate once per agent.
+* Lazily creating one independently activated ``SdkClient`` per agent. The
+  underlying ``SdkClient._get_validated_session_for_agent`` already auto-renews
+  tokens nearing expiry, so each client only has to be activated once.
 
 All operations are guarded by a lock so concurrent tool invocations don't race
 to create the same agent twice.
@@ -38,12 +38,12 @@ class NoAgentConfiguredError(ValueError):
 
 
 class MemantoLifecycle:
-    """Owns the long-lived SdkClient and per-agent session bookkeeping."""
+    """Owns an administrative client and isolated per-agent session clients."""
 
     def __init__(self, settings: MCPServerSettings) -> None:
         self._settings = settings
         self._client = SdkClient(api_key=settings.api_key_value())
-        self._activated_agents: set[str] = set()
+        self._session_clients: dict[str, SdkClient] = {}
         self._ensured_agents: set[str] = set()
         self._lock = threading.Lock()
 
@@ -53,7 +53,7 @@ class MemantoLifecycle:
 
     @property
     def client(self) -> SdkClient:
-        """The shared Memanto SDK client."""
+        """The shared administrative client for agent CRUD operations."""
         return self._client
 
     @property
@@ -82,19 +82,31 @@ class MemantoLifecycle:
         Returns the resolved agent_id (mostly a convenience so callers can
         chain ``ensure_ready(resolve_agent_id(...))``).
         """
+        self.client_for(agent_id)
+        return agent_id
+
+    def client_for(self, agent_id: str) -> SdkClient:
+        """Return a ready client whose session is isolated to ``agent_id``.
+
+        ``SdkClient`` stores the active agent as mutable instance state. Keeping
+        one client per agent prevents a concurrent call for another agent from
+        replacing that state between readiness checks and the actual operation.
+        """
         with self._lock:
+            client = self._session_clients.get(agent_id)
+            if client is None:
+                client = SdkClient(api_key=self._settings.api_key_value())
+
             if agent_id not in self._ensured_agents:
-                self._ensure_agent_exists_locked(agent_id)
+                self._ensure_agent_exists_locked(client, agent_id)
                 self._ensured_agents.add(agent_id)
 
-            if (
-                agent_id not in self._activated_agents
-                or self._client.agent_id != agent_id
-            ):
-                self._activate_locked(agent_id)
-                self._activated_agents.add(agent_id)
+            if client.agent_id != agent_id:
+                self._activate_locked(client, agent_id)
 
-        return agent_id
+            self._session_clients[agent_id] = client
+
+        return client
 
     def shutdown(self) -> None:
         """Best-effort cleanup. Sessions can outlive the process safely."""
@@ -107,9 +119,9 @@ class MemantoLifecycle:
     # Internals
     # ------------------------------------------------------------------ #
 
-    def _ensure_agent_exists_locked(self, agent_id: str) -> None:
+    def _ensure_agent_exists_locked(self, client: SdkClient, agent_id: str) -> None:
         try:
-            self._client.get_agent(agent_id)
+            client.get_agent(agent_id)
             logger.debug("Agent '%s' exists.", agent_id)
             return
         except AgentNotFoundError:
@@ -128,7 +140,7 @@ class MemantoLifecycle:
             self._settings.agent_pattern,
         )
         try:
-            self._client.create_agent(
+            client.create_agent(
                 agent_id=agent_id,
                 pattern=self._settings.agent_pattern,
                 description="Auto-created by memanto-mcp",
@@ -137,9 +149,9 @@ class MemantoLifecycle:
             # Race: another caller created it between our get_agent and create.
             logger.debug("Agent '%s' was created concurrently.", agent_id)
 
-    def _activate_locked(self, agent_id: str) -> None:
+    def _activate_locked(self, client: SdkClient, agent_id: str) -> None:
         try:
-            self._client.activate_agent(
+            client.activate_agent(
                 agent_id=agent_id,
                 duration_hours=self._settings.session_duration_hours,
             )

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -314,13 +314,14 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RememberResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
             resolved_title = title or (
                 content[: _MAX_TITLE_LENGTH - 3] + "..."
                 if len(content) > _MAX_TITLE_LENGTH
                 else content
             )
-            result = lifecycle.client.remember(
+            result = client.remember(
                 agent_id=resolved,
                 memory_type=type,
                 title=resolved_title,
@@ -375,7 +376,8 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> BatchRememberResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
             # Validate before round-trip so we fail fast with a clear error.
             for i, item in enumerate(memories):
                 if not isinstance(item, dict):
@@ -399,7 +401,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                         f"Choose one of: {sorted(VALID_PROVENANCE_TYPES)}"
                     )
 
-            result = lifecycle.client.batch_remember(
+            result = client.batch_remember(
                 agent_id=resolved,
                 memories=memories,
             )
@@ -484,8 +486,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.recall(
                 agent_id=resolved,
                 query=query,
                 limit=limit,
@@ -538,8 +541,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_recent(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.recall_recent(
                 agent_id=resolved,
                 limit=limit,
                 type=list(type) if type else None,
@@ -593,8 +597,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_as_of(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.recall_as_of(
                 agent_id=resolved,
                 as_of=as_of,
                 limit=limit,
@@ -649,8 +654,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_changed_since(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.recall_changed_since(
                 agent_id=resolved,
                 since=since,
                 limit=limit,
@@ -724,8 +730,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> AnswerResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.answer(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.answer(
                 agent_id=resolved,
                 question=question,
                 limit=limit,

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -91,3 +91,42 @@ def test_same_agent_reuses_activated_session_client(
     assert first_client is second_client
     assert first_client.activation_calls == 1
     assert len(_FakeSdkClient.instances) == 2  # admin + one agent session
+
+
+def test_different_agents_initialize_in_parallel(
+    lifecycle: MemantoLifecycle, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Network setup for one agent must not block an unrelated agent."""
+    activation_barrier = threading.Barrier(2)
+    original_activate = _FakeSdkClient.activate_agent
+    clients: list[_FakeSdkClient] = []
+    errors: list[BaseException] = []
+
+    def synchronized_activate(
+        client: _FakeSdkClient,
+        agent_id: str,
+        duration_hours: int | None = None,
+    ) -> dict[str, Any]:
+        activation_barrier.wait(timeout=2)
+        return original_activate(client, agent_id, duration_hours)
+
+    monkeypatch.setattr(_FakeSdkClient, "activate_agent", synchronized_activate)
+
+    def initialize(agent_id: str) -> None:
+        try:
+            clients.append(lifecycle.client_for(agent_id))
+        except BaseException as exc:  # pragma: no cover - reported in main thread
+            errors.append(exc)
+
+    workers = [
+        threading.Thread(target=initialize, args=("agent-a",)),
+        threading.Thread(target=initialize, args=("agent-b",)),
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=3)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert not errors
+    assert {client.agent_id for client in clients} == {"agent-a", "agent-b"}

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -1,0 +1,93 @@
+"""Session isolation tests for the MCP lifecycle."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+from memanto.app.utils.errors import SessionError
+
+import memanto_mcp.lifecycle as lifecycle_module
+from memanto_mcp.config import MCPServerSettings
+from memanto_mcp.lifecycle import MemantoLifecycle
+
+
+class _FakeSdkClient:
+    """Minimal client that enforces the same single-session scope as SdkClient."""
+
+    instances: list[_FakeSdkClient] = []
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self.agent_id: str | None = None
+        self.activation_calls = 0
+        self.instances.append(self)
+
+    def get_agent(self, agent_id: str) -> dict[str, Any]:
+        return {"agent_id": agent_id}
+
+    def activate_agent(
+        self, agent_id: str, duration_hours: int | None = None
+    ) -> dict[str, Any]:
+        self.activation_calls += 1
+        self.agent_id = agent_id
+        return {"agent_id": agent_id}
+
+    def recall(self, *, agent_id: str) -> dict[str, Any]:
+        if self.agent_id != agent_id:
+            raise SessionError(
+                f"Active session is for agent '{self.agent_id}', "
+                f"cannot access '{agent_id}'"
+            )
+        return {"agent_id": agent_id}
+
+
+@pytest.fixture
+def lifecycle(fake_api_key: str, monkeypatch: pytest.MonkeyPatch) -> MemantoLifecycle:
+    _FakeSdkClient.instances.clear()
+    monkeypatch.setattr(lifecycle_module, "SdkClient", _FakeSdkClient)
+    return MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+
+def test_different_agents_keep_independent_session_clients(
+    lifecycle: MemantoLifecycle,
+) -> None:
+    """A second agent becoming ready must not invalidate the first client."""
+    first_ready = threading.Event()
+    second_ready = threading.Event()
+    errors: list[BaseException] = []
+
+    def recall_first_agent() -> None:
+        try:
+            first_client = lifecycle.client_for("agent-a")
+            first_ready.set()
+            assert second_ready.wait(timeout=2)
+            assert first_client.recall(agent_id="agent-a") == {"agent_id": "agent-a"}
+        except BaseException as exc:  # pragma: no cover - reported in main thread
+            errors.append(exc)
+
+    worker = threading.Thread(target=recall_first_agent)
+    worker.start()
+    assert first_ready.wait(timeout=2)
+
+    second_client = lifecycle.client_for("agent-b")
+    assert second_client.recall(agent_id="agent-b") == {"agent_id": "agent-b"}
+    second_ready.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert not errors
+    assert len(_FakeSdkClient.instances) == 3  # admin + one per active agent
+
+
+def test_same_agent_reuses_activated_session_client(
+    lifecycle: MemantoLifecycle,
+) -> None:
+    """Repeated calls for one agent should reuse its activated client."""
+    first_client = lifecycle.client_for("agent-a")
+    second_client = lifecycle.client_for("agent-a")
+
+    assert first_client is second_client
+    assert first_client.activation_calls == 1
+    assert len(_FakeSdkClient.instances) == 2  # admin + one agent session


### PR DESCRIPTION
## Summary

- keep one independently activated `SdkClient` per agent in the MCP lifecycle
- route all seven memory and RAG tools through their agent-scoped client while retaining the shared client for agent administration
- add deterministic concurrency coverage plus a same-agent client reuse test

## Problem

`SdkClient` stores its active agent and session as mutable instance state. The MCP lifecycle previously shared one client across every agent and held its lock only during `ensure_ready`. This allowed the following interleaving:

1. request A activates the shared client for `agent-a` and releases the lifecycle lock
2. request B activates that same client for `agent-b`
3. request A calls an SDK operation for `agent-a`, but the client now carries `agent-b`'s session

The SDK then rejects request A with a `SessionError`. Every MCP memory tool was exposed to this race in multi-agent servers.

## Fix

The lifecycle now lazily creates and activates one session client per agent. A new `client_for(agent_id)` method returns the stable scoped client, and each memory/RAG tool keeps that returned client through its SDK operation. The existing `client` property remains the administrative client used by agent CRUD tools.

## Validation

- `uv run --group dev --with-editable integrations/mcp pytest integrations/mcp/tests -q` — 27 passed
- `uv run --group dev pytest -q` — 374 passed, 24 live E2E tests skipped because external credentials were not configured
- `uv run --group dev ruff check .`
- `uv run --group dev ruff format --check .`
- `uv run --group dev mypy .`
- `git diff --check`

Contribution for #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation for simultaneous operations across different agents by maintaining separate active sessions per agent.
  * Prevented one agent’s session activation from affecting another agent’s session.
  * Ensured repeated operations for the same agent reuse the same active session reliably.
  * Updated agent-scoped tools to consistently acquire the correct per-agent session before making requests.
* **Tests**
  * Added coverage for independent per-agent sessions, session reuse, and concurrent initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->