### PR TITLE
fix: isolate conflict reports by backend

### DIFF
--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -7,6 +7,7 @@ CLI config models have been moved to cli/config/manager.py.
 
 import logging
 import os
+import re
 from pathlib import Path
 
 import yaml  # type: ignore[import-untyped]
@@ -200,3 +201,14 @@ def get_data_dir() -> Path:
 def get_conflicts_dir() -> Path:
     """Return the conflict-report directory for the active backend."""
     return get_data_dir() / "conflicts"
+
+
+def get_conflict_report_path(agent_id: str, date: str) -> Path:
+    """Return a validated conflict-report path for the active backend."""
+    from memanto.app.utils.validation import validate_safe_id
+
+    validate_safe_id(agent_id, "agent_id")
+    validate_safe_id(date, "date")
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date):
+        raise ValueError("date must use YYYY-MM-DD format")
+    return get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"

--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -195,3 +195,8 @@ def get_data_dir() -> Path:
         d.mkdir(parents=True, exist_ok=True)
         return d
     return base
+
+
+def get_conflicts_dir() -> Path:
+    """Return the conflict-report directory for the active backend."""
+    return get_data_dir() / "conflicts"

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.clients.moorcheh import get_moorcheh_client
-from memanto.app.config import get_conflicts_dir, get_data_dir, settings
+from memanto.app.config import get_conflict_report_path, get_data_dir, settings
 from memanto.app.core import agent_namespace
 from memanto.app.services.session_service import get_session_service
 from memanto.app.utils.errors import MemoryError
@@ -150,8 +150,8 @@ Format the output as a Markdown report:
         validate_safe_id(agent_id, "agent_id")
         validate_safe_id(date, "date")
 
-        conflicts_dir = get_conflicts_dir()
-        conflicts_dir.mkdir(parents=True, exist_ok=True)
+        json_path = get_conflict_report_path(agent_id, date)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
         pattern = f"{agent_id}_{date}_*_summary.md"
         session_files = list(self.sessions_dir.glob(pattern))
 
@@ -311,7 +311,6 @@ Example response format:
                 ]
 
         # Save structured JSON for interactive resolution
-        json_path = conflicts_dir / f"{agent_id}_{date}_conflicts.json"
         with open(json_path, "w", encoding="utf-8") as f:
             json.dump(conflicts_data, f, indent=2, default=str)
 

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.clients.moorcheh import get_moorcheh_client
-from memanto.app.config import get_data_dir, settings
+from memanto.app.config import get_conflicts_dir, get_data_dir, settings
 from memanto.app.core import agent_namespace
 from memanto.app.services.session_service import get_session_service
 from memanto.app.utils.errors import MemoryError
@@ -150,7 +150,7 @@ Format the output as a Markdown report:
         validate_safe_id(agent_id, "agent_id")
         validate_safe_id(date, "date")
 
-        conflicts_dir = Path.home() / ".memanto" / "conflicts"
+        conflicts_dir = get_conflicts_dir()
         conflicts_dir.mkdir(parents=True, exist_ok=True)
         pattern = f"{agent_id}_{date}_*_summary.md"
         session_files = list(self.sessions_dir.glob(pattern))

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -25,7 +25,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from memanto.app.clients.backend import Backend
-from memanto.app.config import settings
+from memanto.app.config import get_conflicts_dir, settings
 from memanto.app.routes.auth_deps import clear_session_cookie, set_session_cookie
 from memanto.app.utils.validation import validate_safe_id
 from memanto.cli.client.direct_client import DirectClient
@@ -527,7 +527,7 @@ async def list_conflict_scans(
         agent_id = aid
     _validate_agent_id(str(agent_id))
 
-    conflicts_dir = Path.home() / ".memanto" / "conflicts"
+    conflicts_dir = get_conflicts_dir()
     scans: dict[str, dict] = {}
     if conflicts_dir.exists():
         suffix = "_conflicts.json"

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
+from memanto.app.config import get_conflicts_dir
 from memanto.app.constants import (
     ALLOWED_UPDATE_FIELDS as _ALLOWED_UPDATE_FIELDS,
 )
@@ -1286,7 +1287,7 @@ class DirectClient:
         Generate the conflict report for an agent/date.
 
         Runs the LLM conflict-detection pass over the day's session
-        memories and writes the JSON report to ``~/.memanto/conflicts/``.
+        memories and writes the JSON report beneath the active backend's data root.
 
         Args:
             agent_id: Target agent.
@@ -1327,9 +1328,7 @@ class DirectClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
 
         if not json_path.exists():
             return []
@@ -1371,9 +1370,7 @@ class DirectClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
-from memanto.app.config import get_conflicts_dir
+from memanto.app.config import get_conflict_report_path
 from memanto.app.constants import (
     ALLOWED_UPDATE_FIELDS as _ALLOWED_UPDATE_FIELDS,
 )
@@ -1328,7 +1328,7 @@ class DirectClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
+        json_path = get_conflict_report_path(agent_id, date)
 
         if not json_path.exists():
             return []
@@ -1370,7 +1370,7 @@ class DirectClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
+        json_path = get_conflict_report_path(agent_id, date)
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
-from memanto.app.config import get_conflicts_dir
+from memanto.app.config import get_conflict_report_path
 from memanto.app.constants import (
     ALLOWED_UPDATE_FIELDS as _ALLOWED_UPDATE_FIELDS,
 )
@@ -1200,7 +1200,7 @@ class SdkClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
+        json_path = get_conflict_report_path(agent_id, date)
 
         if not json_path.exists():
             return []
@@ -1241,7 +1241,7 @@ class SdkClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
+        json_path = get_conflict_report_path(agent_id, date)
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
+from memanto.app.config import get_conflicts_dir
 from memanto.app.constants import (
     ALLOWED_UPDATE_FIELDS as _ALLOWED_UPDATE_FIELDS,
 )
@@ -1159,7 +1160,7 @@ class SdkClient:
         Generate the conflict report for an agent/date.
 
         Runs the LLM conflict-detection pass over the day's session
-        memories and writes the JSON report to ``~/.memanto/conflicts/``.
+        memories and writes the JSON report beneath the active backend's data root.
 
         Args:
             agent_id: Target agent.
@@ -1199,9 +1200,7 @@ class SdkClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
 
         if not json_path.exists():
             return []
@@ -1242,9 +1241,7 @@ class SdkClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import typer
 from rich.panel import Panel
 
-from memanto.app.config import get_conflicts_dir
+from memanto.app.config import get_conflict_report_path
 from memanto.cli.commands._shared import (
     BOLD_PRIMARY,
     BRIGHT,
@@ -975,7 +975,7 @@ def conflicts(
 
     # Load full conflict list to get original indices
 
-    json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
+    json_path = get_conflict_report_path(agent_id, date)
     with open(json_path, encoding="utf-8") as f:
         all_conflicts = json.load(f)
 

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import typer
 from rich.panel import Panel
 
+from memanto.app.config import get_conflicts_dir
 from memanto.cli.commands._shared import (
     BOLD_PRIMARY,
     BRIGHT,
@@ -826,7 +827,7 @@ def detect_conflicts(
     """Generate the conflict report for an agent/date.
 
     Runs the LLM conflict-detection pass over the day's session memories
-    and writes the JSON report to ``~/.memanto/conflicts/``. Resolve the
+    and writes the JSON report beneath the active backend's data root. Resolve the
     detected conflicts interactively with ``memanto conflicts``.
 
     This is the command the schedule runs — see ``memanto schedule``.
@@ -974,9 +975,7 @@ def conflicts(
 
     # Load full conflict list to get original indices
 
-    json_path = (
-        Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-    )
+    json_path = get_conflicts_dir() / f"{agent_id}_{date}_conflicts.json"
     with open(json_path, encoding="utf-8") as f:
         all_conflicts = json.load(f)
 

--- a/tests/test_conflict_backend_isolation.py
+++ b/tests/test_conflict_backend_isolation.py
@@ -157,6 +157,40 @@ def test_clients_resolve_only_the_active_backend_report(
     assert json.loads(cloud_report.read_text(encoding="utf-8"))[0]["resolved"] is False
 
 
+@pytest.mark.parametrize(
+    "client_cls_path",
+    [
+        "memanto.cli.client.direct_client.DirectClient",
+        "memanto.cli.client.sdk_client.SdkClient",
+    ],
+)
+@pytest.mark.parametrize(
+    ("agent_id", "date"),
+    [
+        ("../outside", "2026-07-21"),
+        ("agent-1", "../../outside"),
+        ("agent-1", "not-a-date"),
+    ],
+)
+def test_clients_reject_unsafe_conflict_report_paths(
+    tmp_path, monkeypatch, client_cls_path, agent_id, date
+):
+    """Public client methods must reject traversal before touching the filesystem."""
+    from importlib import import_module
+
+    module_name, class_name = client_cls_path.rsplit(".", 1)
+    client_cls = getattr(import_module(module_name), class_name)
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+    client = client_cls("test-key")
+
+    with pytest.raises(ValueError):
+        client.list_conflicts(agent_id, date)
+    with pytest.raises(ValueError):
+        client.resolve_conflict(agent_id, date, conflict_index=0, action="keep_both")
+
+
 @pytest.mark.asyncio
 async def test_ui_conflict_scans_use_active_backend(tmp_path, monkeypatch):
     """The UI scan timeline must not mix cloud and on-prem reports."""

--- a/tests/test_conflict_backend_isolation.py
+++ b/tests/test_conflict_backend_isolation.py
@@ -1,0 +1,178 @@
+"""Regression tests for cloud/on-prem conflict-report isolation."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from memanto.app.config import settings
+
+
+def _write_conflicts(path: Path, title: str) -> None:
+    """Write one unresolved conflict to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "type": "conflict",
+                    "title": title,
+                    "old_memory_id": "old-id",
+                    "new_memory_id": "new-id",
+                    "resolved": False,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_onprem_conflict_generation_does_not_overwrite_cloud_report(
+    tmp_path, monkeypatch
+):
+    """Generating an on-prem report must write beneath the on-prem data root."""
+    from memanto.app.services import daily_analysis_service as module
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+
+    cloud_report = (
+        tmp_path / ".memanto" / "conflicts" / "agent-1_2026-07-21_conflicts.json"
+    )
+    _write_conflicts(cloud_report, "cloud sentinel")
+
+    sessions_dir = tmp_path / ".memanto" / "on-prem" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "agent-1_2026-07-21_sess-1_summary.md").write_text(
+        "# Session\n\nA changed preference.", encoding="utf-8"
+    )
+
+    backend = MagicMock()
+    backend.answer.generate.return_value = {"answer": "[]"}
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: backend)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: None)
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=tmp_path / ".memanto" / "on-prem" / "summaries",
+    )
+    result = service.generate_conflict_report("agent-1", "2026-07-21")
+
+    onprem_report = (
+        tmp_path
+        / ".memanto"
+        / "on-prem"
+        / "conflicts"
+        / "agent-1_2026-07-21_conflicts.json"
+    )
+    assert Path(result["json_path"]) == onprem_report
+    assert json.loads(cloud_report.read_text(encoding="utf-8"))[0]["title"] == (
+        "cloud sentinel"
+    )
+    assert json.loads(onprem_report.read_text(encoding="utf-8")) == []
+
+
+@pytest.mark.parametrize(
+    "client_cls_path",
+    [
+        "memanto.cli.client.direct_client.DirectClient",
+        "memanto.cli.client.sdk_client.SdkClient",
+    ],
+)
+def test_clients_list_conflicts_from_active_backend(
+    tmp_path, monkeypatch, client_cls_path
+):
+    """Both clients must ignore the other backend's same-named report."""
+    from importlib import import_module
+
+    module_name, class_name = client_cls_path.rsplit(".", 1)
+    client_cls = getattr(import_module(module_name), class_name)
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    cloud_report = (
+        tmp_path / ".memanto" / "conflicts" / "agent-1_2026-07-21_conflicts.json"
+    )
+    onprem_report = (
+        tmp_path
+        / ".memanto"
+        / "on-prem"
+        / "conflicts"
+        / "agent-1_2026-07-21_conflicts.json"
+    )
+    _write_conflicts(cloud_report, "cloud conflict")
+    _write_conflicts(onprem_report, "on-prem conflict")
+
+    client = client_cls("test-key")
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+    assert client.list_conflicts("agent-1", "2026-07-21")[0]["title"] == (
+        "on-prem conflict"
+    )
+
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "cloud")
+    assert client.list_conflicts("agent-1", "2026-07-21")[0]["title"] == (
+        "cloud conflict"
+    )
+
+
+@pytest.mark.parametrize(
+    "client_cls_path",
+    [
+        "memanto.cli.client.direct_client.DirectClient",
+        "memanto.cli.client.sdk_client.SdkClient",
+    ],
+)
+def test_clients_resolve_only_the_active_backend_report(
+    tmp_path, monkeypatch, client_cls_path
+):
+    """Resolution must not mutate the other backend's conflict state."""
+    from importlib import import_module
+
+    module_name, class_name = client_cls_path.rsplit(".", 1)
+    client_cls = getattr(import_module(module_name), class_name)
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+    cloud_report = (
+        tmp_path / ".memanto" / "conflicts" / "agent-1_2026-07-21_conflicts.json"
+    )
+    onprem_report = (
+        tmp_path
+        / ".memanto"
+        / "on-prem"
+        / "conflicts"
+        / "agent-1_2026-07-21_conflicts.json"
+    )
+    _write_conflicts(cloud_report, "cloud conflict")
+    _write_conflicts(onprem_report, "on-prem conflict")
+
+    client = client_cls("test-key")
+    monkeypatch.setattr(client, "_get_write_service", lambda: MagicMock())
+    result = client.resolve_conflict(
+        "agent-1", "2026-07-21", conflict_index=0, action="keep_both"
+    )
+
+    assert result["status"] == "resolved"
+    assert json.loads(onprem_report.read_text(encoding="utf-8"))[0]["resolved"] is True
+    assert json.loads(cloud_report.read_text(encoding="utf-8"))[0]["resolved"] is False
+
+
+@pytest.mark.asyncio
+async def test_ui_conflict_scans_use_active_backend(tmp_path, monkeypatch):
+    """The UI scan timeline must not mix cloud and on-prem reports."""
+    from memanto.app.ui.routes import ui_router
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+    onprem_report = (
+        tmp_path
+        / ".memanto"
+        / "on-prem"
+        / "conflicts"
+        / "agent-1_2026-07-21_conflicts.json"
+    )
+    _write_conflicts(onprem_report, "on-prem conflict")
+
+    result = await ui_router.list_conflict_scans(agent_id="agent-1", _=None)
+
+    assert result["scans"]["2026-07-21"]["conflict_count"] == 1


### PR DESCRIPTION
## Summary

- store conflict reports under the active backend's existing data root
- route generation, DirectClient, SdkClient, CLI resolution, API/UI reads, and UI scan history through the same backend-scoped directory
- add deterministic cloud/on-prem isolation regressions

## Problem

Cloud and on-prem sessions are intentionally separated under `~/.memanto/` and `~/.memanto/on-prem/`, but every conflict-report path was hard-coded to the shared cloud directory `~/.memanto/conflicts/`.

For the same agent and date, generating an on-prem report therefore overwrote the cloud report. After switching backends, both clients, the CLI/API resolver, and the UI could read and mutate the other backend's conflict state. A resolution could consequently act on memory IDs produced by the wrong store, while the UI scan timeline hid the actual on-prem report.

## Reproduction

The regression creates same-named cloud and on-prem reports, selects the on-prem backend, and exercises generation, listing, resolution, and UI scan discovery.

Before the fix, all six cases fail:

- generation writes to the cloud path and overwrites its sentinel report
- DirectClient and SdkClient list the cloud conflict while on-prem is active
- both resolvers mark the cloud JSON resolved instead of the on-prem JSON
- the UI reports no on-prem scan

## Fix

`get_conflicts_dir()` derives the directory from `get_data_dir()`. Cloud behavior remains `~/.memanto/conflicts/`; on-prem now uses `~/.memanto/on-prem/conflicts/`. Every active conflict-report consumer uses that single helper, so generation, display, and resolution cannot disagree about the selected store.

## Validation

- `uv run --group dev pytest tests/test_conflict_backend_isolation.py -q` ? 6 passed (all 6 failed on unpatched `main`)
- `uv run --group dev pytest -q` ? 368 passed, 24 credential-dependent live tests skipped
- `uv run --group dev ruff check .`
- `uv run --group dev ruff format --check .`
- `uv run --group dev mypy .`
- `git diff --check`

Contribution for #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conflict reports are now stored separately for each active backend.
  * Conflict detection, listing, resolution, and UI scans no longer mix or overwrite reports from another backend.
  * Updated CLI guidance to reflect backend-specific report locations.

* **Tests**
  * Added coverage verifying backend isolation for conflict generation, listing, resolution, and UI reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
