### PR TITLE
Fix/conflict resolution behavior

### DIFF
--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -1,0 +1,194 @@
+"""
+Memory Validation Service
+
+Write-time contradiction detection and resolution for memory records.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from moorcheh_sdk import MoorchehClient
+
+from memanto.app.config import settings
+from memanto.app.core import MemoryRecord
+
+
+class MemoryValidationService:
+    """Detect and resolve direct contradictions before persisting a memory.
+
+    A stored memory contradicts an incoming one when it is active, shares the
+    same memory type and title (case-insensitive), but carries different
+    content. Resolution follows the keep_new convention used by the conflict
+    report pipeline: the old record is preserved with status "superseded"
+    (annotated with superseded_by/superseded_at, matching search_as_of's
+    timeline fields) and the new record is stored as active.
+
+    Detection is deterministic — no LLM calls — so the write path stays cheap.
+    Deeper semantic conflicts remain the job of the offline conflict report.
+    """
+
+    # How many similar memories to inspect per write.
+    SEARCH_LIMIT = 10
+
+    def __init__(self, moorcheh_client: "MoorchehClient"):
+        self.client = moorcheh_client
+
+    def validate_memory(
+        self, memory: MemoryRecord, context: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Validate a memory against existing records, resolving contradictions.
+
+        Returns a dict with at least ``action`` and ``reason``; when
+        contradictions were resolved it also carries ``superseded_ids``.
+        """
+        memory_type = memory.type or "fact"
+        if memory_type not in settings.REQUIRE_VALIDATION_FOR:
+            return {
+                "action": "store",
+                "reason": f"stored: type '{memory_type}' exempt from conflict validation",
+            }
+
+        try:
+            conflicts = self._find_contradictions(memory)
+        except Exception:
+            # A failed lookup must never block a write, but say the check did
+            # not run rather than pretending it passed.
+            return {
+                "action": "store",
+                "reason": "stored: conflict check unavailable",
+            }
+
+        if not conflicts:
+            return {
+                "action": "store",
+                "reason": "validated: no contradicting memories found",
+            }
+
+        superseded: list[str] = []
+        failed: list[str] = []
+        for old_item in conflicts:
+            old_id = str(old_item.get("id"))
+            if self._supersede(old_item, memory):
+                superseded.append(old_id)
+            else:
+                failed.append(old_id)
+
+        reason_parts = []
+        if superseded:
+            reason_parts.append(
+                f"contradiction resolved: superseded {', '.join(superseded)}"
+            )
+        if failed:
+            reason_parts.append(
+                f"contradiction detected but failed to supersede {', '.join(failed)}"
+            )
+
+        return {
+            "action": "store",
+            "reason": "; ".join(reason_parts),
+            "superseded_ids": superseded,
+        }
+
+    def resolve_batch_contradictions(
+        self, memories: list[MemoryRecord]
+    ) -> dict[str, str]:
+        """Resolve contradictions between memories submitted in one batch.
+
+        For memories sharing a type and title but differing in content, the
+        last submission wins; earlier ones are downgraded to
+        status="superseded" in place. Returns a mapping of superseded memory
+        id -> winning memory id.
+        """
+        superseded: dict[str, str] = {}
+        latest_by_key: dict[tuple[str, str], MemoryRecord] = {}
+
+        for memory in memories:
+            memory_type = memory.type or "fact"
+            if memory_type not in settings.REQUIRE_VALIDATION_FOR:
+                continue
+            key = (memory_type, memory.title.strip().lower())
+            previous = latest_by_key.get(key)
+            if (
+                previous is not None
+                and previous.content.strip() != memory.content.strip()
+            ):
+                previous.status = "superseded"
+                superseded[str(previous.id)] = str(memory.id)
+            latest_by_key[key] = memory
+
+        return superseded
+
+    def _find_contradictions(self, memory: MemoryRecord) -> list[dict[str, Any]]:
+        """Find active memories of the same type/title with different content."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        read_service = MemoryReadService(self.client)
+        search = read_service.search_memories(
+            query=memory.content,
+            agent_id=memory.agent_id,
+            type=[memory.type or "fact"],
+            status_filter=["active"],
+            limit=self.SEARCH_LIMIT,
+        )
+
+        title = memory.title.strip().lower()
+        content = memory.content.strip()
+        conflicts = []
+        for item in search.get("results", []):
+            if not item.get("id") or item.get("id") == memory.id:
+                continue
+            if (item.get("status") or "active") != "active":
+                continue
+            if (item.get("title") or "").strip().lower() != title:
+                continue
+            if (item.get("content") or "").strip() == content:
+                # Identical content is a duplicate, not a contradiction.
+                continue
+            conflicts.append(item)
+        return conflicts
+
+    def _supersede(self, old_item: dict[str, Any], new_memory: MemoryRecord) -> bool:
+        """Mark an existing memory as superseded by the new one.
+
+        Moorcheh has no in-place update, so this follows the same
+        delete-and-recreate pattern as update_memory. Returns False instead of
+        raising so one bad record cannot block the new write.
+        """
+        try:
+            old_id = str(old_item.get("id"))
+            namespace = new_memory.namespace()
+
+            delete_result = self.client.documents.delete(
+                namespace_name=namespace, ids=[old_id]
+            )
+            if delete_result.get("actual_deletions", 0) == 0:
+                return False
+
+            now_iso = datetime.utcnow().isoformat()
+            document: dict[str, Any] = {
+                "id": old_id,
+                "text": old_item.get("text") or "",
+                "memory_type": old_item.get("type") or "fact",
+                "agent_id": new_memory.agent_id,
+                "actor_id": old_item.get("actor_id") or "unknown",
+                "source": old_item.get("source") or "system",
+                "confidence": old_item.get("confidence", 0.8),
+                "status": "superseded",
+                "provenance": old_item.get("provenance") or "explicit_statement",
+                "created_at": old_item.get("created_at") or now_iso,
+                "updated_at": now_iso,
+                "superseded_by": new_memory.id,
+                "superseded_at": now_iso,
+            }
+            tags = old_item.get("tags")
+            if tags:
+                document["tags"] = ",".join(tags) if isinstance(tags, list) else tags
+
+            self.client.documents.upload(
+                namespace_name=namespace, documents=[document]
+            )
+            return True
+
+        except Exception:
+            return False

--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -5,7 +5,7 @@ Write-time contradiction detection and resolution for memory records.
 """
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from moorcheh_sdk import MoorchehClient
@@ -185,8 +185,11 @@ class MemoryValidationService:
             if tags:
                 document["tags"] = ",".join(tags) if isinstance(tags, list) else tags
 
+            from moorcheh_sdk.types.document import Document
+
             self.client.documents.upload(
-                namespace_name=namespace, documents=[document]
+                namespace_name=namespace,
+                documents=[cast(Document, document)],
             )
             return True
 

--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
 from memanto.app.config import settings
 from memanto.app.core import MemoryRecord
 
+_MISSING = object()
+_MAX_VALIDATION_WORKERS = 8
+
 
 class MemoryValidationService:
     """Detect and resolve direct contradictions before persisting a memory.
@@ -37,12 +40,19 @@ class MemoryValidationService:
         self.client = moorcheh_client
 
     def validate_memory(
-        self, memory: MemoryRecord, context: dict[str, Any] | None = None
+        self,
+        memory: MemoryRecord,
+        context: dict[str, Any] | None = None,
+        *,
+        prefetched_conflicts: list[dict[str, Any]] | None | object = _MISSING,
     ) -> dict[str, Any]:
         """Validate a memory against existing records, resolving contradictions.
 
         Returns a dict with at least ``action`` and ``reason``; when
         contradictions were resolved it also carries ``superseded_ids``.
+
+        When ``prefetched_conflicts`` is supplied by batch prefetch, the
+        lookup is skipped. ``None`` means the prefetch lookup failed.
         """
         memory_type = memory.type or "fact"
         if memory_type not in settings.REQUIRE_VALIDATION_FOR:
@@ -51,15 +61,23 @@ class MemoryValidationService:
                 "reason": f"stored: type '{memory_type}' exempt from conflict validation",
             }
 
-        try:
-            conflicts = self._find_contradictions(memory)
-        except Exception:
-            # A failed lookup must never block a write, but say the check did
-            # not run rather than pretending it passed.
+        if prefetched_conflicts is _MISSING:
+            try:
+                conflicts = self._find_contradictions(memory)
+            except Exception:
+                # A failed lookup must never block a write, but say the check did
+                # not run rather than pretending it passed.
+                return {
+                    "action": "store",
+                    "reason": "stored: conflict check unavailable",
+                }
+        elif prefetched_conflicts is None:
             return {
                 "action": "store",
                 "reason": "stored: conflict check unavailable",
             }
+        else:
+            conflicts = cast(list[dict[str, Any]], prefetched_conflicts)
 
         if not conflicts:
             return {
@@ -120,6 +138,39 @@ class MemoryValidationService:
             latest_by_key[key] = memory
 
         return superseded
+
+    def prefetch_contradictions(
+        self, memories: list[MemoryRecord]
+    ) -> dict[str, list[dict[str, Any]] | None]:
+        """Run contradiction lookups in parallel for batch writes.
+
+        Returns a mapping of memory id -> conflicts list, or ``None`` when
+        that memory's lookup failed. Exempt types are omitted.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        targets = [
+            memory
+            for memory in memories
+            if (memory.type or "fact") in settings.REQUIRE_VALIDATION_FOR
+        ]
+        if not targets:
+            return {}
+
+        def lookup(
+            memory: MemoryRecord,
+        ) -> tuple[str, list[dict[str, Any]] | None]:
+            try:
+                return memory.id, self._find_contradictions(memory)
+            except Exception:
+                return memory.id, None
+
+        workers = min(len(targets), _MAX_VALIDATION_WORKERS)
+        prefetched: dict[str, list[dict[str, Any]] | None] = {}
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            for memory_id, conflicts in executor.map(lookup, targets):
+                prefetched[memory_id] = conflicts
+        return prefetched
 
     def _find_contradictions(self, memory: MemoryRecord) -> list[dict[str, Any]]:
         """Find active memories of the same type/title with different content."""

--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -210,19 +210,13 @@ class MemoryValidationService:
     def _supersede(self, old_item: dict[str, Any], new_memory: MemoryRecord) -> bool:
         """Mark an existing memory as superseded by the new one.
 
-        Moorcheh has no in-place update, so this follows the same
-        delete-and-recreate pattern as update_memory. Returns False instead of
-        raising so one bad record cannot block the new write.
+        Upload the superseded document first (same ID overwrites in Moorcheh).
+        Returns False instead of raising so one bad record cannot block the new
+        write; a failed upload leaves the original document untouched.
         """
         try:
             old_id = str(old_item.get("id"))
             namespace = new_memory.namespace()
-
-            delete_result = self.client.documents.delete(
-                namespace_name=namespace, ids=[old_id]
-            )
-            if delete_result.get("actual_deletions", 0) == 0:
-                return False
 
             now_iso = datetime.utcnow().isoformat()
             document: dict[str, Any] = {
@@ -246,10 +240,13 @@ class MemoryValidationService:
 
             from moorcheh_sdk.types.document import Document
 
-            self.client.documents.upload(
+            upload_result = self.client.documents.upload(
                 namespace_name=namespace,
                 documents=[cast(Document, document)],
             )
+            upload_status = str(upload_result.get("status", "unknown")).lower()
+            if upload_status not in {"queued", "success", "ok"}:
+                return False
             return True
 
         except Exception:

--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -28,8 +28,10 @@ class MemoryValidationService:
     Deeper semantic conflicts remain the job of the offline conflict report.
     """
 
-    # How many similar memories to inspect per write.
-    SEARCH_LIMIT = 10
+    # How many candidates to inspect after server-side type/status filtering.
+    # Must align with MemoryReadService's post-filter pool so same-title records
+    # are not dropped by default pagination before title matching runs.
+    CANDIDATE_LIMIT = 100
 
     def __init__(self, moorcheh_client: "MoorchehClient"):
         self.client = moorcheh_client
@@ -123,24 +125,30 @@ class MemoryValidationService:
         """Find active memories of the same type/title with different content."""
         from memanto.app.services.memory_read_service import MemoryReadService
 
+        memory_type = memory.type or "fact"
+        title = memory.title.strip()
+        title_key = title.lower()
+        content = memory.content.strip()
+
         read_service = MemoryReadService(self.client)
+        # Title is embedded in Moorcheh document text (`[TYPE] title\\n\\ncontent`).
+        # Query by title (not incoming content) so same-title records are ranked
+        # in even when content diverges sharply.
         search = read_service.search_memories(
-            query=memory.content,
+            query=title,
             agent_id=memory.agent_id,
-            type=[memory.type or "fact"],
+            type=[memory_type],
             status_filter=["active"],
-            limit=self.SEARCH_LIMIT,
+            limit=self.CANDIDATE_LIMIT,
         )
 
-        title = memory.title.strip().lower()
-        content = memory.content.strip()
         conflicts = []
         for item in search.get("results", []):
             if not item.get("id") or item.get("id") == memory.id:
                 continue
             if (item.get("status") or "active") != "active":
                 continue
-            if (item.get("title") or "").strip().lower() != title:
+            if (item.get("title") or "").strip().lower() != title_key:
                 continue
             if (item.get("content") or "").strip() == content:
                 # Identical content is a duplicate, not a contradiction.

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 from memanto.app.core import MemoryRecord
 from memanto.app.services.memory_parsing_service import MemoryParsingService
+from memanto.app.services.memory_validation_service import MemoryValidationService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
 from memanto.app.utils.temporal_helpers import as_utc_naive
@@ -23,6 +24,7 @@ class MemoryWriteService:
 
         self.client = moorcheh_client
         self._parser = MemoryParsingService()
+        self.validation_service = MemoryValidationService(moorcheh_client)
         self._namespace_service = None
 
     @property
@@ -62,13 +64,13 @@ class MemoryWriteService:
             # Add namespace
             namespace = memory.namespace()
 
-            # skip validation for speed
-            ## Validate memory
-            # validation_result = self.validation_service.validate_memory(memory, context)
-            ## Use validated memory if modified
-            # if "memory" in validation_result:
-            #     memory = validation_result["memory"]
-            validation_result = {"action": "store", "reason": "MVP direct store"}
+            # Validate memory (write-time contradiction resolution)
+            validation_result = self.validation_service.validate_memory(
+                memory, context
+            )
+            # Use validated memory if modified
+            if "memory" in validation_result:
+                memory = validation_result["memory"]
 
             from typing import cast
 
@@ -82,7 +84,7 @@ class MemoryWriteService:
                 namespace_name=namespace, documents=[document]
             )
 
-            return {
+            response = {
                 "id": memory.id,
                 "namespace": namespace,
                 "status": result.get("status", "unknown"),
@@ -92,6 +94,9 @@ class MemoryWriteService:
                 "memory_status": memory.status,
                 "type": memory.type,
             }
+            if validation_result.get("superseded_ids"):
+                response["superseded_ids"] = validation_result["superseded_ids"]
+            return response
 
         except Exception as e:
             raise MemoryError(f"Failed to store memory: {e}")
@@ -122,6 +127,7 @@ class MemoryWriteService:
             first_namespace = None
             results = []
             validated_documents = []
+            prepared: list[MemoryRecord] = []
 
             # Enforce server-side timestamps for batch (single timestamp for all)
             now = datetime.utcnow()
@@ -154,16 +160,43 @@ class MemoryWriteService:
                         )
                         continue
 
-                    # skip validation for speed
-                    ## Validate memory
-                    # validation_result = self.validation_service.validate_memory(memory, context)
-                    ## Use validated memory if modified
-                    # if "memory" in validation_result:
-                    #     memory = validation_result["memory"]
-                    validation_result = {
-                        "action": "store",
-                        "reason": "MVP direct store",
-                    }
+                    prepared.append(memory)
+
+                except Exception as e:
+                    results.append(
+                        {
+                            "id": memory.id
+                            if hasattr(memory, "id") and memory.id
+                            else "unknown",
+                            "status": "failed",
+                            "action": "rejected",
+                            "error": str(e),
+                        }
+                    )
+
+            # Resolve contradictions within the batch itself: for memories of
+            # the same type and title with different content, the last one
+            # wins and earlier ones are stored as superseded history.
+            superseded_in_batch = self.validation_service.resolve_batch_contradictions(
+                prepared
+            )
+
+            for memory in prepared:
+                try:
+                    batch_note = superseded_in_batch.get(memory.id)
+                    if batch_note:
+                        validation_result = {
+                            "action": "store_superseded",
+                            "reason": f"contradiction resolved: superseded within batch by {batch_note}",
+                        }
+                    else:
+                        # Validate memory (write-time contradiction resolution)
+                        validation_result = self.validation_service.validate_memory(
+                            memory, context
+                        )
+                        # Use validated memory if modified
+                        if "memory" in validation_result:
+                            memory = validation_result["memory"]
 
                     from typing import cast
 
@@ -171,20 +204,26 @@ class MemoryWriteService:
 
                     # Convert to Moorcheh document
                     document = cast(Document, memory.to_moorcheh_document())
+                    if batch_note:
+                        document["superseded_by"] = batch_note
+                        document["superseded_at"] = now.isoformat()
                     validated_documents.append(document)
 
                     # Store validation result for later
-                    results.append(
-                        {
-                            "id": memory.id,
-                            "status": "pending",
-                            "action": validation_result.get("action", "store"),
-                            "reason": validation_result.get(
-                                "reason", "Validated successfully"
-                            ),
-                            "type": memory.type,
-                        }
-                    )
+                    result_entry = {
+                        "id": memory.id,
+                        "status": "pending",
+                        "action": validation_result.get("action", "store"),
+                        "reason": validation_result.get(
+                            "reason", "Validated successfully"
+                        ),
+                        "type": memory.type,
+                    }
+                    if validation_result.get("superseded_ids"):
+                        result_entry["superseded_ids"] = validation_result[
+                            "superseded_ids"
+                        ]
+                    results.append(result_entry)
 
                 except Exception as e:
                     results.append(

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -205,6 +205,13 @@ class MemoryWriteService:
                 prepared
             )
 
+            to_validate = [
+                memory for memory in prepared if memory.id not in superseded_in_batch
+            ]
+            prefetched_conflicts = self.validation_service.prefetch_contradictions(
+                to_validate
+            )
+
             for memory in prepared:
                 try:
                     batch_note = superseded_in_batch.get(memory.id)
@@ -213,8 +220,13 @@ class MemoryWriteService:
                             "action": "store_superseded",
                             "reason": f"contradiction resolved: superseded within batch by {batch_note}",
                         }
+                    elif memory.id in prefetched_conflicts:
+                        validation_result = self.validation_service.validate_memory(
+                            memory,
+                            context,
+                            prefetched_conflicts=prefetched_conflicts[memory.id],
+                        )
                     else:
-                        # Validate memory (write-time contradiction resolution)
                         validation_result = self.validation_service.validate_memory(
                             memory, context
                         )

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -3,7 +3,7 @@ Memory Write Service
 """
 
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from moorcheh_sdk import MoorchehClient
@@ -93,14 +93,10 @@ class MemoryWriteService:
             namespace = memory.namespace()
 
             # Validate memory (write-time contradiction resolution)
-            validation_result = self.validation_service.validate_memory(
-                memory, context
-            )
+            validation_result = self.validation_service.validate_memory(memory, context)
             # Use validated memory if modified
             if "memory" in validation_result:
                 memory = validation_result["memory"]
-
-            from typing import cast
 
             from moorcheh_sdk.types.document import Document
 
@@ -224,17 +220,16 @@ class MemoryWriteService:
                         )
                         # Use validated memory if modified
                         if "memory" in validation_result:
-                            memory = validation_result["memory"]
-
-                    from typing import cast
+                            memory = cast(MemoryRecord, validation_result["memory"])
 
                     from moorcheh_sdk.types.document import Document
 
                     # Convert to Moorcheh document
-                    document = cast(Document, memory.to_moorcheh_document())
+                    document_payload = memory.to_moorcheh_document()
                     if batch_note:
-                        document["superseded_by"] = batch_note
-                        document["superseded_at"] = now.isoformat()
+                        document_payload["superseded_by"] = batch_note
+                        document_payload["superseded_at"] = now.isoformat()
+                    document = cast(Document, document_payload)
                     validated_documents.append(document)
 
                     # Store validation result for later
@@ -245,7 +240,7 @@ class MemoryWriteService:
                         "reason": validation_result.get(
                             "reason", "Validated successfully"
                         ),
-                        "type": memory.type,
+                        "type": memory.type or "fact",
                     }
                     if validation_result.get("superseded_ids"):
                         result_entry["superseded_ids"] = validation_result[
@@ -267,8 +262,6 @@ class MemoryWriteService:
 
             # Upload all validated documents in single batch to Moorcheh
             if validated_documents and first_namespace:
-                from typing import cast
-
                 upload_result = self.client.documents.upload(
                     namespace_name=cast(str, first_namespace),
                     documents=validated_documents,

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1363,6 +1363,7 @@ class DirectClient:
 
         write_service = self._get_write_service()
         result_details = {"action": action}
+        delete_failures: list[str] = []
 
         if action == "keep_old":
             # Keep old, delete new
@@ -1371,7 +1372,7 @@ class DirectClient:
                     write_service.delete_memory(new_id, namespace)
                     result_details["deleted"] = new_id
                 except Exception as e:
-                    result_details["warning"] = f"Could not delete new memory: {e}"
+                    delete_failures.append(f"new memory {new_id}: {e}")
 
         elif action == "keep_new":
             # Keep new, delete old
@@ -1380,7 +1381,7 @@ class DirectClient:
                     write_service.delete_memory(old_id, namespace)
                     result_details["deleted"] = old_id
                 except Exception as e:
-                    result_details["warning"] = f"Could not delete old memory: {e}"
+                    delete_failures.append(f"old memory {old_id}: {e}")
 
         elif action == "keep_both":
             # No-op — both memories remain active
@@ -1394,9 +1395,7 @@ class DirectClient:
                         write_service.delete_memory(mem_id, namespace)
                         result_details[f"deleted_{label}"] = mem_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        delete_failures.append(f"{label} memory {mem_id}: {e}")
 
         elif action == "manual":
             if not manual_content:
@@ -1409,9 +1408,14 @@ class DirectClient:
                         write_service.delete_memory(mem_id, namespace)
                         result_details[f"deleted_{label}"] = mem_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+
+            if delete_failures:
+                failures = "; ".join(delete_failures)
+                raise ValueError(
+                    "Could not resolve conflict because required memory deletion "
+                    f"failed: {failures}"
+                )
 
             # Store the manual replacement
             mem_type = manual_type or conflict.get("type", "fact")
@@ -1442,6 +1446,13 @@ class DirectClient:
             )
             store_result = write_service.store_memory(memory)
             result_details["new_memory_id"] = store_result.get("id")
+
+        if delete_failures:
+            failures = "; ".join(delete_failures)
+            raise ValueError(
+                "Could not resolve conflict because required memory deletion "
+                f"failed: {failures}"
+            )
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1402,18 +1402,8 @@ class DirectClient:
             if not manual_content:
                 raise ValueError("manual_content is required when action is 'manual'")
 
-            # Delete both, store manual replacement
-            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
-
-            # Store the manual replacement
+            # Store the replacement before deleting originals so a failed write
+            # cannot erase both sides of the conflict.
             mem_type = manual_type or conflict.get("type", "fact")
             if not isinstance(mem_type, str):
                 mem_type = "fact"
@@ -1442,6 +1432,16 @@ class DirectClient:
             )
             store_result = write_service.store_memory(memory)
             result_details["new_memory_id"] = store_result.get("id")
+
+            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
+                if mem_id:
+                    try:
+                        write_service.delete_memory(mem_id, namespace)
+                        result_details[f"deleted_{label}"] = mem_id
+                    except Exception as e:
+                        result_details[f"warning_{label}"] = (
+                            f"Could not delete {label} memory: {e}"
+                        )
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1365,23 +1365,30 @@ class DirectClient:
         result_details = {"action": action}
         delete_failures: list[str] = []
 
+        def delete_required_memory(
+            mem_id: str | None, label: str, result_key: str
+        ) -> None:
+            if not mem_id:
+                return
+            try:
+                deleted = write_service.delete_memory(mem_id, namespace)
+            except Exception as e:
+                delete_failures.append(f"{label} memory {mem_id}: {e}")
+                return
+
+            if not deleted:
+                delete_failures.append(f"{label} memory {mem_id}: not deleted")
+                return
+
+            result_details[result_key] = mem_id
+
         if action == "keep_old":
             # Keep old, delete new
-            if new_id:
-                try:
-                    write_service.delete_memory(new_id, namespace)
-                    result_details["deleted"] = new_id
-                except Exception as e:
-                    delete_failures.append(f"new memory {new_id}: {e}")
+            delete_required_memory(new_id, "new", "deleted")
 
         elif action == "keep_new":
             # Keep new, delete old
-            if old_id:
-                try:
-                    write_service.delete_memory(old_id, namespace)
-                    result_details["deleted"] = old_id
-                except Exception as e:
-                    delete_failures.append(f"old memory {old_id}: {e}")
+            delete_required_memory(old_id, "old", "deleted")
 
         elif action == "keep_both":
             # No-op — both memories remain active
@@ -1390,12 +1397,7 @@ class DirectClient:
         elif action == "remove_both":
             # Delete both memories
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+                delete_required_memory(mem_id, label, f"deleted_{label}")
 
         elif action == "manual":
             if not manual_content:
@@ -1403,12 +1405,7 @@ class DirectClient:
 
             # Delete both, store manual replacement
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+                delete_required_memory(mem_id, label, f"deleted_{label}")
 
             if delete_failures:
                 failures = "; ".join(delete_failures)

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1231,6 +1231,7 @@ class SdkClient:
 
         write_service = self._get_write_service()
         result_details: dict[str, Any] = {"action": action}
+        delete_failures: list[str] = []
 
         if action == "keep_old":
             if new_id:
@@ -1238,7 +1239,7 @@ class SdkClient:
                     write_service.delete_memory(new_id, namespace)
                     result_details["deleted"] = new_id
                 except Exception as e:
-                    result_details["warning"] = f"Could not delete new memory: {e}"
+                    delete_failures.append(f"new memory {new_id}: {e}")
 
         elif action == "keep_new":
             if old_id:
@@ -1246,7 +1247,7 @@ class SdkClient:
                     write_service.delete_memory(old_id, namespace)
                     result_details["deleted"] = old_id
                 except Exception as e:
-                    result_details["warning"] = f"Could not delete old memory: {e}"
+                    delete_failures.append(f"old memory {old_id}: {e}")
 
         elif action == "keep_both":
             result_details["note"] = "Both memories kept as-is"
@@ -1258,9 +1259,7 @@ class SdkClient:
                         write_service.delete_memory(mem_id, namespace)
                         result_details[f"deleted_{label}"] = mem_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        delete_failures.append(f"{label} memory {mem_id}: {e}")
 
         elif action == "manual":
             if not manual_content:
@@ -1273,9 +1272,14 @@ class SdkClient:
                         write_service.delete_memory(mem_id, namespace)
                         result_details[f"deleted_{label}"] = mem_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+
+            if delete_failures:
+                failures = "; ".join(delete_failures)
+                raise ValueError(
+                    "Could not resolve conflict because required memory deletion "
+                    f"failed: {failures}"
+                )
 
             # Store the manual replacement
             mem_type = manual_type or conflict.get("type", "fact")
@@ -1305,6 +1309,13 @@ class SdkClient:
             )
             store_result = write_service.store_memory(memory)
             result_details["new_memory_id"] = store_result.get("id")
+
+        if delete_failures:
+            failures = "; ".join(delete_failures)
+            raise ValueError(
+                "Could not resolve conflict because required memory deletion "
+                f"failed: {failures}"
+            )
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1266,18 +1266,8 @@ class SdkClient:
             if not manual_content:
                 raise ValueError("manual_content is required when action is 'manual'")
 
-            # Delete both, store manual replacement
-            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
-
-            # Store the manual replacement
+            # Store the replacement before deleting originals so a failed write
+            # cannot erase both sides of the conflict.
             mem_type = manual_type or conflict.get("type", "fact")
             if not isinstance(mem_type, str):
                 mem_type = "fact"
@@ -1305,6 +1295,16 @@ class SdkClient:
             )
             store_result = write_service.store_memory(memory)
             result_details["new_memory_id"] = store_result.get("id")
+
+            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
+                if mem_id:
+                    try:
+                        write_service.delete_memory(mem_id, namespace)
+                        result_details[f"deleted_{label}"] = mem_id
+                    except Exception as e:
+                        result_details[f"warning_{label}"] = (
+                            f"Could not delete {label} memory: {e}"
+                        )
 
         # Mark conflict as resolved in the JSON file
         all_conflicts[conflict_index]["resolved"] = True

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1233,33 +1233,35 @@ class SdkClient:
         result_details: dict[str, Any] = {"action": action}
         delete_failures: list[str] = []
 
+        def delete_required_memory(
+            mem_id: str | None, label: str, result_key: str
+        ) -> None:
+            if not mem_id:
+                return
+            try:
+                deleted = write_service.delete_memory(mem_id, namespace)
+            except Exception as e:
+                delete_failures.append(f"{label} memory {mem_id}: {e}")
+                return
+
+            if not deleted:
+                delete_failures.append(f"{label} memory {mem_id}: not deleted")
+                return
+
+            result_details[result_key] = mem_id
+
         if action == "keep_old":
-            if new_id:
-                try:
-                    write_service.delete_memory(new_id, namespace)
-                    result_details["deleted"] = new_id
-                except Exception as e:
-                    delete_failures.append(f"new memory {new_id}: {e}")
+            delete_required_memory(new_id, "new", "deleted")
 
         elif action == "keep_new":
-            if old_id:
-                try:
-                    write_service.delete_memory(old_id, namespace)
-                    result_details["deleted"] = old_id
-                except Exception as e:
-                    delete_failures.append(f"old memory {old_id}: {e}")
+            delete_required_memory(old_id, "old", "deleted")
 
         elif action == "keep_both":
             result_details["note"] = "Both memories kept as-is"
 
         elif action == "remove_both":
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+                delete_required_memory(mem_id, label, f"deleted_{label}")
 
         elif action == "manual":
             if not manual_content:
@@ -1267,12 +1269,7 @@ class SdkClient:
 
             # Delete both, store manual replacement
             for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
-                    try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
-                    except Exception as e:
-                        delete_failures.append(f"{label} memory {mem_id}: {e}")
+                delete_required_memory(mem_id, label, f"deleted_{label}")
 
             if delete_failures:
                 failures = "; ".join(delete_failures)

--- a/tests/test_conflict_manual_resolution.py
+++ b/tests/test_conflict_manual_resolution.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.client.sdk_client import SdkClient
+
+
+class FailingStoreService:
+    def __init__(self) -> None:
+        self.deleted: list[tuple[str, str]] = []
+
+    def delete_memory(self, memory_id: str, namespace: str) -> bool:
+        self.deleted.append((memory_id, namespace))
+        return True
+
+    def store_memory(self, memory):
+        raise RuntimeError("store failed")
+
+
+@pytest.mark.parametrize("client_cls", [DirectClient, SdkClient])
+def test_manual_conflict_resolution_does_not_delete_on_store_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client_cls
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    conflicts_dir = tmp_path / ".memanto" / "conflicts"
+    conflicts_dir.mkdir(parents=True)
+    conflict_file = conflicts_dir / "agent-1_2026-07-05_conflicts.json"
+    conflict_file.write_text(
+        json.dumps(
+            [
+                {
+                    "title": "Conflicting preference",
+                    "type": "fact",
+                    "old_memory_id": "old-memory",
+                    "new_memory_id": "new-memory",
+                    "resolved": False,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    service = FailingStoreService()
+    client = client_cls("test-api-key")
+    monkeypatch.setattr(client, "_get_write_service", lambda: service)
+
+    with pytest.raises(RuntimeError, match="store failed"):
+        client.resolve_conflict(
+            agent_id="agent-1",
+            date="2026-07-05",
+            conflict_index=0,
+            action="manual",
+            manual_content="Keep the corrected memory.",
+        )
+
+    assert service.deleted == []
+    persisted_conflicts = json.loads(conflict_file.read_text(encoding="utf-8"))
+    assert persisted_conflicts[0]["resolved"] is False

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -1,0 +1,111 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _write_conflict_report(tmp_path, agent_id, date):
+    conflicts_dir = tmp_path / ".memanto" / "conflicts"
+    conflicts_dir.mkdir(parents=True)
+    report_path = conflicts_dir / f"{agent_id}_{date}_conflicts.json"
+    report_path.write_text(
+        json.dumps(
+            [
+                {
+                    "type": "conflict",
+                    "title": "Deployment region mismatch",
+                    "old_memory_id": "old-memory",
+                    "new_memory_id": "new-memory",
+                    "old_content": "Deploy to us-east-1",
+                    "new_content": "Deploy to eu-west-1",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return report_path
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        ("memanto.cli.client.direct_client", "DirectClient"),
+        ("memanto.cli.client.sdk_client", "SdkClient"),
+    ],
+)
+def test_conflict_stays_unresolved_when_required_delete_fails(
+    module_path, class_name, tmp_path, monkeypatch
+):
+    client_module = pytest.importorskip(module_path)
+    client_class = getattr(client_module, class_name)
+    monkeypatch.setattr(
+        client_module.Path,
+        "home",
+        classmethod(lambda cls: tmp_path),
+    )
+
+    agent_id = "test-agent"
+    date = "2026-05-08"
+    report_path = _write_conflict_report(tmp_path, agent_id, date)
+
+    write_service = MagicMock()
+    write_service.delete_memory.side_effect = RuntimeError("backend unavailable")
+
+    client = client_class(api_key="test-key")
+    client._get_write_service = lambda: write_service
+
+    with pytest.raises(ValueError, match="required memory deletion failed"):
+        client.resolve_conflict(
+            agent_id=agent_id,
+            date=date,
+            conflict_index=0,
+            action="keep_old",
+        )
+
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted[0].get("resolved", False) is False
+    assert "resolution" not in persisted[0]
+    write_service.delete_memory.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        ("memanto.cli.client.direct_client", "DirectClient"),
+        ("memanto.cli.client.sdk_client", "SdkClient"),
+    ],
+)
+def test_manual_conflict_resolution_does_not_store_replacement_after_delete_failure(
+    module_path, class_name, tmp_path, monkeypatch
+):
+    client_module = pytest.importorskip(module_path)
+    client_class = getattr(client_module, class_name)
+    monkeypatch.setattr(
+        client_module.Path,
+        "home",
+        classmethod(lambda cls: tmp_path),
+    )
+
+    agent_id = "test-agent"
+    date = "2026-05-08"
+    report_path = _write_conflict_report(tmp_path, agent_id, date)
+
+    write_service = MagicMock()
+    write_service.delete_memory.side_effect = RuntimeError("backend unavailable")
+
+    client = client_class(api_key="test-key")
+    client._get_write_service = lambda: write_service
+
+    with pytest.raises(ValueError, match="required memory deletion failed"):
+        client.resolve_conflict(
+            agent_id=agent_id,
+            date=date,
+            conflict_index=0,
+            action="manual",
+            manual_content="Deploy to us-east-1 unless failover is active",
+        )
+
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted[0].get("resolved", False) is False
+    assert "resolution" not in persisted[0]
+    write_service.store_memory.assert_not_called()

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -119,8 +119,9 @@ def test_conflict_stays_unresolved_when_required_delete_returns_false(
         ("memanto.cli.client.sdk_client", "SdkClient"),
     ],
 )
+@pytest.mark.parametrize("delete_result", [RuntimeError("backend unavailable"), False])
 def test_manual_conflict_resolution_does_not_store_replacement_after_delete_failure(
-    module_path, class_name, tmp_path, monkeypatch
+    module_path, class_name, delete_result, tmp_path, monkeypatch
 ):
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
@@ -135,7 +136,10 @@ def test_manual_conflict_resolution_does_not_store_replacement_after_delete_fail
     report_path = _write_conflict_report(tmp_path, agent_id, date)
 
     write_service = MagicMock()
-    write_service.delete_memory.side_effect = RuntimeError("backend unavailable")
+    if isinstance(delete_result, Exception):
+        write_service.delete_memory.side_effect = delete_result
+    else:
+        write_service.delete_memory.return_value = delete_result
 
     client = client_class(api_key="test-key")
     client._get_write_service = lambda: write_service

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -18,6 +18,8 @@ def _write_conflict_report(tmp_path, agent_id, date):
                     "new_memory_id": "new-memory",
                     "old_content": "Deploy to us-east-1",
                     "new_content": "Deploy to eu-west-1",
+                    "resolved": False,
+                    "resolution": None,
                 }
             ]
         ),
@@ -63,8 +65,50 @@ def test_conflict_stays_unresolved_when_required_delete_fails(
         )
 
     persisted = json.loads(report_path.read_text(encoding="utf-8"))
-    assert persisted[0].get("resolved", False) is False
-    assert "resolution" not in persisted[0]
+    assert persisted[0]["resolved"] is False
+    assert persisted[0]["resolution"] is None
+    write_service.delete_memory.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        ("memanto.cli.client.direct_client", "DirectClient"),
+        ("memanto.cli.client.sdk_client", "SdkClient"),
+    ],
+)
+def test_conflict_stays_unresolved_when_required_delete_returns_false(
+    module_path, class_name, tmp_path, monkeypatch
+):
+    client_module = pytest.importorskip(module_path)
+    client_class = getattr(client_module, class_name)
+    monkeypatch.setattr(
+        client_module.Path,
+        "home",
+        classmethod(lambda cls: tmp_path),
+    )
+
+    agent_id = "test-agent"
+    date = "2026-05-08"
+    report_path = _write_conflict_report(tmp_path, agent_id, date)
+
+    write_service = MagicMock()
+    write_service.delete_memory.return_value = False
+
+    client = client_class(api_key="test-key")
+    client._get_write_service = lambda: write_service
+
+    with pytest.raises(ValueError, match="required memory deletion failed"):
+        client.resolve_conflict(
+            agent_id=agent_id,
+            date=date,
+            conflict_index=0,
+            action="keep_old",
+        )
+
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted[0]["resolved"] is False
+    assert persisted[0]["resolution"] is None
     write_service.delete_memory.assert_called_once()
 
 
@@ -106,6 +150,6 @@ def test_manual_conflict_resolution_does_not_store_replacement_after_delete_fail
         )
 
     persisted = json.loads(report_path.read_text(encoding="utf-8"))
-    assert persisted[0].get("resolved", False) is False
-    assert "resolution" not in persisted[0]
+    assert persisted[0]["resolved"] is False
+    assert persisted[0]["resolution"] is None
     write_service.store_memory.assert_not_called()

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -125,10 +125,10 @@ def test_conflict_stays_unresolved_when_required_delete_returns_false(
     ],
 )
 @pytest.mark.parametrize("delete_result", [RuntimeError("backend unavailable"), False])
-def test_manual_conflict_resolution_does_not_store_replacement_after_delete_failure(
+def test_manual_conflict_resolution_does_not_mark_resolved_after_delete_failure(
     module_path, class_name, delete_result, tmp_path, monkeypatch
 ):
-    """Block manual replacement storage until required deletions succeed."""
+    """Store replacement first, but do not mark resolved if deletions fail."""
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
     monkeypatch.setattr(
@@ -162,4 +162,4 @@ def test_manual_conflict_resolution_does_not_store_replacement_after_delete_fail
     persisted = json.loads(report_path.read_text(encoding="utf-8"))
     assert persisted[0]["resolved"] is False
     assert persisted[0]["resolution"] is None
-    write_service.store_memory.assert_not_called()
+    write_service.store_memory.assert_called_once()

--- a/tests/test_conflict_resolution_delete_failures.py
+++ b/tests/test_conflict_resolution_delete_failures.py
@@ -1,3 +1,5 @@
+"""Regression tests for conflict-resolution cleanup failures."""
+
 import json
 from unittest.mock import MagicMock
 
@@ -5,6 +7,7 @@ import pytest
 
 
 def _write_conflict_report(tmp_path, agent_id, date):
+    """Create a production-shaped conflict report for resolution tests."""
     conflicts_dir = tmp_path / ".memanto" / "conflicts"
     conflicts_dir.mkdir(parents=True)
     report_path = conflicts_dir / f"{agent_id}_{date}_conflicts.json"
@@ -38,6 +41,7 @@ def _write_conflict_report(tmp_path, agent_id, date):
 def test_conflict_stays_unresolved_when_required_delete_fails(
     module_path, class_name, tmp_path, monkeypatch
 ):
+    """Keep the persisted conflict unresolved when deletion raises."""
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
     monkeypatch.setattr(
@@ -80,6 +84,7 @@ def test_conflict_stays_unresolved_when_required_delete_fails(
 def test_conflict_stays_unresolved_when_required_delete_returns_false(
     module_path, class_name, tmp_path, monkeypatch
 ):
+    """Keep the persisted conflict unresolved when deletion returns false."""
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
     monkeypatch.setattr(
@@ -123,6 +128,7 @@ def test_conflict_stays_unresolved_when_required_delete_returns_false(
 def test_manual_conflict_resolution_does_not_store_replacement_after_delete_failure(
     module_path, class_name, delete_result, tmp_path, monkeypatch
 ):
+    """Block manual replacement storage until required deletions succeed."""
     client_module = pytest.importorskip(module_path)
     client_class = getattr(client_module, class_name)
     monkeypatch.setattr(

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import MagicMock
+from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.core import MemoryRecord
+
+class TestContradictionHandling:
+    """
+    Test suite demonstrating that the memory write service fails to properly resolve direct contradictions.
+    """
+
+    def test_store_memory_skips_validation(self):
+        """
+        Demonstrates that store_memory bypasses contradiction validation and forces an MVP direct store.
+        This allows logically contradictory memories to be stored blindly.
+        """
+        mock_client = MagicMock()
+        mock_client.documents.upload.return_value = {"status": "success"}
+        
+        write_service = MemoryWriteService(mock_client)
+        
+        memory = MemoryRecord(
+            content="The user's favorite color is red.",
+            type="fact",
+            title="Favorite Color",
+            agent_id="test-agent"
+        )
+        
+        result = write_service.store_memory(memory)
+        
+        # The test expects proper contradiction validation to be active.
+        # Currently, the code skips validation with the reason "MVP direct store", meaning
+        # it will blindly store contradictions instead of resolving them.
+        assert result.get("reason") != "MVP direct store", "Contradiction validation is completely skipped (MVP direct store)."
+
+    def test_batch_store_memories_skips_validation(self):
+        """
+        Demonstrates that batch_store_memories also bypasses contradiction validation.
+        """
+        mock_client = MagicMock()
+        mock_client.documents.upload.return_value = {"status": "success"}
+        
+        write_service = MemoryWriteService(mock_client)
+        
+        memory1 = MemoryRecord(
+            content="The user lives in New York.",
+            type="fact",
+            title="Location",
+            agent_id="test-agent"
+        )
+        
+        memory2 = MemoryRecord(
+            content="The user lives in London.",
+            type="fact",
+            title="Location",
+            agent_id="test-agent"
+        )
+        
+        result = write_service.batch_store_memories([memory1, memory2])
+        
+        for res in result["results"]:
+            assert res.get("reason") != "MVP direct store", "Contradiction validation is skipped for batch storage (MVP direct store)."

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_validation_service import MemoryValidationService
 from memanto.app.services.memory_write_service import MemoryWriteService
 
 
@@ -61,6 +62,28 @@ class TestContradictionHandling:
         )
         assert result["reason"] == "validated: no contradicting memories found"
         assert result["action"] == "store"
+
+    def test_find_contradictions_matches_same_title_beyond_default_page(self):
+        """Same-title contradictions outside the default top-10 page must still match."""
+        filler = [
+            existing_doc(
+                memory_id=f"filler-{i}",
+                title=f"Other topic {i}",
+                content=f"Unrelated body {i}",
+            )
+            for i in range(12)
+        ]
+        contradicting = existing_doc(
+            memory_id="old-1",
+            title="Favorite Color",
+            content="The user's favorite color is blue.",
+        )
+        client = make_client(search_results=filler + [contradicting])
+        service = MemoryValidationService(client)
+
+        conflicts = service._find_contradictions(make_memory())
+
+        assert [item["id"] for item in conflicts] == ["old-1"]
 
     def test_store_memory_supersedes_contradicting_memory(self):
         """A same-type/same-title active memory with different content is

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -128,9 +128,7 @@ class TestContradictionHandling:
         assert "contradiction resolved: superseded old-1" in result["reason"]
 
         # Old memory was rewritten as superseded history, not dropped.
-        client.documents.delete.assert_called_once_with(
-            namespace_name="memanto_agent_test-agent", ids=["old-1"]
-        )
+        client.documents.delete.assert_not_called()
         uploads = client.documents.upload.call_args_list
         assert len(uploads) == 2
         superseded_doc = uploads[0].kwargs["documents"][0]
@@ -151,6 +149,21 @@ class TestContradictionHandling:
         result = write_service.store_memory(make_memory())
 
         assert result["reason"] == "validated: no contradicting memories found"
+        client.documents.delete.assert_not_called()
+
+    def test_supersede_returns_false_when_upload_fails(self):
+        """Failed supersede upload must not delete the original document."""
+        client = make_client(search_results=[existing_doc()])
+        client.documents.upload.side_effect = [
+            {"status": "failed"},
+            {"status": "success"},
+        ]
+        write_service = MemoryWriteService(client)
+
+        result = write_service.store_memory(make_memory())
+
+        assert result.get("superseded_ids", []) == []
+        assert "failed to supersede old-1" in result["reason"]
         client.documents.delete.assert_not_called()
 
     def test_exempt_type_skips_conflict_check(self):

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,61 +1,165 @@
-import pytest
 from unittest.mock import MagicMock
-from memanto.app.services.memory_write_service import MemoryWriteService
+
 from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_write_service import MemoryWriteService
+
+
+def make_memory(**overrides):
+    defaults = dict(
+        content="The user's favorite color is red.",
+        type="fact",
+        title="Favorite Color",
+        agent_id="test-agent",
+        actor_id="user",
+        source="user",
+    )
+    defaults.update(overrides)
+    return MemoryRecord(**defaults)
+
+
+def make_client(search_results=None):
+    client = MagicMock()
+    client.documents.upload.return_value = {"status": "success"}
+    client.documents.delete.return_value = {"actual_deletions": 1}
+    client.similarity_search.query.return_value = {"results": search_results or []}
+    return client
+
+
+def existing_doc(
+    memory_id="old-1",
+    title="Favorite Color",
+    content="The user's favorite color is blue.",
+    memory_type="fact",
+    status="active",
+):
+    """A stored memory as Moorcheh returns it (flat metadata fields)."""
+    return {
+        "id": memory_id,
+        "text": f"[{memory_type.upper()}] {title}\n\n{content}",
+        "memory_type": memory_type,
+        "status": status,
+        "agent_id": "test-agent",
+        "actor_id": "user",
+        "source": "user",
+        "confidence": 0.8,
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+    }
+
 
 class TestContradictionHandling:
-    """
-    Test suite demonstrating that the memory write service fails to properly resolve direct contradictions.
-    """
+    """Write-time contradiction validation in MemoryWriteService."""
 
-    def test_store_memory_skips_validation(self):
-        """
-        Demonstrates that store_memory bypasses contradiction validation and forces an MVP direct store.
-        This allows logically contradictory memories to be stored blindly.
-        """
-        mock_client = MagicMock()
-        mock_client.documents.upload.return_value = {"status": "success"}
-        
-        write_service = MemoryWriteService(mock_client)
-        
-        memory = MemoryRecord(
-            content="The user's favorite color is red.",
-            type="fact",
-            title="Favorite Color",
-            agent_id="test-agent"
+    def test_store_memory_runs_validation(self):
+        """store_memory must not blindly bypass validation (old 'MVP direct store')."""
+        write_service = MemoryWriteService(make_client())
+
+        result = write_service.store_memory(make_memory())
+
+        assert result.get("reason") != "MVP direct store", (
+            "Contradiction validation is completely skipped (MVP direct store)."
         )
-        
+        assert result["reason"] == "validated: no contradicting memories found"
+        assert result["action"] == "store"
+
+    def test_store_memory_supersedes_contradicting_memory(self):
+        """A same-type/same-title active memory with different content is
+        superseded (keep_new) and the resolution is reported."""
+        client = make_client(search_results=[existing_doc()])
+        write_service = MemoryWriteService(client)
+
+        memory = make_memory()
         result = write_service.store_memory(memory)
-        
-        # The test expects proper contradiction validation to be active.
-        # Currently, the code skips validation with the reason "MVP direct store", meaning
-        # it will blindly store contradictions instead of resolving them.
-        assert result.get("reason") != "MVP direct store", "Contradiction validation is completely skipped (MVP direct store)."
 
-    def test_batch_store_memories_skips_validation(self):
-        """
-        Demonstrates that batch_store_memories also bypasses contradiction validation.
-        """
-        mock_client = MagicMock()
-        mock_client.documents.upload.return_value = {"status": "success"}
-        
-        write_service = MemoryWriteService(mock_client)
-        
-        memory1 = MemoryRecord(
-            content="The user lives in New York.",
-            type="fact",
-            title="Location",
-            agent_id="test-agent"
+        assert result["superseded_ids"] == ["old-1"]
+        assert "contradiction resolved: superseded old-1" in result["reason"]
+
+        # Old memory was rewritten as superseded history, not dropped.
+        client.documents.delete.assert_called_once_with(
+            namespace_name="memanto_agent_test-agent", ids=["old-1"]
         )
-        
-        memory2 = MemoryRecord(
-            content="The user lives in London.",
-            type="fact",
-            title="Location",
-            agent_id="test-agent"
+        uploads = client.documents.upload.call_args_list
+        assert len(uploads) == 2
+        superseded_doc = uploads[0].kwargs["documents"][0]
+        assert superseded_doc["id"] == "old-1"
+        assert superseded_doc["status"] == "superseded"
+        assert superseded_doc["superseded_by"] == memory.id
+        assert "superseded_at" in superseded_doc
+        new_doc = uploads[1].kwargs["documents"][0]
+        assert new_doc["id"] == memory.id
+        assert new_doc["status"] == "active"
+
+    def test_duplicate_content_is_not_a_contradiction(self):
+        """Identical content under the same title is a duplicate, not a conflict."""
+        duplicate = existing_doc(content="The user's favorite color is red.")
+        client = make_client(search_results=[duplicate])
+        write_service = MemoryWriteService(client)
+
+        result = write_service.store_memory(make_memory())
+
+        assert result["reason"] == "validated: no contradicting memories found"
+        client.documents.delete.assert_not_called()
+
+    def test_exempt_type_skips_conflict_check(self):
+        """Types outside REQUIRE_VALIDATION_FOR store directly, without search."""
+        client = make_client()
+        write_service = MemoryWriteService(client)
+
+        result = write_service.store_memory(
+            make_memory(type="event", title="Standup", content="Daily standup at 9am.")
         )
-        
+
+        assert "exempt from conflict validation" in result["reason"]
+        client.similarity_search.query.assert_not_called()
+
+    def test_search_failure_does_not_block_store(self):
+        """A failed conflict lookup is reported honestly but never blocks the write."""
+        client = make_client()
+        client.similarity_search.query.side_effect = RuntimeError("search down")
+        write_service = MemoryWriteService(client)
+
+        result = write_service.store_memory(make_memory())
+
+        assert result["reason"] == "stored: conflict check unavailable"
+        client.documents.upload.assert_called_once()
+
+    def test_batch_store_memories_runs_validation(self):
+        """batch_store_memories must not bypass validation either."""
+        client = make_client()
+        write_service = MemoryWriteService(client)
+
+        memory1 = make_memory(
+            content="The user lives in New York.", title="Location"
+        )
+        memory2 = make_memory(content="The user lives in London.", title="Location")
+
         result = write_service.batch_store_memories([memory1, memory2])
-        
+
         for res in result["results"]:
-            assert res.get("reason") != "MVP direct store", "Contradiction validation is skipped for batch storage (MVP direct store)."
+            assert res.get("reason") != "MVP direct store", (
+                "Contradiction validation is skipped for batch storage (MVP direct store)."
+            )
+
+    def test_batch_resolves_contradictions_within_batch(self):
+        """Contradicting memories submitted together resolve to last-wins,
+        with the earlier one preserved as superseded history."""
+        client = make_client()
+        write_service = MemoryWriteService(client)
+
+        memory1 = make_memory(
+            content="The user lives in New York.", title="Location"
+        )
+        memory2 = make_memory(content="The user lives in London.", title="Location")
+
+        result = write_service.batch_store_memories([memory1, memory2])
+
+        first, second = result["results"]
+        assert first["action"] == "store_superseded"
+        assert f"superseded within batch by {memory2.id}" in first["reason"]
+        assert second["action"] == "store"
+
+        documents = client.documents.upload.call_args.kwargs["documents"]
+        assert documents[0]["status"] == "superseded"
+        assert documents[0]["superseded_by"] == memory2.id
+        assert documents[1]["status"] == "active"
+        assert result["successful"] == 2

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -5,14 +5,14 @@ from memanto.app.services.memory_write_service import MemoryWriteService
 
 
 def make_memory(**overrides):
-    defaults = dict(
-        content="The user's favorite color is red.",
-        type="fact",
-        title="Favorite Color",
-        agent_id="test-agent",
-        actor_id="user",
-        source="user",
-    )
+    defaults = {
+        "content": "The user's favorite color is red.",
+        "type": "fact",
+        "title": "Favorite Color",
+        "agent_id": "test-agent",
+        "actor_id": "user",
+        "source": "user",
+    }
     defaults.update(overrides)
     return MemoryRecord(**defaults)
 
@@ -128,9 +128,7 @@ class TestContradictionHandling:
         client = make_client()
         write_service = MemoryWriteService(client)
 
-        memory1 = make_memory(
-            content="The user lives in New York.", title="Location"
-        )
+        memory1 = make_memory(content="The user lives in New York.", title="Location")
         memory2 = make_memory(content="The user lives in London.", title="Location")
 
         result = write_service.batch_store_memories([memory1, memory2])
@@ -146,9 +144,7 @@ class TestContradictionHandling:
         client = make_client()
         write_service = MemoryWriteService(client)
 
-        memory1 = make_memory(
-            content="The user lives in New York.", title="Location"
-        )
+        memory1 = make_memory(content="The user lives in New York.", title="Location")
         memory2 = make_memory(content="The user lives in London.", title="Location")
 
         result = write_service.batch_store_memories([memory1, memory2])

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -85,6 +85,36 @@ class TestContradictionHandling:
 
         assert [item["id"] for item in conflicts] == ["old-1"]
 
+    def test_prefetch_contradictions_runs_parallel_lookups(self, monkeypatch):
+        """Batch prefetch should not serialize independent contradiction searches."""
+        import time
+
+        active = []
+
+        def slow_find(_self, memory):
+            active.append(memory.id)
+            time.sleep(0.05)
+            assert len(active) <= 8
+            active.remove(memory.id)
+            return []
+
+        monkeypatch.setattr(
+            MemoryValidationService,
+            "_find_contradictions",
+            slow_find,
+        )
+        service = MemoryValidationService(make_client())
+        memories = [
+            make_memory(title=f"Topic {i}", content=f"Body {i}") for i in range(4)
+        ]
+
+        start = time.perf_counter()
+        prefetched = service.prefetch_contradictions(memories)
+        elapsed = time.perf_counter() - start
+
+        assert len(prefetched) == 4
+        assert elapsed < 0.15
+
     def test_store_memory_supersedes_contradicting_memory(self):
         """A same-type/same-title active memory with different content is
         superseded (keep_new) and the resolution is reported."""


### PR DESCRIPTION
## Title
Conflict resolution, contradictions, and dedupe behavior

## Summary
Consolidates community fixes for conflict resolution, contradiction handling, and dedupe safety into one reviewable PR. Covers delete-failure handling, manual replacement ordering, and write-time contradiction supersede across CLI clients and the memory write path.

## Included PRs
| PR | Title | Area |
|---|---|---|
| #869 | Handle false conflict deletion results | CLI conflict resolution (`DirectClient` / `SdkClient`) |
| #1358 | Store manual conflict replacement before deletion | CLI manual conflict resolution ordering |
| #1382 | fix: resolve memory contradictions at write time | Write-time validation + supersede |

## Changes by area

### CLI conflict resolution
- Shared `delete_required_memory()` helper tracks delete failures instead of swallowing them as warnings
- Conflict resolution no longer marks entries `resolved: true` when required deletions fail or return false
- Manual resolution stores the replacement **before** deleting originals, so a failed write cannot erase both sides
- Combined #869 + #1358 behavior: store first, then strict delete failure handling

### Write path / contradiction handling
- New `MemoryValidationService` detects same type + title with different content at write time
- Supersedes older active memories (delete + recreate with `status="superseded"`, `superseded_by`, `superseded_at`)
- Batch writes resolve intra-batch contradictions (last wins; earlier entries stored as superseded history)
- Re-enables validation in `MemoryWriteService` (replacing MVP direct-store bypass)

## Files changed
- `memanto/app/services/memory_validation_service.py` (new)
- `memanto/app/services/memory_write_service.py`
- `memanto/cli/client/direct_client.py`
- `memanto/cli/client/sdk_client.py`
- `tests/test_conflict_manual_resolution.py` (new)
- `tests/test_conflict_resolution_delete_failures.py` (new)
- `tests/test_contradiction.py` (new)

**7 files changed, 717 insertions(+), 100 deletions(-)**

## Supersedes / related
This consolidated PR includes work from:
- #869
- #1358
- #1382

Contributors of the above PRs — thank you. Those individual PRs can be closed in favor of this one once merged.

## Test plan
- [x] `pytest tests/test_conflict_resolution_delete_failures.py` (8 passed)
- [x] `pytest tests/test_conflict_manual_resolution.py` (2 passed)
- [x] `pytest tests/test_contradiction.py` (7 passed)
- [x] `pytest tests/` (429 passed)
- [x] `pytest tests/test_e2e.py` — live Moorcheh E2E (24 passed with real API key)
- [x] `ruff check .` (passed)
- [x] `ruff format --check .` (passed)
- [x] `mypy .` (passed)

## Not included in this PR

### Closed — superseded or not included
These PRs were closed. The fix is either already covered by this consolidation, already on `main`, or was not included because it did not meet the bar for this batch.

| PR | Title | Reason |
|---|---|---|
| #1356 | *(conflict/dedupe related)* | Closed — not included in this batch |
| #1372 | *(conflict/dedupe related)* | Closed — not included in this batch |
| #1388 | *(conflict/dedupe related)* | Closed — not included in this batch |
| #1427 | *(conflict/dedupe related)* | Closed — not included in this batch |
| #860 | fix(conflicts): resolve filtered UI entries by original index | Not included — overlap with #869; UI merge conflict on `index.html` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Deterministic write-time contradiction detection is now applied to single and batch memory saves.
  * Batch uploads now resolve in-batch conflicts using consistent “last-wins” superseding, including reporting superseded items.
  * Parallel prefetching speeds up contradiction checks for batch operations.
* **Bug Fixes**
  * Conflict resolution is more reliable: required deletions must succeed, or the conflict stays unresolved.
  * Manual conflict resolution now stores the replacement before deleting originals.
* **Tests**
  * Added regression coverage for contradiction handling, parallel prefetching, and store/delete failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->