### PR TITLE
fix(ts): harden session recovery and server startup

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -382,12 +382,20 @@ export class Memanto {
   private async ensureReady(): Promise<void> {
     if (this.sessionToken) return;
     if (!this.starting) this.starting = this.bootstrap();
+    const starting = this.starting;
     try {
-      await this.starting;
-    } catch (e) {
-      this.starting = null;
-      throw e;
+      await starting;
+    } finally {
+      if (this.starting === starting) this.starting = null;
     }
+  }
+
+  private async refreshExpiredSession(staleToken: string | null): Promise<void> {
+    // Another request may already have refreshed the shared client while this
+    // request was waiting for its 401 response.
+    if (this.sessionToken && this.sessionToken !== staleToken) return;
+    this.sessionToken = null;
+    await this.ensureReady();
   }
 
   private async bootstrap(): Promise<void> {
@@ -442,11 +450,16 @@ export class Memanto {
     if (requireSession) {
       headers["X-Session-Token"] = this.sessionToken ?? "";
     }
-    const res = await fetch(`${baseUrl}${path}`, {
-      method,
-      headers,
-      body: body === undefined ? undefined : JSON.stringify(body),
-    });
+    const serializedBody = body === undefined ? undefined : JSON.stringify(body);
+    const send = () =>
+      fetch(`${baseUrl}${path}`, { method, headers, body: serializedBody });
+    const staleToken = this.sessionToken;
+    let res = await send();
+    if (requireSession && res.status === 401) {
+      await this.refreshExpiredSession(staleToken);
+      headers["X-Session-Token"] = this.sessionToken ?? "";
+      res = await send();
+    }
     if (!res.ok) throw await asError(res, `${method} ${path} failed`);
     if (res.status === 204) return undefined as T;
     return (await res.json()) as T;
@@ -463,32 +476,44 @@ export class Memanto {
     if (!fileStats.isFile()) {
       throw new Error(`Upload path is not a file: ${filePath}`);
     }
-    const boundary = `----memanto-${randomUUID()}`;
-    const header = Buffer.from(
-      `--${boundary}\r\n` +
-        `Content-Disposition: form-data; name="file"; filename="${escapeMultipartValue(filename)}"\r\n` +
-        "Content-Type: application/octet-stream\r\n\r\n",
-    );
-    const footer = Buffer.from(`\r\n--${boundary}--\r\n`);
-    const body = Readable.from(
-      (async function* streamMultipart() {
-        yield header;
-        for await (const chunk of createReadStream(filePath)) {
-          yield chunk;
-        }
-        yield footer;
-      })(),
-    );
-    const res = await fetch(`${baseUrl}${path}`, {
-      method: "POST",
-      headers: {
-        "X-Session-Token": this.sessionToken ?? "",
-        "Content-Type": `multipart/form-data; boundary=${boundary}`,
-        "Content-Length": String(header.length + fileStats.size + footer.length),
-      },
-      body: body as unknown as BodyInit,
-      duplex: "half",
-    } as RequestInit & { duplex: "half" });
+    const headers: Record<string, string> = {
+      "X-Session-Token": this.sessionToken ?? "",
+    };
+    const send = () => {
+      const boundary = `----memanto-${randomUUID()}`;
+      const header = Buffer.from(
+        `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="file"; filename="${escapeMultipartValue(filename)}"\r\n` +
+          "Content-Type: application/octet-stream\r\n\r\n",
+      );
+      const footer = Buffer.from(`\r\n--${boundary}--\r\n`);
+      const body = Readable.from(
+        (async function* streamMultipart() {
+          yield header;
+          for await (const chunk of createReadStream(filePath)) {
+            yield chunk;
+          }
+          yield footer;
+        })(),
+      );
+      headers["Content-Type"] = `multipart/form-data; boundary=${boundary}`;
+      headers["Content-Length"] = String(
+        header.length + fileStats.size + footer.length,
+      );
+      return fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers,
+        body: body as unknown as BodyInit,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+    };
+    const staleToken = this.sessionToken;
+    let res = await send();
+    if (res.status === 401) {
+      await this.refreshExpiredSession(staleToken);
+      headers["X-Session-Token"] = this.sessionToken ?? "";
+      res = await send();
+    }
     if (!res.ok) throw await asError(res, `POST ${path} failed`);
     return (await res.json()) as T;
   }

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -395,12 +395,23 @@ export class Memanto {
     // request was waiting for its 401 response.
     if (this.sessionToken && this.sessionToken !== staleToken) return;
     this.sessionToken = null;
-    await this.ensureReady();
+    if (!this.starting) this.starting = this.reactivate();
+    const starting = this.starting;
+    try {
+      await starting;
+    } finally {
+      if (this.starting === starting) this.starting = null;
+    }
   }
 
   private async bootstrap(): Promise<void> {
     await this.lifecycle.start();
     if (this.autoCreate) await this.createAgentIfMissing();
+    await this.activate();
+  }
+
+  private async reactivate(): Promise<void> {
+    await this.lifecycle.start();
     await this.activate();
   }
 
@@ -431,6 +442,21 @@ export class Memanto {
     this.sessionToken = session.session_token;
   }
 
+  private async sendWithSessionRetry(
+    send: () => Promise<Response>,
+    headers: Record<string, string>,
+    retryOn401: boolean,
+  ): Promise<Response> {
+    const staleToken = this.sessionToken;
+    let res = await send();
+    if (retryOn401 && res.status === 401) {
+      await this.refreshExpiredSession(staleToken);
+      headers["X-Session-Token"] = this.sessionToken ?? "";
+      res = await send();
+    }
+    return res;
+  }
+
   private async request<T = unknown>(
     method: string,
     path: string,
@@ -453,13 +479,7 @@ export class Memanto {
     const serializedBody = body === undefined ? undefined : JSON.stringify(body);
     const send = () =>
       fetch(`${baseUrl}${path}`, { method, headers, body: serializedBody });
-    const staleToken = this.sessionToken;
-    let res = await send();
-    if (requireSession && res.status === 401) {
-      await this.refreshExpiredSession(staleToken);
-      headers["X-Session-Token"] = this.sessionToken ?? "";
-      res = await send();
-    }
+    const res = await this.sendWithSessionRetry(send, headers, requireSession);
     if (!res.ok) throw await asError(res, `${method} ${path} failed`);
     if (res.status === 204) return undefined as T;
     return (await res.json()) as T;
@@ -507,13 +527,7 @@ export class Memanto {
         duplex: "half",
       } as RequestInit & { duplex: "half" });
     };
-    const staleToken = this.sessionToken;
-    let res = await send();
-    if (res.status === 401) {
-      await this.refreshExpiredSession(staleToken);
-      headers["X-Session-Token"] = this.sessionToken ?? "";
-      res = await send();
-    }
+    const res = await this.sendWithSessionRetry(send, headers, true);
     if (!res.ok) throw await asError(res, `POST ${path} failed`);
     return (await res.json()) as T;
   }

--- a/sdks/typescript/src/lifecycle.ts
+++ b/sdks/typescript/src/lifecycle.ts
@@ -32,6 +32,7 @@ export interface ServerOptions {
 export class ServerLifecycle {
   private process: ChildProcess | null = null;
   private url: string | null = null;
+  private starting: Promise<string> | null = null;
   private cleanupRegistered = false;
 
   constructor(private readonly opts: ServerOptions = {}) {}
@@ -45,7 +46,16 @@ export class ServerLifecycle {
 
   async start(): Promise<string> {
     if (this.url) return this.url;
+    if (!this.starting) this.starting = this.startOnce();
+    const starting = this.starting;
+    try {
+      return await starting;
+    } finally {
+      if (this.starting === starting) this.starting = null;
+    }
+  }
 
+  private async startOnce(): Promise<string> {
     if (this.opts.baseUrl) {
       this.url = this.opts.baseUrl.replace(/\/$/, "");
       return this.url;

--- a/sdks/typescript/test/lifecycle.test.ts
+++ b/sdks/typescript/test/lifecycle.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createServer, type Server } from "node:http";
 import { AddressInfo } from "node:net";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ServerLifecycle } from "../src/lifecycle.js";
 
 function startFakeHealthyServer(): Promise<{ url: string; close: () => void }> {
@@ -20,6 +23,17 @@ function startFakeHealthyServer(): Promise<{ url: string; close: () => void }> {
         url: `http://127.0.0.1:${addr.port}`,
         close: () => srv.close(),
       });
+    });
+  });
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const port = (srv.address() as AddressInfo).port;
+      srv.close(() => resolve(port));
     });
   });
 }
@@ -64,5 +78,42 @@ describe("ServerLifecycle", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
+  });
+
+  it("shares one local server start across concurrent callers", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "memanto-lifecycle-"));
+    cleanupFns.push(() => rm(dir, { recursive: true, force: true }));
+    const marker = join(dir, "starts.log");
+    const serverScript = join(dir, "fake-uvx.mjs");
+    await writeFile(
+      serverScript,
+      `
+import { appendFileSync } from "node:fs";
+import { createServer } from "node:http";
+
+const port = Number(process.argv[process.argv.indexOf("--port") + 1]);
+const host = process.argv[process.argv.indexOf("--host") + 1];
+appendFileSync(${JSON.stringify(marker)}, "start\\n");
+createServer((req, res) => {
+  res.writeHead(req.url === "/health" ? 200 : 404);
+  res.end();
+}).listen(port, host);
+`,
+    );
+    const port = await pickFreePort();
+    const life = new ServerLifecycle({
+      host: "127.0.0.1",
+      port,
+      uvxPath: process.execPath,
+      packageSpec: serverScript,
+      healthTimeoutMs: 5_000,
+    });
+    cleanupFns.push(() => life.stop());
+
+    const [first, second] = await Promise.all([life.start(), life.start()]);
+
+    expect(first).toBe(`http://127.0.0.1:${port}`);
+    expect(second).toBe(first);
+    expect((await readFile(marker, "utf8")).trim().split("\n")).toHaveLength(1);
   });
 });

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -15,7 +15,11 @@ interface Recorded {
 
 function startFakeApi(
   agentId = "test-agent",
-  opts: { expireFirstSession?: boolean; rejectAllSessions?: boolean } = {},
+  opts: {
+    expireFirstSession?: boolean;
+    rejectAllSessions?: boolean;
+    coordinateConcurrentExpiration?: boolean;
+  } = {},
 ): Promise<{
   url: string;
   recorded: Recorded[];
@@ -25,6 +29,8 @@ function startFakeApi(
   return new Promise((resolve) => {
     const recorded: Recorded[] = [];
     let activationCount = 0;
+    let expiredRememberCount = 0;
+    let pendingRefreshReply: (() => void) | null = null;
     const srv: Server = createServer((req, res) => {
       collectBody(req).then((body) => {
         recorded.push({
@@ -54,17 +60,27 @@ function startFakeApi(
           });
         if (url.startsWith(`/api/v2/agents/${encodedAgentId}/activate`)) {
           activationCount += 1;
-          return reply(200, {
-            session_token:
-              activationCount === 1 ? "fake-token" : "refreshed-token",
-            agent_id: agentId,
-            session_id: "sess-1",
-            namespace: "memanto_agent_test_agent",
-            started_at: new Date().toISOString(),
-            expires_at: new Date(Date.now() + 3600_000).toISOString(),
-            status: "active",
-            pattern: "default",
-          });
+          const sendActivation = () =>
+            reply(200, {
+              session_token:
+                activationCount === 1 ? "fake-token" : "refreshed-token",
+              agent_id: agentId,
+              session_id: "sess-1",
+              namespace: "memanto_agent_test_agent",
+              started_at: new Date().toISOString(),
+              expires_at: new Date(Date.now() + 3600_000).toISOString(),
+              status: "active",
+              pattern: "default",
+            });
+          if (
+            opts.coordinateConcurrentExpiration &&
+            activationCount === 2 &&
+            expiredRememberCount < 2
+          ) {
+            pendingRefreshReply = sendActivation;
+            return;
+          }
+          return sendActivation();
         }
         if (url === `/api/v2/agents/${encodedAgentId}` && req.method === "GET")
           return reply(404, { detail: "not found" });
@@ -78,7 +94,14 @@ function startFakeApi(
           (opts.rejectAllSessions ||
             req.headers["x-session-token"] === "fake-token")
         ) {
-          return reply(401, { detail: "Session token expired" });
+          expiredRememberCount += 1;
+          reply(401, { detail: "Session token expired" });
+          if (expiredRememberCount === 2 && pendingRefreshReply) {
+            const releaseRefresh = pendingRefreshReply;
+            pendingRefreshReply = null;
+            releaseRefresh();
+          }
+          return;
         }
         if (url === `/api/v2/agents/${encodedAgentId}/remember`)
           return reply(200, {
@@ -208,7 +231,10 @@ describe("Memanto", () => {
   });
 
   it("shares one reactivation across concurrent expired-session retries", async () => {
-    const api = await startFakeApi("test-agent", { expireFirstSession: true });
+    const api = await startFakeApi("test-agent", {
+      expireFirstSession: true,
+      coordinateConcurrentExpiration: true,
+    });
     cleanupFns.push(api.close);
 
     const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -17,6 +17,7 @@ function startFakeApi(
   agentId = "test-agent",
   opts: {
     expireFirstSession?: boolean;
+    expireFirstUpload?: boolean;
     rejectAllSessions?: boolean;
     coordinateConcurrentExpiration?: boolean;
   } = {},
@@ -86,7 +87,10 @@ function startFakeApi(
           return reply(404, { detail: "not found" });
         if (url === "/api/v2/agents" && req.method === "POST")
           return reply(201, { agent_id: agentId });
-        if (url === `/api/v2/agents/${encodedAgentId}` && req.method === "DELETE")
+        if (
+          url === `/api/v2/agents/${encodedAgentId}` &&
+          req.method === "DELETE"
+        )
           return reply(200, { agent_id: agentId, deleted: true });
         if (
           (opts.rejectAllSessions || opts.expireFirstSession) &&
@@ -125,13 +129,20 @@ function startFakeApi(
         if (
           url === `/api/v2/agents/${encodedAgentId}/upload-file` &&
           req.method === "POST"
-        )
+        ) {
+          if (
+            opts.expireFirstUpload &&
+            req.headers["x-session-token"] === "fake-token"
+          ) {
+            return reply(401, { detail: "Session token expired" });
+          }
           return reply(200, {
             agent_id: agentId,
             session_id: "sess-1",
             status: "queued",
             file_name: "notes.txt",
           });
+        }
         return reply(404, { detail: "unknown route" });
       });
     });
@@ -172,9 +183,7 @@ describe("Memanto", () => {
     const res = await m.remember({ content: "Het likes coffee" });
     expect(res).toMatchObject({ memory_id: "mem-1", status: "queued" });
 
-    const remember = api.recorded.find((r) =>
-      r.url.endsWith("/remember"),
-    );
+    const remember = api.recorded.find((r) => r.url.endsWith("/remember"));
     expect(remember?.headers["x-session-token"]).toBe("fake-token");
   });
 
@@ -249,8 +258,9 @@ describe("Memanto", () => {
     const activations = api.recorded.filter((r) => r.url.endsWith("/activate"));
     const remembers = api.recorded.filter((r) => r.url.endsWith("/remember"));
     expect(activations).toHaveLength(2);
-    expect(remembers.filter((r) => r.headers["x-session-token"] === "fake-token"))
-      .toHaveLength(2);
+    expect(
+      remembers.filter((r) => r.headers["x-session-token"] === "fake-token"),
+    ).toHaveLength(2);
     expect(
       remembers.filter(
         (r) => r.headers["x-session-token"] === "refreshed-token",
@@ -312,9 +322,7 @@ describe("Memanto", () => {
     const res = await m.uploadFile({ path });
     expect(res).toMatchObject({ status: "queued", file_name: "notes.txt" });
 
-    const upload = api.recorded.find((r) =>
-      r.url.endsWith("/upload-file"),
-    );
+    const upload = api.recorded.find((r) => r.url.endsWith("/upload-file"));
     expect(upload?.headers["x-session-token"]).toBe("fake-token");
     expect(upload?.headers["content-type"]).toContain(
       "multipart/form-data; boundary=",
@@ -324,6 +332,37 @@ describe("Memanto", () => {
     );
     expect(upload?.body).toContain('name="file"; filename="notes.txt"');
     expect(upload?.body).toContain("hello upload");
+  });
+
+  it("rebuilds a streamed upload after session reactivation", async () => {
+    const api = await startFakeApi("test-agent", { expireFirstUpload: true });
+    cleanupFns.push(api.close);
+
+    const dir = await mkdtemp(join(tmpdir(), "memanto-sdk-"));
+    cleanupFns.push(() => rm(dir, { recursive: true, force: true }));
+    const path = join(dir, "notes.txt");
+    await writeFile(path, "hello retried upload");
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    const res = await m.uploadFile({ path });
+
+    expect(res).toMatchObject({ status: "queued", file_name: "notes.txt" });
+    const activations = api.recorded.filter((r) => r.url.endsWith("/activate"));
+    const uploads = api.recorded.filter((r) => r.url.endsWith("/upload-file"));
+    expect(activations).toHaveLength(2);
+    expect(uploads).toHaveLength(2);
+    expect(uploads.map((r) => r.headers["x-session-token"])).toEqual([
+      "fake-token",
+      "refreshed-token",
+    ]);
+    expect(uploads.every((r) => r.body.includes("hello retried upload"))).toBe(
+      true,
+    );
+    expect(uploads[0]?.headers["content-type"]).not.toBe(
+      uploads[1]?.headers["content-type"],
+    );
   });
 
   it("rejects empty agentId", () => {
@@ -338,7 +377,9 @@ describe("Memanto", () => {
     const m = new Memanto({ agentId, baseUrl: api.url });
     cleanupFns.push(() => m.close());
 
-    await m.remember({ content: "Scoped agent ids must stay in one path segment" });
+    await m.remember({
+      content: "Scoped agent ids must stay in one path segment",
+    });
 
     const encodedAgentId = encodeURIComponent(agentId);
     expect(api.recorded.map((r) => r.url)).toContain(
@@ -354,6 +395,8 @@ describe("Memanto", () => {
     const create = api.recorded.find(
       (r) => r.method === "POST" && r.url === "/api/v2/agents",
     );
-    expect(JSON.parse(create?.body ?? "{}")).toMatchObject({ agent_id: agentId });
+    expect(JSON.parse(create?.body ?? "{}")).toMatchObject({
+      agent_id: agentId,
+    });
   });
 });

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -15,7 +15,7 @@ interface Recorded {
 
 function startFakeApi(
   agentId = "test-agent",
-  opts: { expireFirstSession?: boolean } = {},
+  opts: { expireFirstSession?: boolean; rejectAllSessions?: boolean } = {},
 ): Promise<{
   url: string;
   recorded: Recorded[];
@@ -73,9 +73,10 @@ function startFakeApi(
         if (url === `/api/v2/agents/${encodedAgentId}` && req.method === "DELETE")
           return reply(200, { agent_id: agentId, deleted: true });
         if (
-          opts.expireFirstSession &&
+          (opts.rejectAllSessions || opts.expireFirstSession) &&
           url === `/api/v2/agents/${encodedAgentId}/remember` &&
-          req.headers["x-session-token"] === "fake-token"
+          (opts.rejectAllSessions ||
+            req.headers["x-session-token"] === "fake-token")
         ) {
           return reply(401, { detail: "Session token expired" });
         }
@@ -175,6 +176,29 @@ describe("Memanto", () => {
     const res = await m.remember({ content: "Het likes coffee" });
 
     expect(res).toMatchObject({ memory_id: "mem-1", status: "queued" });
+    const activations = api.recorded.filter((r) => r.url.endsWith("/activate"));
+    const agentLookups = api.recorded.filter(
+      (r) => r.method === "GET" && r.url === "/api/v2/agents/test-agent",
+    );
+    const remembers = api.recorded.filter((r) => r.url.endsWith("/remember"));
+    expect(activations).toHaveLength(2);
+    expect(agentLookups).toHaveLength(1);
+    expect(remembers).toHaveLength(2);
+    expect(remembers[0]?.headers["x-session-token"]).toBe("fake-token");
+    expect(remembers[1]?.headers["x-session-token"]).toBe("refreshed-token");
+  });
+
+  it("returns a second session failure without retrying again", async () => {
+    const api = await startFakeApi("test-agent", { rejectAllSessions: true });
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    await expect(m.remember({ content: "Het likes coffee" })).rejects.toThrow(
+      /401/,
+    );
+
     const activations = api.recorded.filter((r) => r.url.endsWith("/activate"));
     const remembers = api.recorded.filter((r) => r.url.endsWith("/remember"));
     expect(activations).toHaveLength(2);

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -13,7 +13,10 @@ interface Recorded {
   body: string;
 }
 
-function startFakeApi(agentId = "test-agent"): Promise<{
+function startFakeApi(
+  agentId = "test-agent",
+  opts: { expireFirstSession?: boolean } = {},
+): Promise<{
   url: string;
   recorded: Recorded[];
   close: () => void;
@@ -21,6 +24,7 @@ function startFakeApi(agentId = "test-agent"): Promise<{
   const encodedAgentId = encodeURIComponent(agentId);
   return new Promise((resolve) => {
     const recorded: Recorded[] = [];
+    let activationCount = 0;
     const srv: Server = createServer((req, res) => {
       collectBody(req).then((body) => {
         recorded.push({
@@ -48,9 +52,11 @@ function startFakeApi(agentId = "test-agent"): Promise<{
             pattern: "default",
             time_remaining_seconds: 3600,
           });
-        if (url.startsWith(`/api/v2/agents/${encodedAgentId}/activate`))
+        if (url.startsWith(`/api/v2/agents/${encodedAgentId}/activate`)) {
+          activationCount += 1;
           return reply(200, {
-            session_token: "fake-token",
+            session_token:
+              activationCount === 1 ? "fake-token" : "refreshed-token",
             agent_id: agentId,
             session_id: "sess-1",
             namespace: "memanto_agent_test_agent",
@@ -59,12 +65,20 @@ function startFakeApi(agentId = "test-agent"): Promise<{
             status: "active",
             pattern: "default",
           });
+        }
         if (url === `/api/v2/agents/${encodedAgentId}` && req.method === "GET")
           return reply(404, { detail: "not found" });
         if (url === "/api/v2/agents" && req.method === "POST")
           return reply(201, { agent_id: agentId });
         if (url === `/api/v2/agents/${encodedAgentId}` && req.method === "DELETE")
           return reply(200, { agent_id: agentId, deleted: true });
+        if (
+          opts.expireFirstSession &&
+          url === `/api/v2/agents/${encodedAgentId}/remember` &&
+          req.headers["x-session-token"] === "fake-token"
+        ) {
+          return reply(401, { detail: "Session token expired" });
+        }
         if (url === `/api/v2/agents/${encodedAgentId}/remember`)
           return reply(200, {
             memory_id: "mem-1",
@@ -149,6 +163,49 @@ describe("Memanto", () => {
 
     const res = await m.recall({ query: "coffee" });
     expect(res).toMatchObject({ count: 0 });
+  });
+
+  it("reactivates once and retries when the cached session expires", async () => {
+    const api = await startFakeApi("test-agent", { expireFirstSession: true });
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    const res = await m.remember({ content: "Het likes coffee" });
+
+    expect(res).toMatchObject({ memory_id: "mem-1", status: "queued" });
+    const activations = api.recorded.filter((r) => r.url.endsWith("/activate"));
+    const remembers = api.recorded.filter((r) => r.url.endsWith("/remember"));
+    expect(activations).toHaveLength(2);
+    expect(remembers).toHaveLength(2);
+    expect(remembers[0]?.headers["x-session-token"]).toBe("fake-token");
+    expect(remembers[1]?.headers["x-session-token"]).toBe("refreshed-token");
+  });
+
+  it("shares one reactivation across concurrent expired-session retries", async () => {
+    const api = await startFakeApi("test-agent", { expireFirstSession: true });
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    const results = await Promise.all([
+      m.remember({ content: "Het likes coffee" }),
+      m.remember({ content: "Het likes tea" }),
+    ]);
+
+    expect(results).toHaveLength(2);
+    const activations = api.recorded.filter((r) => r.url.endsWith("/activate"));
+    const remembers = api.recorded.filter((r) => r.url.endsWith("/remember"));
+    expect(activations).toHaveLength(2);
+    expect(remembers.filter((r) => r.headers["x-session-token"] === "fake-token"))
+      .toHaveLength(2);
+    expect(
+      remembers.filter(
+        (r) => r.headers["x-session-token"] === "refreshed-token",
+      ),
+    ).toHaveLength(2);
   });
 
   it("rebootstraps after deleting the active agent", async () => {


### PR DESCRIPTION
## What changed  - Reactivate the bound agent when a session-scoped TypeScript SDK request receives HTTP 401. - Retry the rejected request exactly once with the refreshed session token. - Share one reactivation across concurrent requests that fail with the same stale token. - Apply the same recovery behavior to JSON and multipart requests. - Serialize concurrent `ServerLifecycle.start()` calls so they share one local process startup.  ## Findings and reproduction  ### 1. Expired sessions permanently break a long-running client  The SDK cached its session token indefinitely. Once the server invalidated that session, `ensureReady()` still saw a non-empty token and every later memory operation failed with 401. The regression tests reproduce one expired request, concurrent expired requests, a repeated rejection, and a streamed upload whose body must be rebuilt before retry.  ### 2. Concurrent lifecycle starts can spawn duplicate local servers  `ServerLifecycle.start()` checked only the final URL. While the first local process was still becoming healthy, a second caller could start another `uvx` process on the same port. This could fail both callers and leave the first process orphaned. The new functional test uses a real child process and confirms that two concurrent callers produce exactly one process start and receive the same URL.  ## Behavior  A session-scoped 401 discards only the stale token, activates a fresh session, and retries once. Concurrent failures share the same refresh. A second 401 is returned normally.  Concurrent lifecycle callers now await the same in-flight startup promise. The promise is cleared after success or failure so a later attempt can still recover.  ## Validation  - `npm test`: 43 tests passed across 7 files - `npm run typecheck`: passed - `npm run build`: passed - `git diff --check`: passed - Integration smoke script could not run because the repository does not contain the referenced `sdks/typescript/scripts/smoke-integrations.mjs`  Refs #770  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  * **Bug Fixes**   * Improved expired session handling: stale session tokens trigger session reactivation and prevent repeated failures.   * When session enforcement is enabled, requests that receive a 401 now refresh the session and retry once automatically.   * Improved reliability under concurrency by coordinating session refresh/retry and avoiding redundant reactivation.   * Improved server startup reliability by deduplicating overlapping start requests. * **Tests**   * Expanded integration coverage for expired-session reactivation, single-retry behavior, and coordinated concurrent retries.   * Added coverage to confirm streamed uploads are rebuilt/retried after session reactivation when sessions expire.  <!-- end of auto-generated comment: release notes by coderabbit.ai --> 

## Social write-up

- [Reddit technical deep dive](https://www.reddit.com/r/Memanto/comments/1v4uzgp/what_broke_when_a_typescript_sdk_retried_requests/) (currently awaiting moderator approval after Reddit's automated filter removed it)
