### PR TITLE
fix(read): search_as_of recalls since-expired memories (timeline amnesia)

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -256,7 +256,7 @@ class MemoryReadService:
                     "temporal_mode": "as_of",
                 }
 
-            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags, filter_expired=False)
             all_memories = self._apply_temporal_filter(
                 all_memories, created_before=as_of_dt.isoformat()
             )
@@ -445,6 +445,7 @@ class MemoryReadService:
         namespaces: list[str],
         type: list[str] | None = None,
         tags: list[str] | None = None,
+        filter_expired: bool = True,
     ) -> list[dict[str, Any]]:
         """
         List all stored memories across the given namespaces via Moorcheh's
@@ -498,7 +499,9 @@ class MemoryReadService:
 
             memories.append(formatted)
 
-        return self._filter_expired_memories(memories)
+        if filter_expired:
+            return self._filter_expired_memories(memories)
+        return memories
 
     def _memory_version_key(
         self, memory: dict[str, Any], fetch_index: int

--- a/tests/test_as_of_expired_recall.py
+++ b/tests/test_as_of_expired_recall.py
@@ -1,0 +1,86 @@
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _memory(memory_id: str, created_at: str, expires_at: str | None = None) -> dict:
+    memory = {
+        "id": memory_id,
+        "text": f"[FACT] {memory_id}\n\nStored memory",
+        "memory_type": "fact",
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+    if expires_at:
+        memory["expires_at"] = expires_at
+    return memory
+
+
+class _FakeDocuments:
+    def __init__(self, items):
+        self._items = items
+
+    def fetch_text_data(self, **kwargs):
+        return {
+            "items": self._items,
+            "pagination": {"has_more": False},
+        }
+
+
+class _FakeClient:
+    def __init__(self, items):
+        self.documents = _FakeDocuments(items)
+
+
+def test_search_as_of_recalls_since_expired_memory():
+    """A memory that was live at as_of_date but expired afterward must be recalled."""
+    items = [
+        _memory("temporal-fact", "2026-01-10T00:00:00Z", expires_at="2026-06-01T00:00:00Z"),
+    ]
+    service = MemoryReadService(_FakeClient(items))
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15",
+        agent_id="agent-1",
+        limit=None,
+    )
+
+    ids = [memory["id"] for memory in result["results"]]
+    assert "temporal-fact" in ids, "timeline amnesia: since-expired memory lost"
+
+
+def test_search_as_of_excludes_memory_expired_before_as_of_date():
+    """A memory that expired before as_of_date must NOT be recalled."""
+    items = [
+        _memory("expired-before", "2025-12-01T00:00:00Z", expires_at="2025-12-15T00:00:00Z"),
+    ]
+    service = MemoryReadService(_FakeClient(items))
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15",
+        agent_id="agent-1",
+        limit=None,
+    )
+
+    ids = [memory["id"] for memory in result["results"]]
+    assert "expired-before" not in ids
+
+
+def test_search_as_of_recalls_non_expired_memory():
+    """A memory that never expires must always be recalled."""
+    items = [
+        _memory("permanent", "2026-01-10T00:00:00Z"),
+    ]
+    service = MemoryReadService(_FakeClient(items))
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15",
+        agent_id="agent-1",
+        limit=None,
+    )
+
+    ids = [memory["id"] for memory in result["results"]]
+    assert "permanent" in ids


### PR DESCRIPTION
## Summary

search_as_of answers a point-in-time question: 'What was true at this date?'
It should return memories that were created before as_of_date and not yet
expired at as_of_date.

However, _fetch_all_memories always ran _filter_expired_memories against the
current wall-clock time, so any memory whose expires_at falls between
as_of_date and now was dropped before search_as_of could evaluate it.

## Fix

- Adds a filter_expired parameter to _fetch_all_memories (default True)
- search_as_of now calls _fetch_all_memories with filter_expired=False
- Relies on search_as_of's existing expires_at <= as_of_dt check
- Adds regression tests in tests/test_as_of_expired_recall.py

## Verification

- New regression tests pass (test_as_of_expired_recall.py)
- Existing tests still pass (test_memory_read_as_of.py, test_memory_read_temporal_recall.py, test_memory_read_confidence.py, test_memory_read_filter_sanitization.py)

Refs #770, #1617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved historical memory searches to correctly return memories that were valid at the selected point in time, even if they expired later.
  * Continued excluding memories that had already expired by the selected date.
  * Ensured memories without an expiration time remain available in historical searches.

* **Tests**
  * Added coverage for expiration and historical recall scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->