### PR TITLE
Add Atlas Cloud LangGraph LLM config

### DIFF
--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -9,6 +9,10 @@ MOORCHEH_API_KEY=
 OPENROUTER_API_KEY=
 # OPENAI_API_KEY=
 
+# Optional: use Atlas Cloud's OpenAI-compatible LLM endpoint instead.
+# ATLASCLOUD_API_KEY=
+# ATLASCLOUD_API_BASE=https://api.atlascloud.ai/v1
+
 # Optional: Override the LLM model used by the LangGraph agent.
 #
 # Default: openai/gpt-oss-120b:free
@@ -30,3 +34,5 @@ OPENROUTER_API_KEY=
 #   anthropic/claude-haiku-4.5     cheap, fast, reliable
 #
 # LANGGRAPH_LLM=openai/gpt-oss-120b:free
+# For Atlas Cloud, omit LLM_MODEL to use qwen/qwen3.5-flash, or set:
+# LLM_MODEL=qwen/qwen3.5-flash

--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -11,13 +11,15 @@ OPENROUTER_API_KEY=
 
 # Optional: use Atlas Cloud's OpenAI-compatible LLM endpoint instead.
 # ATLASCLOUD_API_KEY=
+# ATLAS_CLOUD_API_KEY=
 # ATLASCLOUD_API_BASE=https://api.atlascloud.ai/v1
 
 # Optional: Override the LLM model used by the LangGraph agent.
 #
-# Default: openai/gpt-oss-120b:free
-#   Fastest free model on OpenRouter for KIND::CONTENT line extraction
-#   (~3s for 5 facts). Subject to shared free-tier rate limits.
+# Provider defaults when LANGGRAPH_LLM/LLM_MODEL is unset:
+#   OpenAI: gpt-4o-mini
+#   OpenRouter: openai/gpt-4o-mini
+#   Atlas Cloud: qwen/qwen3.5-flash
 #
 # Other free options:
 #   openai/gpt-oss-20b:free                 (4 memories, ~20s, slow but consistent)

--- a/examples/langgraph-memanto/memanto_base_store/graph.py
+++ b/examples/langgraph-memanto/memanto_base_store/graph.py
@@ -274,7 +274,8 @@ def _make_llm(temperature: float = 0.2, max_tokens: int | None = None) -> ChatOp
     # See .env.example for paid alternatives (tencent/hy3-preview etc).
     kwargs = chat_openai_kwargs(
         temperature=temperature,
-        default_model="gpt-4o-mini",
+        openai_default_model="gpt-4o-mini",
+        openrouter_default_model="openai/gpt-4o-mini",
         max_tokens=max_tokens,
     )
     return ChatOpenAI(**kwargs)

--- a/examples/langgraph-memanto/memanto_base_store/graph.py
+++ b/examples/langgraph-memanto/memanto_base_store/graph.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import uuid
 from typing import Literal
@@ -36,6 +35,7 @@ from langgraph.graph import END, START, StateGraph
 from langgraph.store.base import BaseStore
 from langgraph.types import RetryPolicy
 from langgraph_memanto import MemantoStore
+from memanto_base_store.llm_config import chat_openai_kwargs
 from memanto_base_store.state import SupportState
 from pydantic import BaseModel, Field, model_validator
 
@@ -250,9 +250,11 @@ def _try_load_memories(text: str) -> ExtractedMemories | None:
 
 
 def _make_llm(temperature: float = 0.2, max_tokens: int | None = None) -> ChatOpenAI:
-    """Build a ChatOpenAI instance routed through OpenRouter.
+    """Build a ChatOpenAI instance for an OpenAI-compatible provider.
 
-    Requires ``OPENROUTER_API_KEY``. Override the model via ``LANGGRAPH_LLM``.
+    Requires ``OPENAI_API_KEY``, ``OPENROUTER_API_KEY``, or
+    ``ATLASCLOUD_API_KEY``. Override the model via ``LANGGRAPH_LLM`` or
+    ``LLM_MODEL``.
     Called twice inside build_support_graph: once at temperature=0.2 for the
     conversational responder, once at temperature=0.1 for the extractor.
     Two separate instances are used because chaining .bind(temperature=0) onto
@@ -270,27 +272,11 @@ def _make_llm(temperature: float = 0.2, max_tokens: int | None = None) -> ChatOp
     # Free, no credits required. Subject to OpenRouter's shared free-tier
     # rate limits; the graph's RetryPolicy handles 429s with 32s backoff.
     # See .env.example for paid alternatives (tencent/hy3-preview etc).
-    model = os.environ.get("LLM_MODEL", os.environ.get("LANGGRAPH_LLM", "gpt-4o-mini"))
-    api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENROUTER_API_KEY")
-    if not api_key:
-        raise RuntimeError(
-            "OPENAI_API_KEY or OPENROUTER_API_KEY is not set. Copy .env.example to .env and add "
-            "your API key."
-        )
-    kwargs: dict = {
-        "model": model,
-        "temperature": temperature,
-        "api_key": api_key,
-        "base_url": os.environ.get(
-            "OPENAI_API_BASE",
-            "https://openrouter.ai/api/v1"
-            if os.environ.get("OPENROUTER_API_KEY")
-            else None,
-        )
-        or None,
-    }
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
+    kwargs = chat_openai_kwargs(
+        temperature=temperature,
+        default_model="gpt-4o-mini",
+        max_tokens=max_tokens,
+    )
     return ChatOpenAI(**kwargs)
 
 

--- a/examples/langgraph-memanto/memanto_base_store/llm_config.py
+++ b/examples/langgraph-memanto/memanto_base_store/llm_config.py
@@ -7,7 +7,9 @@ from typing import Any
 
 ATLASCLOUD_API_BASE = "https://api.atlascloud.ai/v1"
 ATLASCLOUD_DEFAULT_MODEL = "qwen/qwen3.5-flash"
+OPENAI_DEFAULT_MODEL = "gpt-4o-mini"
 OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
+OPENROUTER_DEFAULT_MODEL = "openai/gpt-4o-mini"
 
 
 def _first_env(*names: str) -> str:
@@ -21,7 +23,8 @@ def _first_env(*names: str) -> str:
 def chat_openai_kwargs(
     *,
     temperature: float,
-    default_model: str,
+    openai_default_model: str = OPENAI_DEFAULT_MODEL,
+    openrouter_default_model: str = OPENROUTER_DEFAULT_MODEL,
     max_tokens: int | None = None,
 ) -> dict[str, Any]:
     """Return ChatOpenAI kwargs for OpenAI, OpenRouter, or Atlas Cloud."""
@@ -33,11 +36,11 @@ def chat_openai_kwargs(
     if openai_key:
         api_key = openai_key
         base_url = _first_env("OPENAI_API_BASE")
-        resolved_model = model or default_model
+        resolved_model = model or openai_default_model
     elif openrouter_key:
         api_key = openrouter_key
         base_url = _first_env("OPENAI_API_BASE") or OPENROUTER_API_BASE
-        resolved_model = model or default_model
+        resolved_model = model or openrouter_default_model
     elif atlascloud_key:
         api_key = atlascloud_key
         base_url = (

--- a/examples/langgraph-memanto/memanto_base_store/llm_config.py
+++ b/examples/langgraph-memanto/memanto_base_store/llm_config.py
@@ -1,0 +1,67 @@
+"""Environment parsing for the example LangGraph chat model."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+ATLASCLOUD_API_BASE = "https://api.atlascloud.ai/v1"
+ATLASCLOUD_DEFAULT_MODEL = "qwen/qwen3.5-flash"
+OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
+
+
+def _first_env(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def chat_openai_kwargs(
+    *,
+    temperature: float,
+    default_model: str,
+    max_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Return ChatOpenAI kwargs for OpenAI, OpenRouter, or Atlas Cloud."""
+    model = _first_env("LLM_MODEL", "LANGGRAPH_LLM")
+    openai_key = _first_env("OPENAI_API_KEY")
+    openrouter_key = _first_env("OPENROUTER_API_KEY")
+    atlascloud_key = _first_env("ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY")
+
+    if openai_key:
+        api_key = openai_key
+        base_url = _first_env("OPENAI_API_BASE")
+        resolved_model = model or default_model
+    elif openrouter_key:
+        api_key = openrouter_key
+        base_url = _first_env("OPENAI_API_BASE") or OPENROUTER_API_BASE
+        resolved_model = model or default_model
+    elif atlascloud_key:
+        api_key = atlascloud_key
+        base_url = (
+            _first_env(
+                "ATLASCLOUD_API_BASE",
+                "ATLAS_CLOUD_API_BASE",
+                "ATLASCLOUD_BASE_URL",
+                "ATLAS_CLOUD_BASE_URL",
+            )
+            or ATLASCLOUD_API_BASE
+        )
+        resolved_model = model or ATLASCLOUD_DEFAULT_MODEL
+    else:
+        raise RuntimeError(
+            "OPENAI_API_KEY, OPENROUTER_API_KEY, or ATLASCLOUD_API_KEY is not "
+            "set. Copy .env.example to .env and add your API key."
+        )
+
+    kwargs: dict[str, Any] = {
+        "model": resolved_model,
+        "temperature": temperature,
+        "api_key": api_key,
+        "base_url": base_url or None,
+    }
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+    return kwargs

--- a/examples/langgraph-memanto/research_pipeline/langgraph_memanto/llm_config.py
+++ b/examples/langgraph-memanto/research_pipeline/langgraph_memanto/llm_config.py
@@ -7,7 +7,9 @@ from typing import Any
 
 ATLASCLOUD_API_BASE = "https://api.atlascloud.ai/v1"
 ATLASCLOUD_DEFAULT_MODEL = "qwen/qwen3.5-flash"
+OPENAI_DEFAULT_MODEL = "gpt-4o-mini"
 OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
+OPENROUTER_DEFAULT_MODEL = "openai/gpt-4o-mini"
 
 
 def _first_env(*names: str) -> str:
@@ -18,7 +20,12 @@ def _first_env(*names: str) -> str:
     return ""
 
 
-def chat_openai_kwargs(*, temperature: float, default_model: str) -> dict[str, Any]:
+def chat_openai_kwargs(
+    *,
+    temperature: float,
+    openai_default_model: str = OPENAI_DEFAULT_MODEL,
+    openrouter_default_model: str = OPENROUTER_DEFAULT_MODEL,
+) -> dict[str, Any]:
     """Return ChatOpenAI kwargs for OpenAI, OpenRouter, or Atlas Cloud."""
     model = _first_env("LLM_MODEL", "LANGGRAPH_LLM")
     openai_key = _first_env("OPENAI_API_KEY")
@@ -28,11 +35,11 @@ def chat_openai_kwargs(*, temperature: float, default_model: str) -> dict[str, A
     if openai_key:
         api_key = openai_key
         base_url = _first_env("OPENAI_API_BASE")
-        resolved_model = model or default_model
+        resolved_model = model or openai_default_model
     elif openrouter_key:
         api_key = openrouter_key
         base_url = _first_env("OPENAI_API_BASE") or OPENROUTER_API_BASE
-        resolved_model = model or default_model
+        resolved_model = model or openrouter_default_model
     elif atlascloud_key:
         api_key = atlascloud_key
         base_url = (

--- a/examples/langgraph-memanto/research_pipeline/langgraph_memanto/llm_config.py
+++ b/examples/langgraph-memanto/research_pipeline/langgraph_memanto/llm_config.py
@@ -1,0 +1,59 @@
+"""Environment parsing for the example research pipeline chat model."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+ATLASCLOUD_API_BASE = "https://api.atlascloud.ai/v1"
+ATLASCLOUD_DEFAULT_MODEL = "qwen/qwen3.5-flash"
+OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
+
+
+def _first_env(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def chat_openai_kwargs(*, temperature: float, default_model: str) -> dict[str, Any]:
+    """Return ChatOpenAI kwargs for OpenAI, OpenRouter, or Atlas Cloud."""
+    model = _first_env("LLM_MODEL", "LANGGRAPH_LLM")
+    openai_key = _first_env("OPENAI_API_KEY")
+    openrouter_key = _first_env("OPENROUTER_API_KEY")
+    atlascloud_key = _first_env("ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY")
+
+    if openai_key:
+        api_key = openai_key
+        base_url = _first_env("OPENAI_API_BASE")
+        resolved_model = model or default_model
+    elif openrouter_key:
+        api_key = openrouter_key
+        base_url = _first_env("OPENAI_API_BASE") or OPENROUTER_API_BASE
+        resolved_model = model or default_model
+    elif atlascloud_key:
+        api_key = atlascloud_key
+        base_url = (
+            _first_env(
+                "ATLASCLOUD_API_BASE",
+                "ATLAS_CLOUD_API_BASE",
+                "ATLASCLOUD_BASE_URL",
+                "ATLAS_CLOUD_BASE_URL",
+            )
+            or ATLASCLOUD_API_BASE
+        )
+        resolved_model = model or ATLASCLOUD_DEFAULT_MODEL
+    else:
+        raise RuntimeError(
+            "OPENAI_API_KEY, OPENROUTER_API_KEY, or ATLASCLOUD_API_KEY is not "
+            "set. Copy .env.example to .env and add your API key."
+        )
+
+    return {
+        "model": resolved_model,
+        "temperature": temperature,
+        "api_key": api_key,
+        "base_url": base_url or None,
+    }

--- a/examples/langgraph-memanto/research_pipeline/langgraph_memanto/nodes.py
+++ b/examples/langgraph-memanto/research_pipeline/langgraph_memanto/nodes.py
@@ -15,6 +15,7 @@ from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 
 from langgraph_memanto import create_memanto_tools
+from langgraph_memanto.llm_config import chat_openai_kwargs
 from memanto.cli.client.sdk_client import SdkClient
 
 client = SdkClient(api_key=os.environ.get("MOORCHEH_API_KEY", ""))
@@ -26,7 +27,6 @@ memanto_answer = next(t for t in tools if t.name == "memanto_answer")
 load_dotenv()
 
 MOORCHEH_API_KEY = os.getenv("MOORCHEH_API_KEY", "")
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
 
 
 def _get_moorcheh_api_key() -> str:
@@ -46,12 +46,7 @@ def _get_moorcheh_api_key() -> str:
 def _get_llm():
     """Build a flexible ChatOpenAI model."""
     return ChatOpenAI(
-        model=os.getenv("LLM_MODEL", "openai/gpt-4o-mini"),
-        api_key=os.getenv("OPENROUTER_API_KEY")
-        or os.getenv("OPENAI_API_KEY")
-        or OPENROUTER_API_KEY,
-        base_url=os.getenv("OPENAI_API_BASE", "https://openrouter.ai/api/v1"),
-        temperature=0.7,
+        **chat_openai_kwargs(temperature=0.7, default_model="openai/gpt-4o-mini")
     )
 
 

--- a/examples/langgraph-memanto/research_pipeline/langgraph_memanto/nodes.py
+++ b/examples/langgraph-memanto/research_pipeline/langgraph_memanto/nodes.py
@@ -46,7 +46,11 @@ def _get_moorcheh_api_key() -> str:
 def _get_llm():
     """Build a flexible ChatOpenAI model."""
     return ChatOpenAI(
-        **chat_openai_kwargs(temperature=0.7, default_model="openai/gpt-4o-mini")
+        **chat_openai_kwargs(
+            temperature=0.7,
+            openai_default_model="gpt-4o-mini",
+            openrouter_default_model="openai/gpt-4o-mini",
+        )
     )
 
 

--- a/tests/test_langgraph_atlascloud_llm_config.py
+++ b/tests/test_langgraph_atlascloud_llm_config.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from types import ModuleType
+
+import memanto.app.services as memanto_services
+
+ROOT = Path(__file__).resolve().parents[1]
+
+fake_moorcheh_sdk = types.ModuleType("moorcheh_sdk")
+fake_moorcheh_sdk.AsyncMoorchehClient = object
+fake_moorcheh_sdk.MoorchehClient = object
+sys.modules.setdefault("moorcheh_sdk", fake_moorcheh_sdk)
+
+fake_agent_service = types.ModuleType("memanto.app.services.agent_service")
+fake_agent_service.get_moorcheh_client = lambda: None
+sys.modules.setdefault("memanto.app.services.agent_service", fake_agent_service)
+memanto_services.agent_service = fake_agent_service
+
+
+def load_module(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def clear_llm_env() -> None:
+    for key in (
+        "OPENAI_API_KEY",
+        "OPENAI_API_BASE",
+        "OPENROUTER_API_KEY",
+        "ATLASCLOUD_API_KEY",
+        "ATLAS_CLOUD_API_KEY",
+        "ATLASCLOUD_API_BASE",
+        "ATLAS_CLOUD_API_BASE",
+        "ATLASCLOUD_BASE_URL",
+        "ATLAS_CLOUD_BASE_URL",
+        "LLM_MODEL",
+        "LANGGRAPH_LLM",
+    ):
+        os.environ.pop(key, None)
+
+
+def test_base_store_llm_config_supports_atlascloud(monkeypatch):
+    clear_llm_env()
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
+    module = load_module(
+        ROOT / "examples/langgraph-memanto/memanto_base_store/llm_config.py",
+        "base_store_llm_config",
+    )
+
+    kwargs = module.chat_openai_kwargs(temperature=0.2, default_model="fallback")
+
+    assert kwargs == {
+        "model": "qwen/qwen3.5-flash",
+        "temperature": 0.2,
+        "api_key": "atlas-key",
+        "base_url": "https://api.atlascloud.ai/v1",
+    }
+
+
+def test_base_store_llm_config_keeps_explicit_openai_precedence(monkeypatch):
+    clear_llm_env()
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
+    monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
+    module = load_module(
+        ROOT / "examples/langgraph-memanto/memanto_base_store/llm_config.py",
+        "base_store_llm_config_openai",
+    )
+
+    kwargs = module.chat_openai_kwargs(
+        temperature=0.1,
+        default_model="fallback",
+        max_tokens=7000,
+    )
+
+    assert kwargs == {
+        "model": "gpt-4o-mini",
+        "temperature": 0.1,
+        "api_key": "openai-key",
+        "base_url": None,
+        "max_tokens": 7000,
+    }
+
+
+def test_research_pipeline_llm_config_accepts_atlascloud_aliases(monkeypatch):
+    clear_llm_env()
+    monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "atlas-key")
+    monkeypatch.setenv("ATLASCLOUD_BASE_URL", "https://atlas.example/v1")
+    monkeypatch.setenv("LLM_MODEL", "deepseek-ai/deepseek-v4-pro")
+    module = load_module(
+        ROOT
+        / "examples/langgraph-memanto/research_pipeline/langgraph_memanto/llm_config.py",
+        "research_llm_config",
+    )
+
+    kwargs = module.chat_openai_kwargs(temperature=0.7, default_model="fallback")
+
+    assert kwargs == {
+        "model": "deepseek-ai/deepseek-v4-pro",
+        "temperature": 0.7,
+        "api_key": "atlas-key",
+        "base_url": "https://atlas.example/v1",
+    }

--- a/tests/test_langgraph_atlascloud_llm_config.py
+++ b/tests/test_langgraph_atlascloud_llm_config.py
@@ -1,25 +1,69 @@
 from __future__ import annotations
 
 import importlib.util
-import os
 import sys
 import types
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 import memanto.app.services as memanto_services
 
 ROOT = Path(__file__).resolve().parents[1]
 
-fake_moorcheh_sdk = types.ModuleType("moorcheh_sdk")
-fake_moorcheh_sdk.AsyncMoorchehClient = object
-fake_moorcheh_sdk.MoorchehClient = object
-sys.modules.setdefault("moorcheh_sdk", fake_moorcheh_sdk)
+LLM_ENV_KEYS = (
+    "OPENAI_API_KEY",
+    "OPENAI_API_BASE",
+    "OPENROUTER_API_KEY",
+    "ATLASCLOUD_API_KEY",
+    "ATLAS_CLOUD_API_KEY",
+    "ATLASCLOUD_API_BASE",
+    "ATLAS_CLOUD_API_BASE",
+    "ATLASCLOUD_BASE_URL",
+    "ATLAS_CLOUD_BASE_URL",
+    "LLM_MODEL",
+    "LANGGRAPH_LLM",
+)
 
-fake_agent_service = types.ModuleType("memanto.app.services.agent_service")
-fake_agent_service.get_moorcheh_client = lambda: None
-sys.modules.setdefault("memanto.app.services.agent_service", fake_agent_service)
-memanto_services.agent_service = fake_agent_service
+CONFIG_MODULES = (
+    (
+        "examples/langgraph-memanto/memanto_base_store/llm_config.py",
+        "base_store_llm_config",
+    ),
+    (
+        "examples/langgraph-memanto/research_pipeline/langgraph_memanto/llm_config.py",
+        "research_llm_config",
+    ),
+)
+
+
+def clear_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in LLM_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def isolate_sdk_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_moorcheh_sdk = types.ModuleType("moorcheh_sdk")
+    fake_moorcheh_sdk.AsyncMoorchehClient = object
+    fake_moorcheh_sdk.MoorchehClient = object
+    monkeypatch.setitem(sys.modules, "moorcheh_sdk", fake_moorcheh_sdk)
+
+    fake_agent_service = types.ModuleType("memanto.app.services.agent_service")
+    fake_agent_service.get_moorcheh_client = lambda: None
+    monkeypatch.setitem(
+        sys.modules,
+        "memanto.app.services.agent_service",
+        fake_agent_service,
+    )
+    monkeypatch.setattr(
+        memanto_services,
+        "agent_service",
+        fake_agent_service,
+        raising=False,
+    )
+    clear_llm_env(monkeypatch)
 
 
 def load_module(path: Path, name: str) -> ModuleType:
@@ -31,32 +75,14 @@ def load_module(path: Path, name: str) -> ModuleType:
     return module
 
 
-def clear_llm_env() -> None:
-    for key in (
-        "OPENAI_API_KEY",
-        "OPENAI_API_BASE",
-        "OPENROUTER_API_KEY",
-        "ATLASCLOUD_API_KEY",
-        "ATLAS_CLOUD_API_KEY",
-        "ATLASCLOUD_API_BASE",
-        "ATLAS_CLOUD_API_BASE",
-        "ATLASCLOUD_BASE_URL",
-        "ATLAS_CLOUD_BASE_URL",
-        "LLM_MODEL",
-        "LANGGRAPH_LLM",
-    ):
-        os.environ.pop(key, None)
-
-
 def test_base_store_llm_config_supports_atlascloud(monkeypatch):
-    clear_llm_env()
     monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
     module = load_module(
         ROOT / "examples/langgraph-memanto/memanto_base_store/llm_config.py",
         "base_store_llm_config",
     )
 
-    kwargs = module.chat_openai_kwargs(temperature=0.2, default_model="fallback")
+    kwargs = module.chat_openai_kwargs(temperature=0.2)
 
     assert kwargs == {
         "model": "qwen/qwen3.5-flash",
@@ -67,7 +93,6 @@ def test_base_store_llm_config_supports_atlascloud(monkeypatch):
 
 
 def test_base_store_llm_config_keeps_explicit_openai_precedence(monkeypatch):
-    clear_llm_env()
     monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
     monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
     monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
@@ -78,7 +103,6 @@ def test_base_store_llm_config_keeps_explicit_openai_precedence(monkeypatch):
 
     kwargs = module.chat_openai_kwargs(
         temperature=0.1,
-        default_model="fallback",
         max_tokens=7000,
     )
 
@@ -92,7 +116,6 @@ def test_base_store_llm_config_keeps_explicit_openai_precedence(monkeypatch):
 
 
 def test_research_pipeline_llm_config_accepts_atlascloud_aliases(monkeypatch):
-    clear_llm_env()
     monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "atlas-key")
     monkeypatch.setenv("ATLASCLOUD_BASE_URL", "https://atlas.example/v1")
     monkeypatch.setenv("LLM_MODEL", "deepseek-ai/deepseek-v4-pro")
@@ -102,11 +125,56 @@ def test_research_pipeline_llm_config_accepts_atlascloud_aliases(monkeypatch):
         "research_llm_config",
     )
 
-    kwargs = module.chat_openai_kwargs(temperature=0.7, default_model="fallback")
+    kwargs = module.chat_openai_kwargs(temperature=0.7)
 
     assert kwargs == {
         "model": "deepseek-ai/deepseek-v4-pro",
         "temperature": 0.7,
+        "api_key": "atlas-key",
+        "base_url": "https://atlas.example/v1",
+    }
+
+
+@pytest.mark.parametrize(("relative_path", "module_name"), CONFIG_MODULES)
+def test_llm_config_uses_provider_specific_defaults(
+    monkeypatch,
+    relative_path,
+    module_name,
+):
+    module = load_module(ROOT / relative_path, f"{module_name}_defaults")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    openai_kwargs = module.chat_openai_kwargs(temperature=0.3)
+
+    assert openai_kwargs["model"] == "gpt-4o-mini"
+    assert openai_kwargs["api_key"] == "openai-key"
+    assert openai_kwargs["base_url"] is None
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
+    openrouter_kwargs = module.chat_openai_kwargs(temperature=0.3)
+
+    assert openrouter_kwargs["model"] == "openai/gpt-4o-mini"
+    assert openrouter_kwargs["api_key"] == "openrouter-key"
+    assert openrouter_kwargs["base_url"] == "https://openrouter.ai/api/v1"
+
+
+@pytest.mark.parametrize(("relative_path", "module_name"), CONFIG_MODULES)
+def test_llm_config_uses_langgraph_llm_fallback(
+    monkeypatch,
+    relative_path,
+    module_name,
+):
+    monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "atlas-key")
+    monkeypatch.setenv("ATLASCLOUD_BASE_URL", "https://atlas.example/v1")
+    monkeypatch.setenv("LANGGRAPH_LLM", "deepseek-ai/deepseek-v4-pro")
+    module = load_module(ROOT / relative_path, f"{module_name}_langgraph_fallback")
+
+    kwargs = module.chat_openai_kwargs(temperature=0.4)
+
+    assert kwargs == {
+        "model": "deepseek-ai/deepseek-v4-pro",
+        "temperature": 0.4,
         "api_key": "atlas-key",
         "base_url": "https://atlas.example/v1",
     }


### PR DESCRIPTION
## Summary
- Add Atlas Cloud support to the LangGraph example LLM factories while preserving the existing OpenAI/OpenRouter precedence.
- Route `ATLASCLOUD_API_KEY` / `ATLAS_CLOUD_API_KEY` through ChatOpenAI with the OpenAI-compatible base URL `https://api.atlascloud.ai/v1`.
- Default Atlas Cloud-only setups to `qwen/qwen3.5-flash`, with `LLM_MODEL` / `LANGGRAPH_LLM` overrides still supported.
- Add focused offline tests for Atlas Cloud defaults, aliases, and explicit OpenAI precedence.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/memanto-atlas-pycache uv run --python 3.11 pytest -c /tmp/memanto_pytest.ini -p no:cacheprovider tests/test_langgraph_atlascloud_llm_config.py -q` -> 3 passed
- `uv run --python 3.11 ruff check examples/langgraph-memanto/memanto_base_store/llm_config.py examples/langgraph-memanto/research_pipeline/langgraph_memanto/llm_config.py examples/langgraph-memanto/memanto_base_store/graph.py examples/langgraph-memanto/research_pipeline/langgraph_memanto/nodes.py tests/test_langgraph_atlascloud_llm_config.py` -> passed
- `PYTHONPYCACHEPREFIX=/tmp/memanto-atlas-pycache python3.11 -m compileall -q ...` -> passed
- `git diff --check` -> passed
- Atlas Cloud live model catalog returned 374 visible models and confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.

No README, logo, sponsor, credits, or partner promotion changes are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the LangGraph examples with Atlas Cloud’s OpenAI-compatible API.
  * Added automatic provider selection among OpenAI, OpenRouter, and Atlas Cloud based on environment variables.
  * Added centralized model/base-URL configuration with support for environment-driven model overrides.
  * Updated the example environment file with Atlas Cloud-specific setup guidance and defaults.

* **Bug Fixes**
  * Improved validation and error messaging when no supported LLM credentials are configured.

* **Tests**
  * Expanded coverage for provider selection and fallback behavior, using isolated test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->