### PR TITLE
fix: reject ambiguous comma-containing tags

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from memanto.app.constants import (
     MemoryType,
@@ -47,6 +47,19 @@ class MemoryRecord(BaseModel):
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime | None = None
     ttl_seconds: int | None = Field(default=None, gt=0)
+
+    @field_validator("tags")
+    @classmethod
+    def reject_commas_in_tag_values(
+        cls,
+        tags: list[str],
+    ) -> list[str]:
+        """Reject tags that cannot survive comma-separated storage."""
+        if any("," in tag for tag in tags):
+            raise ValueError(
+                "tag values must not contain commas; use separate list items instead"
+            )
+        return tags
 
     def to_moorcheh_document(self) -> dict[str, Any]:
         """

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -23,6 +23,8 @@ def agent_namespace(agent_id: str) -> str:
 
 def _normalize_tag_values(tags: list[str]) -> list[str]:
     """Normalize tags and reject values unsafe for comma-separated storage."""
+    if not isinstance(tags, list) or any(not isinstance(tag, str) for tag in tags):
+        raise ValueError("tags must be a list of strings")
     normalized_tags = [tag.strip() for tag in tags]
     if any(not tag for tag in normalized_tags):
         raise ValueError("tag values must not be empty or whitespace")

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -21,6 +21,18 @@ def agent_namespace(agent_id: str) -> str:
     return f"memanto_agent_{agent_id}"
 
 
+def _normalize_tag_values(tags: list[str]) -> list[str]:
+    """Normalize tags and reject values unsafe for comma-separated storage."""
+    normalized_tags = [tag.strip() for tag in tags]
+    if any(not tag for tag in normalized_tags):
+        raise ValueError("tag values must not be empty or whitespace")
+    if any("," in tag for tag in normalized_tags):
+        raise ValueError(
+            "tag values must not contain commas; use separate list items instead"
+        )
+    return normalized_tags
+
+
 class MemoryRecord(BaseModel):
     """Structured memory record with standardized format"""
 
@@ -55,11 +67,7 @@ class MemoryRecord(BaseModel):
         tags: list[str],
     ) -> list[str]:
         """Reject tags that cannot survive comma-separated storage."""
-        if any("," in tag for tag in tags):
-            raise ValueError(
-                "tag values must not contain commas; use separate list items instead"
-            )
-        return tags
+        return _normalize_tag_values(tags)
 
     def to_moorcheh_document(self) -> dict[str, Any]:
         """
@@ -69,11 +77,12 @@ class MemoryRecord(BaseModel):
         powerful filtering using the # syntax (e.g., #memory_type:fact #confidence>0.8)
         """
         memory_type = self.type or "fact"
+        tags = _normalize_tag_values(self.tags)
 
         # Format text as standardized card for semantic search
         text = f"[{memory_type.upper()}] {self.title}\n\n{self.content}"
-        if self.tags:
-            text += f"\n\nTags: {', '.join(self.tags)}"
+        if tags:
+            text += f"\n\nTags: {', '.join(tags)}"
 
         # Build document with flat metadata fields (not nested!)
         document = {
@@ -96,8 +105,8 @@ class MemoryRecord(BaseModel):
         # Add optional fields only if present
         if self.source_ref:
             document["source_ref"] = self.source_ref
-        if self.tags:
-            document["tags"] = ",".join(self.tags)  # Comma-separated for filtering
+        if tags:
+            document["tags"] = ",".join(tags)  # Comma-separated for filtering
         if self.expires_at:
             if isinstance(self.expires_at, datetime):
                 document["expires_at"] = self.expires_at.isoformat()

--- a/tests/test_tag_round_trip_integrity.py
+++ b/tests/test_tag_round_trip_integrity.py
@@ -24,6 +24,43 @@ def test_tag_containing_comma_is_rejected_before_storage():
         build_memory(["customer,priority"])
 
 
+@pytest.mark.parametrize("tag", ["", "   "])
+def test_empty_tag_is_rejected_before_storage(tag: str):
+    with pytest.raises(
+        ValidationError,
+        match="tag values must not be empty or whitespace",
+    ):
+        build_memory([tag])
+
+
+@pytest.mark.parametrize(
+    ("tag", "message"),
+    [
+        ("customer,priority", "tag values must not contain commas"),
+        ("   ", "tag values must not be empty or whitespace"),
+    ],
+)
+def test_invalid_tag_added_after_validation_is_rejected_before_storage(
+    tag: str,
+    message: str,
+):
+    memory = build_memory(["customer"])
+    memory.tags.append(tag)
+
+    with pytest.raises(ValueError, match=message):
+        memory.to_moorcheh_document()
+
+
+def test_tags_are_normalized_before_round_trip():
+    memory = build_memory([" customer ", " priority "])
+
+    stored = memory.to_moorcheh_document()
+    restored = MemoryReadService(object())._format_memory_item(stored)
+
+    assert memory.tags == ["customer", "priority"]
+    assert restored["tags"] == memory.tags
+
+
 def test_separate_tags_survive_round_trip():
     original = build_memory(["customer", "priority"])
 

--- a/tests/test_tag_round_trip_integrity.py
+++ b/tests/test_tag_round_trip_integrity.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def build_memory(tags: list[str]) -> MemoryRecord:
+    return MemoryRecord(
+        title="Tag fidelity test",
+        content="Tags must remain accurate.",
+        agent_id="agent-1",
+        actor_id="user-1",
+        source="system",
+        tags=tags,
+    )
+
+
+def test_tag_containing_comma_is_rejected_before_storage():
+    with pytest.raises(
+        ValidationError,
+        match="tag values must not contain commas",
+    ):
+        build_memory(["customer,priority"])
+
+
+def test_separate_tags_survive_round_trip():
+    original = build_memory(["customer", "priority"])
+
+    stored = original.to_moorcheh_document()
+
+    restored = MemoryReadService(object())._format_memory_item(stored)
+
+    assert restored["tags"] == original.tags

--- a/tests/test_tag_round_trip_integrity.py
+++ b/tests/test_tag_round_trip_integrity.py
@@ -51,6 +51,15 @@ def test_invalid_tag_added_after_validation_is_rejected_before_storage(
         memory.to_moorcheh_document()
 
 
+@pytest.mark.parametrize("tags", ["customer", [None]])
+def test_invalid_tags_assigned_after_validation_are_rejected_before_storage(tags):
+    memory = build_memory(["customer"])
+    memory.tags = tags
+
+    with pytest.raises(ValueError, match="tags must be a list of strings"):
+        memory.to_moorcheh_document()
+
+
 def test_tags_are_normalized_before_round_trip():
     memory = build_memory([" customer ", " priority "])
 


### PR DESCRIPTION
Refs #770

## Summary

This fixes a memory-integrity issue in the tag round trip.

A single legitimate tag containing a comma, such as `customer,priority`, was serialized into comma-separated metadata and later reconstructed as two different tags: `customer` and `priority`. This silently changed the original memory metadata.

## Root cause

The write path stores tags as comma-separated text. The read path treats every comma as a tag separator. Therefore, the storage format cannot distinguish a separator from a literal comma inside one tag value.

## Reproduction

Before this fix:

```python
original = MemoryRecord(
    title="Tag fidelity test",
    content="A tag must not change during storage.",
    agent_id="agent-1",
    actor_id="user-1",
    source="system",
    tags=["customer,priority"],
)

stored = original.to_moorcheh_document()
restored = MemoryReadService(object())._format_memory_item(stored)

assert original.tags == ["customer,priority"]
assert restored["tags"] == ["customer", "priority"]
```

The original tag boundary is lost.

## Fix

- Validate `MemoryRecord.tags` before serialization.
- Reject individual tag values containing commas with a clear error.
- Tell callers to use separate list items instead.
- Preserve the existing storage and filtering format.
- Add regression coverage for ambiguous tags and valid multi-tag round trips.

## Validation

- Relevant pytest suite: 68 passed.
- Ruff lint and formatting checks passed.
- Mypy reported no issues.
- Tests ran without OpenAI or Moorcheh credentials.
- No secrets or credentials are included.

## Expected behavior

Ambiguous input such as:

```python
tags=["customer,priority"]
```

is rejected before storage. Separate tags remain supported:

```python
tags=["customer", "priority"]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tags are now normalized (whitespace trimmed) and validated to be non-empty and free of commas.
  * Normalized tag values are used consistently in both generated text and saved document metadata.
  * Tag round trips preserve separate tag values correctly.

* **Tests**
  * Added coverage for rejecting comma-containing, empty/whitespace-only tags, and post-validation mutations that introduce invalid tags.
  * Added assertions that invalid tag assignments are rejected and that whitespace-padded tags normalize correctly before round-trip persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->