### PR TITLE
feat(examples): add ChatGPT export → OKF migration adapter (#1609)

### DIFF
--- a/examples/migrations/chatgpt/chatgpt_to_okf.py
+++ b/examples/migrations/chatgpt/chatgpt_to_okf.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""
+ChatGPT data export -> OKF bundle adapter.
+
+Liberates the durable memory ChatGPT has built about you — the entries it
+saves through its ``bio`` tool ("Model set context") plus your custom
+instructions — from an official ChatGPT data export, and rewrites it as an
+OKF (Open Knowledge Format) bundle that the shipped Memanto CLI imports
+directly:
+
+    python3 chatgpt_to_okf.py ./chatgpt-export.zip -o ./okf-bundle
+    memanto migrate okf ./okf-bundle --dry-run
+    memanto migrate okf ./okf-bundle
+
+The adapter deliberately *feeds* the existing ``memanto migrate okf``
+pipeline instead of re-implementing any of it: it only performs the
+source-specific work (parsing the export, deduplicating memory writes,
+inferring a memory type) and emits standard OKF markdown documents whose
+frontmatter fields — ``type``, ``title``, ``description``, ``resource``,
+``tags``, ``timestamp``, ``x_memanto`` — are exactly the ones
+``memanto.cli.migrate.okf_loader`` understands. Unknown frontmatter keys
+(the source conversation title) ride along losslessly as OKF "extra"
+fields and end up in the imported memory's ``[Supporting data]`` footer.
+
+Sources extracted from ``conversations.json``:
+
+1. **bio tool writes** — assistant messages with ``recipient == "bio"``.
+   These are the moments ChatGPT decided something about you was worth
+   remembering permanently.
+2. **model_set_context snapshots** — ``model_editable_context`` messages
+   that replay the accumulated memory list into a conversation. Parsed as
+   numbered entries (``1. [2026-01-15]. …``) and deduplicated against the
+   bio writes, so snapshot + deltas never double-import.
+3. **custom instructions** — ``user_context_message_data`` blocks
+   (about-user / about-model), deduplicated across conversations.
+
+Account PII from ``user.json`` (email, phone, ids) is intentionally
+**never** ingested.
+
+Stdlib only — no dependencies beyond Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Keep in sync with memanto.app.services.okf_export_service.ENTRY_DELIMITER —
+# the sentinel the Memanto OKF loader uses to split stacked documents.
+ENTRY_DELIMITER = "<!-- okf-entry -->"
+
+# Matches memanto.app.services.okf_export_service.DEFAULT_SPLIT_THRESHOLD:
+# in `auto` split mode a type with more memories than this collapses into a
+# single stacked file instead of one file per memory.
+DEFAULT_SPLIT_THRESHOLD = 50
+
+TITLE_MAX_CHARS = 80
+DESCRIPTION_MAX_CHARS = 200
+SLUG_MAX_CHARS = 60
+
+# Confidence assigned to imported rows — mirrors the 0.8 the built-in
+# provider mappers use for migrated memories.
+IMPORT_CONFIDENCE = 0.8
+
+# ``model_set_context`` snapshots list entries as "1. [2026-01-15]. Text" —
+# the bracketed date is optional and sometimes absent.
+_SNAPSHOT_ENTRY_RE = re.compile(
+    r"^\s*\d+\.\s*(?:\[(?P<date>\d{4}-\d{2}-\d{2})\]\.?\s*)?(?P<text>\S.*)$"
+)
+
+# Ordered, first-match-wins keyword heuristics mapping a memory sentence to
+# one of Memanto's fixed memory types. ``memanto migrate okf`` coerces the
+# OKF ``type`` onto the matching Memanto type, so these names must stay
+# within memanto.app.constants.VALID_MEMORY_TYPES.
+_TYPE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "preference",
+        (
+            "prefers",
+            "prefer ",
+            "likes",
+            "dislikes",
+            "favorite",
+            "favourite",
+            "enjoys",
+            "loves",
+            "hates",
+            "would rather",
+        ),
+    ),
+    (
+        "goal",
+        (
+            "wants to",
+            "plans to",
+            "is planning",
+            "is training for",
+            "aims to",
+            "goal is",
+            "hopes to",
+            "is working toward",
+            "is saving for",
+        ),
+    ),
+    (
+        "commitment",
+        (
+            "will ",
+            "has committed",
+            "promised",
+            "deadline",
+            "is due",
+            "scheduled for",
+            "signed up for",
+        ),
+    ),
+    (
+        "relationship",
+        (
+            "partner",
+            "wife",
+            "husband",
+            "girlfriend",
+            "boyfriend",
+            "daughter",
+            "son",
+            "mother",
+            "father",
+            "sister",
+            "brother",
+            "friend",
+            "coworker",
+            "colleague",
+            "their dog",
+            "their cat",
+            "named",
+        ),
+    ),
+    (
+        "decision",
+        ("decided to", "has decided", "chose to", "switched to", "opted for"),
+    ),
+    (
+        "event",
+        ("attended", "visited", "traveled to", "travelled to", "went to", "moved to"),
+    ),
+)
+
+
+# Dedup fidelity ranking: an original bio write beats a replayed snapshot
+# entry, which beats a custom-instruction block, regardless of timestamp.
+_KIND_PRECEDENCE = {"custom_instructions": 0, "model_set_context": 1, "bio": 2}
+
+
+@dataclass(frozen=True)
+class ExtractedMemory:
+    """One deduplicated memory liberated from the export."""
+
+    text: str
+    kind: str  # "bio" | "model_set_context" | "custom_instructions"
+    memory_type: str
+    created_at: str | None  # ISO 8601 UTC
+    conversation_id: str | None
+    conversation_title: str | None
+    message_id: str | None
+
+
+@dataclass
+class ExtractionStats:
+    """What the adapter saw while scanning the export."""
+
+    conversations: int = 0
+    bio_writes: int = 0
+    snapshot_entries: int = 0
+    custom_instruction_blocks: int = 0
+    duplicates_skipped: int = 0
+    type_counts: Counter[str] = field(default_factory=Counter)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "conversations_scanned": self.conversations,
+            "bio_writes_found": self.bio_writes,
+            "model_set_context_entries_found": self.snapshot_entries,
+            "custom_instruction_blocks_found": self.custom_instruction_blocks,
+            "duplicates_skipped": self.duplicates_skipped,
+            "memories_by_type": dict(sorted(self.type_counts.items())),
+            "total_memories": sum(self.type_counts.values()),
+        }
+
+
+# --------------------------------------------------------------------------
+# Export loading
+# --------------------------------------------------------------------------
+
+
+def load_conversations(source: Path) -> list[dict[str, Any]]:
+    """Load ``conversations.json`` from an export zip, directory, or file."""
+    if not source.exists():
+        raise FileNotFoundError(f"ChatGPT export not found: {source}")
+
+    if source.is_file() and source.suffix.lower() == ".zip":
+        with zipfile.ZipFile(source) as archive:
+            for name in archive.namelist():
+                if Path(name).name == "conversations.json":
+                    raw = archive.read(name).decode("utf-8")
+                    return _coerce_conversations(json.loads(raw), name)
+        raise ValueError(f"No conversations.json found inside {source}")
+
+    if source.is_file():
+        return _coerce_conversations(
+            json.loads(source.read_text(encoding="utf-8")), str(source)
+        )
+
+    candidate = source / "conversations.json"
+    if not candidate.exists():
+        raise FileNotFoundError(
+            f"{source} does not contain conversations.json — "
+            "point at the export zip, its extracted folder, or the file itself."
+        )
+    return _coerce_conversations(
+        json.loads(candidate.read_text(encoding="utf-8")), str(candidate)
+    )
+
+
+def _coerce_conversations(data: Any, origin: str) -> list[dict[str, Any]]:
+    if isinstance(data, list):
+        return [c for c in data if isinstance(c, dict)]
+    raise ValueError(
+        f"{origin} is not a ChatGPT conversations.json (expected a JSON array)"
+    )
+
+
+# --------------------------------------------------------------------------
+# Memory extraction
+# --------------------------------------------------------------------------
+
+
+def extract_memories(
+    conversations: list[dict[str, Any]],
+    *,
+    include_custom_instructions: bool = True,
+) -> tuple[list[ExtractedMemory], ExtractionStats]:
+    """Walk every conversation and pull out deduplicated durable memories."""
+    stats = ExtractionStats()
+    seen: dict[str, int] = {}  # normalized text -> index into memories
+    memories: list[ExtractedMemory] = []
+
+    def add(memory: ExtractedMemory) -> None:
+        key = _normalize(memory.text)
+        if not key:
+            return
+        existing_idx = seen.get(key)
+        if existing_idx is not None:
+            stats.duplicates_skipped += 1
+            existing = memories[existing_idx]
+            # Original bio writes carry exact timestamps and the conversation
+            # where ChatGPT learned the fact; snapshot replays are day-granular
+            # echoes. Prefer higher-fidelity kinds; within the same kind keep
+            # the earliest sighting (when the fact was first learned).
+            if _KIND_PRECEDENCE[memory.kind] > _KIND_PRECEDENCE[existing.kind] or (
+                memory.kind == existing.kind
+                and _is_earlier(memory.created_at, existing.created_at)
+            ):
+                memories[existing_idx] = memory
+            return
+        seen[key] = len(memories)
+        memories.append(memory)
+        stats.type_counts[memory.memory_type] += 1
+
+    for conv in conversations:
+        stats.conversations += 1
+        conv_id = conv.get("conversation_id") or conv.get("id")
+        conv_title = conv.get("title")
+        mapping = conv.get("mapping") or {}
+        if not isinstance(mapping, dict):
+            continue
+
+        for node in mapping.values():
+            message = (node or {}).get("message")
+            if not isinstance(message, dict):
+                continue
+
+            for memory in _memories_from_message(
+                message,
+                conv_id=str(conv_id) if conv_id else None,
+                conv_title=str(conv_title) if conv_title else None,
+                include_custom_instructions=include_custom_instructions,
+                stats=stats,
+            ):
+                add(memory)
+
+    memories.sort(key=lambda m: (m.created_at or "9999", m.text))
+    return memories, stats
+
+
+def _memories_from_message(
+    message: dict[str, Any],
+    *,
+    conv_id: str | None,
+    conv_title: str | None,
+    include_custom_instructions: bool,
+    stats: ExtractionStats,
+) -> list[ExtractedMemory]:
+    author = message.get("author") or {}
+    role = author.get("role")
+    content = message.get("content") or {}
+    created_at = _iso_from_unix(message.get("create_time"))
+    message_id = str(message.get("id")) if message.get("id") else None
+
+    # 1. The assistant writing to its bio tool — a deliberate "remember this".
+    if role == "assistant" and message.get("recipient") == "bio":
+        text = _text_from_content(content)
+        if text:
+            stats.bio_writes += 1
+            return [
+                ExtractedMemory(
+                    text=text,
+                    kind="bio",
+                    memory_type=infer_memory_type(text),
+                    created_at=created_at,
+                    conversation_id=conv_id,
+                    conversation_title=conv_title,
+                    message_id=message_id,
+                )
+            ]
+        return []
+
+    # 2. A replayed model_set_context snapshot — the accumulated memory list.
+    if content.get("content_type") == "model_editable_context":
+        snapshot = content.get("model_set_context")
+        results: list[ExtractedMemory] = []
+        for entry_date, entry_text in _parse_snapshot(snapshot):
+            stats.snapshot_entries += 1
+            results.append(
+                ExtractedMemory(
+                    text=entry_text,
+                    kind="model_set_context",
+                    memory_type=infer_memory_type(entry_text),
+                    created_at=entry_date or created_at,
+                    conversation_id=conv_id,
+                    conversation_title=conv_title,
+                    message_id=message_id,
+                )
+            )
+        return results
+
+    # 3. Custom instructions embedded as user context metadata.
+    if include_custom_instructions:
+        metadata = message.get("metadata") or {}
+        context_data = metadata.get("user_context_message_data")
+        if isinstance(context_data, dict):
+            results = []
+            for key in ("about_user_message", "about_model_message"):
+                text = (context_data.get(key) or "").strip()
+                if not text:
+                    continue
+                stats.custom_instruction_blocks += 1
+                label = (
+                    "About the user"
+                    if key == "about_user_message"
+                    else "How the user wants responses"
+                )
+                results.append(
+                    ExtractedMemory(
+                        text=f"{label} (custom instructions): {text}",
+                        kind="custom_instructions",
+                        memory_type="instruction",
+                        created_at=created_at,
+                        conversation_id=conv_id,
+                        conversation_title=conv_title,
+                        message_id=message_id,
+                    )
+                )
+            return results
+
+    return []
+
+
+def _parse_snapshot(snapshot: Any) -> list[tuple[str | None, str]]:
+    """Parse a ``model_set_context`` blob into ``(iso_date, text)`` entries."""
+    if not isinstance(snapshot, str) or not snapshot.strip():
+        return []
+    entries: list[tuple[str | None, str]] = []
+    for line in snapshot.splitlines():
+        match = _SNAPSHOT_ENTRY_RE.match(line)
+        if not match:
+            continue
+        text = match.group("text").strip()
+        if not text:
+            continue
+        date = match.group("date")
+        entries.append((f"{date}T00:00:00+00:00" if date else None, text))
+    return entries
+
+
+def _text_from_content(content: dict[str, Any]) -> str:
+    parts = content.get("parts") or []
+    texts = [p.strip() for p in parts if isinstance(p, str) and p.strip()]
+    return "\n".join(texts).strip()
+
+
+def infer_memory_type(text: str) -> str:
+    """Best-effort mapping of a memory sentence onto a Memanto memory type.
+
+    Falls back to ``fact`` — bio writes are, by construction, statements
+    ChatGPT considered durably true about the user.
+    """
+    lowered = f" {text.lower()} "
+    for memory_type, keywords in _TYPE_RULES:
+        if any(keyword in lowered for keyword in keywords):
+            return memory_type
+    return "fact"
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().casefold().rstrip(".")
+
+
+def _iso_from_unix(value: Any) -> str | None:
+    if not isinstance(value, (int, float)) or value <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _is_earlier(candidate: str | None, current: str | None) -> bool:
+    if candidate is None:
+        return False
+    if current is None:
+        return True
+    return candidate < current
+
+
+# --------------------------------------------------------------------------
+# OKF bundle writing
+# --------------------------------------------------------------------------
+
+
+def write_okf_bundle(
+    memories: list[ExtractedMemory],
+    output_dir: Path,
+    *,
+    split: str = "auto",
+    threshold: int = DEFAULT_SPLIT_THRESHOLD,
+) -> dict[str, int]:
+    """Write memories as an OKF bundle under ``output_dir``.
+
+    Layout mirrors Memanto's own OKF exports so the bundle feels native::
+
+        <output_dir>/
+          index.md
+          memories/
+            index.md
+            <type>/
+              index.md
+              <slug>.md            (or a stacked <type>.md when large)
+
+    Returns per-type counts.
+    """
+    if split not in ("auto", "file", "type"):
+        raise ValueError("split must be one of: auto, file, type")
+
+    by_type: dict[str, list[ExtractedMemory]] = {}
+    for memory in memories:
+        by_type.setdefault(memory.memory_type, []).append(memory)
+
+    memories_dir = output_dir / "memories"
+    type_links: list[tuple[str, str]] = []
+
+    for memory_type in sorted(by_type):
+        group = by_type[memory_type]
+        type_dir = memories_dir / memory_type
+        type_dir.mkdir(parents=True, exist_ok=True)
+
+        use_stacked = split == "type" or (split == "auto" and len(group) > threshold)
+        if use_stacked:
+            docs = [_render_okf_doc(m) for m in group]
+            stacked = f"\n{ENTRY_DELIMITER}\n".join(docs)
+            (type_dir / f"{memory_type}.md").write_text(stacked, encoding="utf-8")
+            doc_links = [(_title_from(m.text), f"{memory_type}.md") for m in group]
+        else:
+            used_slugs: set[str] = set()
+            doc_links = []
+            for memory in group:
+                slug = _unique_slug(_title_from(memory.text), used_slugs)
+                (type_dir / f"{slug}.md").write_text(
+                    _render_okf_doc(memory), encoding="utf-8"
+                )
+                doc_links.append((_title_from(memory.text), f"{slug}.md"))
+
+        _write_index(type_dir, memory_type, f"{memory_type} ({len(group)})", doc_links)
+        type_links.append((memory_type, f"{memory_type}/index.md"))
+
+    total = len(memories)
+    if type_links:
+        memories_dir.mkdir(parents=True, exist_ok=True)
+        _write_index(memories_dir, "memories", f"Memories ({total})", type_links)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_root_index(output_dir, total, sorted(by_type))
+    return {memory_type: len(group) for memory_type, group in by_type.items()}
+
+
+def _render_okf_doc(memory: ExtractedMemory) -> str:
+    """Render one memory as an OKF markdown document.
+
+    Frontmatter is emitted by hand (stdlib only, no PyYAML). All values are
+    JSON-quoted strings, which is valid YAML 1.1 scalar syntax and survives
+    any content ChatGPT can produce.
+    """
+    lines = ["---"]
+    lines.append(f"type: {memory.memory_type}")
+    lines.append(f"title: {_yaml_str(_title_from(memory.text))}")
+    description = memory.text.strip().splitlines()[0][:DESCRIPTION_MAX_CHARS]
+    lines.append(f"description: {_yaml_str(description)}")
+    lines.append("tags:")
+    lines.append("- chatgpt")
+    lines.append(f"- {memory.kind.replace('_', '-')}")
+    if memory.created_at:
+        lines.append(f"timestamp: {_yaml_str(memory.created_at)}")
+    resource = _resource_ref(memory)
+    if resource:
+        lines.append(f"resource: {_yaml_str(resource)}")
+    if memory.conversation_title:
+        # Not an OKF baseline field: the Memanto loader preserves it as an
+        # "extra" and surfaces it in the [Supporting data] footer on import.
+        lines.append(f"conversation: {_yaml_str(memory.conversation_title)}")
+    lines.append("x_memanto:")
+    lines.append("  source: chatgpt")
+    lines.append(f"  type: {memory.memory_type}")
+    lines.append(f"  confidence: {IMPORT_CONFIDENCE}")
+    lines.append("---")
+    lines.append("")
+    lines.append(memory.text.strip())
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _resource_ref(memory: ExtractedMemory) -> str | None:
+    if memory.conversation_id and memory.message_id:
+        return f"chatgpt:{memory.conversation_id}:{memory.message_id}"
+    if memory.conversation_id:
+        return f"chatgpt:{memory.conversation_id}"
+    return None
+
+
+def _yaml_str(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _title_from(text: str) -> str:
+    flat = " ".join(text.split())
+    if len(flat) <= TITLE_MAX_CHARS:
+        return flat
+    return flat[: TITLE_MAX_CHARS - 3].rstrip() + "..."
+
+
+def _slugify(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower())
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug[:SLUG_MAX_CHARS].rstrip("-") or "memory"
+
+
+def _unique_slug(title: str, used: set[str]) -> str:
+    base = _slugify(title)
+    slug = base
+    counter = 2
+    while slug in used:
+        slug = f"{base}-{counter}"
+        counter += 1
+    used.add(slug)
+    return slug
+
+
+def _write_index(
+    directory: Path, title: str, heading: str, links: list[tuple[str, str]]
+) -> None:
+    """Write a navigational ``index.md`` (type: index — skipped on import)."""
+    lines = [
+        "---",
+        "type: index",
+        f"title: {_yaml_str(title)}",
+        "---",
+        "",
+        f"# {heading}",
+        "",
+    ]
+    seen_links: set[tuple[str, str]] = set()
+    for text, target in links:
+        if (text, target) in seen_links:
+            continue
+        seen_links.add((text, target))
+        lines.append(f"- [{text}]({target})")
+    lines.append("")
+    (directory / "index.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_root_index(base: Path, total: int, types: list[str]) -> None:
+    lines = [
+        "---",
+        "type: index",
+        "title: ChatGPT liberated memory",
+        "---",
+        "",
+        "# ChatGPT -> OKF memory bundle",
+        "",
+        f"> {total} memories liberated from a ChatGPT data export.",
+        "> Import with: `memanto migrate okf <this-directory>`",
+        "",
+        "- [memories](memories/index.md) — "
+        + f"{total} memories across {len(types)} type(s)",
+        "",
+    ]
+    (base / "index.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert a ChatGPT data export into an OKF bundle for "
+            "`memanto migrate okf`."
+        )
+    )
+    parser.add_argument(
+        "source",
+        type=Path,
+        help="ChatGPT export zip, extracted folder, or conversations.json",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("./okf-bundle"),
+        help="Output OKF bundle directory (default: ./okf-bundle)",
+    )
+    parser.add_argument(
+        "--split",
+        choices=("auto", "file", "type"),
+        default="auto",
+        help="Bundle layout: one file per memory, stacked per type, or auto",
+    )
+    parser.add_argument(
+        "--no-custom-instructions",
+        action="store_true",
+        help="Skip custom-instruction blocks (bio memories only)",
+    )
+    args = parser.parse_args(argv)
+
+    conversations = load_conversations(args.source)
+    memories, stats = extract_memories(
+        conversations,
+        include_custom_instructions=not args.no_custom_instructions,
+    )
+
+    if not memories:
+        print(
+            "No durable memories found in this export. "
+            "(Does the account have ChatGPT Memory enabled?)",
+            file=sys.stderr,
+        )
+        return 1
+
+    per_type = write_okf_bundle(memories, args.output, split=args.split)
+
+    summary = {
+        "source": str(args.source),
+        "output_bundle": str(args.output),
+        **stats.as_dict(),
+    }
+    summary_path = args.output / "migration_summary.json"
+    summary_path.write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    print("ChatGPT -> OKF extraction complete")
+    print(f"  Conversations scanned:      {stats.conversations}")
+    print(f"  bio writes found:           {stats.bio_writes}")
+    print(f"  snapshot entries found:     {stats.snapshot_entries}")
+    print(f"  custom instruction blocks:  {stats.custom_instruction_blocks}")
+    print(f"  duplicates collapsed:       {stats.duplicates_skipped}")
+    print(f"  unique memories written:    {len(memories)}")
+    type_breakdown = ", ".join(f"{t}: {n}" for t, n in sorted(per_type.items()))
+    print(f"  type breakdown:             {type_breakdown}")
+    print(f"  bundle:                     {args.output}")
+    print(f"  summary:                    {summary_path}")
+    print()
+    print("Next: preview the import (no API key needed):")
+    print(f"  memanto migrate okf {args.output} --dry-run")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/examples/migrations/chatgpt/make_sample_export.py
+++ b/examples/migrations/chatgpt/make_sample_export.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""
+Deterministic sample ChatGPT data export generator.
+
+Builds ``sample_data/chatgpt-export-sample/`` — a synthetic but
+schema-faithful ChatGPT data export for demoing and testing the adapter
+without anyone's real conversations. The shapes mirror a genuine export:
+
+- ``conversations.json``: array of conversations with ``mapping`` node
+  graphs, assistant->``bio`` memory writes, tool acknowledgements
+  ("Model set context updated."), a ``model_editable_context`` snapshot
+  replaying the accumulated memory list, and custom-instruction
+  ``user_context_message_data`` metadata repeated across conversations.
+- ``user.json``: placeholder account stub (the adapter never ingests it).
+
+The story is a lived-in account: eight months of a firmware engineer's
+assistant learning preferences, goals, relationships — including a
+correction (moved cities) and a changed preference (coffee order), so the
+migrated memory demonstrably carries *evolution*, not just facts.
+
+Run from this directory:
+
+    python3 make_sample_export.py
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+OUT_DIR = Path(__file__).parent / "sample_data" / "chatgpt-export-sample"
+
+
+def _ts(iso: str) -> float:
+    """ISO date string -> unix timestamp (UTC), like real exports use."""
+    return datetime.fromisoformat(iso).replace(tzinfo=timezone.utc).timestamp()
+
+
+_CUSTOM_INSTRUCTIONS = {
+    "about_user_message": (
+        "I'm a firmware engineer. I work mostly in C and Rust on embedded "
+        "sensor platforms. Keep examples small and hardware-realistic."
+    ),
+    "about_model_message": (
+        "Be concise. Prefer code over prose. Flag unsafe memory patterns."
+    ),
+}
+
+
+def _msg(
+    msg_id: str,
+    role: str,
+    text: str,
+    created: str,
+    *,
+    recipient: str = "all",
+    name: str | None = None,
+    metadata: dict | None = None,
+) -> dict:
+    return {
+        "id": msg_id,
+        "author": {"role": role, "name": name, "metadata": {}},
+        "create_time": _ts(created),
+        "update_time": None,
+        "content": {"content_type": "text", "parts": [text]},
+        "status": "finished_successfully",
+        "end_turn": True,
+        "weight": 1.0,
+        "metadata": metadata or {},
+        "recipient": recipient,
+    }
+
+
+def _snapshot_msg(msg_id: str, snapshot: str, created: str) -> dict:
+    return {
+        "id": msg_id,
+        "author": {"role": "system", "name": None, "metadata": {}},
+        "create_time": _ts(created),
+        "update_time": None,
+        "content": {
+            "content_type": "model_editable_context",
+            "model_set_context": snapshot,
+            "repository": None,
+            "repo_summary": None,
+        },
+        "status": "finished_successfully",
+        "end_turn": None,
+        "weight": 1.0,
+        "metadata": {},
+        "recipient": "all",
+    }
+
+
+def _conversation(conv_id: str, title: str, created: str, messages: list[dict]) -> dict:
+    mapping: dict[str, dict] = {
+        "root": {"id": "root", "message": None, "parent": None, "children": []}
+    }
+    parent = "root"
+    for message in messages:
+        node_id = f"node-{message['id']}"
+        mapping[parent]["children"].append(node_id)
+        mapping[node_id] = {
+            "id": node_id,
+            "message": message,
+            "parent": parent,
+            "children": [],
+        }
+        parent = node_id
+    return {
+        "id": conv_id,
+        "conversation_id": conv_id,
+        "title": title,
+        "create_time": _ts(created),
+        "update_time": _ts(created),
+        "mapping": mapping,
+        "moderation_results": [],
+        "current_node": parent,
+    }
+
+
+def build_conversations() -> list[dict]:
+    """Eight months of a lived-in account, in ten conversations."""
+    conversations = []
+
+    # --- 2025-11: first contact — profile facts land in the bio tool.
+    conversations.append(
+        _conversation(
+            "conv-001",
+            "Debugging an I2C driver",
+            "2025-11-04T09:12:00",
+            [
+                _msg(
+                    "m-001a",
+                    "system",
+                    "",
+                    "2025-11-04T09:12:00",
+                    metadata={
+                        "is_user_system_message": True,
+                        "user_context_message_data": _CUSTOM_INSTRUCTIONS,
+                    },
+                ),
+                _msg(
+                    "m-001b",
+                    "user",
+                    "My I2C driver hangs on the second read. I'm a firmware "
+                    "engineer at Meridian Robotics, mostly C on STM32.",
+                    "2025-11-04T09:12:30",
+                ),
+                _msg(
+                    "m-001c",
+                    "assistant",
+                    "User is a firmware engineer at Meridian Robotics working "
+                    "on STM32 microcontrollers, primarily in C.",
+                    "2025-11-04T09:12:45",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-001d",
+                    "tool",
+                    "Model set context updated.",
+                    "2025-11-04T09:12:46",
+                    name="bio",
+                ),
+                _msg(
+                    "m-001e",
+                    "assistant",
+                    "A hang on the second read usually means the bus wasn't "
+                    "released — check for a missing STOP condition.",
+                    "2025-11-04T09:13:00",
+                ),
+            ],
+        )
+    )
+
+    # --- 2025-11: preferences.
+    conversations.append(
+        _conversation(
+            "conv-002",
+            "Coffee brewing ratios",
+            "2025-11-18T07:45:00",
+            [
+                _msg(
+                    "m-002a",
+                    "user",
+                    "What ratio for a dark roast pour-over? That's my usual.",
+                    "2025-11-18T07:45:00",
+                ),
+                _msg(
+                    "m-002b",
+                    "assistant",
+                    "User prefers dark roast coffee, usually brewed as pour-over.",
+                    "2025-11-18T07:45:20",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-002c",
+                    "tool",
+                    "Model set context updated.",
+                    "2025-11-18T07:45:21",
+                    name="bio",
+                ),
+                _msg(
+                    "m-002d",
+                    "assistant",
+                    "Start at 1:15 and adjust toward 1:16 if it tastes muddy.",
+                    "2025-11-18T07:46:00",
+                ),
+            ],
+        )
+    )
+
+    # --- 2025-12: relationships.
+    conversations.append(
+        _conversation(
+            "conv-003",
+            "Gift ideas",
+            "2025-12-09T19:30:00",
+            [
+                _msg(
+                    "m-003a",
+                    "user",
+                    "Need a gift for my partner Sam. Our dog Biscuit chews "
+                    "everything, so nothing fragile.",
+                    "2025-12-09T19:30:00",
+                ),
+                _msg(
+                    "m-003b",
+                    "assistant",
+                    "User's partner is named Sam. They have a dog named "
+                    "Biscuit who chews on things.",
+                    "2025-12-09T19:30:25",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-003c",
+                    "tool",
+                    "Model set context updated.",
+                    "2025-12-09T19:30:26",
+                    name="bio",
+                ),
+            ],
+        )
+    )
+
+    # --- 2026-01: goals.
+    conversations.append(
+        _conversation(
+            "conv-004",
+            "Marathon training plan",
+            "2026-01-12T06:20:00",
+            [
+                _msg(
+                    "m-004a",
+                    "user",
+                    "I signed up for the Chicago Marathon in October. Build "
+                    "me a base plan — I run about 25 km a week now.",
+                    "2026-01-12T06:20:00",
+                ),
+                _msg(
+                    "m-004b",
+                    "assistant",
+                    "User is training for the Chicago Marathon in October "
+                    "2026, currently running about 25 km per week.",
+                    "2026-01-12T06:20:30",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-004c",
+                    "tool",
+                    "Model set context updated.",
+                    "2026-01-12T06:20:31",
+                    name="bio",
+                ),
+            ],
+        )
+    )
+
+    # --- 2026-02: a decision (language switch).
+    conversations.append(
+        _conversation(
+            "conv-005",
+            "Porting a driver to Rust",
+            "2026-02-03T14:05:00",
+            [
+                _msg(
+                    "m-005a",
+                    "user",
+                    "We decided to port our sensor drivers from C to Rust. "
+                    "Where do I start with embedded-hal?",
+                    "2026-02-03T14:05:00",
+                ),
+                _msg(
+                    "m-005b",
+                    "assistant",
+                    "User's team decided to port their sensor drivers from C "
+                    "to Rust using embedded-hal.",
+                    "2026-02-03T14:05:30",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-005c",
+                    "tool",
+                    "Model set context updated.",
+                    "2026-02-03T14:05:31",
+                    name="bio",
+                ),
+            ],
+        )
+    )
+
+    # --- 2026-03: a correction — user moved cities. Shows memory evolving
+    # with life changes, not just accumulating.
+    conversations.append(
+        _conversation(
+            "conv-006",
+            "Neighborhood advice",
+            "2026-03-21T17:40:00",
+            [
+                _msg(
+                    "m-006a",
+                    "user",
+                    "Update: we finally moved from Austin to Seattle last "
+                    "week. Which neighborhoods are good for runners?",
+                    "2026-03-21T17:40:00",
+                ),
+                _msg(
+                    "m-006b",
+                    "assistant",
+                    "User moved to Seattle in March 2026, previously lived in Austin.",
+                    "2026-03-21T17:40:30",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-006c",
+                    "tool",
+                    "Model set context updated.",
+                    "2026-03-21T17:40:31",
+                    name="bio",
+                ),
+            ],
+        )
+    )
+
+    # --- 2026-04: changed preference — corrects conv-002.
+    conversations.append(
+        _conversation(
+            "conv-007",
+            "Espresso machine shopping",
+            "2026-04-08T08:10:00",
+            [
+                _msg(
+                    "m-007a",
+                    "user",
+                    "I've gone off pour-over honestly — it's espresso now. "
+                    "Recommend a machine under $600.",
+                    "2026-04-08T08:10:00",
+                ),
+                _msg(
+                    "m-007b",
+                    "assistant",
+                    "User now prefers espresso over pour-over coffee and is "
+                    "shopping for an espresso machine under $600.",
+                    "2026-04-08T08:10:30",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-007c",
+                    "tool",
+                    "Model set context updated.",
+                    "2026-04-08T08:10:31",
+                    name="bio",
+                ),
+            ],
+        )
+    )
+
+    # --- 2026-05: commitment.
+    conversations.append(
+        _conversation(
+            "conv-008",
+            "Conference talk outline",
+            "2026-05-14T11:00:00",
+            [
+                _msg(
+                    "m-008a",
+                    "user",
+                    "My embedded Rust talk got accepted for RustConf. Slides "
+                    "are due August 15. Help me outline it.",
+                    "2026-05-14T11:00:00",
+                ),
+                _msg(
+                    "m-008b",
+                    "assistant",
+                    "User will speak about embedded Rust at RustConf; their "
+                    "slides are due August 15, 2026.",
+                    "2026-05-14T11:00:30",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-008c",
+                    "tool",
+                    "Model set context updated.",
+                    "2026-05-14T11:00:31",
+                    name="bio",
+                ),
+            ],
+        )
+    )
+
+    # --- 2026-06: a conversation carrying the replayed memory snapshot,
+    # plus one new bio write. The snapshot repeats earlier entries (dedup
+    # exercise) and contributes two entries never seen as bio writes.
+    snapshot = "\n".join(
+        [
+            "1. [2025-11-04]. User is a firmware engineer at Meridian "
+            "Robotics working on STM32 microcontrollers, primarily in C.",
+            "2. [2025-12-09]. User's partner is named Sam. They have a dog "
+            "named Biscuit who chews on things.",
+            "3. [2026-01-12]. User is training for the Chicago Marathon in "
+            "October 2026, currently running about 25 km per week.",
+            "4. [2026-02-14]. User is allergic to shellfish.",
+            "5. [2026-04-08]. User now prefers espresso over pour-over "
+            "coffee and is shopping for an espresso machine under $600.",
+            "6. User keeps a sourdough starter named Clint Yeastwood.",
+        ]
+    )
+    conversations.append(
+        _conversation(
+            "conv-009",
+            "Meal prep for race week",
+            "2026-06-02T18:25:00",
+            [
+                _msg(
+                    "m-009a",
+                    "system",
+                    "",
+                    "2026-06-02T18:25:00",
+                    metadata={
+                        "is_user_system_message": True,
+                        "user_context_message_data": _CUSTOM_INSTRUCTIONS,
+                    },
+                ),
+                _snapshot_msg("m-009b", snapshot, "2026-06-02T18:25:01"),
+                _msg(
+                    "m-009c",
+                    "user",
+                    "Plan carb-heavy dinners for race week. Remember no "
+                    "shellfish. Sam eats vegetarian on weekdays.",
+                    "2026-06-02T18:25:30",
+                ),
+                _msg(
+                    "m-009d",
+                    "assistant",
+                    "User's partner Sam eats vegetarian on weekdays.",
+                    "2026-06-02T18:26:00",
+                    recipient="bio",
+                ),
+                _msg(
+                    "m-009e",
+                    "tool",
+                    "Model set context updated.",
+                    "2026-06-02T18:26:01",
+                    name="bio",
+                ),
+            ],
+        )
+    )
+
+    # --- Noise: a conversation with no memory activity at all.
+    conversations.append(
+        _conversation(
+            "conv-010",
+            "Regex help",
+            "2026-06-20T15:00:00",
+            [
+                _msg(
+                    "m-010a",
+                    "user",
+                    "Why does my lookbehind fail in JavaScript?",
+                    "2026-06-20T15:00:00",
+                ),
+                _msg(
+                    "m-010b",
+                    "assistant",
+                    "Older engines lack lookbehind support — check the "
+                    "target runtime version.",
+                    "2026-06-20T15:00:20",
+                ),
+            ],
+        )
+    )
+
+    return conversations
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    conversations = build_conversations()
+    (OUT_DIR / "conversations.json").write_text(
+        json.dumps(conversations, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    # Placeholder account stub — present for schema realism only. The
+    # adapter never reads it, so no PII shape is exercised.
+    (OUT_DIR / "user.json").write_text(
+        json.dumps(
+            {
+                "id": "user-sample",
+                "email": "sample@example.com",
+                "chatgpt_plus_user": True,
+                "phone_number": None,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"Sample export written to {OUT_DIR}")
+    print(f"  conversations: {len(conversations)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/migrations/chatgpt/run.sh
+++ b/examples/migrations/chatgpt/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# One-command demo: ChatGPT export -> OKF bundle -> memanto migrate preview.
+#
+#   ./run.sh                          # uses the committed sample export
+#   ./run.sh ~/Downloads/chatgpt-export.zip   # uses YOUR real export
+#
+# The dry-run preview needs no API key. To import for real afterwards:
+#   memanto migrate okf ./out/okf-bundle --agent <agent-id>
+#   python3 validation/validate_recall.py --agent <agent-id>
+set -euo pipefail
+cd "$(dirname "$0")"
+
+SOURCE="${1:-sample_data/chatgpt-export-sample}"
+BUNDLE="out/okf-bundle"
+
+if [ ! -e "$SOURCE" ]; then
+  echo "Regenerating sample export..."
+  python3 make_sample_export.py
+fi
+
+echo "==> 1/2 Extracting ChatGPT memory into an OKF bundle"
+python3 chatgpt_to_okf.py "$SOURCE" -o "$BUNDLE"
+
+echo
+echo "==> 2/2 Previewing the import with the shipped Memanto CLI (dry run)"
+memanto migrate okf "$BUNDLE" --dry-run

--- a/examples/migrations/chatgpt/sample_data/chatgpt-export-sample/conversations.json
+++ b/examples/migrations/chatgpt/sample_data/chatgpt-export-sample/conversations.json
@@ -1,0 +1,1136 @@
+[
+  {
+    "id": "conv-001",
+    "conversation_id": "conv-001",
+    "title": "Debugging an I2C driver",
+    "create_time": 1762247520.0,
+    "update_time": 1762247520.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-001a"
+        ]
+      },
+      "node-m-001a": {
+        "id": "node-m-001a",
+        "message": {
+          "id": "m-001a",
+          "author": {
+            "role": "system",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1762247520.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              ""
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {
+            "is_user_system_message": true,
+            "user_context_message_data": {
+              "about_user_message": "I'm a firmware engineer. I work mostly in C and Rust on embedded sensor platforms. Keep examples small and hardware-realistic.",
+              "about_model_message": "Be concise. Prefer code over prose. Flag unsafe memory patterns."
+            }
+          },
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-001b"
+        ]
+      },
+      "node-m-001b": {
+        "id": "node-m-001b",
+        "message": {
+          "id": "m-001b",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1762247550.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "My I2C driver hangs on the second read. I'm a firmware engineer at Meridian Robotics, mostly C on STM32."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-001a",
+        "children": [
+          "node-m-001c"
+        ]
+      },
+      "node-m-001c": {
+        "id": "node-m-001c",
+        "message": {
+          "id": "m-001c",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1762247565.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User is a firmware engineer at Meridian Robotics working on STM32 microcontrollers, primarily in C."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-001b",
+        "children": [
+          "node-m-001d"
+        ]
+      },
+      "node-m-001d": {
+        "id": "node-m-001d",
+        "message": {
+          "id": "m-001d",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1762247566.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-001c",
+        "children": [
+          "node-m-001e"
+        ]
+      },
+      "node-m-001e": {
+        "id": "node-m-001e",
+        "message": {
+          "id": "m-001e",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1762247580.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "A hang on the second read usually means the bus wasn't released — check for a missing STOP condition."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-001d",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-001e"
+  },
+  {
+    "id": "conv-002",
+    "conversation_id": "conv-002",
+    "title": "Coffee brewing ratios",
+    "create_time": 1763451900.0,
+    "update_time": 1763451900.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-002a"
+        ]
+      },
+      "node-m-002a": {
+        "id": "node-m-002a",
+        "message": {
+          "id": "m-002a",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1763451900.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "What ratio for a dark roast pour-over? That's my usual."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-002b"
+        ]
+      },
+      "node-m-002b": {
+        "id": "node-m-002b",
+        "message": {
+          "id": "m-002b",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1763451920.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User prefers dark roast coffee, usually brewed as pour-over."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-002a",
+        "children": [
+          "node-m-002c"
+        ]
+      },
+      "node-m-002c": {
+        "id": "node-m-002c",
+        "message": {
+          "id": "m-002c",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1763451921.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-002b",
+        "children": [
+          "node-m-002d"
+        ]
+      },
+      "node-m-002d": {
+        "id": "node-m-002d",
+        "message": {
+          "id": "m-002d",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1763451960.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Start at 1:15 and adjust toward 1:16 if it tastes muddy."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-002c",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-002d"
+  },
+  {
+    "id": "conv-003",
+    "conversation_id": "conv-003",
+    "title": "Gift ideas",
+    "create_time": 1765308600.0,
+    "update_time": 1765308600.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-003a"
+        ]
+      },
+      "node-m-003a": {
+        "id": "node-m-003a",
+        "message": {
+          "id": "m-003a",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1765308600.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Need a gift for my partner Sam. Our dog Biscuit chews everything, so nothing fragile."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-003b"
+        ]
+      },
+      "node-m-003b": {
+        "id": "node-m-003b",
+        "message": {
+          "id": "m-003b",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1765308625.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User's partner is named Sam. They have a dog named Biscuit who chews on things."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-003a",
+        "children": [
+          "node-m-003c"
+        ]
+      },
+      "node-m-003c": {
+        "id": "node-m-003c",
+        "message": {
+          "id": "m-003c",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1765308626.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-003b",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-003c"
+  },
+  {
+    "id": "conv-004",
+    "conversation_id": "conv-004",
+    "title": "Marathon training plan",
+    "create_time": 1768198800.0,
+    "update_time": 1768198800.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-004a"
+        ]
+      },
+      "node-m-004a": {
+        "id": "node-m-004a",
+        "message": {
+          "id": "m-004a",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1768198800.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "I signed up for the Chicago Marathon in October. Build me a base plan — I run about 25 km a week now."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-004b"
+        ]
+      },
+      "node-m-004b": {
+        "id": "node-m-004b",
+        "message": {
+          "id": "m-004b",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1768198830.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User is training for the Chicago Marathon in October 2026, currently running about 25 km per week."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-004a",
+        "children": [
+          "node-m-004c"
+        ]
+      },
+      "node-m-004c": {
+        "id": "node-m-004c",
+        "message": {
+          "id": "m-004c",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1768198831.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-004b",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-004c"
+  },
+  {
+    "id": "conv-005",
+    "conversation_id": "conv-005",
+    "title": "Porting a driver to Rust",
+    "create_time": 1770127500.0,
+    "update_time": 1770127500.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-005a"
+        ]
+      },
+      "node-m-005a": {
+        "id": "node-m-005a",
+        "message": {
+          "id": "m-005a",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1770127500.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "We decided to port our sensor drivers from C to Rust. Where do I start with embedded-hal?"
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-005b"
+        ]
+      },
+      "node-m-005b": {
+        "id": "node-m-005b",
+        "message": {
+          "id": "m-005b",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1770127530.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User's team decided to port their sensor drivers from C to Rust using embedded-hal."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-005a",
+        "children": [
+          "node-m-005c"
+        ]
+      },
+      "node-m-005c": {
+        "id": "node-m-005c",
+        "message": {
+          "id": "m-005c",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1770127531.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-005b",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-005c"
+  },
+  {
+    "id": "conv-006",
+    "conversation_id": "conv-006",
+    "title": "Neighborhood advice",
+    "create_time": 1774114800.0,
+    "update_time": 1774114800.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-006a"
+        ]
+      },
+      "node-m-006a": {
+        "id": "node-m-006a",
+        "message": {
+          "id": "m-006a",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1774114800.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Update: we finally moved from Austin to Seattle last week. Which neighborhoods are good for runners?"
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-006b"
+        ]
+      },
+      "node-m-006b": {
+        "id": "node-m-006b",
+        "message": {
+          "id": "m-006b",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1774114830.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User moved to Seattle in March 2026, previously lived in Austin."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-006a",
+        "children": [
+          "node-m-006c"
+        ]
+      },
+      "node-m-006c": {
+        "id": "node-m-006c",
+        "message": {
+          "id": "m-006c",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1774114831.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-006b",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-006c"
+  },
+  {
+    "id": "conv-007",
+    "conversation_id": "conv-007",
+    "title": "Espresso machine shopping",
+    "create_time": 1775635800.0,
+    "update_time": 1775635800.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-007a"
+        ]
+      },
+      "node-m-007a": {
+        "id": "node-m-007a",
+        "message": {
+          "id": "m-007a",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1775635800.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "I've gone off pour-over honestly — it's espresso now. Recommend a machine under $600."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-007b"
+        ]
+      },
+      "node-m-007b": {
+        "id": "node-m-007b",
+        "message": {
+          "id": "m-007b",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1775635830.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User now prefers espresso over pour-over coffee and is shopping for an espresso machine under $600."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-007a",
+        "children": [
+          "node-m-007c"
+        ]
+      },
+      "node-m-007c": {
+        "id": "node-m-007c",
+        "message": {
+          "id": "m-007c",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1775635831.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-007b",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-007c"
+  },
+  {
+    "id": "conv-008",
+    "conversation_id": "conv-008",
+    "title": "Conference talk outline",
+    "create_time": 1778756400.0,
+    "update_time": 1778756400.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-008a"
+        ]
+      },
+      "node-m-008a": {
+        "id": "node-m-008a",
+        "message": {
+          "id": "m-008a",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1778756400.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "My embedded Rust talk got accepted for RustConf. Slides are due August 15. Help me outline it."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-008b"
+        ]
+      },
+      "node-m-008b": {
+        "id": "node-m-008b",
+        "message": {
+          "id": "m-008b",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1778756430.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User will speak about embedded Rust at RustConf; their slides are due August 15, 2026."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-008a",
+        "children": [
+          "node-m-008c"
+        ]
+      },
+      "node-m-008c": {
+        "id": "node-m-008c",
+        "message": {
+          "id": "m-008c",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1778756431.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-008b",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-008c"
+  },
+  {
+    "id": "conv-009",
+    "conversation_id": "conv-009",
+    "title": "Meal prep for race week",
+    "create_time": 1780424700.0,
+    "update_time": 1780424700.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-009a"
+        ]
+      },
+      "node-m-009a": {
+        "id": "node-m-009a",
+        "message": {
+          "id": "m-009a",
+          "author": {
+            "role": "system",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1780424700.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              ""
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {
+            "is_user_system_message": true,
+            "user_context_message_data": {
+              "about_user_message": "I'm a firmware engineer. I work mostly in C and Rust on embedded sensor platforms. Keep examples small and hardware-realistic.",
+              "about_model_message": "Be concise. Prefer code over prose. Flag unsafe memory patterns."
+            }
+          },
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-009b"
+        ]
+      },
+      "node-m-009b": {
+        "id": "node-m-009b",
+        "message": {
+          "id": "m-009b",
+          "author": {
+            "role": "system",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1780424701.0,
+          "update_time": null,
+          "content": {
+            "content_type": "model_editable_context",
+            "model_set_context": "1. [2025-11-04]. User is a firmware engineer at Meridian Robotics working on STM32 microcontrollers, primarily in C.\n2. [2025-12-09]. User's partner is named Sam. They have a dog named Biscuit who chews on things.\n3. [2026-01-12]. User is training for the Chicago Marathon in October 2026, currently running about 25 km per week.\n4. [2026-02-14]. User is allergic to shellfish.\n5. [2026-04-08]. User now prefers espresso over pour-over coffee and is shopping for an espresso machine under $600.\n6. User keeps a sourdough starter named Clint Yeastwood.",
+            "repository": null,
+            "repo_summary": null
+          },
+          "status": "finished_successfully",
+          "end_turn": null,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-009a",
+        "children": [
+          "node-m-009c"
+        ]
+      },
+      "node-m-009c": {
+        "id": "node-m-009c",
+        "message": {
+          "id": "m-009c",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1780424730.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Plan carb-heavy dinners for race week. Remember no shellfish. Sam eats vegetarian on weekdays."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-009b",
+        "children": [
+          "node-m-009d"
+        ]
+      },
+      "node-m-009d": {
+        "id": "node-m-009d",
+        "message": {
+          "id": "m-009d",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1780424760.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "User's partner Sam eats vegetarian on weekdays."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "bio"
+        },
+        "parent": "node-m-009c",
+        "children": [
+          "node-m-009e"
+        ]
+      },
+      "node-m-009e": {
+        "id": "node-m-009e",
+        "message": {
+          "id": "m-009e",
+          "author": {
+            "role": "tool",
+            "name": "bio",
+            "metadata": {}
+          },
+          "create_time": 1780424761.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Model set context updated."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-009d",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-009e"
+  },
+  {
+    "id": "conv-010",
+    "conversation_id": "conv-010",
+    "title": "Regex help",
+    "create_time": 1781967600.0,
+    "update_time": 1781967600.0,
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "node-m-010a"
+        ]
+      },
+      "node-m-010a": {
+        "id": "node-m-010a",
+        "message": {
+          "id": "m-010a",
+          "author": {
+            "role": "user",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1781967600.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Why does my lookbehind fail in JavaScript?"
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root",
+        "children": [
+          "node-m-010b"
+        ]
+      },
+      "node-m-010b": {
+        "id": "node-m-010b",
+        "message": {
+          "id": "m-010b",
+          "author": {
+            "role": "assistant",
+            "name": null,
+            "metadata": {}
+          },
+          "create_time": 1781967620.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": [
+              "Older engines lack lookbehind support — check the target runtime version."
+            ]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "node-m-010a",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "node-m-010b"
+  }
+]

--- a/examples/migrations/chatgpt/sample_data/chatgpt-export-sample/user.json
+++ b/examples/migrations/chatgpt/sample_data/chatgpt-export-sample/user.json
@@ -1,0 +1,6 @@
+{
+  "id": "user-sample",
+  "email": "sample@example.com",
+  "chatgpt_plus_user": true,
+  "phone_number": null
+}

--- a/examples/migrations/chatgpt/sample_output/dry_run_preview.txt
+++ b/examples/migrations/chatgpt/sample_output/dry_run_preview.txt
@@ -1,0 +1,18 @@
+╭─────────────────────────╮
+│ OKF -> Memanto  Dry run │
+╰─────────────────────────╯
+  … Loading OKF bundle from examples/migrations/chatgpt/sample_output/okf-bundle
+  … Mapping OKF nodes onto Memanto schema...
+
+╭────────────────────────────── Dry run complete ──────────────────────────────╮
+│ OKF nodes: 13                                                                │
+│ Mapped memories: 13  (skipped 0)                                             │
+│ Type breakdown: commitment: 1, decision: 1, event: 1, fact: 2, goal: 1,      │
+│ instruction: 2, preference: 2, relationship: 3                               │
+│                                                                              │
+│ Dry run — no writes performed.                                               │
+│                                                                              │
+│ Run dir: /Users/colincasson/.memanto/migrate/okf/20260723_002623             │
+│ Mapped preview:                                                              │
+│ /Users/colincasson/.memanto/migrate/okf/20260723_002623/mapped_preview.json  │
+╰──────────────────────────────────────────────────────────────────────────────╯

--- a/examples/migrations/chatgpt/sample_output/mapped_preview.json
+++ b/examples/migrations/chatgpt/sample_output/mapped_preview.json
@@ -1,0 +1,197 @@
+[
+  {
+    "title": "User will speak about embedded Rust at RustConf; their slides are due August...",
+    "content": "User will speak about embedded Rust at RustConf; their slides are due August 15, 2026.\n\n---\n[Supporting data]\n- OKF source: memories/commitment/user-will-speak-about-embedded-rust-at-rustconf-their-slides.md\n- OKF resource: chatgpt:conv-008:m-008b\n- OKF conversation: Conference talk outline",
+    "type": "commitment",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-008:m-008b",
+    "provenance": "imported",
+    "created_at": "2026-05-14 11:00:30+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User's team decided to port their sensor drivers from C to Rust using embedde...",
+    "content": "User's team decided to port their sensor drivers from C to Rust using embedded-hal.\n\n---\n[Supporting data]\n- OKF source: memories/decision/user-s-team-decided-to-port-their-sensor-drivers-from-c-to-r.md\n- OKF resource: chatgpt:conv-005:m-005b\n- OKF conversation: Porting a driver to Rust",
+    "type": "decision",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-005:m-005b",
+    "provenance": "imported",
+    "created_at": "2026-02-03 14:05:30+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User moved to Seattle in March 2026, previously lived in Austin.",
+    "content": "User moved to Seattle in March 2026, previously lived in Austin.\n\n---\n[Supporting data]\n- OKF source: memories/event/user-moved-to-seattle-in-march-2026-previously-lived-in-aust.md\n- OKF resource: chatgpt:conv-006:m-006b\n- OKF conversation: Neighborhood advice",
+    "type": "event",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-006:m-006b",
+    "provenance": "imported",
+    "created_at": "2026-03-21 17:40:30+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User is a firmware engineer at Meridian Robotics working on STM32 microcontro...",
+    "content": "User is a firmware engineer at Meridian Robotics working on STM32 microcontrollers, primarily in C.\n\n---\n[Supporting data]\n- OKF source: memories/fact/user-is-a-firmware-engineer-at-meridian-robotics-working-on.md\n- OKF resource: chatgpt:conv-001:m-001c\n- OKF conversation: Debugging an I2C driver",
+    "type": "fact",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-001:m-001c",
+    "provenance": "imported",
+    "created_at": "2025-11-04 09:12:45+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User is allergic to shellfish.",
+    "content": "User is allergic to shellfish.\n\n---\n[Supporting data]\n- OKF source: memories/fact/user-is-allergic-to-shellfish.md\n- OKF resource: chatgpt:conv-009:m-009b\n- OKF conversation: Meal prep for race week",
+    "type": "fact",
+    "tags": [
+      "chatgpt",
+      "model-set-context"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-009:m-009b",
+    "provenance": "imported",
+    "created_at": "2026-02-14 00:00:00+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User is training for the Chicago Marathon in October 2026, currently running...",
+    "content": "User is training for the Chicago Marathon in October 2026, currently running about 25 km per week.\n\n---\n[Supporting data]\n- OKF source: memories/goal/user-is-training-for-the-chicago-marathon-in-october-2026-cu.md\n- OKF resource: chatgpt:conv-004:m-004b\n- OKF conversation: Marathon training plan",
+    "type": "goal",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-004:m-004b",
+    "provenance": "imported",
+    "created_at": "2026-01-12 06:20:30+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "About the user (custom instructions): I'm a firmware engineer. I work mostly...",
+    "content": "About the user (custom instructions): I'm a firmware engineer. I work mostly in C and Rust on embedded sensor platforms. Keep examples small and hardware-realistic.\n\n---\n[Supporting data]\n- OKF source: memories/instruction/about-the-user-custom-instructions-i-m-a-firmware-engineer-i.md\n- OKF resource: chatgpt:conv-001:m-001a\n- OKF conversation: Debugging an I2C driver",
+    "type": "instruction",
+    "tags": [
+      "chatgpt",
+      "custom-instructions"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-001:m-001a",
+    "provenance": "imported",
+    "created_at": "2025-11-04 09:12:00+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "How the user wants responses (custom instructions): Be concise. Prefer code o...",
+    "content": "How the user wants responses (custom instructions): Be concise. Prefer code over prose. Flag unsafe memory patterns.\n\n---\n[Supporting data]\n- OKF source: memories/instruction/how-the-user-wants-responses-custom-instructions-be-concise.md\n- OKF resource: chatgpt:conv-001:m-001a\n- OKF conversation: Debugging an I2C driver",
+    "type": "instruction",
+    "tags": [
+      "chatgpt",
+      "custom-instructions"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-001:m-001a",
+    "provenance": "imported",
+    "created_at": "2025-11-04 09:12:00+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User now prefers espresso over pour-over coffee and is shopping for an espres...",
+    "content": "User now prefers espresso over pour-over coffee and is shopping for an espresso machine under $600.\n\n---\n[Supporting data]\n- OKF source: memories/preference/user-now-prefers-espresso-over-pour-over-coffee-and-is-shopp.md\n- OKF resource: chatgpt:conv-007:m-007b\n- OKF conversation: Espresso machine shopping",
+    "type": "preference",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-007:m-007b",
+    "provenance": "imported",
+    "created_at": "2026-04-08 08:10:30+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User prefers dark roast coffee, usually brewed as pour-over.",
+    "content": "User prefers dark roast coffee, usually brewed as pour-over.\n\n---\n[Supporting data]\n- OKF source: memories/preference/user-prefers-dark-roast-coffee-usually-brewed-as-pour-over.md\n- OKF resource: chatgpt:conv-002:m-002b\n- OKF conversation: Coffee brewing ratios",
+    "type": "preference",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-002:m-002b",
+    "provenance": "imported",
+    "created_at": "2025-11-18 07:45:20+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User keeps a sourdough starter named Clint Yeastwood.",
+    "content": "User keeps a sourdough starter named Clint Yeastwood.\n\n---\n[Supporting data]\n- OKF source: memories/relationship/user-keeps-a-sourdough-starter-named-clint-yeastwood.md\n- OKF resource: chatgpt:conv-009:m-009b\n- OKF conversation: Meal prep for race week",
+    "type": "relationship",
+    "tags": [
+      "chatgpt",
+      "model-set-context"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-009:m-009b",
+    "provenance": "imported",
+    "created_at": "2026-06-02 18:25:01+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User's partner is named Sam. They have a dog named Biscuit who chews on things.",
+    "content": "User's partner is named Sam. They have a dog named Biscuit who chews on things.\n\n---\n[Supporting data]\n- OKF source: memories/relationship/user-s-partner-is-named-sam-they-have-a-dog-named-biscuit-wh.md\n- OKF resource: chatgpt:conv-003:m-003b\n- OKF conversation: Gift ideas",
+    "type": "relationship",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-003:m-003b",
+    "provenance": "imported",
+    "created_at": "2025-12-09 19:30:25+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  },
+  {
+    "title": "User's partner Sam eats vegetarian on weekdays.",
+    "content": "User's partner Sam eats vegetarian on weekdays.\n\n---\n[Supporting data]\n- OKF source: memories/relationship/user-s-partner-sam-eats-vegetarian-on-weekdays.md\n- OKF resource: chatgpt:conv-009:m-009d\n- OKF conversation: Meal prep for race week",
+    "type": "relationship",
+    "tags": [
+      "chatgpt",
+      "bio"
+    ],
+    "confidence": 0.8,
+    "source": "chatgpt",
+    "source_ref": "chatgpt:conv-009:m-009d",
+    "provenance": "imported",
+    "created_at": "2026-06-02 18:26:00+00:00",
+    "updated_at": "2026-07-23 00:26:23.790798+00:00"
+  }
+]

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/index.md
@@ -1,0 +1,11 @@
+---
+type: index
+title: ChatGPT liberated memory
+---
+
+# ChatGPT -> OKF memory bundle
+
+> 13 memories liberated from a ChatGPT data export.
+> Import with: `memanto migrate okf <this-directory>`
+
+- [memories](memories/index.md) — 13 memories across 8 type(s)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/commitment/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/commitment/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: "commitment"
+---
+
+# commitment (1)
+
+- [User will speak about embedded Rust at RustConf; their slides are due August...](user-will-speak-about-embedded-rust-at-rustconf-their-slides.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/commitment/user-will-speak-about-embedded-rust-at-rustconf-their-slides.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/commitment/user-will-speak-about-embedded-rust-at-rustconf-their-slides.md
@@ -1,0 +1,17 @@
+---
+type: commitment
+title: "User will speak about embedded Rust at RustConf; their slides are due August..."
+description: "User will speak about embedded Rust at RustConf; their slides are due August 15, 2026."
+tags:
+- chatgpt
+- bio
+timestamp: "2026-05-14T11:00:30+00:00"
+resource: "chatgpt:conv-008:m-008b"
+conversation: "Conference talk outline"
+x_memanto:
+  source: chatgpt
+  type: commitment
+  confidence: 0.8
+---
+
+User will speak about embedded Rust at RustConf; their slides are due August 15, 2026.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/decision/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/decision/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: "decision"
+---
+
+# decision (1)
+
+- [User's team decided to port their sensor drivers from C to Rust using embedde...](user-s-team-decided-to-port-their-sensor-drivers-from-c-to-r.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/decision/user-s-team-decided-to-port-their-sensor-drivers-from-c-to-r.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/decision/user-s-team-decided-to-port-their-sensor-drivers-from-c-to-r.md
@@ -1,0 +1,17 @@
+---
+type: decision
+title: "User's team decided to port their sensor drivers from C to Rust using embedde..."
+description: "User's team decided to port their sensor drivers from C to Rust using embedded-hal."
+tags:
+- chatgpt
+- bio
+timestamp: "2026-02-03T14:05:30+00:00"
+resource: "chatgpt:conv-005:m-005b"
+conversation: "Porting a driver to Rust"
+x_memanto:
+  source: chatgpt
+  type: decision
+  confidence: 0.8
+---
+
+User's team decided to port their sensor drivers from C to Rust using embedded-hal.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/event/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/event/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: "event"
+---
+
+# event (1)
+
+- [User moved to Seattle in March 2026, previously lived in Austin.](user-moved-to-seattle-in-march-2026-previously-lived-in-aust.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/event/user-moved-to-seattle-in-march-2026-previously-lived-in-aust.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/event/user-moved-to-seattle-in-march-2026-previously-lived-in-aust.md
@@ -1,0 +1,17 @@
+---
+type: event
+title: "User moved to Seattle in March 2026, previously lived in Austin."
+description: "User moved to Seattle in March 2026, previously lived in Austin."
+tags:
+- chatgpt
+- bio
+timestamp: "2026-03-21T17:40:30+00:00"
+resource: "chatgpt:conv-006:m-006b"
+conversation: "Neighborhood advice"
+x_memanto:
+  source: chatgpt
+  type: event
+  confidence: 0.8
+---
+
+User moved to Seattle in March 2026, previously lived in Austin.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/fact/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/fact/index.md
@@ -1,0 +1,9 @@
+---
+type: index
+title: "fact"
+---
+
+# fact (2)
+
+- [User is a firmware engineer at Meridian Robotics working on STM32 microcontro...](user-is-a-firmware-engineer-at-meridian-robotics-working-on.md)
+- [User is allergic to shellfish.](user-is-allergic-to-shellfish.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/fact/user-is-a-firmware-engineer-at-meridian-robotics-working-on.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/fact/user-is-a-firmware-engineer-at-meridian-robotics-working-on.md
@@ -1,0 +1,17 @@
+---
+type: fact
+title: "User is a firmware engineer at Meridian Robotics working on STM32 microcontro..."
+description: "User is a firmware engineer at Meridian Robotics working on STM32 microcontrollers, primarily in C."
+tags:
+- chatgpt
+- bio
+timestamp: "2025-11-04T09:12:45+00:00"
+resource: "chatgpt:conv-001:m-001c"
+conversation: "Debugging an I2C driver"
+x_memanto:
+  source: chatgpt
+  type: fact
+  confidence: 0.8
+---
+
+User is a firmware engineer at Meridian Robotics working on STM32 microcontrollers, primarily in C.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/fact/user-is-allergic-to-shellfish.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/fact/user-is-allergic-to-shellfish.md
@@ -1,0 +1,17 @@
+---
+type: fact
+title: "User is allergic to shellfish."
+description: "User is allergic to shellfish."
+tags:
+- chatgpt
+- model-set-context
+timestamp: "2026-02-14T00:00:00+00:00"
+resource: "chatgpt:conv-009:m-009b"
+conversation: "Meal prep for race week"
+x_memanto:
+  source: chatgpt
+  type: fact
+  confidence: 0.8
+---
+
+User is allergic to shellfish.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/goal/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/goal/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: "goal"
+---
+
+# goal (1)
+
+- [User is training for the Chicago Marathon in October 2026, currently running...](user-is-training-for-the-chicago-marathon-in-october-2026-cu.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/goal/user-is-training-for-the-chicago-marathon-in-october-2026-cu.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/goal/user-is-training-for-the-chicago-marathon-in-october-2026-cu.md
@@ -1,0 +1,17 @@
+---
+type: goal
+title: "User is training for the Chicago Marathon in October 2026, currently running..."
+description: "User is training for the Chicago Marathon in October 2026, currently running about 25 km per week."
+tags:
+- chatgpt
+- bio
+timestamp: "2026-01-12T06:20:30+00:00"
+resource: "chatgpt:conv-004:m-004b"
+conversation: "Marathon training plan"
+x_memanto:
+  source: chatgpt
+  type: goal
+  confidence: 0.8
+---
+
+User is training for the Chicago Marathon in October 2026, currently running about 25 km per week.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/index.md
@@ -1,0 +1,15 @@
+---
+type: index
+title: "memories"
+---
+
+# Memories (13)
+
+- [commitment](commitment/index.md)
+- [decision](decision/index.md)
+- [event](event/index.md)
+- [fact](fact/index.md)
+- [goal](goal/index.md)
+- [instruction](instruction/index.md)
+- [preference](preference/index.md)
+- [relationship](relationship/index.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/instruction/about-the-user-custom-instructions-i-m-a-firmware-engineer-i.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/instruction/about-the-user-custom-instructions-i-m-a-firmware-engineer-i.md
@@ -1,0 +1,17 @@
+---
+type: instruction
+title: "About the user (custom instructions): I'm a firmware engineer. I work mostly..."
+description: "About the user (custom instructions): I'm a firmware engineer. I work mostly in C and Rust on embedded sensor platforms. Keep examples small and hardware-realistic."
+tags:
+- chatgpt
+- custom-instructions
+timestamp: "2025-11-04T09:12:00+00:00"
+resource: "chatgpt:conv-001:m-001a"
+conversation: "Debugging an I2C driver"
+x_memanto:
+  source: chatgpt
+  type: instruction
+  confidence: 0.8
+---
+
+About the user (custom instructions): I'm a firmware engineer. I work mostly in C and Rust on embedded sensor platforms. Keep examples small and hardware-realistic.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/instruction/how-the-user-wants-responses-custom-instructions-be-concise.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/instruction/how-the-user-wants-responses-custom-instructions-be-concise.md
@@ -1,0 +1,17 @@
+---
+type: instruction
+title: "How the user wants responses (custom instructions): Be concise. Prefer code o..."
+description: "How the user wants responses (custom instructions): Be concise. Prefer code over prose. Flag unsafe memory patterns."
+tags:
+- chatgpt
+- custom-instructions
+timestamp: "2025-11-04T09:12:00+00:00"
+resource: "chatgpt:conv-001:m-001a"
+conversation: "Debugging an I2C driver"
+x_memanto:
+  source: chatgpt
+  type: instruction
+  confidence: 0.8
+---
+
+How the user wants responses (custom instructions): Be concise. Prefer code over prose. Flag unsafe memory patterns.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/instruction/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/instruction/index.md
@@ -1,0 +1,9 @@
+---
+type: index
+title: "instruction"
+---
+
+# instruction (2)
+
+- [About the user (custom instructions): I'm a firmware engineer. I work mostly...](about-the-user-custom-instructions-i-m-a-firmware-engineer-i.md)
+- [How the user wants responses (custom instructions): Be concise. Prefer code o...](how-the-user-wants-responses-custom-instructions-be-concise.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/preference/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/preference/index.md
@@ -1,0 +1,9 @@
+---
+type: index
+title: "preference"
+---
+
+# preference (2)
+
+- [User prefers dark roast coffee, usually brewed as pour-over.](user-prefers-dark-roast-coffee-usually-brewed-as-pour-over.md)
+- [User now prefers espresso over pour-over coffee and is shopping for an espres...](user-now-prefers-espresso-over-pour-over-coffee-and-is-shopp.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/preference/user-now-prefers-espresso-over-pour-over-coffee-and-is-shopp.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/preference/user-now-prefers-espresso-over-pour-over-coffee-and-is-shopp.md
@@ -1,0 +1,17 @@
+---
+type: preference
+title: "User now prefers espresso over pour-over coffee and is shopping for an espres..."
+description: "User now prefers espresso over pour-over coffee and is shopping for an espresso machine under $600."
+tags:
+- chatgpt
+- bio
+timestamp: "2026-04-08T08:10:30+00:00"
+resource: "chatgpt:conv-007:m-007b"
+conversation: "Espresso machine shopping"
+x_memanto:
+  source: chatgpt
+  type: preference
+  confidence: 0.8
+---
+
+User now prefers espresso over pour-over coffee and is shopping for an espresso machine under $600.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/preference/user-prefers-dark-roast-coffee-usually-brewed-as-pour-over.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/preference/user-prefers-dark-roast-coffee-usually-brewed-as-pour-over.md
@@ -1,0 +1,17 @@
+---
+type: preference
+title: "User prefers dark roast coffee, usually brewed as pour-over."
+description: "User prefers dark roast coffee, usually brewed as pour-over."
+tags:
+- chatgpt
+- bio
+timestamp: "2025-11-18T07:45:20+00:00"
+resource: "chatgpt:conv-002:m-002b"
+conversation: "Coffee brewing ratios"
+x_memanto:
+  source: chatgpt
+  type: preference
+  confidence: 0.8
+---
+
+User prefers dark roast coffee, usually brewed as pour-over.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/relationship/index.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/relationship/index.md
@@ -1,0 +1,10 @@
+---
+type: index
+title: "relationship"
+---
+
+# relationship (3)
+
+- [User's partner is named Sam. They have a dog named Biscuit who chews on things.](user-s-partner-is-named-sam-they-have-a-dog-named-biscuit-wh.md)
+- [User keeps a sourdough starter named Clint Yeastwood.](user-keeps-a-sourdough-starter-named-clint-yeastwood.md)
+- [User's partner Sam eats vegetarian on weekdays.](user-s-partner-sam-eats-vegetarian-on-weekdays.md)

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/relationship/user-keeps-a-sourdough-starter-named-clint-yeastwood.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/relationship/user-keeps-a-sourdough-starter-named-clint-yeastwood.md
@@ -1,0 +1,17 @@
+---
+type: relationship
+title: "User keeps a sourdough starter named Clint Yeastwood."
+description: "User keeps a sourdough starter named Clint Yeastwood."
+tags:
+- chatgpt
+- model-set-context
+timestamp: "2026-06-02T18:25:01+00:00"
+resource: "chatgpt:conv-009:m-009b"
+conversation: "Meal prep for race week"
+x_memanto:
+  source: chatgpt
+  type: relationship
+  confidence: 0.8
+---
+
+User keeps a sourdough starter named Clint Yeastwood.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/relationship/user-s-partner-is-named-sam-they-have-a-dog-named-biscuit-wh.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/relationship/user-s-partner-is-named-sam-they-have-a-dog-named-biscuit-wh.md
@@ -1,0 +1,17 @@
+---
+type: relationship
+title: "User's partner is named Sam. They have a dog named Biscuit who chews on things."
+description: "User's partner is named Sam. They have a dog named Biscuit who chews on things."
+tags:
+- chatgpt
+- bio
+timestamp: "2025-12-09T19:30:25+00:00"
+resource: "chatgpt:conv-003:m-003b"
+conversation: "Gift ideas"
+x_memanto:
+  source: chatgpt
+  type: relationship
+  confidence: 0.8
+---
+
+User's partner is named Sam. They have a dog named Biscuit who chews on things.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/memories/relationship/user-s-partner-sam-eats-vegetarian-on-weekdays.md
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/memories/relationship/user-s-partner-sam-eats-vegetarian-on-weekdays.md
@@ -1,0 +1,17 @@
+---
+type: relationship
+title: "User's partner Sam eats vegetarian on weekdays."
+description: "User's partner Sam eats vegetarian on weekdays."
+tags:
+- chatgpt
+- bio
+timestamp: "2026-06-02T18:26:00+00:00"
+resource: "chatgpt:conv-009:m-009d"
+conversation: "Meal prep for race week"
+x_memanto:
+  source: chatgpt
+  type: relationship
+  confidence: 0.8
+---
+
+User's partner Sam eats vegetarian on weekdays.

--- a/examples/migrations/chatgpt/sample_output/okf-bundle/migration_summary.json
+++ b/examples/migrations/chatgpt/sample_output/okf-bundle/migration_summary.json
@@ -1,0 +1,20 @@
+{
+  "source": "sample_data/chatgpt-export-sample",
+  "output_bundle": "sample_output/okf-bundle",
+  "conversations_scanned": 10,
+  "bio_writes_found": 9,
+  "model_set_context_entries_found": 6,
+  "custom_instruction_blocks_found": 4,
+  "duplicates_skipped": 6,
+  "memories_by_type": {
+    "commitment": 1,
+    "decision": 1,
+    "event": 1,
+    "fact": 2,
+    "goal": 1,
+    "instruction": 2,
+    "preference": 2,
+    "relationship": 3
+  },
+  "total_memories": 13
+}

--- a/examples/migrations/chatgpt/validation/golden_qa.json
+++ b/examples/migrations/chatgpt/validation/golden_qa.json
@@ -1,0 +1,65 @@
+{
+  "description": "Golden Q&A set for round-trip recall validation. Ask each question of the source assistant (ChatGPT, before migration) and of Memanto (after `memanto migrate okf`). An answer passes when it contains every keyword group (each inner list is OR-matched, case-insensitive).",
+  "questions": [
+    {
+      "id": "qa-01",
+      "question": "Where do I work and what do I work on?",
+      "expected_keywords": [["Meridian"], ["firmware", "STM32"]],
+      "memory_ref": "chatgpt:conv-001:m-001c"
+    },
+    {
+      "id": "qa-02",
+      "question": "How do I take my coffee these days?",
+      "expected_keywords": [["espresso"]],
+      "memory_ref": "chatgpt:conv-009:m-009b"
+    },
+    {
+      "id": "qa-03",
+      "question": "What is my partner's name?",
+      "expected_keywords": [["Sam"]],
+      "memory_ref": "chatgpt:conv-003:m-003b"
+    },
+    {
+      "id": "qa-04",
+      "question": "What's my dog called?",
+      "expected_keywords": [["Biscuit"]],
+      "memory_ref": "chatgpt:conv-003:m-003b"
+    },
+    {
+      "id": "qa-05",
+      "question": "What race am I training for?",
+      "expected_keywords": [["Chicago"], ["marathon"]],
+      "memory_ref": "chatgpt:conv-004:m-004b"
+    },
+    {
+      "id": "qa-06",
+      "question": "What language are we porting our sensor drivers to?",
+      "expected_keywords": [["Rust"]],
+      "memory_ref": "chatgpt:conv-005:m-005b"
+    },
+    {
+      "id": "qa-07",
+      "question": "Which city do I live in now?",
+      "expected_keywords": [["Seattle"]],
+      "memory_ref": "chatgpt:conv-006:m-006b"
+    },
+    {
+      "id": "qa-08",
+      "question": "When are my RustConf slides due?",
+      "expected_keywords": [["August 15", "Aug 15", "2026-08-15"]],
+      "memory_ref": "chatgpt:conv-008:m-008b"
+    },
+    {
+      "id": "qa-09",
+      "question": "Do I have any food allergies?",
+      "expected_keywords": [["shellfish"]],
+      "memory_ref": "chatgpt:conv-009:m-009b"
+    },
+    {
+      "id": "qa-10",
+      "question": "What did I name my sourdough starter?",
+      "expected_keywords": [["Clint Yeastwood", "Yeastwood"]],
+      "memory_ref": "chatgpt:conv-009:m-009b"
+    }
+  ]
+}

--- a/examples/migrations/chatgpt/validation/validate_recall.py
+++ b/examples/migrations/chatgpt/validation/validate_recall.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Round-trip recall validation: golden Q&A against a migrated Memanto agent.
+
+After importing the OKF bundle for real::
+
+    memanto migrate okf ./sample_output/okf-bundle --agent <agent-id>
+
+run this script to prove zero amnesia — every question a well-used ChatGPT
+account could answer from its memory should now be answerable by Memanto::
+
+    python3 validate_recall.py [--agent <agent-id>] [--qa golden_qa.json]
+
+Requires a configured Memanto CLI (``MOORCHEH_API_KEY``) and an active or
+``--agent``-specified agent. Grading is deliberately dumb-simple keyword
+matching so results are reproducible without an LLM judge: an answer passes
+when every keyword *group* matches (groups are AND-ed, alternatives within
+a group are OR-ed, case-insensitive).
+
+For the "before" half of the comparison, ask the same questions in the
+source ChatGPT account and grade the answers with the same keyword rule.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def grade(answer: str, expected_keywords: list[list[str]]) -> bool:
+    lowered = answer.lower()
+    return all(
+        any(alternative.lower() in lowered for alternative in group)
+        for group in expected_keywords
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--agent", default=None, help="Memanto agent id (defaults to active agent)"
+    )
+    parser.add_argument(
+        "--qa",
+        type=Path,
+        default=Path(__file__).parent / "golden_qa.json",
+        help="Golden Q&A file",
+    )
+    args = parser.parse_args()
+
+    from memanto.cli.commands._shared import config_manager, get_client
+
+    agent_id = args.agent
+    if not agent_id:
+        agent_id, _ = config_manager.get_active_session()
+    if not agent_id:
+        print(
+            "No agent: pass --agent <id> or run 'memanto agent activate <id>' first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    qa_set = json.loads(args.qa.read_text(encoding="utf-8"))
+    questions = qa_set["questions"]
+    client = get_client()
+
+    passed = 0
+    print(
+        f"Round-trip recall validation — agent '{agent_id}', "
+        f"{len(questions)} questions\n"
+    )
+    for item in questions:
+        try:
+            result = client.answer(agent_id, item["question"])
+            answer = (result or {}).get("answer", "") or ""
+        except Exception as exc:  # noqa: BLE001 — report and keep scoring
+            answer = f"<error: {exc}>"
+
+        is_ok = grade(answer, item["expected_keywords"])
+        passed += int(is_ok)
+        status = "PASS" if is_ok else "FAIL"
+        print(f"[{status}] {item['id']}: {item['question']}")
+        print(f"       -> {' '.join(answer.split())[:160]}\n")
+
+    total = len(questions)
+    print(f"Recall parity: {passed}/{total} ({100 * passed // max(total, 1)}%)")
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chatgpt_okf_adapter.py
+++ b/tests/test_chatgpt_okf_adapter.py
@@ -1,0 +1,213 @@
+"""
+Tests for the ChatGPT -> OKF migration adapter example
+(examples/migrations/chatgpt/chatgpt_to_okf.py).
+
+The adapter is a standalone stdlib-only script, so it is loaded via
+importlib rather than a package import. The round-trip tests prove the
+generated bundle is consumed by the *shipped* Memanto OKF pipeline
+(``load_okf_bundle`` + ``map_okf``) — the same code path
+``memanto migrate okf`` runs.
+"""
+
+import importlib.util
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from memanto.cli.migrate.mappers import map_okf
+from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+_EXAMPLE_DIR = Path(__file__).parent.parent / "examples" / "migrations" / "chatgpt"
+
+
+def _load_module(name: str):
+    spec = importlib.util.spec_from_file_location(name, _EXAMPLE_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass annotation resolution can find it.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+adapter = _load_module("chatgpt_to_okf")
+sample = _load_module("make_sample_export")
+
+
+@pytest.fixture(scope="module")
+def conversations():
+    return sample.build_conversations()
+
+
+@pytest.fixture(scope="module")
+def extracted(conversations):
+    return adapter.extract_memories(conversations)
+
+
+class TestExtraction:
+    def test_extracts_bio_writes_and_skips_tool_acks(self, extracted):
+        memories, stats = extracted
+
+        assert stats.bio_writes == 9
+        texts = [m.text for m in memories]
+        assert not any("Model set context updated" in t for t in texts)
+        assert any("Meridian Robotics" in t for t in texts)
+
+    def test_deduplicates_snapshot_against_bio_writes(self, extracted):
+        memories, stats = extracted
+
+        # 9 bio + 6 snapshot + 4 custom-instruction blocks = 19 raw sightings;
+        # 4 snapshot repeats + 2 repeated custom-instruction blocks collapse.
+        assert stats.duplicates_skipped == 6
+        assert len(memories) == 13
+        normalized = [adapter._normalize(m.text) for m in memories]
+        assert len(normalized) == len(set(normalized))
+
+    def test_snapshot_only_entries_survive(self, extracted):
+        memories, _ = extracted
+        texts = [m.text for m in memories]
+
+        assert any("shellfish" in t for t in texts)
+        assert any("Clint Yeastwood" in t for t in texts)
+
+    def test_custom_instructions_become_instruction_memories(self, extracted):
+        memories, stats = extracted
+
+        instructions = [m for m in memories if m.kind == "custom_instructions"]
+        assert stats.custom_instruction_blocks == 4  # repeated in 2 conversations
+        assert len(instructions) == 2  # deduplicated to one about-user + one style
+        assert all(m.memory_type == "instruction" for m in instructions)
+
+    def test_bio_write_beats_snapshot_echo_on_duplicates(self, extracted):
+        memories, _ = extracted
+
+        # The espresso memory appears both as an original bio write (exact
+        # timestamp, source conversation) and as a day-granular snapshot echo.
+        # The higher-fidelity bio version must win.
+        espresso = next(m for m in memories if "espresso" in m.text)
+        assert espresso.kind == "bio"
+        assert espresso.created_at == "2026-04-08T08:10:30+00:00"
+        assert espresso.conversation_id == "conv-007"
+
+    def test_timestamps_are_iso_utc(self, extracted):
+        memories, _ = extracted
+
+        meridian = next(m for m in memories if "Meridian" in m.text)
+        assert meridian.created_at == "2025-11-04T09:12:45+00:00"
+
+    def test_type_inference_heuristics(self):
+        infer = adapter.infer_memory_type
+
+        assert infer("User prefers dark roast coffee.") == "preference"
+        assert infer("User is training for the Chicago Marathon.") == "goal"
+        assert infer("User's partner is named Sam.") == "relationship"
+        assert infer("User decided to port drivers to Rust.") == "decision"
+        assert infer("User moved to Seattle in March.") == "event"
+        assert infer("User is allergic to shellfish.") == "fact"
+
+
+class TestInputFormats:
+    def test_zip_and_directory_inputs_are_equivalent(self, tmp_path, conversations):
+        export_dir = tmp_path / "export"
+        export_dir.mkdir()
+        payload = json.dumps(conversations)
+        (export_dir / "conversations.json").write_text(payload, encoding="utf-8")
+
+        zip_path = tmp_path / "chatgpt-export.zip"
+        with zipfile.ZipFile(zip_path, "w") as archive:
+            archive.writestr("nested/conversations.json", payload)
+
+        from_dir = adapter.load_conversations(export_dir)
+        from_zip = adapter.load_conversations(zip_path)
+        assert from_dir == from_zip
+
+    def test_missing_conversations_json_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            adapter.load_conversations(tmp_path)
+
+    def test_non_array_export_raises(self, tmp_path):
+        bad = tmp_path / "conversations.json"
+        bad.write_text('{"not": "an array"}', encoding="utf-8")
+        with pytest.raises(ValueError):
+            adapter.load_conversations(bad)
+
+
+class TestOkfRoundTrip:
+    """The generated bundle must be consumable by the shipped CLI pipeline."""
+
+    @pytest.fixture(scope="class")
+    def bundle(self, tmp_path_factory):
+        conversations = sample.build_conversations()
+        memories, _ = adapter.extract_memories(conversations)
+        out = tmp_path_factory.mktemp("okf") / "bundle"
+        adapter.write_okf_bundle(memories, out)
+        return out, memories
+
+    def test_loader_reads_every_memory(self, bundle):
+        out, memories = bundle
+        export = load_okf_bundle(out)
+        assert len(export["memories"]) == len(memories) == 13
+
+    def test_mapper_produces_import_ready_rows(self, bundle):
+        out, memories = bundle
+        rows = map_okf(load_okf_bundle(out))
+
+        assert len(rows) == 13
+        assert all(row["source"] == "chatgpt" for row in rows)
+        assert all(row["provenance"] == "imported" for row in rows)
+        expected_types = sorted(m.memory_type for m in memories)
+        assert sorted(row["type"] for row in rows) == expected_types
+
+    def test_source_refs_and_timestamps_survive_round_trip(self, bundle):
+        out, _ = bundle
+        rows = map_okf(load_okf_bundle(out))
+
+        meridian = next(r for r in rows if "Meridian" in r["content"])
+        assert meridian["source_ref"] == "chatgpt:conv-001:m-001c"
+        assert meridian["created_at"].isoformat() == "2025-11-04T09:12:45+00:00"
+
+    def test_conversation_title_preserved_in_supporting_data(self, bundle):
+        out, _ = bundle
+        rows = map_okf(load_okf_bundle(out))
+
+        meridian = next(r for r in rows if "Meridian" in r["content"])
+        assert "[Supporting data]" in meridian["content"]
+        assert "Debugging an I2C driver" in meridian["content"]
+
+    def test_stacked_split_mode_round_trips(self, tmp_path):
+        conversations = sample.build_conversations()
+        memories, _ = adapter.extract_memories(conversations)
+        out = tmp_path / "stacked"
+        adapter.write_okf_bundle(memories, out, split="type")
+
+        rows = map_okf(load_okf_bundle(out))
+        assert len(rows) == 13
+
+    def test_index_files_are_skipped_on_import(self, bundle):
+        out, _ = bundle
+        index_files = list(out.rglob("index.md"))
+        assert index_files  # bundle is navigable...
+        rows = map_okf(load_okf_bundle(out))
+        assert len(rows) == 13  # ...but indexes never become memories
+
+
+class TestCommittedSampleArtifacts:
+    """The committed sample bundle must stay in sync with the generator."""
+
+    def test_committed_sample_bundle_is_valid(self):
+        bundle_dir = _EXAMPLE_DIR / "sample_output" / "okf-bundle"
+        rows = map_okf(load_okf_bundle(bundle_dir))
+        assert len(rows) == 13
+
+    def test_committed_sample_export_matches_generator(self):
+        committed = json.loads(
+            (
+                _EXAMPLE_DIR
+                / "sample_data"
+                / "chatgpt-export-sample"
+                / "conversations.json"
+            ).read_text(encoding="utf-8")
+        )
+        assert committed == sample.build_conversations()


### PR DESCRIPTION
# The Great Memory Migration: ChatGPT export → OKF adapter (bounty #1609)

## What this adds

`examples/migrations/chatgpt/` — a stdlib-only Python adapter that liberates the durable
memory ChatGPT has accumulated about a user from an **official ChatGPT data export** and
rewrites it as an **OKF (Open Knowledge Format) bundle** that the shipped
`memanto migrate okf` command imports directly.

The adapter deliberately does *not* re-implement any Memanto import logic. It only does the
source-specific work and then hands off to the existing pipeline
(`memanto.cli.migrate.okf_loader.load_okf_bundle` + `memanto.cli.migrate.mappers.map_okf`).

Three memory sources are extracted from `conversations.json`:

1. **bio tool writes** — assistant messages with `recipient == "bio"`, the moments ChatGPT
   decided something was worth remembering permanently.
2. **`model_set_context` snapshots** — replayed accumulated-memory lists, parsed as numbered
   entries (`1. [2026-01-15]. …`) and deduplicated against the bio writes so snapshot +
   deltas never double-import. On a duplicate, the higher-fidelity original bio write (exact
   timestamp, source conversation) wins over the day-granular snapshot echo.
3. **Custom instructions** — `user_context_message_data` blocks (about-user / about-model),
   deduplicated across conversations, imported as `instruction` memories. Skippable with
   `--no-custom-instructions`.

Each memory gets a heuristic Memanto type (`preference`, `goal`, `commitment`,
`relationship`, `decision`, `event`, `instruction`, falling back to `fact`), an ISO-8601 UTC
timestamp, a `chatgpt:<conversation_id>:<message_id>` source ref, and confidence 0.8
(matching the built-in provider mappers). Account PII from `user.json` (email, phone, ids)
is intentionally never ingested.

## Files

| Path | Purpose |
|---|---|
| `examples/migrations/chatgpt/chatgpt_to_okf.py` | The adapter CLI (Python ≥3.10, no deps) |
| `examples/migrations/chatgpt/make_sample_export.py` | Deterministic generator for a realistic 10-conversation sample export |
| `examples/migrations/chatgpt/run.sh` | One-command demo: extract → `memanto migrate okf --dry-run` |
| `examples/migrations/chatgpt/sample_data/` | Committed sample export (generator output) |
| `examples/migrations/chatgpt/sample_output/` | Committed adapter output for that sample: OKF bundle + summary + previews |
| `examples/migrations/chatgpt/validation/validate_recall.py` | Post-import golden-QA recall check against a live agent |
| `tests/test_chatgpt_okf_adapter.py` | 18-test pytest suite, including round-trips through the shipped OKF pipeline |

## How to run

```bash
# Convert an export (zip, extracted folder, or conversations.json all work)
python3 examples/migrations/chatgpt/chatgpt_to_okf.py ~/Downloads/chatgpt-export.zip -o ./okf-bundle

# Preview the import with the shipped CLI — no API key needed
memanto migrate okf ./okf-bundle --dry-run

# Import for real, then optionally validate recall
memanto migrate okf ./okf-bundle --agent <agent-id>
python3 examples/migrations/chatgpt/validation/validate_recall.py --agent <agent-id>
```

Or the one-command demo on the committed sample data:

```bash
cd examples/migrations/chatgpt && ./run.sh
```

Sample run output (from the committed sample export):

```
ChatGPT -> OKF extraction complete
  Conversations scanned:      10
  bio writes found:           9
  snapshot entries found:     6
  custom instruction blocks:  4
  duplicates collapsed:       6
  unique memories written:    13
  type breakdown:             commitment: 1, decision: 1, event: 1, fact: 2, goal: 1,
                              instruction: 2, preference: 2, relationship: 3
```

## Tests

```bash
python3 -m pytest tests/test_chatgpt_okf_adapter.py -x
```

All 18 tests pass. Coverage includes:

- extraction of bio writes (tool acks like "Model set context updated" are excluded)
- snapshot-vs-bio deduplication, with bio fidelity winning on conflicts
- custom-instruction dedup and typing
- type-inference heuristics
- zip / directory / bare-file input equivalence and input validation errors
- **round-trip through the real `load_okf_bundle` + `map_okf` code path** (per-file and
  stacked split modes), verifying source refs, timestamps, and conversation titles
  (preserved via OKF extras into the `[Supporting data]` footer)
- committed sample artifacts stay in sync with the generator

## What a reviewer should verify

1. `python3 -m pytest tests/test_chatgpt_okf_adapter.py -x` is green (needs the project's
   dev deps for the `memanto` import; the adapter itself is stdlib-only).
2. `cd examples/migrations/chatgpt && ./run.sh` produces a bundle and a clean
   `memanto migrate okf … --dry-run` preview of 13 memories.
3. The frontmatter fields emitted in `sample_output/okf-bundle/memories/**.md` are exactly
   the ones `okf_loader` understands (`type`, `title`, `description`, `tags`, `timestamp`,
   `resource`, `x_memanto`), and `index.md` files are `type: index` so they are skipped on
   import.
4. No PII from `user.json` appears anywhere in the generated bundle.
5. Dedup behavior: the espresso memory exists in the sample both as a bio write and a
   snapshot echo, and the imported row carries the bio write's exact timestamp
   (`2026-04-08T08:10:30+00:00`) and conversation ref (`conv-007`).

## Scope notes

- No changes to `memanto/` itself — this is purely an example adapter plus tests.
- Import limits, embedding, and recall are handled by the existing CLI; the recall
  validation script is optional and requires a configured agent/API key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI workflow for converting ChatGPT exports into import-ready OKF memory bundles.
  * Supports ZIP archives, extracted folders, and direct JSON exports.
  * Extracts, categorizes, deduplicates, and preserves metadata for durable memories.
  * Added configurable bundle splitting and migration summaries.
  * Added sample export data, generated bundle examples, and a dry-run demonstration.

* **Validation**
  * Added round-trip recall validation and comprehensive migration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->