### PR TITLE
fix(okf): preserve temporal metadata across round trips

### DIFF
--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -15,8 +15,8 @@ Layout is controlled by ``split``:
     - ``file``: always one file per memory.
     - ``type``: always one stacked file per type.
 
-Memanto-only fields (id, confidence, provenance, source, status) are preserved
-under a namespaced ``x_memanto`` frontmatter block so that
+Memanto-only fields (id, confidence, provenance, source, status, and temporal
+metadata) are preserved under a namespaced ``x_memanto`` frontmatter block so that
 Memanto -> OKF -> Memanto round-trips keep them. OKF consumers ignore unknown
 frontmatter keys.
 """
@@ -296,7 +296,16 @@ class OkfExportService:
             frontmatter["resource"] = source_ref
 
         x_memanto: dict[str, Any] = {}
-        for key in ("id", "confidence", "provenance", "source", "status"):
+        for key in (
+            "id",
+            "confidence",
+            "provenance",
+            "source",
+            "status",
+            "updated_at",
+            "expires_at",
+            "ttl_seconds",
+        ):
             val = mem.get(key)
             if val not in (None, ""):
                 x_memanto[key] = val

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -743,7 +743,13 @@ class DirectClient:
                 "source": item.get("source") or "user",
                 "provenance": provenance,
             }
-            for opt_key in ("source_ref", "created_at", "updated_at"):
+            for opt_key in (
+                "source_ref",
+                "created_at",
+                "updated_at",
+                "expires_at",
+                "ttl_seconds",
+            ):
                 val = item.get(opt_key)
                 if val is not None:
                     kwargs[opt_key] = val

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -572,7 +572,13 @@ class SdkClient:
                 "source": item.get("source") or "user",
                 "provenance": provenance,
             }
-            for opt_key in ("source_ref", "created_at", "updated_at"):
+            for opt_key in (
+                "source_ref",
+                "created_at",
+                "updated_at",
+                "expires_at",
+                "ttl_seconds",
+            ):
                 val = item.get(opt_key)
                 if val is not None:
                     kwargs[opt_key] = val

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -16,6 +16,8 @@ accepted by ``SdkClient.batch_remember``:
         "provenance": "imported",
         "created_at": datetime, # original source timestamp (when present)
         "updated_at": datetime, # migration time = now
+        "expires_at": datetime, # source expiration timestamp (when present)
+        "ttl_seconds": int,     # source retention window (when present)
     }
 
 Mappers extract every useful field from the source. Anything that maps
@@ -119,6 +121,19 @@ def _pick_first_dt(record: dict[str, Any], keys: tuple[str, ...]) -> datetime | 
         if dt is not None:
             return dt
     return None
+
+
+def _parse_positive_int(value: Any) -> int | None:
+    """Parse a positive integer without silently truncating fractional values."""
+    if isinstance(value, bool) or value in (None, ""):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _format_supporting_data(items: list[tuple[str, Any]]) -> str:
@@ -453,6 +468,9 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
 
         source = x_memanto.get("source") or "okf"
         created_at = _parse_dt(entry.get("timestamp"))
+        updated_at = _parse_dt(x_memanto.get("updated_at")) or migrated_at
+        expires_at = _parse_dt(x_memanto.get("expires_at"))
+        ttl_seconds = _parse_positive_int(x_memanto.get("ttl_seconds"))
 
         footer_items: list[tuple[str, Any]] = [
             ("OKF source", entry.get("source_path")),
@@ -481,7 +499,9 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
                 "source_ref": str(resource) if resource else None,
                 "provenance": "imported",
                 "created_at": created_at,
-                "updated_at": migrated_at,
+                "updated_at": updated_at,
+                "expires_at": expires_at,
+                "ttl_seconds": ttl_seconds,
             }
         )
     return rows

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -91,6 +91,10 @@ def _parse_dt(value: Any) -> datetime | None:
     and already-parsed ``datetime`` objects. Returns ``None`` when nothing
     sensible can be extracted — the caller falls back to the server default.
     """
+    # ``bool`` subclasses ``int``; without this guard, YAML ``true`` becomes
+    # 1970-01-01T00:00:01Z and can accidentally expire a durable memory.
+    if isinstance(value, bool):
+        return None
     if value in (None, "", 0):
         return None
     if isinstance(value, datetime):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -510,6 +510,51 @@ class TestMEMANTOCLI:
 
         mock_write_service.batch_store_memories.assert_not_called()
 
+    @pytest.mark.parametrize("client_path", ["direct_client", "sdk_client"])
+    def test_batch_clients_preserve_temporal_metadata(
+        self, mock_all_clients, client_path
+    ):
+        """Migration writes must not turn expiring memories into permanent ones."""
+        if client_path == "direct_client":
+            from memanto.cli.client.direct_client import DirectClient as Client
+        else:
+            from memanto.cli.client.sdk_client import SdkClient as Client
+
+        mock_write_service = MagicMock()
+        mock_write_service.batch_store_memories.return_value = {"results": []}
+        mock_session = MagicMock()
+        mock_session.namespace = "memanto_agent_test-agent"
+        updated_at = datetime(2026, 6, 1, 9, 15, tzinfo=timezone.utc)
+        expires_at = datetime(2026, 8, 1, 9, 15, tzinfo=timezone.utc)
+
+        with (
+            patch.object(Client, "_get_write_service", return_value=mock_write_service),
+            patch.object(
+                Client,
+                "_get_validated_session_for_agent",
+                return_value=mock_session,
+            ),
+        ):
+            client = Client.__new__(Client)
+            client.api_key = "test-api-key"
+            client.session_token = None
+            client.batch_remember(
+                agent_id="test-agent",
+                memories=[
+                    {
+                        "content": "Temporary operational context",
+                        "updated_at": updated_at,
+                        "expires_at": expires_at,
+                        "ttl_seconds": 5_529_600,
+                    }
+                ],
+            )
+
+        record = mock_write_service.batch_store_memories.call_args.args[0][0]
+        assert record.updated_at == updated_at
+        assert record.expires_at == expires_at
+        assert record.ttl_seconds == 5_529_600
+
     def test_edit_sdk_normalizes_confidence_and_accepts_valid_payload(
         self, mock_all_clients
     ):

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -145,9 +145,9 @@ def test_okf_import_ignores_invalid_temporal_extensions(tmp_path):
         "type: fact\n"
         "title: Durable fact\n"
         "x_memanto:\n"
-        "  updated_at: not-a-date\n"
-        "  expires_at: impossible\n"
-        "  ttl_seconds: -30\n"
+        "  updated_at: true\n"
+        "  expires_at: true\n"
+        "  ttl_seconds: true\n"
         "---\n\n"
         "This memory remains importable.\n",
         encoding="utf-8",

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -96,8 +96,7 @@ def test_context_sections_and_import_scope(tmp_path):
 
 
 def test_memanto_round_trip_preserves_extras(tmp_path):
-    """Memanto -> OKF -> Memanto keeps type/confidence/source_ref/tags/body via
-    the ``x_memanto`` block, and always marks provenance as imported."""
+    """Memanto -> OKF -> Memanto keeps metadata via ``x_memanto``."""
     memories_by_type = {
         "fact": [
             _mem(
@@ -110,6 +109,9 @@ def test_memanto_round_trip_preserves_extras(tmp_path):
                 source="user",
                 status="active",
                 created_at="2026-05-28T14:30:00Z",
+                updated_at="2026-06-01T09:15:00Z",
+                expires_at="2026-08-01T09:15:00Z",
+                ttl_seconds=5_529_600,
                 source_ref="https://example.com/db",
             )
         ],
@@ -129,8 +131,33 @@ def test_memanto_round_trip_preserves_extras(tmp_path):
     assert pg["provenance"] == "imported"
     assert set(pg["tags"]) == {"infra", "db"}
     assert pg["created_at"] is not None
+    assert pg["updated_at"].isoformat() == "2026-06-01T09:15:00+00:00"
+    assert pg["expires_at"].isoformat() == "2026-08-01T09:15:00+00:00"
+    assert pg["ttl_seconds"] == 5_529_600
     assert "PostgreSQL 16" in pg["content"]
     assert by_title["Chose Redis"]["type"] == "decision"
+
+
+def test_okf_import_ignores_invalid_temporal_extensions(tmp_path):
+    """Malformed foreign extensions must not break an otherwise valid import."""
+    (tmp_path / "memory.md").write_text(
+        "---\n"
+        "type: fact\n"
+        "title: Durable fact\n"
+        "x_memanto:\n"
+        "  updated_at: not-a-date\n"
+        "  expires_at: impossible\n"
+        "  ttl_seconds: -30\n"
+        "---\n\n"
+        "This memory remains importable.\n",
+        encoding="utf-8",
+    )
+
+    row = map_okf(load_okf_bundle(tmp_path))[0]
+
+    assert row["updated_at"] is not None
+    assert row["expires_at"] is None
+    assert row["ttl_seconds"] is None
 
 
 def test_foreign_okf_bundle_is_lossless(tmp_path):


### PR DESCRIPTION
## Summary

Memanto's own OKF export/import round trip silently discards temporal metadata:

- `expires_at` is lost, so a temporary memory is re-imported as permanent;
- `ttl_seconds` is lost with it, removing the original retention policy; and
- `updated_at` is replaced with the migration time, so historical memories appear
  newly modified to `changed-since` recall.

This is a non-security memory-integrity flaw in a normal production workflow:
exporting an agent's portable OKF bundle and later restoring it.

## Reproduction

Run this against current `main`:

```python
from pathlib import Path
from tempfile import TemporaryDirectory

from memanto.app.services.okf_export_service import OkfExportService
from memanto.cli.migrate.mappers import map_okf
from memanto.cli.migrate.okf_loader import load_okf_bundle

with TemporaryDirectory() as tmp:
    service = OkfExportService(exports_dir=Path(tmp))
    result = service.write_okf_bundle(
        "agent1",
        {
            "fact": [
                {
                    "id": "temp-1",
                    "title": "Temporary fact",
                    "content": "Expires later.",
                    "confidence": 0.8,
                    "updated_at": "2026-06-01T09:15:00Z",
                    "expires_at": "2026-08-01T09:15:00Z",
                    "ttl_seconds": 5_529_600,
                }
            ]
        },
    )
    row = map_okf(load_okf_bundle(result["output_path"]))[0]
    print(
        {
            key: row.get(key)
            for key in ("updated_at", "expires_at", "ttl_seconds")
        }
    )
```

Before this fix, `expires_at` and `ttl_seconds` are `None`, while `updated_at`
is the current import time. After this fix, the output is:

```text
{
  'updated_at': datetime(2026, 6, 1, 9, 15, tzinfo=UTC),
  'expires_at': datetime(2026, 8, 1, 9, 15, tzinfo=UTC),
  'ttl_seconds': 5529600
}
```

## Root cause

`OkfExportService` exported only a subset of Memanto's namespaced extension
fields. `map_okf()` then unconditionally assigned the migration timestamp to
`updated_at`. Even if a caller manually supplied temporal extension fields,
both batch clients omitted them while constructing `MemoryRecord`, so the
storage layer could not persist them.

## Fix

- Include `updated_at`, `expires_at`, and `ttl_seconds` in the `x_memanto`
  extension generated by Memanto exports.
- Parse those values safely on OKF import, preserving the existing migration-time
  fallback for missing or malformed `updated_at`.
- Ignore malformed expiration/TTL extensions instead of rejecting an otherwise
  valid foreign OKF document.
- Forward temporal fields through both `SdkClient` and `DirectClient` batch
  migration paths into `MemoryRecord`.
- Add regression coverage for the full OKF round trip, malformed extensions, and
  both storage clients.

## Validation

- `pytest -q` — 391 passed, 24 live Moorcheh tests skipped without a real API key
- focused OKF/CLI suite — 106 passed
- `ruff check .`
- `ruff format --check .`
- `mypy .` — no issues in 100 source files
- `git diff --check`

Refs #770

BountyHub: https://www.bountyhub.dev/en/bounty/view/a7d4cc29-f927-4939-bc77-d7b8bb36c3da

/claim #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch memory operations now accept and preserve per-item expiration dates, TTL settings, and updated timestamps.
  * OKF exports retain additional Memanto temporal metadata to improve migration round-trips.

* **Bug Fixes**
  * Migrated OKF documents now use `x_memanto.updated_at` when present (falling back only when missing).
  * Importing OKF data with invalid temporal values no longer fails; invalid `expires_at`/`ttl_seconds` are safely ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->