### PR TITLE
fix(extraction): cap generated memory content

### DIFF
--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -21,6 +21,7 @@ class ConversationMemoryExtractionService:
     MAX_MESSAGES = 200
     MAX_MEMORIES = 100
     MAX_CONTENT_CHARS = 12_000
+    MAX_MEMORY_CONTENT_CHARS = 10_000
 
     def __init__(self, client: Any) -> None:
         self.client = client
@@ -100,6 +101,7 @@ class ConversationMemoryExtractionService:
             "commitments, errors, observations, relationships, context, events, "
             "artifacts, or learnings that would be useful in future sessions. "
             "Do not include secrets, API keys, passwords, tokens, or transient chatter. "
+            f"Keep each memory content at or below {self.MAX_MEMORY_CONTENT_CHARS} characters. "
             f"Return at most {max_memories} memories. Valid types: {memory_types}."
         )
 
@@ -143,6 +145,8 @@ class ConversationMemoryExtractionService:
             content = str(item.get("content", "")).strip()
             if not content:
                 continue
+            if len(content) > self.MAX_MEMORY_CONTENT_CHARS:
+                content = content[: self.MAX_MEMORY_CONTENT_CHARS - 3].rstrip() + "..."
 
             memory_type = item.get("type")
             if memory_type:

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from memanto.app.services.conversation_memory_extraction_service import (
@@ -113,3 +115,29 @@ def test_extract_requires_messages():
 
     with pytest.raises(ValueError, match="at least one message"):
         service.extract(namespace="memanto_agent_test", messages=[])
+
+
+def test_extract_caps_candidate_content_to_memory_record_limit():
+    oversized = "x" * 10_001
+    service = ConversationMemoryExtractionService(
+        FakeClient(
+            json.dumps(
+                [
+                    {
+                        "type": "fact",
+                        "title": "Large memory",
+                        "content": oversized,
+                        "confidence": 0.9,
+                    }
+                ]
+            )
+        )
+    )
+
+    candidates = service.extract(
+        namespace="memanto_agent_test",
+        messages=[{"role": "user", "content": "Remember the supplied document."}],
+    )
+
+    assert len(candidates[0]["content"]) == 10_000
+    assert candidates[0]["content"].endswith("...")


### PR DESCRIPTION
### Summary

Prevent conversation-memory extraction from returning candidates that the persistence model cannot store.

Refs #770

### Root cause and impact

`ConversationMemoryExtractionService` accepts model-generated `content` at any length, while `MemoryRecord.content` has a hard 10,000-character limit. A model response containing one candidate with 10,001 or more characters therefore passes extraction normalization but fails when the route constructs `MemoryRecord`, aborting the entire non-dry-run request before any candidate is stored.

This is realistic when a conversation contains a long pasted document or the generation model returns an over-detailed extracted memory. The extraction prompt previously did not state the storage limit, and model output is not a trustworthy validation boundary.

### Reproduction

1. Return a valid extraction JSON array with one candidate whose `content` is 10,001 characters.
2. Call `ConversationMemoryExtractionService.extract()`.
3. Before this fix, the service returns the oversized candidate unchanged.
4. The `/remember/extract` persistence path then constructs `MemoryRecord`, which rejects the candidate because `content` exceeds 10,000 characters; the whole request fails.

The added regression test reproduces the boundary deterministically without an API key.

### Fix

- State the 10,000-character storage contract in the extraction prompt.
- Enforce the same boundary during candidate normalization.
- Preserve a visible ellipsis when truncation occurs.
- Add regression coverage for a 10,001-character generated candidate.

### Validation

- Replayed without conflict on upstream `main` commit `92e044b449858025e4de01f104ccc2c240d9cc63` on 2026-07-24.
- `uv run pytest -q tests/test_conversation_memory_extraction.py` — 5 passed.
- `uv run pytest -q` — 389 passed; 24 live E2E tests skipped because no real Moorcheh API key was used.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .` — no issues in 100 source files.
- `git diff --check`

Bounty submission: `/claim #770`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited extracted conversation memories to 10,000 characters each.
  * Oversized memory content is automatically truncated with a trailing ellipsis.
  * Updated extraction guidance to help keep generated memories within the supported limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->