### PR TITLE
fix: bound yesterday temporal recall

### DIFF
--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -240,12 +240,21 @@ def build_temporal_query(
           }
         }
     """
-    # Parse relative time if provided and no absolute time given
+    # Parse relative time if provided and no absolute time given. Most relative
+    # phrases describe an open-ended lookback window, but "yesterday" is a
+    # closed calendar-day window. Supplying only its start would also return
+    # today's memories, which contradicts the caller's requested time range.
     if relative_time and not created_after:
-        parsed_relative_time = parse_relative_time(relative_time)
-        if parsed_relative_time is None:
-            raise ValueError(f"Invalid relative_time: {relative_time!r}")
-        created_after = parsed_relative_time
+        normalized_relative_time = relative_time.lower().strip()
+        if normalized_relative_time == "yesterday":
+            created_after, yesterday_end = get_yesterday_range()
+            if not created_before:
+                created_before = yesterday_end
+        else:
+            parsed_relative_time = parse_relative_time(relative_time)
+            if parsed_relative_time is None:
+                raise ValueError(f"Invalid relative_time: {relative_time!r}")
+            created_after = parsed_relative_time
 
     body: dict[str, Any] = {"query": query, "limit": limit}
     if created_after:

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import typer
 from rich.panel import Panel
 
+from memanto.app.utils.temporal_helpers import get_yesterday_range
 from memanto.cli.commands._shared import (
     BOLD_PRIMARY,
     BRIGHT,
@@ -512,6 +513,14 @@ def recall(
 
         if not ts:
             return ts
+
+        # ``--as-of yesterday`` means the state at the end of that calendar
+        # day. The generic relative helper returns the start of the day because
+        # its normal consumer is a changed-since / created-after query; using
+        # that value here drops almost all memories created yesterday.
+        if flag_name == "--as-of" and ts.lower().strip() == "yesterday":
+            _, yesterday_end = get_yesterday_range()
+            return yesterday_end
 
         # Try parsing as relative time (e.g., "today", "last 2 hours")
         rel_ts = parse_relative_time(ts)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -757,6 +757,18 @@ class TestMEMANTOCLI:
         assert "Invalid timestamp format" in result.stdout
         mock_all_clients.recall_changed_since.assert_not_called()
 
+    def test_recall_as_of_yesterday_uses_end_of_day(self, mock_all_clients):
+        """Relative as-of recall must include the whole of yesterday."""
+        from memanto.app.utils.temporal_helpers import get_yesterday_range
+
+        mock_all_clients.recall_as_of.return_value = {"memories": [], "count": 0}
+        _, yesterday_end = get_yesterday_range()
+
+        result = runner.invoke(app, ["recall", "--as-of", "yesterday"])
+
+        assert result.exit_code == 0
+        assert mock_all_clients.recall_as_of.call_args.kwargs["as_of"] == yesterday_end
+
     @pytest.mark.parametrize(
         "client_class_path",
         [

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -6,6 +6,7 @@ from memanto.app.routes.memory import RecallRequest
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.utils.temporal_helpers import (
     build_temporal_query,
+    get_yesterday_range,
     parse_as_of_timestamp,
     parse_iso_timestamp,
     parse_relative_time,
@@ -71,6 +72,20 @@ def test_build_temporal_query_rejects_invalid_relative_time():
             "deployment notes",
             relative_time="last 0 days",
         )
+
+
+def test_build_temporal_query_bounds_yesterday_to_that_calendar_day():
+    start, end = get_yesterday_range()
+
+    payload = build_temporal_query(
+        "http://localhost:8000",
+        "agent-1",
+        "deployment notes",
+        relative_time="yesterday",
+    )["json"]
+
+    assert payload["created_after"] == start
+    assert payload["created_before"] == end
 
 
 def test_parse_as_of_timestamp_treats_date_only_as_end_of_day():


### PR DESCRIPTION
Fixes two reproducible #770 temporal-recall errors: relative_time="yesterday" previously had no end boundary, so today’s memories leaked into results; memanto recall --as-of yesterday used midnight, excluding almost the entire requested day. This change bounds standard recall to yesterday’s UTC calendar day and resolves CLI as-of to end-of-day. Validation: 47 focused tests passed; Ruff check/format, mypy and git diff checks passed.