### PR TITLE
fix: sanitize # characters in user query to prevent filter injection

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -556,10 +556,15 @@ class MemoryReadService:
                 value = _validate_filter_token(value, f"metadata '{key}'")
                 filter_parts.append(f"#{key}:{value}")
 
+        # Sanitize user query — strip # to prevent filter injection.
+        # Without this, a user can inject #memory_type:fact into the query
+        # string to bypass caller-specified type/status/tag filters.
+        sanitized_query = query.replace("#", "")
+
         # Combine query with filters
         if filter_parts:
-            return f"{query} {' '.join(filter_parts)}"
-        return query
+            return f"{sanitized_query} {' '.join(filter_parts)}"
+        return sanitized_query
 
     def _apply_temporal_filter(
         self,


### PR DESCRIPTION
## Bug Report: Query String Filter Injection

Found as part of the [Memanto Bug & Exploit Challenge (#770)](https://github.com/moorcheh-ai/memanto/issues/770).

### Problem

`_build_filtered_query()` concatenates the user's `query` string directly into the Moorcheh search string alongside `#key:value` metadata filters, with no escaping of `#` characters. A user can inject `#memory_type:fact` into the query string to bypass a caller-specified `type=["preference"]` filter — the injected filter appears *before* the legit filter in the final query string.

### Impact

- **Filter bypass**: caller-specified type/status/tag filters can be overridden by user-supplied query text
- **Namespace scope confusion**: injected filters could cause the backend to return documents from an unintended scope
- **Security**: if query text comes from untrusted user input (common in agent workflows), this is a prompt injection vector

### Reproduction

```python
# Caller requests type=["preference"]
# User query: "benign query #memory_type:fact"
# Final query: "benign query #memory_type:fact #memory_type:preference"
# The injected filter appears FIRST — on some backends, first filter wins.
```

### Fix

Strip `#` from user query text before concatenation with filter parts.

### Testing

- All 381 existing unit tests pass (23 E2E skipped — no API key)
- Reproduction script confirms the injected filter is no longer present in the query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory search filtering by preventing query text from overriding specified type, tag, status, or metadata filters.
  * Ensured searches consistently respect the filters selected by the caller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->