### PR TITLE
fix: allow update_memory to modify expired memories

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -55,8 +55,13 @@ class MemoryReadService:
             self._namespace_service = NamespaceService(self.client)
         return self._namespace_service
 
-    def get_memory(self, memory_id: str, namespace: str) -> dict[str, Any] | None:
-        """Retrieve specific memory by ID with TTL enforcement"""
+    def get_memory(self, memory_id: str, namespace: str, include_expired: bool = False) -> dict[str, Any] | None:
+        """Retrieve specific memory by ID with TTL enforcement.
+
+        When include_expired is True, expired memories are returned without
+        TTL filtering. This is needed by update_memory to allow reviving or
+        modifying expired memories (e.g. extending TTL, editing content).
+        """
         try:
             result = self.client.documents.get(
                 namespace_name=namespace, ids=[memory_id]
@@ -71,7 +76,10 @@ class MemoryReadService:
             if items and isinstance(items, list) and len(items) > 0:
                 memory = self._format_memory_item(items[0])
 
-                # Apply TTL enforcement
+                # Apply TTL enforcement (unless caller requests expired memories)
+                if include_expired:
+                    return memory
+
                 filtered = self._filter_expired_memories([memory])
                 if filtered:
                     return filtered[0]

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -304,7 +304,7 @@ class MemoryWriteService:
 
             # Step 1: Retrieve existing memory
             read_service = MemoryReadService(self.client)
-            existing_memory_data = read_service.get_memory(memory_id, namespace)
+            existing_memory_data = read_service.get_memory(memory_id, namespace, include_expired=True)
 
             if not existing_memory_data:
                 raise MemoryError(


### PR DESCRIPTION
## Bug Report: update_memory Cannot Modify Expired Memories

Found as part of the [Memanto Bug & Exploit Challenge (#770)](https://github.com/moorcheh-ai/memanto/issues/770).

### Problem

`update_memory()` calls `read_service.get_memory()` to fetch the existing record. But `get_memory()` applies `_filter_expired_memories` and returns `None` for expired memories. So `update_memory()` raises "Memory not found" for any expired memory — making it impossible to:

- Remove or extend a TTL
- Edit content of an expired memory
- Resurrect an expired memory through the update API

### Reproduction

```python
# Memory expired yesterday.
# update_memory("mem-expired", namespace, updates={"confidence": 0.95})
# Raises: "Memory mem-expired not found in namespace ..."
```

### Fix

Added `include_expired` parameter to `get_memory()` (default `False`, preserving existing behavior). `update_memory()` now calls `get_memory()` with `include_expired=True` so expired memories can be found and updated.

### Testing

- All 381 existing unit tests pass (23 E2E skipped — no API key)
- Reproduction script confirms the expired memory is now found and updated successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory updates can now revive expired memories.
  * Expired memories can be retrieved when explicitly requested, allowing their retention period to be extended.

* **Bug Fixes**
  * Fixed updates failing when the target memory had already expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->