### PR TITLE
fix(api): preserve source_ref in recall responses

### DIFF
--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -419,6 +419,7 @@ class MemoryItem(BaseModel):
     ttl_seconds: int | None = None
     actor_id: str | None = None
     source: str | None = None
+    source_ref: str | None = None
     agent_id: str | None = None
     score: float | None = None
     provenance: str = "explicit_statement"

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -3529,6 +3529,17 @@
             ],
             "title": "Source"
           },
+          "source_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Ref"
+          },
           "agent_id": {
             "anyOf": [
               {

--- a/tests/test_memory_format.py
+++ b/tests/test_memory_format.py
@@ -3,11 +3,56 @@
 from unittest.mock import MagicMock
 
 from memanto.app.core import MemoryRecord
+from memanto.app.models import RecallResponse, TemporalRecallResponse
 from memanto.app.services.memory_read_service import MemoryReadService
 
 
 def _make_read_service():
     return MemoryReadService(MagicMock())
+
+
+def _formatted_memory_with_source_ref():
+    memory = MemoryRecord(
+        type="fact",
+        title="Imported fact",
+        content="This memory came from an external document.",
+        agent_id="test-agent",
+        actor_id="user",
+        source="document",
+        source_ref="document://guide/section-2",
+    )
+
+    return _make_read_service()._format_memory_item(memory.to_moorcheh_document())
+
+
+def test_recall_response_preserves_formatted_source_ref():
+    formatted = _formatted_memory_with_source_ref()
+
+    response = RecallResponse(
+        agent_id="test-agent",
+        session_id="test-session",
+        query="external document",
+        memories=[formatted],
+        count=1,
+    )
+
+    assert formatted["source_ref"] == "document://guide/section-2"
+    assert response.model_dump()["memories"][0]["source_ref"] == formatted["source_ref"]
+
+
+def test_temporal_recall_response_preserves_formatted_source_ref():
+    formatted = _formatted_memory_with_source_ref()
+
+    response = TemporalRecallResponse(
+        agent_id="test-agent",
+        session_id="test-session",
+        memories=[formatted],
+        count=1,
+        temporal_mode="recent",
+    )
+
+    assert formatted["source_ref"] == "document://guide/section-2"
+    assert response.model_dump()["memories"][0]["source_ref"] == formatted["source_ref"]
 
 
 def test_content_with_newlines_and_tags_preserves_content_integrity():


### PR DESCRIPTION
## Summary

Recall formatting already carried `source_ref`, but the API response schema did not. When a formatted memory was validated as a `MemoryItem`, Pydantic silently dropped that field, so normal and temporal recall responses lost the original document/reference identifier.

This is a source-attribution integrity issue: the backend can return the correct reference while API clients receive a memory with no way to trace it back to its source.

## Reproduction

1. Create a `MemoryRecord` with `source="document"` and a non-null `source_ref`.
2. Format it through `MemoryReadService._format_memory_item()`.
3. Put the formatted item into `RecallResponse` or `TemporalRecallResponse`.
4. Serialize the response with `model_dump()`.

Before this change, `source_ref` is present after step 2 but absent after step 4.

## Fix

- add optional `source_ref` to `MemoryItem`
- expose the field in the TypeScript OpenAPI schema
- add regressions for standard and temporal recall responses

## Validation

- focused tests: 10 passed
- full Python suite: 382 passed; 24 live-key E2E tests skipped
- Ruff, formatting, and MyPy passed
- OpenAPI regeneration, TypeScript typecheck, build, and 37 tests passed

Refs #770

## AI assistance

OpenAI Codex was used for code inspection, implementation, and test execution. The final scope, reproduction, and reported results were reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory responses now include an optional source reference, providing additional context about where each memory originated.
  * The TypeScript API schema reflects this new field.

* **Bug Fixes**
  * Source references are now preserved when memory items are returned in recall and temporal recall responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->