### PR TITLE
fix: timeline amnesia in search_as_of, search_changed_since, search_recent

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -237,7 +237,7 @@ class MemoryReadService:
                     "temporal_mode": "as_of",
                 }
 
-            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags, skip_ttl_filter=True)
             all_memories = self._apply_temporal_filter(
                 all_memories, created_before=as_of_dt.isoformat()
             )
@@ -300,7 +300,7 @@ class MemoryReadService:
             if not namespaces:
                 return {"results": [], "total_found": 0, "since_date": since_date}
 
-            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags, skip_ttl_filter=True)
 
             # Filter to only changed memories
             changed_memories = []
@@ -393,7 +393,7 @@ class MemoryReadService:
             if not namespaces:
                 return {"results": [], "total_found": 0}
 
-            unique_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            unique_memories = self._fetch_all_memories(namespaces, type=type, tags=tags, skip_ttl_filter=True)
 
             if created_after or created_before:
                 unique_memories = self._apply_temporal_filter(
@@ -426,6 +426,7 @@ class MemoryReadService:
         namespaces: list[str],
         type: list[str] | None = None,
         tags: list[str] | None = None,
+        skip_ttl_filter: bool = False,
     ) -> list[dict[str, Any]]:
         """
         List all stored memories across the given namespaces via Moorcheh's
@@ -434,6 +435,12 @@ class MemoryReadService:
 
         Iterates through all pages using cursor-based pagination (next_token)
         so results are not truncated at the 100-item per-page cap.
+
+        When skip_ttl_filter is True, expired memories are returned without
+        pre-filtering. This is needed by temporal query methods (search_as_of,
+        search_changed_since, search_recent) that apply their own time-relative
+        expiry logic and must not have currently-expired memories removed before
+        they can evaluate them.
         """
         items: list[Any] = []
         for ns in namespaces:
@@ -479,6 +486,8 @@ class MemoryReadService:
 
             memories.append(formatted)
 
+        if skip_ttl_filter:
+            return memories
         return self._filter_expired_memories(memories)
 
     def _memory_version_key(


### PR DESCRIPTION
## Bug Report: Timeline Amnesia in Temporal Query Methods

Found as part of the [Memanto Bug & Exploit Challenge (#770)](https://github.com/moorcheh-ai/memanto/issues/770).

### Problem

`_fetch_all_memories()` unconditionally calls `_filter_expired_memories()` using `datetime.now()` (current wall clock). This breaks three temporal query methods that need to see currently-expired memories in order to apply their own time-relative logic:

1. **`search_as_of`** — A memory valid *at* the `as_of` date but expired *now* is silently dropped. Point-in-time recall returns incomplete results.
2. **`search_changed_since`** — Same root cause. A memory created after `since_date` but expired now is excluded from differential retrieval.
3. **`search_recent`** — A recently-stored memory with a short TTL is invisible, making audit impossible.

### Reproduction

```python
# Memory created Jan 10, TTL 30 days (expires Feb 9).
# Query as_of Jan 15 — memory was alive on Jan 15.
# But _fetch_all_memories filters it out using datetime.now() (Jul 22).
# search_as_of returns [] instead of the memory.
```

### Fix

Added `skip_ttl_filter` parameter to `_fetch_all_memories()` (default `False`, preserving existing behavior). The three temporal methods now pass `skip_ttl_filter=True` so they can apply their own expiry logic without pre-filtering.

### Testing

- All 381 existing unit tests pass (23 E2E skipped — no API key)
- Reproduction scripts confirm the bugs are fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-based memory searches to correctly return memories according to their historical validity.
  * Fixed searches for memories changed since a given time or retrieved recently, including items that have since expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->