### PR TITLE
Validation/merge prs

### DIFF
--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -24,6 +24,7 @@ from memanto.app.utils.errors import (
     AgentAlreadyExistsError,
     AgentNotFoundError,
     MemantoError,
+    MemoryError,
 )
 from memanto.app.utils.validation import InputLimits
 from pydantic import BaseModel, Field
@@ -931,15 +932,16 @@ def _string_or_none(value: Any) -> str | None:
 
 
 def _to_batch_item_results(raw_results: Any) -> list[BatchRememberItemResult]:
-    """Normalize per-item batch results without failing on malformed rows."""
+    """Normalize per-item batch results, failing fast on malformed data."""
     if not isinstance(raw_results, list):
-        return []
+        raise MemoryError(
+            message="Data corruption detected: Received malformed batch result array from storage layer in MCP integration.",
+            details={"items_preview": str(raw_results)[:100]},
+        )
 
     items: list[BatchRememberItemResult] = []
     for raw in raw_results:
         if not isinstance(raw, dict):
-            from memanto.app.utils.errors import MemoryError
-
             raise MemoryError(
                 message="Data corruption detected: Received malformed batch result from storage layer in MCP integration.",
                 details={"item_preview": str(raw)[:100]},

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -939,9 +939,10 @@ def _to_batch_item_results(raw_results: Any) -> list[BatchRememberItemResult]:
     for raw in raw_results:
         if not isinstance(raw, dict):
             from memanto.app.utils.errors import MemoryError
+
             raise MemoryError(
                 message="Data corruption detected: Received malformed batch result from storage layer in MCP integration.",
-                details={"item_preview": str(raw)[:100]}
+                details={"item_preview": str(raw)[:100]},
             )
         try:
             items.append(

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -419,14 +419,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 agent_id=resolved,
                 memories=normalized_memories,
             )
-            sub_results = [
-                BatchRememberItemResult(
-                    id=r.get("id"),
-                    status=r.get("status", "queued"),
-                    error=r.get("error"),
-                )
-                for r in result.get("results", [])
-            ]
+            sub_results = _to_batch_item_results(result.get("results"))
             return BatchRememberResult(
                 status="ok",
                 agent_id=resolved,
@@ -931,3 +924,33 @@ def _to_memory_hit(raw: dict[str, Any]) -> MemoryHit:
             else raw.get("similarity_score")
         ),
     )
+
+
+def _string_or_none(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _to_batch_item_results(raw_results: Any) -> list[BatchRememberItemResult]:
+    """Normalize per-item batch results without failing on malformed rows."""
+    if not isinstance(raw_results, list):
+        return []
+
+    items: list[BatchRememberItemResult] = []
+    for raw in raw_results:
+        if not isinstance(raw, dict):
+            from memanto.app.utils.errors import MemoryError
+            raise MemoryError(
+                message="Data corruption detected: Received malformed batch result from storage layer in MCP integration.",
+                details={"item_preview": str(raw)[:100]}
+            )
+        try:
+            items.append(
+                BatchRememberItemResult(
+                    id=_string_or_none(raw.get("id")),
+                    status=str(raw.get("status") or "queued"),
+                    error=_string_or_none(raw.get("error")),
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return items

--- a/memanto/app/constants.py
+++ b/memanto/app/constants.py
@@ -18,7 +18,7 @@ MemoryType = Literal[
 ]
 
 # Source Types
-SourceType = str  # e.g., "user", "agent", "tool", "system", or specific "agent_name"
+SourceType = Literal["user", "agent", "tool", "system"]  # e.g., "user", "agent", "tool", "system", or specific "agent_name"
 
 # Status Types
 StatusType = Literal["active", "superseded", "deleted", "provisional"]

--- a/memanto/app/constants.py
+++ b/memanto/app/constants.py
@@ -18,7 +18,9 @@ MemoryType = Literal[
 ]
 
 # Source Types
-SourceType = Literal["user", "agent", "tool", "system"]  # e.g., "user", "agent", "tool", "system", or specific "agent_name"
+SourceType = Literal[
+    "user", "agent", "tool", "system"
+]  # e.g., "user", "agent", "tool", "system", or specific "agent_name"
 
 # Status Types
 StatusType = Literal["active", "superseded", "deleted", "provisional"]

--- a/memanto/app/constants.py
+++ b/memanto/app/constants.py
@@ -20,7 +20,7 @@ MemoryType = Literal[
 # Source Types
 SourceType = Literal[
     "user", "agent", "tool", "system"
-]  # e.g., "user", "agent", "tool", "system", or specific "agent_name"
+]  # Valid sources for memory creation
 
 # Status Types
 StatusType = Literal["active", "superseded", "deleted", "provisional"]

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -4,9 +4,9 @@ MEMANTO Core Architecture - Namespace Strategy & Memory Records
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StringConstraints
 
 from memanto.app.constants import (
     MemoryType,
@@ -14,6 +14,15 @@ from memanto.app.constants import (
     SourceType,
     StatusType,
 )
+
+MemoryTag = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)
+]
+BoundedTags = Annotated[list[MemoryTag], Field(max_length=20)]
+
+BoundedSourceRef = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=512)
+]
 
 
 def agent_namespace(agent_id: str) -> str:
@@ -34,10 +43,10 @@ class MemoryRecord(BaseModel):
     agent_id: str
     actor_id: str
     source: SourceType
-    source_ref: str | None = None
+    source_ref: BoundedSourceRef | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
     status: StatusType = "active"
-    tags: list[str] = Field(default_factory=list)
+    tags: BoundedTags = Field(default_factory=list)
 
     # Provenance
     provenance: ProvenanceType = "explicit_statement"

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -3,12 +3,11 @@ MEMANTO API Models
 """
 
 from datetime import datetime
-from typing import Annotated, Any, Literal
+from typing import Any, Literal
 
 from pydantic import (
     BaseModel,
     Field,
-    StringConstraints,
     field_validator,
     model_validator,
 )
@@ -19,6 +18,10 @@ from memanto.app.constants import (
     SourceType,
     StatusType,
 )
+from memanto.app.core import (
+    BoundedSourceRef,
+    BoundedTags,
+)
 
 
 def _validate_non_blank_content(value: str) -> str:
@@ -26,19 +29,6 @@ def _validate_non_blank_content(value: str) -> str:
     if not value.strip():
         raise ValueError("Memory content must be a non-empty string")
     return value
-
-
-MemoryTag = Annotated[
-    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)
-]
-BoundedTags = Annotated[list[MemoryTag], Field(max_length=20)]
-
-BoundedSource = Annotated[
-    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)
-]
-BoundedSourceRef = Annotated[
-    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=512)
-]
 
 
 # Request Models

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -5,7 +5,13 @@ MEMANTO API Models
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, StringConstraints, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 from memanto.app.constants import (
     VALID_PROVENANCE_TYPES,
@@ -22,11 +28,17 @@ def _validate_non_blank_content(value: str) -> str:
     return value
 
 
-MemoryTag = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)]
+MemoryTag = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)
+]
 BoundedTags = Annotated[list[MemoryTag], Field(max_length=20)]
 
-BoundedSource = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)]
-BoundedSourceRef = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=512)]
+BoundedSource = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)
+]
+BoundedSourceRef = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=512)
+]
 
 
 # Request Models
@@ -38,7 +50,7 @@ class MemoryStoreRequest(BaseModel):
     content: str = Field(max_length=10000)
     agent_id: str
     actor_id: str
-    source: BoundedSource
+    source: SourceType
     source_ref: BoundedSourceRef | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
     tags: BoundedTags = Field(default_factory=list)
@@ -58,7 +70,7 @@ class MemoryBatchItem(BaseModel):
     type: MemoryType
     title: str = Field(max_length=100)
     content: str = Field(max_length=10000)
-    source: BoundedSource
+    source: SourceType
     source_ref: BoundedSourceRef | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
     tags: BoundedTags = Field(default_factory=list)
@@ -96,7 +108,7 @@ class BatchRememberItem(BaseModel):
     )
     confidence: float = Field(0.8, ge=0.0, le=1.0, description="Confidence score (0-1)")
     tags: BoundedTags | None = Field(None, description="Tags for this memory")
-    source: BoundedSource = Field("agent", description="Source of memory")
+    source: SourceType = Field("agent", description="Source of memory")
     provenance: str = Field(
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -3,9 +3,9 @@ MEMANTO API Models
 """
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, StringConstraints, field_validator, model_validator
 
 from memanto.app.constants import (
     VALID_PROVENANCE_TYPES,
@@ -22,6 +22,13 @@ def _validate_non_blank_content(value: str) -> str:
     return value
 
 
+MemoryTag = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)]
+BoundedTags = Annotated[list[MemoryTag], Field(max_length=20)]
+
+BoundedSource = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)]
+BoundedSourceRef = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=512)]
+
+
 # Request Models
 class MemoryStoreRequest(BaseModel):
     """Request body for storing a single memory."""
@@ -31,10 +38,10 @@ class MemoryStoreRequest(BaseModel):
     content: str = Field(max_length=10000)
     agent_id: str
     actor_id: str
-    source: SourceType
-    source_ref: str | None = None
+    source: BoundedSource
+    source_ref: BoundedSourceRef | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
-    tags: list[str] = Field(default_factory=list)
+    tags: BoundedTags = Field(default_factory=list)
     ttl_seconds: int | None = Field(default=None, gt=0)
     user_confirmed: bool = False
 
@@ -51,10 +58,10 @@ class MemoryBatchItem(BaseModel):
     type: MemoryType
     title: str = Field(max_length=100)
     content: str = Field(max_length=10000)
-    source: SourceType
-    source_ref: str | None = None
+    source: BoundedSource
+    source_ref: BoundedSourceRef | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
-    tags: list[str] = Field(default_factory=list)
+    tags: BoundedTags = Field(default_factory=list)
     ttl_seconds: int | None = Field(default=None, gt=0)
     id: str | None = None  # Optional custom ID
 
@@ -88,8 +95,8 @@ class BatchRememberItem(BaseModel):
         None, max_length=100, description="Memory title (defaults to truncated content)"
     )
     confidence: float = Field(0.8, ge=0.0, le=1.0, description="Confidence score (0-1)")
-    tags: list[str] | None = Field(None, description="Tags for this memory")
-    source: str = Field("agent", description="Source of memory")
+    tags: BoundedTags | None = Field(None, description="Tags for this memory")
+    source: BoundedSource = Field("agent", description="Source of memory")
     provenance: str = Field(
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field, field_validator
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import settings
-from memanto.app.constants import VALID_MEMORY_TYPES
+from memanto.app.constants import VALID_MEMORY_TYPES, MemoryType
 from memanto.app.core import MemoryRecord
 from memanto.app.models import (
     AnswerRequest,
@@ -296,7 +296,7 @@ class MemoryEditRequest(BaseModel):
 
     title: str | None = Field(default=None, max_length=100)
     content: str | None = Field(default=None, max_length=10000)
-    type: str | None = None
+    type: MemoryType | None = None
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
     tags: list[str] | None = None
     source: str | None = None

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -651,10 +651,14 @@ async def extract_memories_from_conversation(
         session_service = get_session_service()
         batch_results = result.get("results", [])
         for index, record in enumerate(memory_records):
-            memory_id = (
-                batch_results[index].get("id") if index < len(batch_results) else None
-            )
             item_result = batch_results[index] if index < len(batch_results) else None
+            if item_result is not None and not isinstance(item_result, dict):
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed batch result from storage layer.",
+                    details={"item_preview": str(item_result)[:100]},
+                )
+
+            memory_id = item_result.get("id") if item_result else None
             if not is_successful_write_result(item_result):
                 continue
             await asyncio.to_thread(

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -18,14 +18,13 @@ from pydantic import BaseModel, Field, field_validator
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import settings
-from memanto.app.constants import VALID_MEMORY_TYPES, MemoryType
+from memanto.app.constants import VALID_MEMORY_TYPES, MemoryType, SourceType
 from memanto.app.core import MemoryRecord
 from memanto.app.models import (
     AnswerRequest,
     AnswerResponse,
     BatchRememberRequest,
     BatchRememberResponse,
-    BoundedSource,
     BoundedTags,
     ConflictResolveRequest,
     ExtractMemoriesRequest,
@@ -305,7 +304,7 @@ class MemoryEditRequest(BaseModel):
     type: MemoryType | None = None
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
     tags: BoundedTags | None = None
-    source: BoundedSource | None = None
+    source: SourceType | None = None
 
     def to_updates(self) -> dict[str, object]:
         """Return only fields the caller explicitly wants to update."""
@@ -655,10 +654,25 @@ async def extract_memories_from_conversation(
         )
 
         session_service = get_session_service()
+
+        if not isinstance(result, dict):
+            raise MemoryError(
+                message="Data corruption detected: Received malformed batch result from storage layer.",
+                details={"item_preview": str(result)[:100]},
+            )
+
         batch_results = result.get("results", [])
+        if not isinstance(batch_results, list):
+            raise MemoryError(
+                message="Data corruption detected: Received malformed batch result array from storage layer.",
+                details={"item_preview": str(batch_results)[:100]},
+            )
+
         for index, record in enumerate(memory_records):
             item_result = batch_results[index] if index < len(batch_results) else None
-            if item_result is not None and not isinstance(item_result, dict):
+            if item_result is not None and (
+                not isinstance(item_result, dict) or not item_result
+            ):
                 raise MemoryError(
                     message="Data corruption detected: Received malformed batch result from storage layer.",
                     details={"item_preview": str(item_result)[:100]},

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -25,6 +25,8 @@ from memanto.app.models import (
     AnswerResponse,
     BatchRememberRequest,
     BatchRememberResponse,
+    BoundedSource,
+    BoundedTags,
     ConflictResolveRequest,
     ExtractMemoriesRequest,
     RecallResponse,
@@ -32,8 +34,6 @@ from memanto.app.models import (
     RememberResponse,
     TemporalRecallResponse,
     UploadFileResponse,
-    BoundedSource,
-    BoundedTags,
 )
 from memanto.app.models.session import Session
 from memanto.app.routes.auth_deps import get_current_session, get_session_service
@@ -42,7 +42,11 @@ from memanto.app.services.conversation_memory_extraction_service import (
 )
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.services.memory_write_service import MemoryWriteService
-from memanto.app.utils.errors import AuthorizationError, map_error_to_http_exception
+from memanto.app.utils.errors import (
+    AuthorizationError,
+    MemoryError,
+    map_error_to_http_exception,
+)
 from memanto.app.utils.validation import (
     CostGuard,
     is_successful_write_result,

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -32,6 +32,8 @@ from memanto.app.models import (
     RememberResponse,
     TemporalRecallResponse,
     UploadFileResponse,
+    BoundedSource,
+    BoundedTags,
 )
 from memanto.app.models.session import Session
 from memanto.app.routes.auth_deps import get_current_session, get_session_service
@@ -298,8 +300,8 @@ class MemoryEditRequest(BaseModel):
     content: str | None = Field(default=None, max_length=10000)
     type: MemoryType | None = None
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
-    tags: list[str] | None = None
-    source: str | None = None
+    tags: BoundedTags | None = None
+    source: BoundedSource | None = None
 
     def to_updates(self) -> dict[str, object]:
         """Return only fields the caller explicitly wants to update."""

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -172,7 +172,7 @@ class ConversationMemoryExtractionService:
                     "title": title,
                     "content": content,
                     "confidence": confidence,
-                    "source": "conversation",
+                    "source": "system",
                     "provenance": "inferred",
                 }
             )

--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -41,7 +41,6 @@ class MemoryParsingService:
         for pattern in [
             r"https?://[^\s<>()\[\]{},;:\"']*[^\s<>()\[\]{},;:\"'.,!?]",
             r"\b(?:endpoint|url|api key|path|email|phone|address)\b",
-            r"\b(?:is|are|was|were)\b",
         ]
     ]
 

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -62,13 +62,20 @@ class MemoryReadService:
                 namespace_name=namespace, ids=[memory_id]
             )
 
-            from typing import Any, cast
-
             if not isinstance(result, dict):
-                return None
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed get result from storage layer.",
+                    details={"result_preview": str(result)[:100]},
+                )
 
-            items: list[Any] = cast(list[Any], result.get("items", []))
-            if items and isinstance(items, list) and len(items) > 0:
+            items: Any = result.get("items", [])
+            if not isinstance(items, list):
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed get items array from storage layer.",
+                    details={"items_preview": str(items)[:100]},
+                )
+
+            if items and len(items) > 0:
                 memory = self._format_memory_item(items[0])
 
                 # Apply TTL enforcement
@@ -80,6 +87,8 @@ class MemoryReadService:
 
             return None
 
+        except MemoryError:
+            raise
         except Exception as e:
             raise MemoryError(f"Failed to retrieve memory: {e}")
 
@@ -158,7 +167,26 @@ class MemoryReadService:
                 kiosk_mode=use_kiosk,
             )
 
-            search_items = search_result.get("results", [])
+            if not isinstance(search_result, dict):
+                try:
+                    search_result_dict = dict(search_result)
+                    search_result = search_result_dict
+                except (TypeError, ValueError):
+                    raise MemoryError(
+                        message="Data corruption detected: Received malformed search result from storage layer.",
+                        details={"result_preview": str(search_result)[:100]},
+                    )
+
+            search_items = (
+                search_result.get("results", [])
+                if isinstance(search_result, dict)
+                else []
+            )
+            if not isinstance(search_items, list):
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed search result array from storage layer.",
+                    details={"items_preview": str(search_items)[:100]},
+                )
 
             # Format results
             all_results = [self._format_memory_item(item) for item in search_items]
@@ -195,6 +223,8 @@ class MemoryReadService:
                 "execution_time": search_result.get("execution_time", 0),
             }
 
+        except MemoryError:
+            raise
         except Exception as e:
             raise MemoryError(f"Failed to search memories: {e}")
 

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -383,8 +383,8 @@ class MemoryReadService:
             type: Optional memory type filters
             tags: Optional tag filters
             limit: Max results to return
-            created_after: ISO timestamp - include only memories created after this time
-            created_before: ISO timestamp - include only memories created before this time
+            created_after: ISO timestamp - include only memories created at/after this time
+            created_before: ISO timestamp - include only memories created at/before this time
         """
         try:
             from memanto.app.utils.temporal_helpers import parse_iso_timestamp

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -383,8 +383,8 @@ class MemoryReadService:
             type: Optional memory type filters
             tags: Optional tag filters
             limit: Max results to return
-            created_after: ISO timestamp - include only memories created at/after this time
-            created_before: ISO timestamp - include only memories created at/before this time
+            created_after: ISO timestamp - include only memories created after this time
+            created_before: ISO timestamp - include only memories created before this time
         """
         try:
             from memanto.app.utils.temporal_helpers import parse_iso_timestamp
@@ -766,6 +766,12 @@ class MemoryReadService:
         """
         Format memory item for response.
         """
+        if not isinstance(item, dict):
+            raise MemoryError(
+                message="Data corruption detected: Received malformed memory item from storage layer.",
+                details={"item_preview": str(item)[:100]},
+            )
+
         if not hasattr(self, "_memory_record_cls"):
             from memanto.app.core import MemoryRecord
 
@@ -774,7 +780,10 @@ class MemoryReadService:
         # Check if metadata is in nested format (Moorcheh API spec)
         metadata = item.get("metadata", {})
         if not isinstance(metadata, dict):
-            metadata = {}
+            raise MemoryError(
+                message="Data corruption detected: Received malformed metadata from storage layer.",
+                details={"item_preview": str(item)[:100]},
+            )
 
         # Helper to get field from either nested metadata or flat structure
         def get_field(field_name, flat_field_name=None):

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -330,6 +330,11 @@ class MemoryWriteService:
                     f"in namespace {namespace}"
                 )
 
+            # Normalize legacy source values
+            source_val = updates.get("source", metadata.get("source", "system"))
+            if source_val not in {"user", "agent", "tool", "system"}:
+                source_val = "system"
+
             # Build updated memory record
             updated_memory = MemoryRecord(
                 id=memory_id,  # Keep same ID
@@ -340,7 +345,7 @@ class MemoryWriteService:
                 content=updates.get("content", existing_memory_data.get("content", "")),
                 agent_id=agent_id,
                 actor_id=updates.get("actor_id", metadata.get("actor_id", "unknown")),
-                source=updates.get("source", metadata.get("source", "system")),
+                source=source_val,
                 source_ref=updates.get("source_ref", metadata.get("source_ref")),
                 confidence=updates.get("confidence", metadata.get("confidence", 0.8)),
                 status=updates.get("status", metadata.get("status", "active")),

--- a/memanto/app/utils/rate_limiting.py
+++ b/memanto/app/utils/rate_limiting.py
@@ -50,7 +50,7 @@ class RateLimiter:
         Returns: (allowed, retry_after_seconds)
         """
         if operation not in self.limits:
-            return True, None
+            raise ValueError(f"Unknown rate limit operation: {operation}")
 
         limit = self.limits[operation]
         key = self._get_key(operation, agent_id)

--- a/memanto/app/utils/rate_limiting.py
+++ b/memanto/app/utils/rate_limiting.py
@@ -50,7 +50,13 @@ class RateLimiter:
         Returns: (allowed, retry_after_seconds)
         """
         if operation not in self.limits:
-            raise ValueError(f"Unknown rate limit operation: {operation}")
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "invalid_rate_limit_operation",
+                    "message": f"Unknown rate limit operation: {operation}",
+                },
+            )
 
         limit = self.limits[operation]
         key = self._get_key(operation, agent_id)

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -28,6 +28,7 @@ from memanto.app.constants import (
 )
 from memanto.app.constants import (
     MemoryType,
+    SourceType,
 )
 from memanto.app.constants import (
     ProvenanceType as MemoryProvenance,
@@ -601,7 +602,7 @@ class DirectClient:
         content: str,
         confidence: float = 0.8,
         tags: list[str] | None = None,
-        source: str = "user",
+        source: SourceType = "user",
         provenance: str | None = None,
     ) -> dict[str, Any]:
         """

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -769,11 +769,24 @@ class DirectClient:
             session_svc = self._get_session_service()
 
             # Extract per-memory IDs from the batch result
+            if not isinstance(result, dict):
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed batch result from storage layer.",
+                    details={"item_preview": str(result)[:100]},
+                )
+
             batch_results = result.get("results", [])
+            if not isinstance(batch_results, list):
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed batch result array from storage layer.",
+                    details={"item_preview": str(batch_results)[:100]},
+                )
 
             for i, mem in enumerate(memory_records):
                 item_result = batch_results[i] if i < len(batch_results) else None
-                if item_result is not None and not isinstance(item_result, dict):
+                if item_result is not None and (
+                    not isinstance(item_result, dict) or not item_result
+                ):
                     raise MemoryError(
                         message="Data corruption detected: Received malformed batch result from storage layer.",
                         details={"item_preview": str(item_result)[:100]},

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -35,6 +35,7 @@ from memanto.app.constants import (
 from memanto.app.utils.errors import (
     AgentNotFoundError,
     InvalidSessionTokenError,
+    MemoryError,
     SessionError,
     SessionExpiredError,
     SessionNotFoundError,
@@ -771,9 +772,14 @@ class DirectClient:
 
             for i, mem in enumerate(memory_records):
                 item_result = batch_results[i] if i < len(batch_results) else None
+                if item_result is not None and not isinstance(item_result, dict):
+                    raise MemoryError(
+                        message="Data corruption detected: Received malformed batch result from storage layer.",
+                        details={"item_preview": str(item_result)[:100]},
+                    )
                 if not is_successful_write_result(item_result):
                     continue
-                mem_id = batch_results[i].get("id")
+                mem_id = item_result.get("id") if item_result else None
                 session_svc.log_memory_to_session_summary(
                     agent_id=agent_id,
                     session_id=session_id,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -25,6 +25,7 @@ from memanto.app.constants import (
 )
 from memanto.app.constants import (
     MemoryType,
+    SourceType,
 )
 from memanto.app.constants import (
     ProvenanceType as MemoryProvenance,
@@ -430,7 +431,7 @@ class SdkClient:
         content: str,
         confidence: float = 0.8,
         tags: list[str] | None = None,
-        source: str = "user",
+        source: SourceType = "user",
         provenance: str | None = None,
     ) -> dict[str, Any]:
         """

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -32,6 +32,7 @@ from memanto.app.constants import (
 from memanto.app.utils.errors import (
     AgentNotFoundError,
     InvalidSessionTokenError,
+    MemoryError,
     SessionError,
     SessionExpiredError,
     SessionNotFoundError,
@@ -600,11 +601,14 @@ class SdkClient:
 
             for i, mem in enumerate(memory_records):
                 item_result = batch_results[i] if i < len(batch_results) else None
+                if item_result is not None and not isinstance(item_result, dict):
+                    raise MemoryError(
+                        message="Data corruption detected: Received malformed batch result from storage layer.",
+                        details={"item_preview": str(item_result)[:100]},
+                    )
                 if not is_successful_write_result(item_result):
                     continue
-                mem_id = (
-                    item_result.get("id") if isinstance(item_result, dict) else None
-                )
+                mem_id = item_result.get("id") if item_result else None
                 session_svc.log_memory_to_session_summary(
                     agent_id=agent_id,
                     session_id=session_id,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -598,11 +598,24 @@ class SdkClient:
             session_svc = self._get_session_service()
 
             # Extract per-memory IDs from the batch result
+            if not isinstance(result, dict):
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed batch result from storage layer.",
+                    details={"item_preview": str(result)[:100]},
+                )
+
             batch_results = result.get("results", [])
+            if not isinstance(batch_results, list):
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed batch result array from storage layer.",
+                    details={"item_preview": str(batch_results)[:100]},
+                )
 
             for i, mem in enumerate(memory_records):
                 item_result = batch_results[i] if i < len(batch_results) else None
-                if item_result is not None and not isinstance(item_result, dict):
+                if item_result is not None and (
+                    not isinstance(item_result, dict) or not item_result
+                ):
                     raise MemoryError(
                         message="Data corruption detected: Received malformed batch result from storage layer.",
                         details={"item_preview": str(item_result)[:100]},

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -8,10 +8,12 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import cast
 
 import typer
 from rich.panel import Panel
 
+from memanto.app.constants import SourceType
 from memanto.cli.commands._shared import (
     BOLD_PRIMARY,
     BRIGHT,
@@ -270,7 +272,7 @@ def remember(
                 content=content,
                 confidence=confidence,
                 tags=tag_list,
-                source=source,
+                source=cast(SourceType, source),
                 provenance=provenance,
             )
         elapsed = time.perf_counter() - start

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -263,6 +263,11 @@ def remember(
     # Parse tags
     tag_list = [t.strip() for t in tags.split(",")] if tags else None
 
+    if source not in {"user", "agent", "tool", "system"}:
+        _error(
+            f"Invalid source: '{source}'. Must be one of user, agent, tool, or system."
+        )
+
     try:
         with console.status("[cyan]Storing memory...", spinner="dots"):
             result = client.remember(

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -147,6 +147,12 @@ def run_migration(
 
         # batch_remember reports per-item errors in results[]; surface a few.
         for item in (result.get("results") or [])[:5]:
+            if not isinstance(item, dict):
+                from memanto.app.utils.errors import MemoryError
+                raise MemoryError(
+                    message="Data corruption detected: Received malformed batch result from storage layer during migration.",
+                    details={"item_preview": str(item)[:100]}
+                )
             err = item.get("error")
             if err:
                 summary.errors.append(f"batch {idx}: {err}")

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -149,9 +149,10 @@ def run_migration(
         for item in (result.get("results") or [])[:5]:
             if not isinstance(item, dict):
                 from memanto.app.utils.errors import MemoryError
+
                 raise MemoryError(
                     message="Data corruption detected: Received malformed batch result from storage layer during migration.",
-                    details={"item_preview": str(item)[:100]}
+                    details={"item_preview": str(item)[:100]},
                 )
             err = item.get("error")
             if err:

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -128,6 +128,8 @@ def run_migration(
     batches = list(chunked(rows, BATCH_LIMIT))
     summary.batches = len(batches)
 
+    from memanto.app.utils.errors import MemoryError
+
     for idx, batch in enumerate(batches, 1):
         if on_progress:
             on_progress(
@@ -135,21 +137,34 @@ def run_migration(
             )
         try:
             result = client.batch_remember(agent_id=agent_id, memories=batch)
-        except Exception as exc:  # noqa: BLE001 — surface any client failure
+        except MemoryError:
+            raise
+        except Exception as exc:
             summary.failed += len(batch)
             summary.errors.append(f"batch {idx}: {exc}")
             continue
+
+        if not isinstance(result, dict):
+            raise MemoryError(
+                message="Data corruption detected: Received malformed batch response envelope during migration.",
+                details={"result_preview": str(result)[:100]},
+            )
+
+        batch_results = result.get("results")
+        if not isinstance(batch_results, list):
+            raise MemoryError(
+                message="Data corruption detected: Received malformed batch result array during migration.",
+                details={"results_preview": str(batch_results)[:100]},
+            )
 
         successful = int(result.get("successful") or 0)
         failed = int(result.get("failed") or 0)
         summary.imported += successful
         summary.failed += failed
 
-        # batch_remember reports per-item errors in results[]; surface a few.
-        for item in (result.get("results") or [])[:5]:
-            if not isinstance(item, dict):
-                from memanto.app.utils.errors import MemoryError
-
+        # batch_remember reports per-item errors in results[]; surface all errors.
+        for item in batch_results:
+            if not isinstance(item, dict) or not item:
                 raise MemoryError(
                     message="Data corruption detected: Received malformed batch result from storage layer during migration.",
                     details={"item_preview": str(item)[:100]},

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -2916,9 +2916,12 @@
             "anyOf": [
               {
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "maxLength": 64,
+                  "minLength": 1
                 },
-                "type": "array"
+                "type": "array",
+                "maxItems": 20
               },
               {
                 "type": "null"
@@ -2929,6 +2932,12 @@
           },
           "source": {
             "type": "string",
+            "enum": [
+              "user",
+              "agent",
+              "tool",
+              "system"
+            ],
             "title": "Source",
             "description": "Source of memory",
             "default": "agent"
@@ -3344,7 +3353,22 @@
           "type": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "fact",
+                  "preference",
+                  "goal",
+                  "decision",
+                  "artifact",
+                  "learning",
+                  "event",
+                  "instruction",
+                  "relationship",
+                  "context",
+                  "observation",
+                  "commitment",
+                  "error"
+                ]
               },
               {
                 "type": "null"
@@ -3369,9 +3393,12 @@
             "anyOf": [
               {
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "maxLength": 64,
+                  "minLength": 1
                 },
-                "type": "array"
+                "type": "array",
+                "maxItems": 20
               },
               {
                 "type": "null"
@@ -3382,7 +3409,9 @@
           "source": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 128,
+                "minLength": 1
               },
               {
                 "type": "null"
@@ -3977,9 +4006,12 @@
             "anyOf": [
               {
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "maxLength": 64,
+                  "minLength": 1
                 },
-                "type": "array"
+                "type": "array",
+                "maxItems": 20
               },
               {
                 "type": "null"
@@ -3990,6 +4022,12 @@
           },
           "source": {
             "type": "string",
+            "enum": [
+              "user",
+              "agent",
+              "tool",
+              "system"
+            ],
             "title": "Source",
             "description": "Source of memory",
             "default": "agent"

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -3410,8 +3410,12 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 128,
-                "minLength": 1
+                "enum": [
+                  "user",
+                  "agent",
+                  "tool",
+                  "system"
+                ]
               },
               {
                 "type": "null"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1026,6 +1026,34 @@ class TestMEMANTOAPI:
         mock_moorcheh.documents.upload.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_remember_rejects_oversized_metadata_labels(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Tags/source metadata should be bounded before expanding upload text."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers=headers,
+            json={
+                "content": "Small content should not hide oversized tags",
+                "tags": ["x" * 65],
+            },
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_global_status_no_active_session(self, client, auth_headers):
         """Test GET /api/v2/status returns 404 when no session is active"""
         response = await client.get("/api/v2/status", headers=auth_headers)
@@ -1112,6 +1140,38 @@ class TestMEMANTOAPI:
                         "content": "Invalid provenance should not be batched",
                         "type": "fact",
                         "provenance": "guessed",
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 422
+        mock_moorcheh.documents.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_batch_remember_rejects_too_many_tags(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Batch writes should reject unbounded tag metadata before upload."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        headers = {**auth_headers, "X-Session-Token": token}
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/batch-remember",
+            headers=headers,
+            json={
+                "memories": [
+                    {
+                        "content": "Batch item with too many tags",
+                        "tags": [f"tag-{index}" for index in range(21)],
                     }
                 ]
             },

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -63,7 +63,7 @@ def test_extract_conversation_memories_normalizes_candidates():
             "title": "Editor preference",
             "content": "The user prefers concise pull request summaries.",
             "confidence": 0.91,
-            "source": "conversation",
+            "source": "system",
             "provenance": "inferred",
         },
         {
@@ -71,7 +71,7 @@ def test_extract_conversation_memories_normalizes_candidates():
             "title": "Fallback type",
             "content": "The project uses pytest for unit tests.",
             "confidence": 1.0,
-            "source": "conversation",
+            "source": "system",
             "provenance": "inferred",
         },
     ]

--- a/tests/test_memory_format.py
+++ b/tests/test_memory_format.py
@@ -25,7 +25,7 @@ def test_content_with_newlines_and_tags_preserves_content_integrity():
         content="This is paragraph one.\n\nThis is paragraph two.",
         agent_id="test-agent",
         actor_id="user",
-        source="test",
+        source="system",
         tags=["important", "test"],
     )
 
@@ -54,7 +54,7 @@ def test_content_without_newlines_is_unchanged():
         content="Single line content.",
         agent_id="test-agent",
         actor_id="user",
-        source="test",
+        source="system",
         tags=["tag1"],
     )
 
@@ -75,7 +75,7 @@ def test_content_with_multiple_newlines_and_no_tags():
         content="Para one.\n\nPara two.\n\nPara three.",
         agent_id="test-agent",
         actor_id="user",
-        source="test",
+        source="system",
     )
 
     document = memory.to_moorcheh_document()
@@ -118,7 +118,7 @@ def test_memory_with_tags_in_middle_paragraph_does_not_leak():
         content="Use the #Tags: feature for organization.\n\nThis is fine.",
         agent_id="test-agent",
         actor_id="user",
-        source="test",
+        source="system",
         tags=["label"],
     )
 
@@ -140,7 +140,7 @@ def test_content_only_tag_line_not_confused_with_tags_suffix():
         content="Tags: this is not a tag line\n\nActual second paragraph.",
         agent_id="test-agent",
         actor_id="user",
-        source="test",
+        source="system",
         tags=["foo"],
     )
 
@@ -168,7 +168,7 @@ def test_content_with_tags_line_but_no_metadata_tags_is_not_stripped():
         content="First paragraph.\n\nTags: this is not actually tag metadata",
         agent_id="test-agent",
         actor_id="user",
-        source="test",
+        source="system",
         tags=[],  # No tags stored — "Tags: ..." is content, not metadata
     )
 
@@ -200,7 +200,7 @@ def test_content_with_tags_line_and_real_tags_keeps_content_intact():
         content="Tags: this is inline in the content\n\nMore content here.",
         agent_id="test-agent",
         actor_id="user",
-        source="test",
+        source="system",
         tags=["real-tag"],
     )
 

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -12,7 +12,7 @@ def make_memory(content: str, memory_type: MemoryType | None = None) -> MemoryRe
         type=memory_type or "fact",
         title="test",
         actor_id="user",
-        source="test",
+        source="system",
         agent_id="test",
     )
     if memory_type is None:

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -190,3 +190,23 @@ def test_fuzzy_fallback_does_not_fire_on_unrelated_text():
     parser.parse_memory(memory)
 
     assert memory.type == "fact"
+
+
+def test_ambiguity_guard_and_fuzzy_fallback_interactions():
+    parser = MemoryParsingService()
+
+    cases = {
+        # "is" should no longer bypass the fuzzy fallback for typos
+        "The project uses Django and it is maintained, and we decded on Postgres": "decision",
+        # Strong fact patterns should still classify as fact
+        "The API endpoint is called /v1/search and it was enabled last week": "fact",
+        # Bare auxiliary alone falls back correctly to decision due to fuzzy matching
+        "It is nice and we decded on the new plan": "decision",
+        # High confidence fact patterns are unaffected
+        "The database port is 5432": "fact",
+    }
+
+    for content, expected_type in cases.items():
+        memory = make_memory(content)
+        parser.parse_memory(memory)
+        assert memory.type == expected_type

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -432,7 +432,7 @@ class TestMemoryWriteServiceDelete:
             "scope_type": "agent",
             "scope_id": "test-agent",
             "actor_id": "tester",
-            "source": "manual",
+            "source": "system",
             "confidence": 0.8,
             "status": "active",
             "tags": [],
@@ -837,7 +837,7 @@ class TestMemoryWriteServiceTimestamps:
             content="Original imported memory",
             agent_id="test-agent",
             actor_id="test-agent",
-            source="mem0",
+            source="system",
             provenance="imported",
             created_at=source_created,
         )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1129,6 +1129,22 @@ class TestValidateSafeId:
 
         assert not (tmp_path / "etc").exists()
 
+def test_memory_edit_rejects_oversized_source():
+    from pydantic import ValidationError
+
+    from memanto.app.routes.memory import MemoryEditRequest
+
+    with pytest.raises(ValidationError):
+        MemoryEditRequest(source="x" * 129)
+
+
+def test_memory_edit_strips_valid_tags():
+    from memanto.app.routes.memory import MemoryEditRequest
+
+    request = MemoryEditRequest(tags=[" project ", "important"])
+
+    assert request.tags == ["project", "important"]
+
 
 def test_format_memory_item_tag_stripping():
     from unittest.mock import MagicMock

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1129,6 +1129,7 @@ class TestValidateSafeId:
 
         assert not (tmp_path / "etc").exists()
 
+
 def test_memory_edit_rejects_oversized_source():
     from pydantic import ValidationError
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -487,6 +487,36 @@ class TestMemoryWriteServiceDelete:
         assert uploaded.get("original_id") == "orig-123"
         assert "validation_count" not in uploaded
 
+    def test_update_memory_normalizes_legacy_source_values(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "queued"}
+        existing_memory = {
+            "id": "mem-1",
+            "type": "fact",
+            "title": "Title",
+            "content": "Content",
+            "actor_id": "tester",
+            "source": "manual",  # legacy value
+            "confidence": 0.8,
+            "status": "active",
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            MemoryWriteService(client).update_memory(
+                "mem-1",
+                "memanto_agent_test",
+                {"title": "New title"},
+            )
+
+        uploaded = client.documents.upload.call_args.kwargs["documents"][0]
+        # Should normalize 'manual' (invalid SourceType) to 'system'
+        assert uploaded.get("source") == "system"
+
 
 class TestMemoryReadServiceFormatting:
     def test_format_memory_item_preserves_falsey_metadata_values(self):
@@ -543,14 +573,14 @@ class TestMemoryWriteServiceBatch:
                 content="Alex prefers concise status updates.",
                 agent_id="agent-1",
                 actor_id="user-1",
-                source="test",
+                source="system",
             ),
             MemoryRecord(
                 title="Second preference",
                 content="Alex prefers weekly summaries.",
                 agent_id="agent-1",
                 actor_id="user-1",
-                source="test",
+                source="system",
             ),
         ]
 
@@ -572,7 +602,7 @@ class TestMemoryWriteServiceBatch:
                 content="This write should be counted as failed.",
                 agent_id="agent-1",
                 actor_id="user-1",
-                source="test",
+                source="system",
             )
         ]
 
@@ -1175,7 +1205,7 @@ def test_to_moorcheh_document_handles_string_expires_at():
         content="Expires at is a string",
         agent_id="test-agent",
         actor_id="user",
-        source="test",
+        source="system",
     )
     memory.expires_at = "2026-07-10T00:00:00"
 


### PR DESCRIPTION
- Enforce fail-fast for malformed storage responses during read #1293
- Enforce fail-fast for malformed storage responses during migration #1295
- Enforce fail-fast malformed item result for MCP batch_remember #1316
- Common auxiliary verbs (is/are/was/were) used for type matching #1377 
- Enforce memory type schema validation on writes #1394
- Bound memory metadata labels before storage #1430
- Enforce strict SourceType validation and fail-closed rate limit #1450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strengthened validation for `source`, `source_ref`, and `tags` with bounded/typed constraints across the API, SDK, and OpenAPI (including length/count limits).
* **Bug Fixes**
  * Hardened batch and read/edit flows to detect malformed/corrupted storage payloads and fail fast with structured `MemoryError`.
  * Improved batch-item handling and normalized legacy `source="manual"` to `system`.
  * Refined memory extraction/labeling and updated strong-fact classification.
  * Unknown rate-limit operations now return a client error.
* **Tests**
  * Added/updated API, unit, parsing, extraction, migration, and formatting tests for validation limits, normalization, and corruption scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->