### PR TITLE
fix(langgraph): preserve namespace tuple boundaries

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -8,7 +8,7 @@ Mapping between abstractions
 ----------------------------
 
     BaseStore                         ->  Memanto
-    namespace (tuple[str, ...])       ->  agent_id       (``langgraph_<p0>_<p1>...``)
+    namespace (tuple[str, ...])       ->  agent_id       (legacy or reversible ID)
     key (str)                         ->  reserved tag   ``lg:key:<key>``
     value["kind"] / value["type"]     ->  memory_type    (auto-parsed if absent)
     value["title"]                    ->  title          (auto-derived if absent)
@@ -34,7 +34,11 @@ Documented limitations
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
+import json
 import logging
+import re
 import threading
 import time
 from collections.abc import Iterable
@@ -59,6 +63,8 @@ logger = logging.getLogger(__name__)
 _KEY_TAG_PREFIX = "lg:key:"
 _ENCODED_KEY_TAG_PREFIX = "lg:key:v1:"
 _RESERVED_PREFIX = "lg:"
+_NAMESPACE_ENCODING_MARKER = "v1_"
+_LEGACY_NAMESPACE_PART = re.compile(r"[A-Za-z0-9-]+")
 
 _VALID_MEMORY_TYPES = {
     "fact",
@@ -111,8 +117,7 @@ class MemantoStore(BaseStore):
         self._last_good: dict[tuple[str, ...], list[SearchItem]] = {}
 
     def _ensure_client(self, namespace: tuple[str, ...]) -> tuple[SdkClient, str]:
-        ns_str = "_".join(namespace) or "default"
-        agent_id = f"{self._agent_prefix}{ns_str}"
+        agent_id = self._namespace_to_agent_id(namespace)
         with self._lock:
             if agent_id in self._client_pool:
                 return self._client_pool[agent_id], agent_id
@@ -127,6 +132,26 @@ class MemantoStore(BaseStore):
             client.activate_agent(agent_id=agent_id)
             self._client_pool[agent_id] = client
             return client, agent_id
+
+    def _namespace_to_agent_id(self, namespace: tuple[str, ...]) -> str:
+        """Map tuple namespaces without losing their structural boundaries."""
+        if not namespace:
+            return f"{self._agent_prefix}default"
+
+        legacy = "_".join(namespace)
+        can_use_legacy = (
+            namespace != ("default",)
+            and not legacy.startswith(_NAMESPACE_ENCODING_MARKER)
+            and all(_LEGACY_NAMESPACE_PART.fullmatch(part) for part in namespace)
+        )
+        if can_use_legacy:
+            return f"{self._agent_prefix}{legacy}"
+
+        payload = json.dumps(
+            list(namespace), ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8")
+        encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+        return f"{self._agent_prefix}{_NAMESPACE_ENCODING_MARKER}{encoded}"
 
     # ------------------------------------------------------------------ #
     # Required abstract methods                                          #
@@ -382,11 +407,7 @@ class MemantoStore(BaseStore):
         for agent in agents:
             agent_id = agent.get("agent_id") or agent.get("id") or ""
             if agent_id.startswith(self._agent_prefix):
-                ns_str = agent_id[len(self._agent_prefix) :]
-                if ns_str == "default":
-                    namespaces.append(())
-                else:
-                    namespaces.append(tuple(ns_str.split("_")))
+                namespaces.append(self._agent_id_to_namespace(agent_id))
 
         if op.match_conditions:
             for cond in op.match_conditions:
@@ -403,6 +424,29 @@ class MemantoStore(BaseStore):
         if op.max_depth is not None:
             result = sorted({ns[: op.max_depth] for ns in result})
         return result[: op.limit] if op.limit else result
+
+    def _agent_id_to_namespace(self, agent_id: str) -> tuple[str, ...]:
+        """Recover an encoded namespace, falling back to the legacy mapping."""
+        ns_str = agent_id[len(self._agent_prefix) :]
+        if ns_str == "default":
+            return ()
+
+        if ns_str.startswith(_NAMESPACE_ENCODING_MARKER):
+            encoded = ns_str[len(_NAMESPACE_ENCODING_MARKER) :]
+            padded = encoded + "=" * (-len(encoded) % 4)
+            try:
+                decoded = json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))
+            except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError):
+                pass
+            else:
+                if isinstance(decoded, list) and all(
+                    isinstance(part, str) for part in decoded
+                ):
+                    namespace = tuple(decoded)
+                    if self._namespace_to_agent_id(namespace) == agent_id:
+                        return namespace
+
+        return tuple(ns_str.split("_"))
 
     # ------------------------------------------------------------------ #
     # Encoding helpers                                                   #

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -56,6 +56,23 @@ def test_ensure_client_empty_namespace(mock_sdk_client):
     assert agent_id == "langgraph_default"
 
 
+def test_ensure_client_keeps_structurally_distinct_namespaces_isolated(
+    mock_sdk_client,
+):
+    """Tuple boundaries must not collapse distinct LangGraph namespaces."""
+    store = MemantoStore(api_key="test_key")
+    first_client = MagicMock()
+    second_client = MagicMock()
+    mock_sdk_client.side_effect = [first_client, second_client]
+
+    first, first_agent_id = store._ensure_client(("team_alpha", "project"))
+    second, second_agent_id = store._ensure_client(("team", "alpha_project"))
+
+    assert first_agent_id != second_agent_id
+    assert first is first_client
+    assert second is second_client
+
+
 def test_do_get_recent_success(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()
@@ -89,7 +106,7 @@ def test_do_get_recent_success(mock_sdk_client):
     assert item.value["kind"] == "fact"
 
     client_instance.recall_recent.assert_called_once_with(
-        agent_id="langgraph_my_ns", limit=100
+        agent_id=store._namespace_to_agent_id(("my_ns",)), limit=100
     )
 
 
@@ -151,7 +168,10 @@ def test_do_get_fallback_success(mock_sdk_client):
     assert item is not None
     assert item.value["content"] == "fallback content"
     client_instance.recall.assert_called_once_with(
-        agent_id="langgraph_my_ns", query="my_key", limit=100, tags=["lg:key:my_key"]
+        agent_id=store._namespace_to_agent_id(("my_ns",)),
+        query="my_key",
+        limit=100,
+        tags=["lg:key:my_key"],
     )
 
 
@@ -182,7 +202,7 @@ def test_do_put_success(mock_sdk_client):
     store._do_put(op)
 
     client_instance.remember.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id=store._namespace_to_agent_id(("my_ns",)),
         memory_type="fact",
         title="fact title",
         content="my new fact",
@@ -247,7 +267,7 @@ def test_do_search_recent(mock_sdk_client):
     assert len(items) == 1
     assert items[0].key == "key1"
     client_instance.recall_recent.assert_called_once_with(
-        agent_id="langgraph_my_ns", limit=100, type=None
+        agent_id=store._namespace_to_agent_id(("my_ns",)), limit=100, type=None
     )
 
 
@@ -279,7 +299,7 @@ def test_do_search_wildcard_with_tags_uses_backend_tag_filter(mock_sdk_client):
     assert items[0].key == "key3"
     client_instance.recall_recent.assert_not_called()
     client_instance.recall.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id=store._namespace_to_agent_id(("my_ns",)),
         query="*",
         limit=10,
         type=None,
@@ -312,7 +332,7 @@ def test_do_search_semantic(mock_sdk_client):
     assert len(items) == 1
     assert items[0].key == "key2"
     client_instance.recall.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id=store._namespace_to_agent_id(("my_ns",)),
         query="test query",
         limit=10,
         type=["observation"],
@@ -345,7 +365,7 @@ def test_do_search_accepts_string_tag_filter(mock_sdk_client):
     assert len(items) == 1
     assert items[0].key == "key2"
     client_instance.recall.assert_called_once_with(
-        agent_id="langgraph_my_ns",
+        agent_id=store._namespace_to_agent_id(("my_ns",)),
         query="test query",
         limit=10,
         type=None,
@@ -421,6 +441,74 @@ def test_do_list_namespaces(mock_sdk_client):
     assert ("my", "ns") in namespaces
     assert ("other", "ns", "sub") in namespaces
     assert len(namespaces) == 3
+
+
+def test_do_list_namespaces_round_trips_encoded_tuple_boundaries(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+    original = ("team_alpha", "project")
+    client_instance.list_agents.return_value = [
+        {"agent_id": store._namespace_to_agent_id(original)}
+    ]
+
+    namespaces = store._do_list_namespaces(ListNamespacesOp())
+
+    assert namespaces == [original]
+
+
+def test_do_list_namespaces_distinguishes_empty_from_default_namespace(
+    mock_sdk_client,
+):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+    client_instance.list_agents.return_value = [
+        {"agent_id": store._namespace_to_agent_id(())},
+        {"agent_id": store._namespace_to_agent_id(("default",))},
+    ]
+
+    namespaces = store._do_list_namespaces(ListNamespacesOp())
+
+    assert namespaces == [(), ("default",)]
+
+
+@pytest.mark.parametrize(
+    "original",
+    [
+        ("equipo", "日本語"),
+        ("team", "", "project"),
+    ],
+)
+def test_do_list_namespaces_round_trips_unicode_and_empty_segments(
+    mock_sdk_client, original
+):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+    encoded_agent_id = store._namespace_to_agent_id(original)
+    client_instance.list_agents.return_value = [{"agent_id": encoded_agent_id}]
+
+    namespaces = store._do_list_namespaces(ListNamespacesOp())
+
+    assert namespaces == [original]
+    assert encoded_agent_id.isascii()
+    assert encoded_agent_id.replace("_", "").replace("-", "").isalnum()
+
+
+def test_do_list_namespaces_keeps_legacy_id_that_resembles_encoding(
+    mock_sdk_client,
+):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+    client_instance.list_agents.return_value = [
+        {"agent_id": "langgraph_v1_WyJsZWdhY3kiXQ"}
+    ]
+
+    namespaces = store._do_list_namespaces(ListNamespacesOp())
+
+    assert namespaces == [("v1", "WyJsZWdhY3kiXQ")]
 
 
 def test_do_list_namespaces_match_conditions(mock_sdk_client):


### PR DESCRIPTION
## Summary

- prevent structurally distinct LangGraph namespace tuples from collapsing onto the same Memanto agent
- preserve unambiguous legacy agent IDs while using a versioned, reversible representation when the legacy mapping is ambiguous
- decode versioned IDs when listing namespaces without misinterpreting legacy IDs that merely resemble the new marker

## Impact

The integration relies on a namespace tuple to select the backend Memanto agent. The current mapping is not one-to-one:

```python
("team_alpha", "project")
("team", "alpha_project")
```

Both become:

```text
langgraph_team_alpha_project
```

Because `_ensure_client` pools and activates clients by that derived `agent_id`, reads, writes, and searches from both structural namespaces are routed to the same backend agent.

In applications that use namespaces to separate workflows—or encode tenant or customer boundaries in namespace segments—this can cause cross-workflow or cross-tenant memory mixing, unintended disclosure during recall/search, and wrong-context reads or writes that logically corrupt the application's memory state. This is a deterministic collision, not a probabilistic hash collision.

## Root cause

The integration derived `agent_id` with `"_".join(namespace)` and reconstructed namespaces with `split("_")`. Delimiters inside a namespace segment were therefore indistinguishable from tuple boundaries.

## Fix

- Use the legacy representation only when every namespace segment is unambiguous.
- Encode ambiguous namespaces as versioned URL-safe Base64 over canonical JSON UTF-8.
- Validate decoded values by re-encoding them before accepting the versioned interpretation.
- Keep the empty namespace, ordinary legacy namespaces, and marker-like legacy IDs backward compatible.
- Route `_ensure_client` and namespace listing through the same centralized mapping helpers.

## Compatibility

The empty namespace and simple legacy namespaces retain their current IDs. Namespaces containing underscores, Unicode, empty segments, the singleton `("default",)`, or the version marker use the reversible representation.

Existing memories already stored under a previously ambiguous legacy ID are not migrated automatically. Correct isolation requires distinct IDs for those namespaces going forward.

## Current branch status and #1317

The same root collision was identified independently in #1317. GitHub records that PR as merged into `integrations/merge-prs`, but at the current branch tips its exact head (`b185984`) is not an ancestor of either `main=c4e3401` or `integrations/merge-prs=ccb192e`. Both live branches still contain the original `"_".join(namespace)` mapping, so the collision remains reachable in the code maintainers would ship today.

This PR targets `main` directly. It also preserves ordinary unambiguous legacy agent IDs and switches only ambiguous namespaces to the reversible form. This is a current-branch reachability and compatibility distinction, not a claim that #1317's diagnosis was invalid.

## Validation

- Focused store suite: **25 passed**
- Full LangGraph integration suite: **48 passed**
- Ruff check: passed on both changed files
- Ruff format check: passed on both changed files
- MyPy: passed on `integrations/langgraph/langgraph_memanto/store.py`
- `git diff --check`: passed
- CodeRabbit: successful, with no actionable review comments

Related to #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace-to-agent mapping to prevent distinct namespaces from being conflated.
  * Preserved support for legacy namespace mappings while enabling safe handling of empty, Unicode, and complex namespace segments.
  * Improved namespace listing so encoded namespaces are accurately restored, including default and empty namespaces.
  * Ensured memory operations consistently target the correct namespace-specific agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->