### PR TITLE
Add LangMem -> Memanto (OKF) migration example

### DIFF
--- a/examples/migrations/langmem/.env.example
+++ b/examples/migrations/langmem/.env.example
@@ -1,0 +1,12 @@
+# --- Offline pipeline (default): no keys required ---
+# `python run.py` runs populate -> export -> adapt -> validate with zero keys.
+
+# --- Optional: import the bundle into a live Memanto agent ---
+# Needed only for `python run.py --import-memanto` and `--after memanto`.
+# Get a free key at https://console.moorcheh.ai/api-keys
+# MOORCHEH_API_KEY=your_moorcheh_api_key_here
+
+# --- Optional: LLM-driven extraction (`python run.py --extract live`) ---
+# Let LangMem's create_memory_store_manager extract memories from the
+# transcript instead of replaying scripted tool operations.
+# OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/migrations/langmem/.gitignore
+++ b/examples/migrations/langmem/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+# transient adapter work dir (auto-cleaned; never commit)
+artifacts/_okf_work/

--- a/examples/migrations/langmem/README.md
+++ b/examples/migrations/langmem/README.md
@@ -1,0 +1,161 @@
+# LangMem → Memanto (OKF) migration
+
+LangMem (LangChain's memory library) isn't one of the providers Memanto
+supports out of the box. This adds one: an adapter that takes a LangMem store
+and converts it into a valid OKF bundle, importable with the existing
+`memanto migrate okf` command. No changes to Memanto's core needed.
+
+Short version of what it does: populate a LangMem store with a realistic
+multi-week history for a developer ("Alex") — preferences, decisions, a
+correction, a stale to-do getting cleaned up — export it, convert it to OKF,
+import it into Memanto, and check that recall still gives the same answers
+afterward.
+
+## Why
+
+LangMem memories are untyped free text living in a LangGraph store. If you
+want to move to a different memory layer there's currently no path out.
+Adding one folder under `examples/migrations/` gives people an actual escape
+hatch, and forces the mapping logic (untyped LangMem content → Memanto's 13
+typed primitives) to exist somewhere reusable instead of being copy-pasted
+by whoever needs it next.
+
+## Quickstart
+
+From the repo root:
+
+```bash
+pip install -e .
+pip install -r examples/migrations/langmem/requirements.txt
+cd examples/migrations/langmem
+python run.py
+```
+
+No API keys needed for this. It runs five steps and writes everything to
+`artifacts/`:
+
+```
+1/5  Populating a LangMem store (extract=replay)...
+2/5  Exporting the LangMem store...
+      -> artifacts/langmem_export.json (10 memories)
+3/5  Adapting LangMem export -> OKF bundle...
+      -> artifacts/okf-bundle  types: {'decision': 1, 'fact': 2, 'goal': 2, 'preference': 4, 'relationship': 1}
+4/5  Validating recall parity (after=bundle)...
+      before 7/7  after 7/7  parity 100.0%
+5/5  Writing migration summary + mapping table...
+```
+
+Worth opening `artifacts/okf-bundle/memories/preference/` afterward — it's
+just plain markdown files with frontmatter, readable without any tooling.
+
+## What each step does
+
+| Step | Module | What happens |
+| --- | --- | --- |
+| 1. Populate | `langmem_migration/populate.py` | Replays a scripted history through LangMem's `manage_memory` tool (create / update / delete), so the resulting store is a real `InMemoryStore` in LangMem's actual schema. |
+| 2. Export | `langmem_migration/export.py` | Dumps `store.search()` results to `artifacts/langmem_export.json`. |
+| 3. Adapt | `langmem_migration/adapter.py` + `mapping.py` | Maps each LangMem record to a Memanto memory dict and writes it out via Memanto's existing `OkfExportService`. |
+| 4. Validate | `langmem_migration/validate.py` | Asks the same set of questions against the store before migration and against the migrated memories after, and compares. |
+| 5. Summarize | `run.py` | Writes `migration-summary.md` and `mapping-table.md`. |
+
+The sample history is built to actually exercise the annoying cases: a
+preference that changes (pytest → Vitest, updated in place rather than
+duplicated), a goal that gets descoped, a teammate who moves off the project,
+and a to-do that gets deleted once it's done. If the mapping dropped or
+duplicated something, the recall check would catch it.
+
+## Importing into a live Memanto agent (optional)
+
+Needs a free key from [console.moorcheh.ai](https://console.moorcheh.ai/api-keys):
+
+```bash
+cp .env.example .env      # add MOORCHEH_API_KEY
+memanto agent create alex && memanto agent activate alex
+
+memanto migrate okf ./artifacts/okf-bundle --agent alex
+
+python run.py --after memanto --agent alex
+```
+
+Or in one command: `python run.py --import-memanto --after memanto --agent alex`.
+
+## Using it on your own LangMem data
+
+The adapter just takes an export dict, so this works against any store, not
+just the sample one:
+
+```python
+from langmem_migration.export import export_store
+from langmem_migration.adapter import write_okf_bundle
+
+export = export_store(my_langmem_store, user_id="me")
+write_okf_bundle(export, "./my-okf-bundle", agent_id="me")
+# memanto migrate okf ./my-okf-bundle --agent me
+```
+
+Custom fields beyond `content` on a LangMem memory get preserved in a
+`[Supporting data]` footer rather than dropped.
+
+### LLM-driven extraction
+
+Default mode replays scripted tool calls (deterministic, no keys needed). To
+instead let an LLM pull memories out of the raw transcript via LangMem's
+`create_memory_store_manager`:
+
+```bash
+export OPENAI_API_KEY=...
+python run.py --extract live --model openai:gpt-4o-mini
+```
+
+## Mapping reference
+
+| LangMem field | Memanto / OKF field | Notes |
+| --- | --- | --- |
+| `value.content` | memory body + derived `title` | kept verbatim |
+| `namespace[1]` (user id) | tag `user=<id>`, `x_memanto.source=langmem` | scope preserved |
+| `key` (uuid) | `source_ref` / OKF `resource` `langmem:<key>` | |
+| `created_at` | OKF `timestamp` | |
+| *(inferred)* | memory `type` → `x_memanto.type` | lexical classifier, same idea as the existing Mem0 mapper |
+| *(constant)* | `provenance=imported`, `confidence=0.75` | |
+
+Type is inferred since LangMem content is untyped; anything that doesn't
+match a rule falls back to `observation` rather than being dropped. Full
+per-memory breakdown is in `artifacts/mapping-table.md`.
+
+## Tests
+
+```bash
+pytest examples/migrations/langmem/tests -q
+```
+
+Checks that the bundle loads back through Memanto's own `load_okf_bundle` /
+`map_okf` with no memories lost, correct type/source/provenance stamping, and
+full recall parity.
+
+## Layout
+
+```
+langmem/
+├── run.py
+├── requirements.txt
+├── .env.example
+├── langmem_migration/
+│   ├── conversation.py     # sample history + the recall check questions
+│   ├── populate.py         # writes it into a real LangMem store
+│   ├── export.py           # store -> langmem_export.json
+│   ├── mapping.py          # LangMem record -> Memanto memory dict
+│   ├── adapter.py          # export -> OKF bundle
+│   └── validate.py         # before/after recall check
+├── tests/test_adapter.py
+└── artifacts/               # generated output
+```
+
+## A note on the sample data
+
+The three-week timeline in `conversation.py` is scripted rather than
+collected from a real month-long agent session — that wasn't practical to
+produce for an example. What's real is that every memory in it goes through
+LangMem's actual `manage_memory` tool and lands in LangMem's actual storage
+schema; only the session dates are backfilled afterward in `populate.py`.
+`--extract live` is there if you'd rather generate the memories with an LLM
+instead of the scripted replay.

--- a/examples/migrations/langmem/artifacts/langmem_export.json
+++ b/examples/migrations/langmem/artifacts/langmem_export.json
@@ -1,0 +1,131 @@
+{
+  "source": "langmem",
+  "namespace": [
+    "memories",
+    "alex"
+  ],
+  "user_id": "alex",
+  "count": 10,
+  "memories": [
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "5c409098-6838-40ee-bce4-40920a79e9f0",
+      "value": {
+        "content": "Alex prefers TypeScript for new frontend work and dislikes untyped JavaScript."
+      },
+      "created_at": "2026-06-02T00:00:00+00:00",
+      "updated_at": "2026-06-02T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "84a87c0c-292b-4fc3-abbb-4da82db7cd4c",
+      "value": {
+        "content": "Alex is a senior backend engineer on the Payments team at Northwind, working primarily in Go and Python."
+      },
+      "created_at": "2026-06-02T00:00:00+00:00",
+      "updated_at": "2026-06-02T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "d3fbaba8-7f52-49e1-a305-e7f440820120",
+      "value": {
+        "content": "Alex uses dark mode in all editors and tools."
+      },
+      "created_at": "2026-06-02T00:00:00+00:00",
+      "updated_at": "2026-06-02T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "1ee9a880-c71d-4153-a6c7-c69f2dbdf028",
+      "value": {
+        "content": "The ledger service is written in Go and backed by Postgres."
+      },
+      "created_at": "2026-06-06T00:00:00+00:00",
+      "updated_at": "2026-06-06T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "580bd5ff-c12e-4c17-b381-8284c10a24f4",
+      "value": {
+        "content": "Alex runs pytest for Python projects and Vitest for all TypeScript repos."
+      },
+      "created_at": "2026-06-11T00:00:00+00:00",
+      "updated_at": "2026-06-11T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "740adbfd-a070-48df-9dc9-050876fdc51f",
+      "value": {
+        "content": "Alex never deploys on Fridays, regardless of how small the change is."
+      },
+      "created_at": "2026-06-16T00:00:00+00:00",
+      "updated_at": "2026-06-16T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "b4ca48b5-2068-483e-8cf7-ee418713204a",
+      "value": {
+        "content": "Decision: the ledger service stores all monetary amounts as decimals, never floats, to avoid rounding errors in audits."
+      },
+      "created_at": "2026-06-16T00:00:00+00:00",
+      "updated_at": "2026-06-16T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "9db581a9-277e-4d97-9286-1cda05cf2de9",
+      "value": {
+        "content": "Alex wants to learn Rust and eventually rewrite the settlement worker in it."
+      },
+      "created_at": "2026-06-20T00:00:00+00:00",
+      "updated_at": "2026-06-20T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "ace9bce2-6357-4b29-a0f6-c74acf15cb42",
+      "value": {
+        "content": "Alex's goal: ship a single-currency (USD) double-entry ledger core to staging by end of Q3 2026; multi-currency is descoped for now."
+      },
+      "created_at": "2026-06-20T00:00:00+00:00",
+      "updated_at": "2026-06-20T00:00:00+00:00"
+    },
+    {
+      "namespace": [
+        "memories",
+        "alex"
+      ],
+      "key": "bab0c21b-7f67-4fb6-883a-3904e9c0892d",
+      "value": {
+        "content": "Priya moved from the ledger service to the Fraud team; Alex is now the sole engineer on the ledger."
+      },
+      "created_at": "2026-06-20T00:00:00+00:00",
+      "updated_at": "2026-06-20T00:00:00+00:00"
+    }
+  ]
+}

--- a/examples/migrations/langmem/artifacts/mapping-table.md
+++ b/examples/migrations/langmem/artifacts/mapping-table.md
@@ -1,0 +1,25 @@
+# LangMem -> Memanto / OKF field mapping
+
+| LangMem field | Memanto / OKF field | Notes |
+| --- | --- | --- |
+| `value.content` | memory body + derived `title` | verbatim, never lossy |
+| `namespace[1]` (user id) | tag `user=<id>`, `x_memanto.source=langmem` | scope preserved |
+| `key` (uuid) | `source_ref` / OKF `resource` `langmem:<key>` | back-reference |
+| `created_at` | OKF `timestamp` | temporal recall fidelity |
+| *(inferred)* | memory `type` -> `x_memanto.type` | deterministic classifier |
+| *(constant)* | `provenance=imported`, `confidence=0.75` | migration marker |
+
+## Per-memory resolution
+
+| # | Inferred type | Title |
+| :---: | --- | --- |
+| 1 | preference | Alex prefers TypeScript for new frontend work and dislikes untyped JavaScript. |
+| 2 | fact | Alex is a senior backend engineer on the Payments team at Northwind, working... |
+| 3 | preference | Alex uses dark mode in all editors and tools. |
+| 4 | fact | The ledger service is written in Go and backed by Postgres. |
+| 5 | preference | Alex runs pytest for Python projects and Vitest for all TypeScript repos. |
+| 6 | preference | Alex never deploys on Fridays, regardless of how small the change is. |
+| 7 | decision | Decision: the ledger service stores all monetary amounts as decimals, never f... |
+| 8 | goal | Alex wants to learn Rust and eventually rewrite the settlement worker in it. |
+| 9 | goal | Alex's goal: ship a single-currency (USD) double-entry ledger core to staging... |
+| 10 | relationship | Priya moved from the ledger service to the Fraud team; Alex is now the sole e... |

--- a/examples/migrations/langmem/artifacts/migration-summary.md
+++ b/examples/migrations/langmem/artifacts/migration-summary.md
@@ -1,0 +1,24 @@
+# Migration summary — LangMem -> Memanto (OKF)
+
+- Extraction backend: **replay**
+- Source LangMem memories: **10**
+- Mapped Memanto memories: **10**
+- OKF bundle sections: memories, metrics
+
+## Type breakdown (inferred from untyped LangMem content)
+
+| Memanto type | Count |
+| --- | :---: |
+| decision | 1 |
+| fact | 2 |
+| goal | 2 |
+| preference | 4 |
+| relationship | 1 |
+
+## Recall parity (before vs after)
+
+- Before (LangMem): 7/7 (100.0%)
+- After (Memanto):  7/7 (100.0%)
+- Parity: 100.0%
+
+See `validation-report.md` for the per-question breakdown and `okf-bundle/` for the human-readable, portable memory bundle.

--- a/examples/migrations/langmem/artifacts/okf-bundle/index.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/index.md
@@ -1,0 +1,10 @@
+---
+type: index
+title: langmem-import knowledge bundle
+timestamp: 2026-07-23T10:38:37
+---
+
+# langmem-import — OKF bundle
+
+- [memories](memories/index.md) — 10 memories across 5 type(s)
+- [metrics](metrics/index.md) — aggregate stats & visualizations

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/decision/decision-the-ledger-service-stores-all-monetary-amounts-as-d.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/decision/decision-the-ledger-service-stores-all-monetary-amounts-as-d.md
@@ -1,0 +1,18 @@
+---
+type: decision
+title: 'Decision: the ledger service stores all monetary amounts as decimals, never
+  f...'
+description: 'Decision: the ledger service stores all monetary amounts as decimals,
+  never floats, to avoid rounding errors in audits.'
+tags:
+- user=alex
+timestamp: '2026-06-16T00:00:00+00:00'
+resource: langmem:b4ca48b5-2068-483e-8cf7-ee418713204a
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: decision
+---
+
+Decision: the ledger service stores all monetary amounts as decimals, never floats, to avoid rounding errors in audits.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/decision/index.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/decision/index.md
@@ -1,0 +1,9 @@
+---
+type: index
+title: decision
+timestamp: 2026-07-23T10:38:37
+---
+
+# decision (1)
+
+- [Decision: the ledger service stores all monetary amounts as decimals, never f...](decision-the-ledger-service-stores-all-monetary-amounts-as-d.md)

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/fact/alex-is-a-senior-backend-engineer-on-the-payments-team-at-no.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/fact/alex-is-a-senior-backend-engineer-on-the-payments-team-at-no.md
@@ -1,0 +1,17 @@
+---
+type: fact
+title: Alex is a senior backend engineer on the Payments team at Northwind, working...
+description: Alex is a senior backend engineer on the Payments team at Northwind,
+  working primarily in Go and Python.
+tags:
+- user=alex
+timestamp: '2026-06-02T00:00:00+00:00'
+resource: langmem:84a87c0c-292b-4fc3-abbb-4da82db7cd4c
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: fact
+---
+
+Alex is a senior backend engineer on the Payments team at Northwind, working primarily in Go and Python.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/fact/index.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/fact/index.md
@@ -1,0 +1,10 @@
+---
+type: index
+title: fact
+timestamp: 2026-07-23T10:38:37
+---
+
+# fact (2)
+
+- [Alex is a senior backend engineer on the Payments team at Northwind, working...](alex-is-a-senior-backend-engineer-on-the-payments-team-at-no.md)
+- [The ledger service is written in Go and backed by Postgres.](the-ledger-service-is-written-in-go-and-backed-by-postgres.md)

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/fact/the-ledger-service-is-written-in-go-and-backed-by-postgres.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/fact/the-ledger-service-is-written-in-go-and-backed-by-postgres.md
@@ -1,0 +1,16 @@
+---
+type: fact
+title: The ledger service is written in Go and backed by Postgres.
+description: The ledger service is written in Go and backed by Postgres.
+tags:
+- user=alex
+timestamp: '2026-06-06T00:00:00+00:00'
+resource: langmem:1ee9a880-c71d-4153-a6c7-c69f2dbdf028
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: fact
+---
+
+The ledger service is written in Go and backed by Postgres.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/goal/alex-s-goal-ship-a-single-currency-usd-double-entry-ledger-c.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/goal/alex-s-goal-ship-a-single-currency-usd-double-entry-ledger-c.md
@@ -1,0 +1,17 @@
+---
+type: goal
+title: 'Alex''s goal: ship a single-currency (USD) double-entry ledger core to staging...'
+description: 'Alex''s goal: ship a single-currency (USD) double-entry ledger core
+  to staging by end of Q3 2026; multi-currency is descoped for now.'
+tags:
+- user=alex
+timestamp: '2026-06-20T00:00:00+00:00'
+resource: langmem:ace9bce2-6357-4b29-a0f6-c74acf15cb42
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: goal
+---
+
+Alex's goal: ship a single-currency (USD) double-entry ledger core to staging by end of Q3 2026; multi-currency is descoped for now.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/goal/alex-wants-to-learn-rust-and-eventually-rewrite-the-settleme.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/goal/alex-wants-to-learn-rust-and-eventually-rewrite-the-settleme.md
@@ -1,0 +1,17 @@
+---
+type: goal
+title: Alex wants to learn Rust and eventually rewrite the settlement worker in it.
+description: Alex wants to learn Rust and eventually rewrite the settlement worker
+  in it.
+tags:
+- user=alex
+timestamp: '2026-06-20T00:00:00+00:00'
+resource: langmem:9db581a9-277e-4d97-9286-1cda05cf2de9
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: goal
+---
+
+Alex wants to learn Rust and eventually rewrite the settlement worker in it.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/goal/index.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/goal/index.md
@@ -1,0 +1,10 @@
+---
+type: index
+title: goal
+timestamp: 2026-07-23T10:38:37
+---
+
+# goal (2)
+
+- [Alex wants to learn Rust and eventually rewrite the settlement worker in it.](alex-wants-to-learn-rust-and-eventually-rewrite-the-settleme.md)
+- [Alex's goal: ship a single-currency (USD) double-entry ledger core to staging...](alex-s-goal-ship-a-single-currency-usd-double-entry-ledger-c.md)

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/index.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/index.md
@@ -1,0 +1,13 @@
+---
+type: index
+title: memories
+timestamp: 2026-07-23T10:38:37
+---
+
+# Memories (10)
+
+- [fact](fact/index.md)
+- [decision](decision/index.md)
+- [goal](goal/index.md)
+- [preference](preference/index.md)
+- [relationship](relationship/index.md)

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/alex-never-deploys-on-fridays-regardless-of-how-small-the-ch.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/alex-never-deploys-on-fridays-regardless-of-how-small-the-ch.md
@@ -1,0 +1,16 @@
+---
+type: preference
+title: Alex never deploys on Fridays, regardless of how small the change is.
+description: Alex never deploys on Fridays, regardless of how small the change is.
+tags:
+- user=alex
+timestamp: '2026-06-16T00:00:00+00:00'
+resource: langmem:740adbfd-a070-48df-9dc9-050876fdc51f
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: preference
+---
+
+Alex never deploys on Fridays, regardless of how small the change is.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/alex-prefers-typescript-for-new-frontend-work-and-dislikes-u.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/alex-prefers-typescript-for-new-frontend-work-and-dislikes-u.md
@@ -1,0 +1,16 @@
+---
+type: preference
+title: Alex prefers TypeScript for new frontend work and dislikes untyped JavaScript.
+description: Alex prefers TypeScript for new frontend work and dislikes untyped JavaScript.
+tags:
+- user=alex
+timestamp: '2026-06-02T00:00:00+00:00'
+resource: langmem:5c409098-6838-40ee-bce4-40920a79e9f0
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: preference
+---
+
+Alex prefers TypeScript for new frontend work and dislikes untyped JavaScript.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/alex-runs-pytest-for-python-projects-and-vitest-for-all-type.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/alex-runs-pytest-for-python-projects-and-vitest-for-all-type.md
@@ -1,0 +1,16 @@
+---
+type: preference
+title: Alex runs pytest for Python projects and Vitest for all TypeScript repos.
+description: Alex runs pytest for Python projects and Vitest for all TypeScript repos.
+tags:
+- user=alex
+timestamp: '2026-06-11T00:00:00+00:00'
+resource: langmem:580bd5ff-c12e-4c17-b381-8284c10a24f4
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: preference
+---
+
+Alex runs pytest for Python projects and Vitest for all TypeScript repos.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/alex-uses-dark-mode-in-all-editors-and-tools.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/alex-uses-dark-mode-in-all-editors-and-tools.md
@@ -1,0 +1,16 @@
+---
+type: preference
+title: Alex uses dark mode in all editors and tools.
+description: Alex uses dark mode in all editors and tools.
+tags:
+- user=alex
+timestamp: '2026-06-02T00:00:00+00:00'
+resource: langmem:d3fbaba8-7f52-49e1-a305-e7f440820120
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: preference
+---
+
+Alex uses dark mode in all editors and tools.

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/index.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/preference/index.md
@@ -1,0 +1,12 @@
+---
+type: index
+title: preference
+timestamp: 2026-07-23T10:38:37
+---
+
+# preference (4)
+
+- [Alex prefers TypeScript for new frontend work and dislikes untyped JavaScript.](alex-prefers-typescript-for-new-frontend-work-and-dislikes-u.md)
+- [Alex uses dark mode in all editors and tools.](alex-uses-dark-mode-in-all-editors-and-tools.md)
+- [Alex runs pytest for Python projects and Vitest for all TypeScript repos.](alex-runs-pytest-for-python-projects-and-vitest-for-all-type.md)
+- [Alex never deploys on Fridays, regardless of how small the change is.](alex-never-deploys-on-fridays-regardless-of-how-small-the-ch.md)

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/relationship/index.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/relationship/index.md
@@ -1,0 +1,9 @@
+---
+type: index
+title: relationship
+timestamp: 2026-07-23T10:38:37
+---
+
+# relationship (1)
+
+- [Priya moved from the ledger service to the Fraud team; Alex is now the sole e...](priya-moved-from-the-ledger-service-to-the-fraud-team-alex-i.md)

--- a/examples/migrations/langmem/artifacts/okf-bundle/memories/relationship/priya-moved-from-the-ledger-service-to-the-fraud-team-alex-i.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/memories/relationship/priya-moved-from-the-ledger-service-to-the-fraud-team-alex-i.md
@@ -1,0 +1,18 @@
+---
+type: relationship
+title: Priya moved from the ledger service to the Fraud team; Alex is now the sole
+  e...
+description: Priya moved from the ledger service to the Fraud team; Alex is now the
+  sole engineer on the ledger.
+tags:
+- user=alex
+timestamp: '2026-06-20T00:00:00+00:00'
+resource: langmem:bab0c21b-7f67-4fb6-883a-3904e9c0892d
+x_memanto:
+  confidence: 0.75
+  provenance: imported
+  source: langmem
+  type: relationship
+---
+
+Priya moved from the ledger service to the Fraud team; Alex is now the sole engineer on the ledger.

--- a/examples/migrations/langmem/artifacts/okf-bundle/metrics/index.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/metrics/index.md
@@ -1,0 +1,9 @@
+---
+type: index
+title: metrics
+timestamp: 2026-07-23T10:38:37
+---
+
+# Metrics
+
+- [overview](overview.md)

--- a/examples/migrations/langmem/artifacts/okf-bundle/metrics/overview.md
+++ b/examples/migrations/langmem/artifacts/okf-bundle/metrics/overview.md
@@ -1,0 +1,41 @@
+# Metrics — aggregate
+
+> 10 memories
+
+
+---
+
+## 📊 Visual Insights
+
+### Memory Activity Timeline
+
+```
+Hour  00  03  06  09  12  15  18  21  24
+      ╠═══╬═══╬═══╬═══╬═══╬═══╬═══╬═══╣
+      ●●●●                            
+```
+
+**10** memories across **1** active hours
+
+### Memory Type Distribution
+
+```
+PREFERENCE    ████████████████████ 4
+FACT          ██████████ 2
+GOAL          ██████████ 2
+DECISION      █████ 1
+RELATIONSHIP  █████ 1
+```
+
+### Confidence Overview
+
+| Metric          | Value |
+|-----------------|-------|
+| Total Memories  | 10     |
+| Avg Confidence  | 0.75  |
+| High (≥0.8)     | 0     |
+| Medium (0.5–0.8)| 10     |
+| Low (<0.5)      | 0     |
+
+*Visualizations auto-generated at Jul 23, 2026 10:38 AM*
+

--- a/examples/migrations/langmem/artifacts/validation-report.md
+++ b/examples/migrations/langmem/artifacts/validation-report.md
@@ -1,0 +1,16 @@
+# Round-trip recall parity
+
+- Questions: **7**
+- Recall before migration (LangMem): **7/7** (100.0%)
+- Recall after migration (Memanto): **7/7** (100.0%)
+- Before/after parity: **100.0%**
+
+| Question | Before | After | Parity |
+| --- | :---: | :---: | :---: |
+| What test runner does Alex use for TypeScript repos? | PASS | PASS | OK |
+| What is Alex's rule about deploying on Fridays? | PASS | PASS | OK |
+| Is the ledger multi-currency for the Q3 target? | PASS | PASS | OK |
+| Who works with Alex on the ledger service now? | PASS | PASS | OK |
+| How does the ledger store monetary amounts? | PASS | PASS | OK |
+| What does Alex want to learn long-term? | PASS | PASS | OK |
+| What editor theme does Alex prefer? | PASS | PASS | OK |

--- a/examples/migrations/langmem/langmem_migration/__init__.py
+++ b/examples/migrations/langmem/langmem_migration/__init__.py
@@ -1,0 +1,25 @@
+"""LangMem -> Memanto (OKF) migration path.
+
+Takes a LangMem memory store and moves it into Memanto as a portable Open
+Knowledge Format (OKF) bundle.
+
+Modules:
+    conversation  A scripted, multi-session developer history to migrate.
+    populate      Writes that history into a LangMem store using LangMem's
+                  own ``manage_memory`` tool (create/update/delete).
+    export        Dumps the LangMem store to ``langmem_export.json`` via
+                  ``store.search`` -- the real LangMem export shape.
+    mapping       LangMem-concept -> Memanto-type / OKF-field mapping.
+    adapter       ``langmem_export.json`` -> valid OKF bundle, reusing
+                  Memanto's shipped ``OkfExportService`` for serialization.
+    validate      Recall-parity check (before vs after migration).
+"""
+
+__all__ = [
+    "conversation",
+    "populate",
+    "export",
+    "mapping",
+    "adapter",
+    "validate",
+]

--- a/examples/migrations/langmem/langmem_migration/adapter.py
+++ b/examples/migrations/langmem/langmem_migration/adapter.py
@@ -1,0 +1,92 @@
+"""LangMem export -> OKF bundle.
+
+Doesn't re-implement OKF serialization -- maps LangMem records onto Memanto
+memory dicts (``mapping.map_record``) and hands them to the existing
+``OkfExportService.write_okf_bundle``. Building on the shipped writer keeps
+the bundle compatible with ``memanto migrate okf`` and keeps this file small.
+
+Flow:
+
+    langmem_export.json
+        -> mapping.map_record (per record)         # LangMem -> Memanto dict
+        -> group by inferred type                  # memories_by_type
+        -> OkfExportService.write_okf_bundle(...)   # shipped serializer
+        -> OKF bundle (index.md + memories/<type>/*.md)
+
+The produced bundle is consumable as-is:
+
+    memanto migrate okf ./okf-bundle --agent <id>
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+from memanto.app.services.okf_export_service import OkfExportService
+
+from .export import load_export
+from .mapping import map_record, type_breakdown
+
+
+def build_memories_by_type(export: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Map every LangMem record and group the results by inferred Memanto type."""
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in export.get("memories", []) or []:
+        if not (record.get("value") or {}).get("content"):
+            continue
+        row = map_record(record)
+        grouped.setdefault(row["type"], []).append(row)
+    return grouped
+
+
+def write_okf_bundle(
+    export: dict[str, Any],
+    output_dir: Path,
+    agent_id: str = "langmem-import",
+) -> dict[str, Any]:
+    """Convert a LangMem export dict into an OKF bundle at ``output_dir``.
+
+    Returns a summary dict: source/mapped counts, per-type breakdown, and the
+    resolved bundle path.
+    """
+    output_dir = Path(output_dir)
+    memories_by_type = build_memories_by_type(export)
+    mapped = [row for rows in memories_by_type.values() for row in rows]
+
+    # OkfExportService guards writes to within ``exports_dir.parent``. Point its
+    # exports_dir at a work area whose parent contains our target, so the guard
+    # is satisfied, then relocate the finished bundle to ``output_dir``.
+    work_root = output_dir.parent / "_okf_work"
+    exports_dir = work_root / "exports"
+    exports_dir.mkdir(parents=True, exist_ok=True)
+
+    service = OkfExportService(exports_dir=exports_dir)
+    result = service.write_okf_bundle(
+        agent_id=agent_id,
+        memories_by_type=memories_by_type,
+        output_dir=None,  # -> exports_dir/<agent_id>_okf
+        split="file",  # one readable markdown file per memory
+    )
+
+    produced = Path(result["output_path"])
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    shutil.move(str(produced), str(output_dir))
+    shutil.rmtree(work_root, ignore_errors=True)
+
+    return {
+        "source_count": export.get("count", len(export.get("memories", []) or [])),
+        "mapped_count": len(mapped),
+        "type_counts": type_breakdown(mapped),
+        "bundle_path": str(output_dir.resolve()),
+        "sections": result.get("sections", []),
+    }
+
+
+def adapt_file(
+    export_path: Path, output_dir: Path, agent_id: str = "langmem-import"
+) -> dict[str, Any]:
+    """Convenience: load a ``langmem_export.json`` and build the bundle."""
+    return write_okf_bundle(load_export(Path(export_path)), Path(output_dir), agent_id)

--- a/examples/migrations/langmem/langmem_migration/conversation.py
+++ b/examples/migrations/langmem/langmem_migration/conversation.py
@@ -1,0 +1,263 @@
+"""Sample LangMem history for one developer, "Alex".
+
+Rather than hand-writing a ``langmem_export.json``, this is a transcript plus
+the memory operations an agent would perform over five sessions across three
+weeks. ``populate.py`` replays these through LangMem's own ``manage_memory``
+tool, so the resulting store has LangMem's real on-disk schema.
+
+Each operation carries a stable ``ref`` so later sessions can ``update`` or
+``delete`` an earlier memory without hard-coding LangMem's random UUIDs. The
+history covers the cases a migration needs to get right:
+
+    * evolving preferences (Alex changes their mind about the test runner)
+    * direct corrections (a fact is revised, not duplicated)
+    * stale data cleanup (a completed to-do is deleted, not left behind)
+    * a timeline spread across three weeks, so "when did this happen"
+      survives the migration
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class MemoryOp:
+    """One LangMem ``manage_memory`` operation to replay."""
+
+    action: str  # "create" | "update" | "delete"
+    ref: str  # stable local handle, resolved to a LangMem UUID at replay time
+    content: str | None = None  # None for deletes
+
+
+@dataclass(frozen=True)
+class Session:
+    """One working session: a date, the raw user turns, and the memory ops the
+    agent committed to LangMem during it."""
+
+    date: str  # ISO date; applied to created_at/updated_at for temporal fidelity
+    title: str
+    user_turns: list[str] = field(default_factory=list)
+    ops: list[MemoryOp] = field(default_factory=list)
+
+
+# The namespace's dynamic segment -- LangMem stores per-user memories under
+# ("memories", USER_ID). Carried into the migration as a scope tag.
+USER_ID = "alex"
+
+SESSIONS: list[Session] = [
+    Session(
+        date="2026-06-02",
+        title="Onboarding the assistant",
+        user_turns=[
+            "Hey -- I'm Alex, a senior backend engineer on the Payments team at "
+            "Northwind. I mostly write Go and Python.",
+            "For anything new, default to TypeScript on the frontend. I really "
+            "dislike untyped JavaScript.",
+            "Also: I use dark mode everywhere, and I run pytest for Python tests.",
+        ],
+        ops=[
+            MemoryOp(
+                "create",
+                "role",
+                "Alex is a senior backend engineer on the Payments team at "
+                "Northwind, working primarily in Go and Python.",
+            ),
+            MemoryOp(
+                "create",
+                "pref_ts",
+                "Alex prefers TypeScript for new frontend work and dislikes "
+                "untyped JavaScript.",
+            ),
+            MemoryOp(
+                "create",
+                "pref_darkmode",
+                "Alex uses dark mode in all editors and tools.",
+            ),
+            MemoryOp(
+                "create",
+                "pref_testrunner",
+                "Alex runs pytest as the test runner for Python projects.",
+            ),
+        ],
+    ),
+    Session(
+        date="2026-06-06",
+        title="Kicking off the ledger service",
+        user_turns=[
+            "We're starting a new ledger service. The goal is to have a working "
+            "double-entry core shipped to staging by end of Q3.",
+            "It'll be Go, backed by Postgres. I'm pairing with Priya on it.",
+            "Remind me to write an ADR before we lock the schema.",
+        ],
+        ops=[
+            MemoryOp(
+                "create",
+                "goal_ledger",
+                "Alex's goal: ship a working double-entry core for the new "
+                "ledger service to staging by end of Q3 2026.",
+            ),
+            MemoryOp(
+                "create",
+                "fact_stack",
+                "The ledger service is written in Go and backed by Postgres.",
+            ),
+            MemoryOp(
+                "create",
+                "rel_priya",
+                "Alex is pairing with Priya on the ledger service.",
+            ),
+            MemoryOp(
+                "create",
+                "commit_adr",
+                "Alex needs to write an ADR before locking the ledger database schema.",
+            ),
+        ],
+    ),
+    Session(
+        date="2026-06-11",
+        title="Changing the test runner",
+        user_turns=[
+            "I've switched the frontend test setup over to Vitest -- forget "
+            "pytest for the TS packages, that was only ever for the Python side.",
+            "Actually, going forward assume Vitest for all the TypeScript repos.",
+        ],
+        ops=[
+            # Update in place rather than duplicating -- LangMem keeps the
+            # same memory id.
+            MemoryOp(
+                "update",
+                "pref_testrunner",
+                "Alex runs pytest for Python projects and Vitest for all "
+                "TypeScript repos.",
+            ),
+        ],
+    ),
+    Session(
+        date="2026-06-16",
+        title="A decision and a scheduling rule",
+        user_turns=[
+            "We decided to use decimal (not float) for all monetary amounts in "
+            "the ledger -- money in floats is how you get audited.",
+            "Hard rule for me: never deploy on Fridays. I don't care how small "
+            "the change is.",
+            "The ADR is done and merged, by the way.",
+        ],
+        ops=[
+            MemoryOp(
+                "create",
+                "decision_decimal",
+                "Decision: the ledger service stores all monetary amounts as "
+                "decimals, never floats, to avoid rounding errors in audits.",
+            ),
+            MemoryOp(
+                "create",
+                "pref_nofriday",
+                "Alex never deploys on Fridays, regardless of how small the change is.",
+            ),
+            # The commitment to write the ADR is now fulfilled -> the stale
+            # to-do is deleted (contradiction/obsolescence handling).
+            MemoryOp("delete", "commit_adr"),
+        ],
+    ),
+    Session(
+        date="2026-06-20",
+        title="Reprioritizing",
+        user_turns=[
+            "Change of plan on the ledger: we're descoping multi-currency for "
+            "now. Q3 target is single-currency (USD) double-entry only.",
+            "Priya rolled off to the Fraud team, so I'm solo on the ledger now.",
+            "Long-term I still want to learn Rust and eventually rewrite the "
+            "settlement worker in it.",
+        ],
+        ops=[
+            # Evolving goal: revise the Q3 target in place.
+            MemoryOp(
+                "update",
+                "goal_ledger",
+                "Alex's goal: ship a single-currency (USD) double-entry ledger "
+                "core to staging by end of Q3 2026; multi-currency is descoped "
+                "for now.",
+            ),
+            # The pairing relationship is no longer true -> revise it.
+            MemoryOp(
+                "update",
+                "rel_priya",
+                "Priya moved from the ledger service to the Fraud team; Alex is "
+                "now the sole engineer on the ledger.",
+            ),
+            MemoryOp(
+                "create",
+                "goal_rust",
+                "Alex wants to learn Rust and eventually rewrite the settlement "
+                "worker in it.",
+            ),
+        ],
+    ),
+]
+
+
+# --------------------------------------------------------------------------
+# Golden Q&A -- the "does memory survive the move" oracle.
+#
+# Each question probes a fact that the final LangMem state should answer. The
+# validation harness asks these before migration (against LangMem) and after
+# (against Memanto) and scores recall parity. Answers are graded by keyword
+# presence so the harness runs without an LLM judge (an optional LLM-judge mode
+# is available when an API key is present).
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GoldenQA:
+    question: str
+    # any one of these substrings (case-insensitive) counts as a correct recall
+    expect_any: list[str]
+    # substrings that MUST NOT appear -- catches stale/contradicted memory
+    forbid: list[str] = field(default_factory=list)
+
+
+GOLDEN_QA: list[GoldenQA] = [
+    GoldenQA(
+        "What test runner does Alex use for TypeScript repos?",
+        expect_any=["vitest"],
+    ),
+    GoldenQA(
+        "What is Alex's rule about deploying on Fridays?",
+        expect_any=["never", "no friday", "not on friday"],
+    ),
+    GoldenQA(
+        "Is the ledger multi-currency for the Q3 target?",
+        expect_any=["single", "usd", "descoped", "no"],
+        forbid=[],
+    ),
+    GoldenQA(
+        "Who works with Alex on the ledger service now?",
+        expect_any=["solo", "sole", "alone", "no one", "nobody"],
+        forbid=["pairing with priya", "pairing"],
+    ),
+    GoldenQA(
+        "How does the ledger store monetary amounts?",
+        expect_any=["decimal"],
+    ),
+    GoldenQA(
+        "What does Alex want to learn long-term?",
+        expect_any=["rust"],
+    ),
+    GoldenQA(
+        "What editor theme does Alex prefer?",
+        expect_any=["dark"],
+    ),
+]
+
+
+def raw_transcript() -> str:
+    """The full conversation as plain text -- fed to the optional live-LLM
+    extraction path (``create_memory_store_manager``)."""
+    blocks: list[str] = []
+    for s in SESSIONS:
+        blocks.append(f"## Session {s.date} -- {s.title}")
+        for turn in s.user_turns:
+            blocks.append(f"Alex: {turn}")
+        blocks.append("")
+    return "\n".join(blocks).strip()

--- a/examples/migrations/langmem/langmem_migration/export.py
+++ b/examples/migrations/langmem/langmem_migration/export.py
@@ -1,0 +1,63 @@
+"""Export a LangMem store to ``langmem_export.json``.
+
+Just ``store.search`` over the namespace, one record per surviving memory,
+keeping LangMem's native fields (namespace, key, value, created_at,
+updated_at). This file is the hand-off point -- anyone with their own LangMem
+store can produce the same shape (``store.search(namespace)`` -> item dicts)
+and run the adapter against it directly, without the sample conversation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from langgraph.store.base import BaseStore
+
+from .conversation import USER_ID
+
+
+def export_store(store: BaseStore, user_id: str = USER_ID) -> dict[str, Any]:
+    """Return the LangMem store as a portable export dict."""
+    namespace = ("memories", user_id)
+    items = store.search(namespace)
+    records: list[dict[str, Any]] = []
+    for item in items:
+        records.append(
+            {
+                "namespace": list(item.namespace),
+                "key": item.key,
+                "value": item.value,
+                "created_at": _iso(item.created_at),
+                "updated_at": _iso(item.updated_at),
+            }
+        )
+    # Stable order (oldest first) so the export and bundle are reproducible.
+    records.sort(key=lambda r: (r["created_at"] or "", r["key"]))
+    return {
+        "source": "langmem",
+        "namespace": list(namespace),
+        "user_id": user_id,
+        "count": len(records),
+        "memories": records,
+    }
+
+
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    # LangGraph may hand back either a datetime or an ISO string.
+    isoformat = getattr(value, "isoformat", None)
+    return isoformat() if callable(isoformat) else str(value)
+
+
+def write_export(store: BaseStore, dest: Path, user_id: str = USER_ID) -> Path:
+    export = export_store(store, user_id=user_id)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(export, indent=2, ensure_ascii=False), encoding="utf-8")
+    return dest
+
+
+def load_export(path: Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))

--- a/examples/migrations/langmem/langmem_migration/mapping.py
+++ b/examples/migrations/langmem/langmem_migration/mapping.py
@@ -1,0 +1,169 @@
+"""LangMem concept -> Memanto type / OKF field mapping.
+
+LangMem's semantic memory is *untyped* free text: each item is just
+``{"content": "..."}`` under a namespace. Memanto has 13 typed primitives
+(fact, preference, goal, decision, ...), so bridging the two means picking a
+type for each memory. This uses the same approach as Memanto's shipped Mem0
+mapper: a deterministic lexical classifier instead of a hardcoded label.
+
+Notes on the approach:
+
+* Type is inferred from lightweight lexical cues (see ``_TYPE_RULES``). When no
+  rule matches it falls back to ``observation`` rather than guessing -- the
+  original text is always kept verbatim, so a wrong type never loses data.
+* The inferred type is written to OKF's ``x_memanto.type`` so Memanto's loader
+  can use it directly (``map_okf`` honours ``x_memanto.type`` when it's a
+  valid Memanto type) instead of re-classifying from scratch.
+* LangMem fields with no Memanto slot (namespace, key, timestamps) are kept
+  around: namespace -> a ``user=<id>`` scope tag, key -> ``source_ref``,
+  created_at -> OKF ``timestamp``.
+
+Mapping table (LangMem -> Memanto / OKF):
+
+    value.content        -> memory content (body) + derived title
+    namespace[1] (user)  -> tag  "user=<id>"  and  x_memanto.source="langmem"
+    key (uuid)           -> source_ref / OKF resource "langmem:<key>"
+    created_at           -> OKF timestamp (temporal recall fidelity)
+    (inferred)           -> memory type via _TYPE_RULES -> x_memanto.type
+    (constant)           -> provenance="imported", confidence=0.75
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Ordered rules: the first whose pattern matches the content wins. Patterns are
+# intentionally conservative -- they encode the vocabulary LangMem memories
+# actually use, and anything unmatched falls through to ``observation``.
+_TYPE_RULES: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "preference",
+        re.compile(
+            r"\b(prefer|prefers|likes?|dislikes?|favou?rite|uses? .*(mode|theme)|runs? .*(pytest|vitest|jest|test runner|linter)|never deploys?|always)\b",
+            re.I,
+        ),
+    ),
+    (
+        "decision",
+        re.compile(r"\b(decision|decided|we (chose|use|will use)|agreed to)\b", re.I),
+    ),
+    (
+        "goal",
+        re.compile(
+            r"\b(goal|wants? to|plans? to|aims? to|by end of|ship .* by|eventually)\b",
+            re.I,
+        ),
+    ),
+    (
+        "commitment",
+        re.compile(
+            r"\b(needs? to|must|to-?do|reminder|remind|will write|action item)\b", re.I
+        ),
+    ),
+    (
+        "relationship",
+        re.compile(
+            r"\b(pairing with|works? with|teammate|reports? to|moved (from|to) the|sole engineer|solo)\b",
+            re.I,
+        ),
+    ),
+    (
+        "event",
+        re.compile(
+            r"\b(happened|occurred|shipped|merged|released|rolled off|on \d{4}-\d{2}-\d{2})\b",
+            re.I,
+        ),
+    ),
+    (
+        "fact",
+        re.compile(
+            r"\b(is a|is an|is the|written in|backed by|based in|located|works? at|on the .* team)\b",
+            re.I,
+        ),
+    ),
+]
+
+_FALLBACK_TYPE = "observation"
+
+# Kept in sync with memanto.app.constants.VALID_MEMORY_TYPES. Duplicated here so
+# the adapter can be reasoned about standalone; a unit test asserts they match.
+VALID_MEMORY_TYPES = {
+    "fact",
+    "preference",
+    "goal",
+    "decision",
+    "artifact",
+    "learning",
+    "event",
+    "instruction",
+    "relationship",
+    "context",
+    "observation",
+    "commitment",
+    "error",
+}
+
+_TITLE_CHARS = 80
+DEFAULT_CONFIDENCE = 0.75
+
+
+def classify(content: str) -> str:
+    """Infer a Memanto memory type from LangMem free-text content."""
+    for mem_type, pattern in _TYPE_RULES:
+        if pattern.search(content):
+            return mem_type
+    return _FALLBACK_TYPE
+
+
+def title_from(content: str) -> str:
+    text = " ".join(content.strip().split())
+    if len(text) <= _TITLE_CHARS:
+        return text
+    return text[: _TITLE_CHARS - 3].rstrip() + "..."
+
+
+def map_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Map one LangMem export record to a Memanto memory dict.
+
+    The output shape matches what ``OkfExportService.write_okf_bundle`` expects
+    per memory (``title``, ``content``, ``tags``, ``created_at``, ``source``,
+    ``source_ref``, ``confidence``, ``provenance``, plus the resolved ``type``).
+    """
+    value = record.get("value") or {}
+    content = str(value.get("content") or "").strip()
+    namespace = record.get("namespace") or []
+    user = namespace[1] if len(namespace) > 1 else None
+    key = record.get("key")
+
+    mem_type = classify(content)
+    tags: list[str] = []
+    if user:
+        tags.append(f"user={user}")
+
+    # Anything LangMem carried beyond `content` is preserved in a footer so the
+    # migration is lossless even for custom-schema LangMem memories.
+    extra = {k: v for k, v in value.items() if k != "content"}
+    body = content
+    if extra:
+        footer_lines = "\n".join(f"- {k}: {v}" for k, v in extra.items())
+        body = f"{content}\n\n---\n[Supporting data]\n{footer_lines}"
+
+    return {
+        "title": title_from(content),
+        "content": body,
+        "type": mem_type,
+        "tags": tags,
+        "confidence": DEFAULT_CONFIDENCE,
+        "source": "langmem",
+        "source_ref": f"langmem:{key}" if key else None,
+        "provenance": "imported",
+        "created_at": record.get("created_at"),
+    }
+
+
+def type_breakdown(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row["type"]] = counts.get(row["type"], 0) + 1
+    return dict(sorted(counts.items()))

--- a/examples/migrations/langmem/langmem_migration/populate.py
+++ b/examples/migrations/langmem/langmem_migration/populate.py
@@ -1,0 +1,185 @@
+"""Populate a LangMem store from the scripted history in conversation.py.
+
+The store is a real ``langgraph.store.memory.InMemoryStore`` and every write
+goes through LangMem's own ``create_manage_memory_tool`` -- the same tool a
+LangMem agent would call at runtime.
+
+Two extraction backends:
+
+* ``replay`` (default, offline, deterministic):
+  Replays the ``MemoryOp`` list in ``conversation.py`` through the
+  ``manage_memory`` tool. No LLM, no API key -- this is how the committed
+  sample artifacts are produced, so they reproduce byte-for-byte.
+
+* ``live`` (``--extract live``, needs an LLM key):
+  Feeds the raw transcript to LangMem's ``create_memory_store_manager`` and
+  lets the model extract/consolidate memories on its own. Requires
+  ``OPENAI_API_KEY`` (or another provider) and an embedding model.
+
+After writing, per-session dates from the transcript are stamped onto each
+item's ``created_at``/``updated_at`` so the three-week timeline carries
+through into the OKF export -- this is the one part of the source data that's
+simulated rather than produced live, done transparently here.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+
+from langgraph.store.memory import InMemoryStore
+from langmem import create_manage_memory_tool
+
+from .conversation import SESSIONS, USER_ID, MemoryOp, raw_transcript
+
+
+def _namespace() -> tuple[str, str]:
+    return ("memories", USER_ID)
+
+
+def _session_dt(date_str: str) -> datetime:
+    return datetime.fromisoformat(date_str).replace(tzinfo=timezone.utc)
+
+
+def build_store_replay() -> InMemoryStore:
+    """Populate a store by replaying the scripted tool operations."""
+    store = InMemoryStore()
+    ns = _namespace()
+    tool = create_manage_memory_tool(namespace=ns, store=store)
+
+    # Map our stable local refs -> the UUIDs LangMem assigns on create, so
+    # later update/delete operations target the right memory.
+    ref_to_id: dict[str, str] = {}
+    # Track which session date each surviving memory should be stamped with.
+    ref_to_date: dict[str, str] = {}
+
+    for session in SESSIONS:
+        for op in session.ops:
+            _apply_op(tool, op, ref_to_id, ref_to_date, session.date)
+
+    _stamp_dates(store, ns, ref_to_id, ref_to_date)
+    return store
+
+
+def _apply_op(
+    tool,
+    op: MemoryOp,
+    ref_to_id: dict[str, str],
+    ref_to_date: dict[str, str],
+    session_date: str,
+) -> None:
+    if op.action == "create":
+        result = tool.invoke({"content": op.content, "action": "create"})
+        ref_to_id[op.ref] = _extract_id(result)
+        ref_to_date[op.ref] = session_date
+    elif op.action == "update":
+        mem_id = ref_to_id.get(op.ref)
+        if mem_id is None:
+            raise KeyError(f"update before create for ref {op.ref!r}")
+        tool.invoke({"content": op.content, "action": "update", "id": mem_id})
+        # A correction refreshes the "last touched" date but keeps the memory.
+        ref_to_date[op.ref] = session_date
+    elif op.action == "delete":
+        mem_id = ref_to_id.get(op.ref)
+        if mem_id is None:
+            raise KeyError(f"delete before create for ref {op.ref!r}")
+        tool.invoke({"content": None, "action": "delete", "id": mem_id})
+        ref_to_id.pop(op.ref, None)
+        ref_to_date.pop(op.ref, None)
+    else:  # pragma: no cover - guarded by the dataclass authoring
+        raise ValueError(f"unknown action {op.action!r}")
+
+
+def _extract_id(tool_result: str) -> str:
+    """LangMem's manage_memory returns e.g. 'created memory <uuid>'."""
+    return str(tool_result).strip().split()[-1]
+
+
+def _stamp_dates(
+    store: InMemoryStore,
+    ns: tuple[str, str],
+    ref_to_id: dict[str, str],
+    ref_to_date: dict[str, str],
+) -> None:
+    """Backdate surviving items to their session date for temporal fidelity.
+
+    ``store.search`` returns *copies*, so we write through the canonical Item
+    objects held in the store's backing map. The access is defensive: if a
+    future LangGraph release changes the internal shape, the dates simply stay
+    at "now" rather than raising -- the migration itself is unaffected.
+    """
+    backing = getattr(store, "_data", None)
+    if backing is None:  # pragma: no cover - defensive
+        return
+    ns_items = backing.get(ns, {})
+    id_to_date = {ref_to_id[ref]: date for ref, date in ref_to_date.items()}
+    for key, item in ns_items.items():
+        date_str = id_to_date.get(key)
+        if not date_str:
+            continue
+        stamp = _session_dt(date_str).isoformat()
+        for attr in ("created_at", "updated_at"):
+            try:
+                setattr(item, attr, stamp)
+            except (AttributeError, TypeError):  # pragma: no cover - defensive
+                pass
+
+
+def build_store_live(model: str) -> InMemoryStore:
+    """Populate a store by letting an LLM extract memories from the transcript.
+
+    Requires a provider key (e.g. ``OPENAI_API_KEY``) and an embeddings model.
+    Same downstream pipeline, but the memories come from model extraction
+    instead of the scripted replay.
+    """
+    from langmem import create_memory_store_manager
+
+    store = InMemoryStore(
+        index={"dims": 1536, "embed": "openai:text-embedding-3-small"}
+    )
+    manager = create_memory_store_manager(
+        model,
+        namespace=("memories", USER_ID),
+        store=store,
+    )
+    # Feed the whole conversation; the manager extracts + consolidates.
+    manager.invoke({"messages": [{"role": "user", "content": raw_transcript()}]})
+    return store
+
+
+def build_store(extract: str = "replay", model: str = "openai:gpt-4o-mini"):
+    if extract == "replay":
+        return build_store_replay()
+    if extract == "live":
+        return build_store_live(model)
+    raise ValueError("extract must be 'replay' or 'live'")
+
+
+def _summarize(store: InMemoryStore) -> None:
+    items = store.search(_namespace())
+    print(f"LangMem store populated: {len(items)} live memories under {_namespace()}")
+    for it in sorted(items, key=lambda i: i.created_at or datetime.min):
+        when = (it.created_at or "").isoformat()[:10] if it.created_at else "?"
+        print(f"  [{when}] {it.value.get('content', '')[:70]}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Populate a LangMem store.")
+    parser.add_argument(
+        "--extract",
+        choices=["replay", "live"],
+        default="replay",
+        help="replay = deterministic offline tool replay; live = LLM extraction.",
+    )
+    parser.add_argument(
+        "--model",
+        default="openai:gpt-4o-mini",
+        help="LLM for --extract live (provider:model).",
+    )
+    args = parser.parse_args()
+    store = build_store(extract=args.extract, model=args.model)
+    _summarize(store)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/migrations/langmem/langmem_migration/validate.py
+++ b/examples/migrations/langmem/langmem_migration/validate.py
@@ -115,10 +115,15 @@ def bundle_retriever(export: dict[str, Any]) -> Callable[[str], str]:
 
 
 def memanto_retriever(agent_id: str, k: int = 5) -> Callable[[str], str]:
-    """Retrieve from a live Memanto agent (needs MOORCHEH_API_KEY)."""
-    from memanto.cli.client.sdk_client import SdkClient  # imported lazily
+    """Retrieve from a live Memanto agent.
 
-    client = SdkClient(api_key=os.environ["MOORCHEH_API_KEY"])
+    Reuses Memanto's own ``get_client`` so the key is resolved the same way as
+    every other ``memanto`` command (from ``~/.memanto`` config or the
+    ``MOORCHEH_API_KEY`` env var), rather than requiring the env var directly.
+    """
+    from memanto.cli.commands._shared import get_client  # imported lazily
+
+    client = get_client()
 
     def retrieve(question: str) -> str:
         result = client.recall(agent_id=agent_id, query=question, limit=k)

--- a/examples/migrations/langmem/langmem_migration/validate.py
+++ b/examples/migrations/langmem/langmem_migration/validate.py
@@ -1,0 +1,206 @@
+"""Round-trip recall-parity check: does memory survive the move?
+
+Uses the Q&A set in ``conversation.py``. Each question is asked twice and the
+answers compared:
+
+* **before** -- against the source LangMem store, using LangMem's own semantic
+  ``store.search`` to retrieve candidate memories.
+* **after** -- against the migrated Memanto memories. Two backends:
+    - ``bundle`` (default, offline): retrieve over the generated OKF bundle's
+      memory bodies. Checks that the content survived the migration without
+      needing a Moorcheh key.
+    - ``memanto`` (``--after memanto``): query the live Memanto/Moorcheh agent
+      the bundle was imported into (needs ``MOORCHEH_API_KEY`` + an active
+      agent). Checks retrieval parity on the real backend.
+
+Grading is deterministic keyword matching (an ``expect_any`` hit with no
+``forbid`` hit = correct), so the harness runs with no LLM judge. A wrong
+answer on a memory that should have been updated (e.g. still saying "pytest"
+after the switch to Vitest, or "pairing with Priya" after she moved teams)
+fails the check -- that's exactly the kind of regression this is meant to catch.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .conversation import GOLDEN_QA, USER_ID, GoldenQA
+
+
+@dataclass
+class QAResult:
+    question: str
+    retrieved: str
+    passed: bool
+    reason: str
+
+
+def _grade(qa: GoldenQA, retrieved_text: str) -> tuple[bool, str]:
+    text = retrieved_text.lower()
+    for bad in qa.forbid:
+        if bad.lower() in text:
+            return False, f"stale/contradicted term present: {bad!r}"
+    for good in qa.expect_any:
+        if good.lower() in text:
+            return True, f"matched {good!r}"
+    return False, "no expected term found"
+
+
+def _run(qa_set: list[GoldenQA], retriever: Callable[[str], str]) -> list[QAResult]:
+    results: list[QAResult] = []
+    for qa in qa_set:
+        retrieved = retriever(qa.question)
+        passed, reason = _grade(qa, retrieved)
+        results.append(QAResult(qa.question, retrieved, passed, reason))
+    return results
+
+
+# --------------------------------------------------------------------------
+# Retrievers
+# --------------------------------------------------------------------------
+
+
+def _lexical_retrieve(corpus: list[str], question: str, k: int = 3) -> str:
+    """Rank memories by query-term overlap and return the top ``k`` joined.
+
+    A dependency-free stand-in for semantic search so the offline harness
+    measures both sides (LangMem before, Memanto after) on identical footing:
+    did the *content* survive the migration and stay findable?
+    """
+    q_terms = {w for w in _tokens(question) if len(w) > 2}
+    scored = sorted(corpus, key=lambda c: len(q_terms & set(_tokens(c))), reverse=True)
+    return "\n".join(scored[:k])
+
+
+def langmem_retriever(
+    store, user_id: str = USER_ID, k: int = 3
+) -> Callable[[str], str]:
+    """Retrieve over the LangMem store.
+
+    When the store has a semantic index (``--extract live``), use LangMem's own
+    ``store.search(query=...)``. Otherwise fall back to the shared lexical
+    ranker over the stored contents, so the offline "before" number is a fair
+    peer of the offline "after" number.
+    """
+    namespace = ("memories", user_id)
+    indexed = getattr(store, "index_config", None) is not None
+
+    def retrieve(question: str) -> str:
+        if indexed:
+            try:
+                hits = store.search(namespace, query=question, limit=k)
+                return "\n".join((h.value or {}).get("content", "") for h in hits)
+            except (TypeError, ValueError):
+                pass
+        corpus = [(h.value or {}).get("content", "") for h in store.search(namespace)]
+        return _lexical_retrieve(corpus, question, k)
+
+    return retrieve
+
+
+def bundle_retriever(export: dict[str, Any]) -> Callable[[str], str]:
+    """Retrieve over the migrated memory *content* (offline parity check)."""
+    corpus = [
+        str((m.get("value") or {}).get("content") or "")
+        for m in export.get("memories", []) or []
+    ]
+
+    def retrieve(question: str) -> str:
+        return _lexical_retrieve(corpus, question, k=3)
+
+    return retrieve
+
+
+def memanto_retriever(agent_id: str, k: int = 5) -> Callable[[str], str]:
+    """Retrieve from a live Memanto agent (needs MOORCHEH_API_KEY)."""
+    from memanto.cli.client.sdk_client import SdkClient  # imported lazily
+
+    client = SdkClient(api_key=os.environ["MOORCHEH_API_KEY"])
+
+    def retrieve(question: str) -> str:
+        result = client.recall(agent_id=agent_id, query=question, limit=k)
+        memories = (result or {}).get("memories", []) or []
+        return "\n".join(
+            str(m.get("content") or m.get("title") or "") for m in memories
+        )
+
+    return retrieve
+
+
+def _tokens(text: str) -> list[str]:
+    return "".join(c.lower() if c.isalnum() else " " for c in text).split()
+
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+
+
+def parity_report(before: list[QAResult], after: list[QAResult]) -> dict[str, Any]:
+    b_pass = sum(r.passed for r in before)
+    a_pass = sum(r.passed for r in after)
+    n = len(before)
+    rows = []
+    for b, a in zip(before, after, strict=False):
+        rows.append(
+            {
+                "question": b.question,
+                "before": b.passed,
+                "after": a.passed,
+                "parity": b.passed == a.passed,
+                "after_reason": a.reason,
+            }
+        )
+    return {
+        "n": n,
+        "before_pass": b_pass,
+        "after_pass": a_pass,
+        "before_pct": round(100 * b_pass / n, 1) if n else 0.0,
+        "after_pct": round(100 * a_pass / n, 1) if n else 0.0,
+        "parity_pct": round(100 * sum(r["parity"] for r in rows) / n, 1) if n else 0.0,
+        "rows": rows,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Round-trip recall parity",
+        "",
+        f"- Questions: **{report['n']}**",
+        f"- Recall before migration (LangMem): **{report['before_pass']}/{report['n']}** "
+        f"({report['before_pct']}%)",
+        f"- Recall after migration (Memanto): **{report['after_pass']}/{report['n']}** "
+        f"({report['after_pct']}%)",
+        f"- Before/after parity: **{report['parity_pct']}%**",
+        "",
+        "| Question | Before | After | Parity |",
+        "| --- | :---: | :---: | :---: |",
+    ]
+    for row in report["rows"]:
+        b = "PASS" if row["before"] else "FAIL"
+        a = "PASS" if row["after"] else "FAIL"
+        p = "OK" if row["parity"] else "DRIFT"
+        lines.append(f"| {row['question']} | {b} | {a} | {p} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def validate(
+    store,
+    export: dict[str, Any],
+    after: str = "bundle",
+    agent_id: str | None = None,
+) -> dict[str, Any]:
+    """Run before/after parity and return the report dict."""
+    before = _run(GOLDEN_QA, langmem_retriever(store))
+
+    if after == "memanto":
+        aid = agent_id or os.environ.get("MEMANTO_AGENT_ID") or "langmem-import"
+        after_results = _run(GOLDEN_QA, memanto_retriever(aid))
+    else:
+        after_results = _run(GOLDEN_QA, bundle_retriever(export))
+
+    return parity_report(before, after_results)

--- a/examples/migrations/langmem/requirements.txt
+++ b/examples/migrations/langmem/requirements.txt
@@ -1,0 +1,13 @@
+# LangMem -> Memanto (OKF) migration example.
+#
+# The offline pipeline (python run.py) needs only these two plus Memanto
+# itself (install the repo with `pip install -e .` from the repo root, or
+# `pip install memanto`).
+langmem>=0.0.27
+langgraph>=0.2.0
+
+# --- optional ---
+# For `--extract live` (LLM-driven memory extraction) you also need a chat +
+# embedding provider, e.g.:
+#   pip install "langchain[openai]"
+# and an OPENAI_API_KEY. See .env.example.

--- a/examples/migrations/langmem/run.py
+++ b/examples/migrations/langmem/run.py
@@ -1,0 +1,176 @@
+"""One-command LangMem -> Memanto (OKF) migration.
+
+    python run.py                 # full offline pipeline (no keys needed)
+    python run.py --extract live  # use an LLM to extract memories from the transcript
+    python run.py --import-memanto --agent alex   # also import into a live Memanto agent
+
+Pipeline:
+    1. populate  a LangMem store from the scripted 3-week history
+    2. export    the store -> artifacts/langmem_export.json
+    3. adapt     the export -> artifacts/okf-bundle/  (valid OKF)
+    4. validate  before/after recall parity -> artifacts/validation-report.md
+    5. summarize -> artifacts/migration-summary.md
+
+Everything except step 3's optional live import runs offline and
+deterministically, so the committed artifacts reproduce exactly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ARTIFACTS = HERE / "artifacts"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--extract", choices=["replay", "live"], default="replay")
+    parser.add_argument("--model", default="openai:gpt-4o-mini")
+    parser.add_argument("--after", choices=["bundle", "memanto"], default="bundle")
+    parser.add_argument(
+        "--import-memanto",
+        action="store_true",
+        help="Run `memanto migrate okf` on the bundle (needs MOORCHEH_API_KEY + active agent).",
+    )
+    parser.add_argument(
+        "--agent", default=None, help="Target Memanto agent id for import/validation."
+    )
+    args = parser.parse_args()
+
+    # Imported here so `python run.py` works from the example dir.
+    from langmem_migration import validate as V
+    from langmem_migration.adapter import write_okf_bundle
+    from langmem_migration.export import export_store, write_export
+    from langmem_migration.mapping import type_breakdown
+    from langmem_migration.populate import build_store
+
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+
+    print(f"1/5  Populating a LangMem store (extract={args.extract})...")
+    store = build_store(extract=args.extract, model=args.model)
+
+    print("2/5  Exporting the LangMem store...")
+    export = export_store(store)
+    export_path = write_export(store, ARTIFACTS / "langmem_export.json")
+    print(f"      -> {export_path.relative_to(HERE)} ({export['count']} memories)")
+
+    print("3/5  Adapting LangMem export -> OKF bundle...")
+    bundle_dir = ARTIFACTS / "okf-bundle"
+    summary = write_okf_bundle(
+        export, bundle_dir, agent_id=args.agent or "langmem-import"
+    )
+    print(f"      -> {bundle_dir.relative_to(HERE)}  types: {summary['type_counts']}")
+
+    if args.import_memanto:
+        print("3b/5 Importing bundle into Memanto (memanto migrate okf)...")
+        _memanto_import(bundle_dir, args.agent)
+
+    print(f"4/5  Validating recall parity (after={args.after})...")
+    report = V.validate(store, export, after=args.after, agent_id=args.agent)
+    (ARTIFACTS / "validation-report.md").write_text(
+        V.render_markdown(report), encoding="utf-8"
+    )
+    print(
+        f"      before {report['before_pass']}/{report['n']}  "
+        f"after {report['after_pass']}/{report['n']}  "
+        f"parity {report['parity_pct']}%"
+    )
+
+    print("5/5  Writing migration summary + mapping table...")
+    _write_summary(summary, report, extract=args.extract)
+    _write_mapping_table(export, type_breakdown)
+
+    print("\nDone. Artifacts in ./artifacts/:")
+    for p in sorted(ARTIFACTS.rglob("*")):
+        if p.is_file() and p.suffix in {".json", ".md"} and p.parent == ARTIFACTS:
+            print(f"  {p.relative_to(HERE)}")
+    if report["after_pass"] < report["before_pass"]:
+        print(
+            "\nWARNING: recall dropped after migration — investigate before claiming parity."
+        )
+        sys.exit(1)
+
+
+def _memanto_import(bundle_dir: Path, agent: str | None) -> None:
+    cmd = [sys.executable, "-m", "memanto", "migrate", "okf", str(bundle_dir)]
+    if agent:
+        cmd += ["--agent", agent]
+    try:
+        subprocess.run(cmd, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(
+            f"      migrate okf failed: {exc}\n"
+            "      (needs MOORCHEH_API_KEY and an active agent — see README)"
+        )
+
+
+def _write_summary(summary: dict, report: dict, extract: str) -> None:
+    lines = [
+        "# Migration summary — LangMem -> Memanto (OKF)",
+        "",
+        f"- Extraction backend: **{extract}**",
+        f"- Source LangMem memories: **{summary['source_count']}**",
+        f"- Mapped Memanto memories: **{summary['mapped_count']}**",
+        f"- OKF bundle sections: {', '.join(summary['sections'])}",
+        "",
+        "## Type breakdown (inferred from untyped LangMem content)",
+        "",
+        "| Memanto type | Count |",
+        "| --- | :---: |",
+    ]
+    for t, c in summary["type_counts"].items():
+        lines.append(f"| {t} | {c} |")
+    lines += [
+        "",
+        "## Recall parity (before vs after)",
+        "",
+        f"- Before (LangMem): {report['before_pass']}/{report['n']} ({report['before_pct']}%)",
+        f"- After (Memanto):  {report['after_pass']}/{report['n']} ({report['after_pct']}%)",
+        f"- Parity: {report['parity_pct']}%",
+        "",
+        "See `validation-report.md` for the per-question breakdown and "
+        "`okf-bundle/` for the human-readable, portable memory bundle.",
+        "",
+    ]
+    (ARTIFACTS / "migration-summary.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_mapping_table(export: dict, type_breakdown) -> None:
+    from langmem_migration.mapping import map_record
+
+    rows = [
+        map_record(r)
+        for r in export["memories"]
+        if (r.get("value") or {}).get("content")
+    ]
+    lines = [
+        "# LangMem -> Memanto / OKF field mapping",
+        "",
+        "| LangMem field | Memanto / OKF field | Notes |",
+        "| --- | --- | --- |",
+        "| `value.content` | memory body + derived `title` | verbatim, never lossy |",
+        "| `namespace[1]` (user id) | tag `user=<id>`, `x_memanto.source=langmem` | scope preserved |",
+        "| `key` (uuid) | `source_ref` / OKF `resource` `langmem:<key>` | back-reference |",
+        "| `created_at` | OKF `timestamp` | temporal recall fidelity |",
+        "| *(inferred)* | memory `type` -> `x_memanto.type` | deterministic classifier |",
+        "| *(constant)* | `provenance=imported`, `confidence=0.75` | migration marker |",
+        "",
+        "## Per-memory resolution",
+        "",
+        "| # | Inferred type | Title |",
+        "| :---: | --- | --- |",
+    ]
+    for i, row in enumerate(rows, 1):
+        lines.append(f"| {i} | {row['type']} | {row['title']} |")
+    lines.append("")
+    (ARTIFACTS / "mapping-table.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/migrations/langmem/tests/test_adapter.py
+++ b/examples/migrations/langmem/tests/test_adapter.py
@@ -1,0 +1,96 @@
+"""Offline tests for the LangMem -> OKF migration path.
+
+No network, no API keys needed. Covers the two things that matter most:
+
+1. The pipeline produces a bundle that Memanto's own loader + mapper accept,
+   with no memory lost and correct provenance/source stamping.
+2. The before/after recall check reports full parity on the sample data.
+
+Run:  pytest examples/migrations/langmem/tests -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from langmem_migration import validate as V
+from langmem_migration.adapter import write_okf_bundle
+from langmem_migration.export import export_store
+from langmem_migration.mapping import VALID_MEMORY_TYPES, classify, map_record
+from langmem_migration.populate import build_store_replay
+
+
+@pytest.fixture(scope="module")
+def store():
+    return build_store_replay()
+
+
+@pytest.fixture(scope="module")
+def export(store):
+    return export_store(store)
+
+
+def test_langmem_store_has_expected_live_memories(export):
+    # 12 create ops, 1 delete (the fulfilled ADR to-do) => 10 survive.
+    assert export["count"] == 10
+    contents = " ".join(m["value"]["content"] for m in export["memories"]).lower()
+    # Correction applied in place, not duplicated:
+    assert "vitest" in contents
+    # Deleted commitment is gone:
+    assert "write an adr" not in contents
+    # Superseded plan revised:
+    assert "single-currency" in contents or "single currency" in contents
+
+
+def test_adapter_types_are_all_valid_memanto_types():
+    # The local mirror of VALID_MEMORY_TYPES must match memanto's source of truth.
+    from memanto.app.constants import VALID_MEMORY_TYPES as CANON
+
+    assert VALID_MEMORY_TYPES == CANON
+    for record_content in ["Alex prefers dark mode", "some unclassifiable text xyz"]:
+        assert classify(record_content) in CANON
+
+
+def test_bundle_loads_back_through_memanto_loader(export, tmp_path: Path):
+    from memanto.cli.migrate.mappers import map_okf, type_breakdown
+    from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+    bundle = tmp_path / "okf-bundle"
+    summary = write_okf_bundle(export, bundle, agent_id="test-agent")
+
+    assert summary["mapped_count"] == export["count"]
+
+    reloaded = load_okf_bundle(bundle)
+    rows = map_okf(reloaded)
+
+    # No memory lost in the LangMem -> OKF -> Memanto round trip.
+    assert len(rows) == export["count"]
+    # Type breakdown from the bundle matches what the adapter reported.
+    assert type_breakdown(rows) == summary["type_counts"]
+    # Provenance + source survive for every migrated memory.
+    assert all(r["source"] == "langmem" for r in rows)
+    assert all(r["provenance"] == "imported" for r in rows)
+    # Temporal fidelity: timestamps are carried through.
+    assert all(r["created_at"] is not None for r in rows)
+
+
+def test_mapping_is_lossless_for_custom_schema_fields():
+    # A LangMem memory with extra (custom-schema) fields keeps them in a footer.
+    record = {
+        "namespace": ["memories", "alex"],
+        "key": "k1",
+        "value": {"content": "Alex likes espresso", "importance": "high"},
+        "created_at": "2026-06-01T00:00:00+00:00",
+    }
+    row = map_record(record)
+    assert "espresso" in row["content"]
+    assert "importance" in row["content"]  # preserved in [Supporting data]
+    assert row["source_ref"] == "langmem:k1"
+
+
+def test_recall_parity_is_full_on_sample(store, export):
+    report = V.validate(store, export, after="bundle")
+    assert report["before_pass"] == report["n"]
+    assert report["after_pass"] == report["n"]
+    assert report["parity_pct"] == 100.0


### PR DESCRIPTION
Memanto doesn't have a migration path for LangMem yet, so I built one. This
adds `examples/migrations/langmem/` — it takes a LangMem store and converts
it into an OKF bundle you can import with the existing `memanto migrate okf`
command. Didn't touch core at all, just built on top of what's already there.

The example includes a sample LangMem history (a few weeks of a developer's
preferences, decisions, one correction, one deleted to-do) written through
LangMem's real `manage_memory` tool, an adapter that maps the untyped LangMem
content onto Memanto's typed memories and writes it out with the existing
`OkfExportService`, and a before/after check that asks the same questions
against the store pre- and post-migration to make sure nothing got lost in
the process. Right now that check comes back 7/7 both times.

`python run.py` runs the whole pipeline with no API keys needed. There's also
`--extract live` if you want an LLM pulling the memories out instead of the
scripted replay, and `--import-memanto` to push it into a real agent.

Ran `ruff check`, `ruff format --check`, and `pytest` locally, all clean, and
confirmed `memanto migrate okf ./artifacts/okf-bundle --dry-run` picks up the
bundle correctly (10 mapped, 0 skipped).

Demo video: https://youtu.be/2XflkNGZqTo
Social posts: https://x.com/Techspeedy4lb2/status/2080175771927375959