### PR TITLE
fix(read): search_as_of recalls since-expired memories (bounty #770)

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -237,7 +237,9 @@ class MemoryReadService:
                     "temporal_mode": "as_of",
                 }
 
-            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            all_memories = self._fetch_all_memories(
+                namespaces, type=type, tags=tags, filter_expired=False
+            )
             all_memories = self._apply_temporal_filter(
                 all_memories, created_before=as_of_dt.isoformat()
             )
@@ -426,6 +428,7 @@ class MemoryReadService:
         namespaces: list[str],
         type: list[str] | None = None,
         tags: list[str] | None = None,
+        filter_expired: bool = True,
     ) -> list[dict[str, Any]]:
         """
         List all stored memories across the given namespaces via Moorcheh's
@@ -434,6 +437,13 @@ class MemoryReadService:
 
         Iterates through all pages using cursor-based pagination (next_token)
         so results are not truncated at the 100-item per-page cap.
+
+        ``filter_expired`` controls whether memories expired at the current
+        wall-clock time are dropped. Point-in-time callers such as
+        ``search_as_of`` must pass ``filter_expired=False`` and apply their
+        own expiry check against the target date, otherwise memories that
+        were valid at that past date but have since expired are silently
+        dropped (timeline amnesia).
         """
         items: list[Any] = []
         for ns in namespaces:
@@ -479,7 +489,9 @@ class MemoryReadService:
 
             memories.append(formatted)
 
-        return self._filter_expired_memories(memories)
+        if filter_expired:
+            return self._filter_expired_memories(memories)
+        return memories
 
     def _memory_version_key(
         self, memory: dict[str, Any], fetch_index: int

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -238,7 +238,11 @@ class MemoryReadService:
                 }
 
             all_memories = self._fetch_all_memories(
-                namespaces, type=type, tags=tags, filter_expired=False
+                namespaces,
+                type=type,
+                tags=tags,
+                filter_expired=False,
+                created_before=as_of_dt.isoformat(),
             )
             all_memories = self._apply_temporal_filter(
                 all_memories, created_before=as_of_dt.isoformat()
@@ -429,6 +433,7 @@ class MemoryReadService:
         type: list[str] | None = None,
         tags: list[str] | None = None,
         filter_expired: bool = True,
+        created_before: str | None = None,
     ) -> list[dict[str, Any]]:
         """
         List all stored memories across the given namespaces via Moorcheh's
@@ -444,7 +449,22 @@ class MemoryReadService:
         own expiry check against the target date, otherwise memories that
         were valid at that past date but have since expired are silently
         dropped (timeline amnesia).
+
+        ``created_before`` drops any version whose ``created_at`` is after the
+        given ISO timestamp *before* de-duplication, so point-in-time callers
+        can stop a delete-and-recreate that happened after ``as_of`` from
+        evicting the version that was valid then during newest-version
+        selection (bounty #770).
         """
+        from memanto.app.utils.temporal_helpers import parse_iso_timestamp
+
+        before_dt: datetime | None = None
+        if created_before:
+            try:
+                before_dt = parse_iso_timestamp(created_before)
+            except (TypeError, ValueError, AttributeError):
+                pass  # Fail open: keep newest-version dedup behaviour.
+
         items: list[Any] = []
         for ns in namespaces:
             next_token: str | None = None
@@ -472,6 +492,19 @@ class MemoryReadService:
             mid = formatted.get("id")
             if not mid:
                 continue
+
+            # Point-in-time dedup: only versions that existed at the target
+            # date compete for the newest-version slot, so a delete-and-recreate
+            # after as_of cannot displace the version valid then (bounty #770).
+            if before_dt is not None:
+                raw_created = formatted.get("created_at")
+                if not raw_created:
+                    continue
+                try:
+                    if parse_iso_timestamp(str(raw_created)) > before_dt:
+                        continue
+                except (TypeError, ValueError):
+                    continue
 
             version_key = self._memory_version_key(formatted, index)
             existing = latest_by_id.get(cast(str, mid))

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -251,14 +251,25 @@ class MemoryReadService:
             # Filter to only include memories valid at as_of_date
             valid_memories = []
             for memory in all_memories:
-                # Skip if expired before as_of_date
+                # Skip if expired before as_of_date. Mirror the datetime
+                # handling in _filter_expired_memories so a datetime-valued
+                # expires_at cannot crash a historical recall (bounty #770).
                 expires_at = memory.get("expires_at")
                 if expires_at:
                     try:
-                        expires_dt = parse_iso_timestamp(expires_at)
-                        if expires_dt <= as_of_dt:
+                        if isinstance(expires_at, str):
+                            expires_dt = parse_iso_timestamp(expires_at)
+                        elif isinstance(expires_at, datetime):
+                            expires_dt = (
+                                expires_at
+                                if expires_at.tzinfo
+                                else expires_at.replace(tzinfo=timezone.utc)
+                            )
+                        else:
+                            expires_dt = None  # Unknown type: fail open
+                        if expires_dt is not None and expires_dt <= as_of_dt:
                             continue  # Already expired at as_of_date
-                    except (ValueError, AttributeError):
+                    except (ValueError, AttributeError, TypeError):
                         pass
 
                 valid_memories.append(memory)

--- a/tests/test_as_of_expired_recall.py
+++ b/tests/test_as_of_expired_recall.py
@@ -1,0 +1,67 @@
+"""Regression tests for point-in-time (``search_as_of``) recall.
+
+These guard against timeline amnesia: memories that were valid at the target
+``as_of`` date but have *since* expired must still be recalled, because the
+query asks "what was true at this point in time?", not "what is true now?".
+"""
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _memory(memory_id: str, created_at: str, expires_at: str | None = None) -> dict:
+    m = {
+        "id": memory_id,
+        "text": f"[FACT] {memory_id}\n\nStored memory",
+        "memory_type": "fact",
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+    if expires_at:
+        m["expires_at"] = expires_at
+    return m
+
+
+class _FakeDocuments:
+    def fetch_text_data(self, **kwargs):
+        return {
+            "items": [
+                # Created before as_of, valid at as_of, but expired *after* as_of
+                # and before "now" -> must still be recalled by search_as_of.
+                _memory(
+                    "temporal-fact",
+                    "2026-01-10T09:00:00Z",
+                    expires_at="2026-06-01T00:00:00Z",
+                ),
+                # Created before as_of, never expires -> always recalled.
+                _memory("permanent-fact", "2026-01-12T09:00:00Z"),
+                # Already expired *before* as_of -> must be excluded.
+                _memory(
+                    "stale-fact",
+                    "2026-01-05T09:00:00Z",
+                    expires_at="2026-01-08T00:00:00Z",
+                ),
+            ],
+            "pagination": {"has_more": False},
+        }
+
+
+class _FakeClient:
+    documents = _FakeDocuments()
+
+
+def test_as_of_recalls_memory_that_has_since_expired():
+    service = MemoryReadService(_FakeClient())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15", agent_id="agent-1", limit=None
+    )
+    ids = {m["id"] for m in result["results"]}
+
+    assert "temporal-fact" in ids, "timeline amnesia: since-expired memory lost"
+    assert "permanent-fact" in ids
+    assert "stale-fact" not in ids, "memory expired before as_of should be excluded"

--- a/tests/test_as_of_expired_recall.py
+++ b/tests/test_as_of_expired_recall.py
@@ -99,3 +99,41 @@ def test_as_of_keeps_historical_version_over_post_asof_recreate():
     assert "dup-fact" in by_id, "historical version lost to post-as_of recreate"
     assert by_id["dup-fact"]["created_at"] == "2026-01-10T09:00:00Z"
 
+
+def test_as_of_handles_datetime_valued_expiration():
+    """expires_at stored as a datetime object (not a string) must not crash
+    search_as_of and must still be excluded when it predates as_of. Regression
+    for the datetime-expiry gap flagged on PR #1617 / bounty #770."""
+    from datetime import datetime, timezone
+
+    class _DateTimeDocuments:
+        def fetch_text_data(self, **kwargs):
+            return {
+                "items": [
+                    # datetime expiry BEFORE as_of -> must be excluded
+                    {
+                        **_memory("dt-stale", "2026-01-10T09:00:00Z"),
+                        "expires_at": datetime(2026, 1, 8, tzinfo=timezone.utc),
+                    },
+                    # datetime expiry AFTER as_of -> must be kept
+                    {
+                        **_memory("dt-valid", "2026-01-10T09:00:00Z"),
+                        "expires_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    },
+                ],
+                "pagination": {"has_more": False},
+            }
+
+    class _DateTimeClient:
+        documents = _DateTimeDocuments()
+
+    service = MemoryReadService(_DateTimeClient())
+    result = service.search_as_of(
+        as_of_date="2026-01-15", agent_id="agent-1", limit=None
+    )
+    ids = {m["id"] for m in result["results"]}
+
+    assert "dt-valid" in ids
+    assert "dt-stale" not in ids, "datetime expiry before as_of must exclude"
+
+

--- a/tests/test_as_of_expired_recall.py
+++ b/tests/test_as_of_expired_recall.py
@@ -65,3 +65,37 @@ def test_as_of_recalls_memory_that_has_since_expired():
     assert "temporal-fact" in ids, "timeline amnesia: since-expired memory lost"
     assert "permanent-fact" in ids
     assert "stale-fact" not in ids, "memory expired before as_of should be excluded"
+
+
+class _DupDocuments:
+    """Same id exposed twice: a version valid at as_of and a newer
+    delete-and-recreate version created *after* as_of."""
+
+    def fetch_text_data(self, **kwargs):
+        return {
+            "items": [
+                _memory("dup-fact", "2026-01-10T09:00:00Z"),
+                _memory("dup-fact", "2026-02-20T09:00:00Z"),
+            ],
+            "pagination": {"has_more": False},
+        }
+
+
+class _DupClient:
+    documents = _DupDocuments()
+
+
+def test_as_of_keeps_historical_version_over_post_asof_recreate():
+    """A delete-and-recreate after as_of must not evict the version that was
+    valid at as_of. Regression for the dedup-before-temporal-filter ordering
+    flagged on PR #1617 / bounty #770."""
+    service = MemoryReadService(_DupClient())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15", agent_id="agent-1", limit=None
+    )
+    by_id = {m["id"]: m for m in result["results"]}
+
+    assert "dup-fact" in by_id, "historical version lost to post-as_of recreate"
+    assert by_id["dup-fact"]["created_at"] == "2026-01-10T09:00:00Z"
+


### PR DESCRIPTION
# [Bounty #770] Fix search_as_of timeline amnesia: since-expired memories silently dropped

## Summary of the flaw

`search_as_of` answers a **point-in-time** question: "What was true at this date?" It should return every memory that was **created on/before `as_of_date` and not yet expired at `as_of_date`**.

However, it delegates fetching to `MemoryReadService._fetch_all_memories`, which **always runs `_filter_expired_memories` against the current wall-clock time** before returning. As a result, any memory whose `expires_at` falls **between `as_of_date` and now** (valid at the target date, but already expired today) is removed **before** `search_as_of` ever gets to evaluate it.

The net effect is **timeline amnesia / recall accuracy loss**: a TTL-bearing memory can never be recalled for the historical window in which it was actually live. This matches the High-severity criteria in the bounty scope ("loses track of when an event occurred (timeline amnesia)", "fails to recall highly relevant facts").

The code itself acknowledges the risk of "timeline amnesia / poor recall" in a comment near `search_memories`, yet `search_as_of` still inherits the current-time expiry filter through `_fetch_all_memories`.

## Reproduction steps

1. Create a memory with:
   - `created_at = 2026-01-10` (before the target date)
   - `expires_at = 2026-06-01` (after the target date, but before "now")
2. Query `search_as_of(as_of_date="2026-01-15", ...)`.
3. **Before fix:** the memory is **absent** (dropped by `_filter_expired_memories` because it is expired *now*), even though it was live on 2026-01-15.
4. **After fix:** the memory is correctly returned.

A self-contained regression test is in `tests/test_as_of_expired_recall.py` (fake client, no backend/API key). On unpatched code it fails with `timeline amnesia: since-expired memory lost`; on patched code it passes.

Minimal PoC (see tests/test_as_of_expired_recall.py for the full case):

    service.search_as_of(as_of_date="2026-01-15", agent_id="agent-1", limit=None)
    # expected: "temporal-fact" (created 01-10, expires 06-01) IS recalled
    # actual (bug): it is missing

## Fix / architectural proposal

1. Add a `filter_expired: bool = True` parameter to `_fetch_all_memories`.
2. When `filter_expired` is `False`, skip the current-time `_filter_expired_memories` pass.
3. `search_as_of` now calls `_fetch_all_memories(..., filter_expired=False)` and relies on its **existing** `expires_at <= as_of_dt` check, which already correctly excludes only memories that had expired *by the target date*.

Other callers (`search_changed_since`, `search_recent`) keep the default `filter_expired=True` (unchanged) - for "recent"/"changed since" queries, dropping currently-expired memories is desired; for a **past point-in-time** query it is not.

## Impact

- **Severity: High** - silently corrupts point-in-time recall for any TTL-based memory; the entire purpose of `search_as_of` ("what was true then?") is defeated for expiring memories.
- **Reproducibility: deterministic** - pure logic flaw, reproduced with a fake client (no network/backend), consistent across runs.
- Backward compatible: no API/schema changes; only `search_as_of` behaviour changes (only toward *more correct* recall).

## Verification

- New regression test `tests/test_as_of_expired_recall.py` passes after the fix and fails before it.
- Existing `test_memory_read_as_of.py`, `test_memory_read_temporal_recall.py`, `test_memory_read_confidence.py`, `test_memory_read_filter_sanitization.py` still pass (no regression).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved point-in-time (“as of”) memory searches to correctly include items that were valid at the requested date, even if they expired afterward.
  * Fixed delete-and-recreate cases to consistently return the historical version that existed at the selected time.
  * Enhanced handling of memory expiration when `expires_at` is stored as a datetime, preventing incorrect exclusions/keeps.

* **Tests**
  * Added regression coverage for datetime-typed expiration values in “as of” queries, alongside existing expiration and delete-and-recreate scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->