### PR TITLE
fix: revoke sessions when deleting agents

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -482,6 +482,7 @@ class DirectClient:
         """
         logger.debug("Deleting agent '%s'", agent_id)
         self._get_agent_service().delete_agent(agent_id)
+        self._get_session_service().delete_session(agent_id)
         if self.agent_id == agent_id:
             self.session_token = None
             self.agent_id = None

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -314,6 +314,7 @@ class SdkClient:
         """
         logger.debug("Deleting agent '%s'", agent_id)
         self._get_agent_service().delete_agent(agent_id)
+        self._get_session_service().delete_session(agent_id)
         if self.agent_id == agent_id:
             self.session_token = None
             self.agent_id = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,6 +615,44 @@ class TestMEMANTOCLI:
         assert client._cached_session is new_session
         session_service.validate_session.assert_called_once_with("new-token")
 
+    @pytest.mark.parametrize("client_path", ["direct_client", "sdk_client"])
+    def test_delete_agent_invalidates_persisted_session(
+        self, tmp_path, mock_all_clients, client_path
+    ):
+        """Deleting agent metadata must revoke every persisted session token."""
+        from memanto.app.services.session_service import SessionService
+        from memanto.app.utils.errors import InvalidSessionTokenError
+
+        if client_path == "direct_client":
+            from memanto.cli.client.direct_client import DirectClient as Client
+        else:
+            from memanto.cli.client.sdk_client import SdkClient as Client
+
+        session_service = SessionService(
+            secret_key="test-secret-key-min-32-bytes-1234",
+            sessions_dir=tmp_path / "sessions",
+        )
+        session = session_service.create_session(agent_id="deleted-agent")
+
+        client = Client("test-api-key")
+        client._agent_service = MagicMock()
+        client._session_service = session_service
+
+        # Reproduce the CLI path: it clears its in-memory/config session before
+        # constructing the client, while the persisted session remains active.
+        client.agent_id = None
+        client.session_token = None
+        client._cached_session = None
+        session_service.validate_session(session.session_token)
+
+        client.delete_agent("deleted-agent")
+
+        client._agent_service.delete_agent.assert_called_once_with("deleted-agent")
+        assert session_service.get_session("deleted-agent") is None
+        assert session_service.get_active_session() is None
+        with pytest.raises(InvalidSessionTokenError, match="no longer active"):
+            session_service.validate_session(session.session_token)
+
     def test_upload_file_sdk_accepts_snake_case_file_size(
         self, tmp_path, mock_all_clients
     ):


### PR DESCRIPTION
## Summary

- revoke persisted session state whenever either CLI client deletes an agent
- remove the active-session marker for the deleted agent through the existing `SessionService.delete_session` path
- add a regression test for both `SdkClient` and `DirectClient`

## Root cause and impact

The FastAPI delete route removes an agent's persisted session, but the two CLI client implementations only removed agent metadata. The CLI clears its in-memory/config session before constructing the client, so the clients' existing `self.agent_id` cleanup could not detect the deleted agent.

This is a CLI-client follow-up to #851, which added session cleanup to the FastAPI route. `memanto agent delete` calls `SdkClient.delete_agent` directly and never passes through that route; `DirectClient` had the same lifecycle gap.

As a result, the saved session record remained active and an already-issued JWT still passed `SessionService.validate_session` until expiry. Because deleting an agent preserves its Moorcheh namespace by default, a retained token could continue accessing that namespace after the user believed the agent had been deleted.

## Reproduction

The regression creates a real persisted session, reproduces the CLI path with cleared client state, deletes the agent through each client, and verifies that:

- the session record is removed
- the active marker is cleared
- the previously valid JWT is rejected

Before the fix, both client variants fail because the session remains active.

## Tests

- `python -m pytest tests -q -p no:cacheprovider` (364 passed, 24 live-key E2E tests skipped)
- `python -m ruff check memanto/cli/client/sdk_client.py memanto/cli/client/direct_client.py tests/test_cli.py`
- `python -m ruff format --check memanto/cli/client/sdk_client.py memanto/cli/client/direct_client.py tests/test_cli.py`
- `git diff --check`

Refs #770
