### PR TITLE
fix(ui): reject cross-site localhost requests

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -12,6 +12,7 @@ import signal
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from fastapi import (
     APIRouter,
@@ -73,13 +74,53 @@ def _is_loopback(host: str | None) -> bool:
         return False
 
 
+def _is_local_http_host(host: str | None) -> bool:
+    """Return True for IP loopback and names reserved for localhost."""
+    if not host:
+        return False
+    normalized = host.rstrip(".").lower()
+    return (
+        normalized == "localhost"
+        or normalized.endswith(".localhost")
+        or _is_loopback(normalized)
+    )
+
+
+def _canonical_origin(value: str) -> tuple[str, str, int] | None:
+    """Normalize an HTTP(S) origin for strict same-origin comparisons."""
+    try:
+        parsed = urlsplit(value)
+        scheme = parsed.scheme.lower()
+        if (
+            scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        port = parsed.port or (443 if scheme == "https" else 80)
+    except ValueError:
+        return None
+    return scheme, parsed.hostname.rstrip(".").lower(), port
+
+
 async def _require_local(request: Request) -> None:
-    """Reject requests that do not originate from the loopback interface.
+    """Require a loopback client, local Host, and same-origin browser request.
 
     UI management endpoints (shutdown, browse, config update, API key update)
     are designed for local desktop use only.  Allowing them from arbitrary
     network addresses would let any reachable host kill the server, enumerate
     the filesystem, or replace API credentials without authentication.
+
+    A client-address check alone is insufficient: when a hostile website sends
+    a request to ``127.0.0.1``, the server sees the victim's browser as a
+    loopback client.  Fetch Metadata and Origin validation prevent that
+    localhost CSRF path, while requests from non-browser local tools (which
+    normally omit both headers) remain supported.  Restricting Host to a
+    localhost name/address also blocks DNS-rebinding origins.
     """
     client_host = request.client.host if request.client else None
     if not _is_loopback(client_host):
@@ -90,6 +131,29 @@ async def _require_local(request: Request) -> None:
                 f"Request origin: {client_host}"
             ),
         )
+
+    request_host = request.url.hostname
+    if not _is_local_http_host(request_host):
+        raise HTTPException(
+            status_code=403,
+            detail="UI management endpoints require a localhost Host header.",
+        )
+
+    fetch_site = request.headers.get("sec-fetch-site", "").strip().lower()
+    if fetch_site and fetch_site not in {"none", "same-origin"}:
+        raise HTTPException(
+            status_code=403,
+            detail="Cross-site requests to UI management endpoints are forbidden.",
+        )
+
+    origin = request.headers.get("origin")
+    if origin:
+        request_origin = _canonical_origin(str(request.base_url).rstrip("/"))
+        if _canonical_origin(origin) != request_origin:
+            raise HTTPException(
+                status_code=403,
+                detail="Cross-origin requests to UI management endpoints are forbidden.",
+            )
 
 
 def _build_ui_direct_client() -> DirectClient | None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,7 +58,7 @@ def test_env_setup():
 async def client():
     """Create an async client for testing the FastAPI app"""
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+    async with AsyncClient(transport=transport, base_url="http://127.0.0.1") as ac:
         yield ac
 
 

--- a/tests/test_remaining_ui_auth.py
+++ b/tests/test_remaining_ui_auth.py
@@ -139,4 +139,7 @@ class TestGlobInjectionGuard:
 
         mock_request = MagicMock()
         mock_request.client.host = "127.0.0.1"
+        mock_request.url.hostname = "127.0.0.1"
+        mock_request.base_url = "http://127.0.0.1/"
+        mock_request.headers = {}
         asyncio.run(_require_local(mock_request))  # must not raise

--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -24,6 +24,16 @@ def _make_app():
     return app
 
 
+def _make_loopback_client(app):
+    """Create a client whose ASGI peer and Host are both loopback."""
+    return TestClient(
+        app,
+        base_url="http://127.0.0.1",
+        client=("127.0.0.1", 54321),
+        raise_server_exceptions=False,
+    )
+
+
 class TestUnauthenticatedUIEndpoints:
     """Unauthenticated requests from non-localhost must be refused with HTTP 403.
 
@@ -63,6 +73,67 @@ class TestUnauthenticatedUIEndpoints:
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.put("/api/ui/api-key", json={"api_key": "stolen"})
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_cross_site_form_post_rejected_from_loopback_browser(self):
+        """A hostile site must not pass the guard through the victim browser."""
+        app = _make_app()
+        client = _make_loopback_client(app)
+
+        resp = client.post(
+            "/api/ui/shutdown",
+            headers={
+                "Origin": "https://attacker.example",
+                "Sec-Fetch-Site": "cross-site",
+                "Sec-Fetch-Mode": "navigate",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+        )
+
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_dns_rebinding_host_rejected_from_loopback_browser(self):
+        """A same-origin attacker hostname resolving to loopback must be refused."""
+        app = _make_app()
+        client = TestClient(
+            app,
+            base_url="http://attacker.example",
+            client=("127.0.0.1", 54321),
+            raise_server_exceptions=False,
+        )
+
+        resp = client.post(
+            "/api/ui/shutdown",
+            headers={
+                "Origin": "http://attacker.example",
+                "Sec-Fetch-Site": "same-origin",
+            },
+        )
+
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+
+    def test_same_origin_loopback_browser_allowed(self):
+        """The real localhost UI must continue to reach management routes."""
+        app = _make_app()
+        client = _make_loopback_client(app)
+
+        resp = client.post(
+            "/api/ui/shutdown",
+            headers={
+                "Origin": "http://127.0.0.1",
+                "Sec-Fetch-Site": "same-origin",
+            },
+        )
+
+        assert resp.status_code == 200, f"expected 200, got {resp.status_code}"
+
+    def test_loopback_cli_without_browser_headers_allowed(self):
+        """Local CLI clients that omit browser security headers remain supported."""
+        app = _make_app()
+        client = _make_loopback_client(app)
+
+        resp = client.post("/api/ui/shutdown")
+
+        assert resp.status_code == 200, f"expected 200, got {resp.status_code}"
 
 
 class TestLoopbackDetection:
@@ -110,6 +181,9 @@ class TestLoopbackDetection:
 
         mock_request = MagicMock()
         mock_request.client.host = "127.0.0.1"
+        mock_request.url.hostname = "127.0.0.1"
+        mock_request.base_url = "http://127.0.0.1/"
+        mock_request.headers = {}
         asyncio.run(_require_local(mock_request))  # must not raise
 
     def test_require_local_allows_ipv4_mapped_loopback(self):
@@ -118,4 +192,7 @@ class TestLoopbackDetection:
 
         mock_request = MagicMock()
         mock_request.client.host = "::ffff:127.0.0.1"
+        mock_request.url.hostname = "::1"
+        mock_request.base_url = "http://[::1]/"
+        mock_request.headers = {}
         asyncio.run(_require_local(mock_request))  # must not raise


### PR DESCRIPTION
## Summary

The Web UI management guard trusted only the connection's client IP. That does not establish that a browser request originated from the Memanto UI: when a hostile website submits a form to `127.0.0.1`, the victim browser connects to Memanto from a loopback socket and passes the existing guard.

This change requires the complete local-browser boundary: a loopback peer, a localhost Host, non-cross-site Fetch Metadata, and a matching Origin when present. Headerless local CLI requests remain supported.

Bounty submission for #770.

## Root cause and impact

Every `/api/ui/*` management route depends on `_require_local`, including shutdown, on-prem restart, configuration/API-key changes, filesystem browsing, integration installation, migrations, summaries, and conflict resolution. `_require_local` previously checked only `request.client.host`.

A hostile page could therefore use a simple, no-preflight HTML form to send:

```http
POST /api/ui/shutdown HTTP/1.1
Host: 127.0.0.1:8000
Origin: https://attacker.example
Sec-Fetch-Site: cross-site
Content-Type: application/x-www-form-urlencoded
```

The request was accepted with HTTP 200. In UI mode, that route schedules `SIGINT` against the Memanto process. The bodyless on-prem restart route was exposed through the same cross-site form primitive. A DNS-rebinding origin also passed because the guard did not validate Host.

## Reproduction

The new regression recreates the browser boundary with an ASGI client whose network peer is `127.0.0.1`, then sends the hostile Origin/Fetch Metadata headers above. Before this fix:

```text
200 {"status":"ignored","reason":"Not in UI mode"}
```

The `ignored` response is expected only because the deterministic test leaves UI mode disabled; it proves the request reached the privileged handler. With UI mode enabled, the handler queues process termination.

## Fix

- Keep the existing loopback peer check.
- Require the HTTP Host to be an IP loopback address, `localhost`, or a reserved `.localhost` name.
- Reject `Sec-Fetch-Site` values other than `same-origin` and `none`.
- Canonicalize and compare HTTP(S) Origin scheme, hostname, and effective port.
- Continue allowing local CLI clients that omit browser-only Origin and Fetch Metadata headers.
- Add regressions for a cross-site form POST, DNS rebinding, valid same-origin UI traffic, and headerless local CLI traffic.

## Validation

- `python -m pytest tests/test_ui_auth.py tests/test_remaining_ui_auth.py tests/test_api.py -q --disable-warnings` — passed
- `python -m pytest -q --disable-warnings` — full non-live suite passed; 24 credential-dependent live tests skipped
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy memanto/app/ui/routes/ui_router.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened protection for local-only UI management endpoints by validating the request host, origin, and browser fetch metadata.
  * Blocked cross-site and DNS-rebinding-style requests, including attempts using loopback-resolving hostnames.
  * Preserved access for same-origin loopback browser requests and local command-line usage.
* **Tests**
  * Added coverage for loopback, cross-origin, IPv4-mapped IPv6, and missing-header scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->