### PR TITLE
feat(migration): add Open WebUI chat export to OKF adapter

### DIFF
--- a/examples/migrations/open_webui/README.md
+++ b/examples/migrations/open_webui/README.md
@@ -35,6 +35,12 @@ retains the source chat ID, source message IDs, model names, timestamps, and
 Open WebUI tags in frontmatter. Message bodies remain plain Markdown and can be
 inspected or versioned before import.
 
+`sample-okf/` is the committed, human-inspectable output generated from
+`sample-export.json`. It demonstrates the exact bundle contract and can be
+loaded with `memanto migrate okf sample-okf --dry-run`. The small sample is a
+format fixture, not a claim of real-world migration evidence; bounty showcases
+should run the same command against their own genuine Open WebUI export.
+
 ## Mapping
 
 | Open WebUI | OKF / Memanto |

--- a/examples/migrations/open_webui/README.md
+++ b/examples/migrations/open_webui/README.md
@@ -1,0 +1,52 @@
+# Open WebUI to Memanto via OKF
+
+This adapter converts Open WebUI's built-in **Settings > Data Controls > Export
+Chats** JSON into a portable Open Knowledge Format bundle. It requires no
+Open WebUI server, API token, or Memanto key.
+
+## Why branch selection matters
+
+Open WebUI stores a conversation as a message graph. Regenerating or editing a
+response leaves abandoned sibling branches in `history.messages`, while
+`history.currentId` identifies the branch visible to the user. Importing every
+message would preserve contradictory answers that the user deliberately
+discarded. This adapter walks from `currentId` to the root and migrates only
+that selected branch.
+
+If an older export lacks `currentId`, the newest terminal message is selected
+deterministically. Broken parent references and cycles fail closed instead of
+silently producing a partial transcript.
+
+## Run
+
+```bash
+python examples/migrations/open_webui/adapter.py \
+  ~/Downloads/chat-export-123.json \
+  ./open-webui-okf
+
+memanto migrate okf ./open-webui-okf --dry-run
+memanto migrate okf ./open-webui-okf --agent my-agent
+memanto memory export --okf --agent my-agent
+```
+
+The output contains one `artifact` memory per non-empty conversation and a
+`migration-manifest.json` with exact chat/message counts. Each OKF document
+retains the source chat ID, source message IDs, model names, timestamps, and
+Open WebUI tags in frontmatter. Message bodies remain plain Markdown and can be
+inspected or versioned before import.
+
+## Mapping
+
+| Open WebUI | OKF / Memanto |
+| --- | --- |
+| chat title | `title` |
+| selected message graph | artifact Markdown body |
+| chat creation time | `timestamp` |
+| `meta.tags` | `tags` |
+| message model | `source_models` |
+| chat/message IDs | `source_chat_id`, `source_message_ids` |
+| provider provenance | `x_memanto.source: open-webui` |
+
+Attachments and generated binary assets are not embedded because the standard
+chat export does not contain their bytes. Their textual references remain in
+message content.

--- a/examples/migrations/open_webui/__init__.py
+++ b/examples/migrations/open_webui/__init__.py
@@ -1,0 +1,1 @@
+"""Open WebUI chat export to OKF migration example."""

--- a/examples/migrations/open_webui/adapter.py
+++ b/examples/migrations/open_webui/adapter.py
@@ -8,7 +8,7 @@ import json
 import re
 import shutil
 import tempfile
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -26,7 +26,11 @@ def _timestamp(value: Any) -> str | None:
         stamp = float(value)
     except (TypeError, ValueError):
         return None
-    return datetime.fromtimestamp(stamp, tz=UTC).isoformat().replace("+00:00", "Z")
+    return (
+        datetime.fromtimestamp(stamp, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def _slug(value: str, fallback: str) -> str:
@@ -87,7 +91,7 @@ def current_branch(history: dict[str, Any]) -> list[dict[str, Any]]:
         message = messages.get(message_id)
         if message is None:
             raise ExportError(f"missing parent message {message_id}")
-        branch.append({"id": message_id, **message})
+        branch.append({**message, "id": message_id})
         parent_id = message.get("parentId")
         message_id = str(parent_id) if parent_id else None
     branch.reverse()
@@ -170,8 +174,11 @@ def convert_export(
             meta = (
                 envelope.get("meta") if isinstance(envelope.get("meta"), dict) else {}
             )
+            raw_tags = meta.get("tags") or []
+            if not isinstance(raw_tags, list):
+                raise ExportError(f"chat {index} meta.tags must be an array")
             tags = ["open-webui", "conversation"]
-            tags.extend(str(tag) for tag in meta.get("tags", []) if tag)
+            tags.extend(str(tag) for tag in raw_tags if tag)
             timestamp = _timestamp(envelope.get("created_at") or chat.get("created_at"))
             frontmatter: dict[str, Any] = {
                 "type": "artifact",
@@ -226,9 +233,24 @@ def convert_export(
             encoding="utf-8",
             newline="\n",
         )
+        backup_root: Path | None = None
+        backup: Path | None = None
         if output_dir.exists():
-            shutil.rmtree(output_dir)
-        staging.replace(output_dir)
+            backup_root = Path(
+                tempfile.mkdtemp(
+                    prefix=f".{output_dir.name}-backup-", dir=output_dir.parent
+                )
+            )
+            backup = backup_root / output_dir.name
+            output_dir.replace(backup)
+        try:
+            staging.replace(output_dir)
+        except Exception:
+            if backup is not None:
+                backup.replace(output_dir)
+            raise
+        if backup_root is not None:
+            shutil.rmtree(backup_root, ignore_errors=True)
         return manifest
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)

--- a/examples/migrations/open_webui/adapter.py
+++ b/examples/migrations/open_webui/adapter.py
@@ -1,0 +1,250 @@
+"""Convert an Open WebUI chat export into an importable OKF bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class ExportError(ValueError):
+    """Raised when an Open WebUI export cannot be converted safely."""
+
+
+def _timestamp(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        stamp = float(value)
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(stamp, tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _slug(value: str, fallback: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")[:64]
+    return slug or fallback
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts).strip()
+    return ""
+
+
+def current_branch(history: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the root-to-leaf branch selected by Open WebUI's currentId."""
+    raw_messages = history.get("messages")
+    if not isinstance(raw_messages, dict):
+        raise ExportError("chat history.messages must be an object")
+    messages = {
+        key: value for key, value in raw_messages.items() if isinstance(value, dict)
+    }
+    if not messages:
+        return []
+
+    current_id = history.get("currentId")
+    if current_id not in messages:
+        leaves = [
+            (key, message)
+            for key, message in messages.items()
+            if not any(
+                child in messages for child in message.get("childrenIds", []) or []
+            )
+        ]
+        if not leaves:
+            raise ExportError("chat history has no currentId or terminal message")
+        current_id = max(
+            leaves,
+            key=lambda item: (item[1].get("timestamp") or 0, item[0]),
+        )[0]
+
+    branch: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    message_id: str | None = str(current_id)
+    while message_id:
+        if message_id in seen:
+            raise ExportError(f"cycle detected in message ancestry at {message_id}")
+        seen.add(message_id)
+        message = messages.get(message_id)
+        if message is None:
+            raise ExportError(f"missing parent message {message_id}")
+        branch.append({"id": message_id, **message})
+        parent_id = message.get("parentId")
+        message_id = str(parent_id) if parent_id else None
+    branch.reverse()
+    return branch
+
+
+def _transcript(messages: list[dict[str, Any]]) -> str:
+    sections: list[str] = []
+    for message in messages:
+        role = str(message.get("role") or "unknown").strip().title()
+        content = _content_text(message.get("content"))
+        if not content:
+            continue
+        details = [f"message_id={message['id']}"]
+        model = message.get("model")
+        if model:
+            details.append(f"model={model}")
+        stamp = _timestamp(message.get("timestamp"))
+        if stamp:
+            details.append(f"timestamp={stamp}")
+        sections.append(f"## {role}\n\n{content}\n\n_({' | '.join(details)})_")
+    return "\n\n".join(sections)
+
+
+def normalize_export(data: Any) -> list[dict[str, Any]]:
+    """Validate current and legacy Open WebUI export envelopes."""
+    if isinstance(data, dict) and isinstance(data.get("chats"), list):
+        data = data["chats"]
+    if not isinstance(data, list):
+        raise ExportError(
+            "export root must be a JSON array or an object with a chats array"
+        )
+    chats: list[dict[str, Any]] = []
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ExportError(f"chat {index} must be an object")
+        chat = item.get("chat") if isinstance(item.get("chat"), dict) else item
+        history = chat.get("history")
+        if not isinstance(history, dict):
+            raise ExportError(f"chat {index} has no history object")
+        chats.append({"envelope": item, "chat": chat, "history": history})
+    return chats
+
+
+def convert_export(
+    data: Any, output_dir: Path, source_name: str = "chat-export.json"
+) -> dict[str, Any]:
+    """Write a deterministic OKF bundle and return its manifest."""
+    normalized = normalize_export(data)
+    output_dir = output_dir.resolve()
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{output_dir.name}-", dir=output_dir.parent)
+    )
+    try:
+        memories_dir = staging / "memories" / "artifact"
+        memories_dir.mkdir(parents=True)
+        records: list[dict[str, Any]] = []
+        used_names: set[str] = set()
+        skipped_empty = 0
+
+        for index, record in enumerate(normalized):
+            envelope, chat = record["envelope"], record["chat"]
+            messages = current_branch(record["history"])
+            body = _transcript(messages)
+            if not body:
+                skipped_empty += 1
+                continue
+            title = str(
+                chat.get("title") or envelope.get("title") or f"Chat {index + 1}"
+            )
+            chat_id = str(envelope.get("id") or chat.get("id") or f"chat-{index + 1}")
+            stem = _slug(title, f"chat-{index + 1}")
+            suffix = hashlib.sha256(chat_id.encode()).hexdigest()[:10]
+            filename = f"{stem}-{suffix}.md"
+            if filename in used_names:
+                raise ExportError(f"duplicate output filename for chat {chat_id}")
+            used_names.add(filename)
+
+            meta = (
+                envelope.get("meta") if isinstance(envelope.get("meta"), dict) else {}
+            )
+            tags = ["open-webui", "conversation"]
+            tags.extend(str(tag) for tag in meta.get("tags", []) if tag)
+            timestamp = _timestamp(envelope.get("created_at") or chat.get("created_at"))
+            frontmatter: dict[str, Any] = {
+                "type": "artifact",
+                "title": title,
+                "description": "Conversation migrated from an Open WebUI chat export.",
+                "tags": sorted(set(tags)),
+                "x_memanto": {
+                    "type": "artifact",
+                    "source": "open-webui",
+                    "confidence": 1.0,
+                },
+                "source_chat_id": chat_id,
+                "source_message_ids": [message["id"] for message in messages],
+                "source_message_count": len(messages),
+            }
+            if timestamp:
+                frontmatter["timestamp"] = timestamp
+            models = sorted(
+                {str(message["model"]) for message in messages if message.get("model")}
+            )
+            if models:
+                frontmatter["source_models"] = models
+            document = f"---\n{yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()}\n---\n\n{body}\n"
+            (memories_dir / filename).write_text(
+                document, encoding="utf-8", newline="\n"
+            )
+            records.append(
+                {
+                    "chat_id": chat_id,
+                    "file": f"memories/artifact/{filename}",
+                    "messages": len(messages),
+                }
+            )
+
+        (staging / "index.md").write_text(
+            "---\ntype: index\ntitle: Open WebUI migration\n---\n\n"
+            f"Migrated {len(records)} conversations from `{source_name}`.\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        manifest = {
+            "format": "okf",
+            "source": "open-webui",
+            "source_file": source_name,
+            "conversations": len(records),
+            "messages": sum(record["messages"] for record in records),
+            "skipped_empty": skipped_empty,
+            "records": records,
+        }
+        (staging / "migration-manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        if output_dir.exists():
+            shutil.rmtree(output_dir)
+        staging.replace(output_dir)
+        return manifest
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("export", type=Path, help="Open WebUI chat-export JSON file")
+    parser.add_argument("output", type=Path, help="Destination OKF bundle directory")
+    args = parser.parse_args()
+    data = json.loads(args.export.read_text(encoding="utf-8"))
+    manifest = convert_export(data, args.output, args.export.name)
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/migrations/open_webui/sample-export.json
+++ b/examples/migrations/open_webui/sample-export.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "planning-chat",
+    "created_at": 1784764800,
+    "meta": {"tags": ["release"]},
+    "chat": {
+      "title": "Atlas release plan",
+      "history": {
+        "currentId": "a2",
+        "messages": {
+          "u1": {"id": "u1", "role": "user", "content": "Ship Atlas on September 14.", "parentId": null, "childrenIds": ["a1", "a2"], "timestamp": 1784764800},
+          "a1": {"id": "a1", "role": "assistant", "content": "I will remember September 13.", "parentId": "u1", "childrenIds": [], "timestamp": 1784764801, "model": "model-old"},
+          "a2": {"id": "a2", "role": "assistant", "content": "The Atlas release date is September 14.", "parentId": "u1", "childrenIds": [], "timestamp": 1784764802, "model": "model-current"}
+        }
+      }
+    }
+  }
+]

--- a/examples/migrations/open_webui/sample-okf/index.md
+++ b/examples/migrations/open_webui/sample-okf/index.md
@@ -1,0 +1,6 @@
+---
+type: index
+title: Open WebUI migration
+---
+
+Migrated 1 conversations from `sample-export.json`.

--- a/examples/migrations/open_webui/sample-okf/memories/artifact/atlas-release-plan-6787392ce9.md
+++ b/examples/migrations/open_webui/sample-okf/memories/artifact/atlas-release-plan-6787392ce9.md
@@ -1,0 +1,33 @@
+---
+type: artifact
+title: Atlas release plan
+description: Conversation migrated from an Open WebUI chat export.
+tags:
+- conversation
+- open-webui
+- release
+x_memanto:
+  type: artifact
+  source: open-webui
+  confidence: 1.0
+source_chat_id: planning-chat
+source_message_ids:
+- u1
+- a2
+source_message_count: 2
+timestamp: '2026-07-23T00:00:00Z'
+source_models:
+- model-current
+---
+
+## User
+
+Ship Atlas on September 14.
+
+_(message_id=u1 | timestamp=2026-07-23T00:00:00Z)_
+
+## Assistant
+
+The Atlas release date is September 14.
+
+_(message_id=a2 | model=model-current | timestamp=2026-07-23T00:00:02Z)_

--- a/examples/migrations/open_webui/sample-okf/migration-manifest.json
+++ b/examples/migrations/open_webui/sample-okf/migration-manifest.json
@@ -1,0 +1,15 @@
+{
+  "conversations": 1,
+  "format": "okf",
+  "messages": 2,
+  "records": [
+    {
+      "chat_id": "planning-chat",
+      "file": "memories/artifact/atlas-release-plan-6787392ce9.md",
+      "messages": 2
+    }
+  ],
+  "skipped_empty": 0,
+  "source": "open-webui",
+  "source_file": "sample-export.json"
+}

--- a/tests/test_open_webui_okf_adapter.py
+++ b/tests/test_open_webui_okf_adapter.py
@@ -94,6 +94,21 @@ def test_missing_current_id_chooses_newest_leaf():
     assert [message["id"] for message in current_branch(history)] == ["root", "b"]
 
 
+def test_history_key_is_authoritative_message_id():
+    history = {
+        "currentId": "actual-id",
+        "messages": {
+            "actual-id": {
+                "id": "embedded-stale-id",
+                "role": "user",
+                "content": "x",
+                "parentId": None,
+            }
+        },
+    }
+    assert current_branch(history)[0]["id"] == "actual-id"
+
+
 def test_cycle_and_missing_parent_fail_closed():
     with pytest.raises(ExportError, match="cycle"):
         current_branch({"currentId": "a", "messages": {"a": {"parentId": "a"}}})
@@ -124,6 +139,22 @@ def test_legacy_envelope_and_empty_chat_count(tmp_path):
         ]
         == 0
     )
+
+
+def test_null_tags_are_empty_and_malformed_tags_fail_cleanly(tmp_path):
+    history = {
+        "currentId": "u",
+        "messages": {"u": {"role": "user", "content": "kept", "parentId": None}},
+    }
+    data = _export(history)
+    data[0]["meta"]["tags"] = None
+    convert_export(data, tmp_path / "null-tags")
+    rows = map_okf(load_okf_bundle(tmp_path / "null-tags"))
+    assert set(rows[0]["tags"]) == {"open-webui", "conversation"}
+
+    data[0]["meta"]["tags"] = "not-a-list"
+    with pytest.raises(ExportError, match=r"chat 0 meta\.tags must be an array"):
+        convert_export(data, tmp_path / "bad-tags")
 
 
 def test_repeated_conversion_replaces_stale_files(tmp_path):

--- a/tests/test_open_webui_okf_adapter.py
+++ b/tests/test_open_webui_okf_adapter.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -137,3 +138,19 @@ def test_repeated_conversion_replaces_stale_files(tmp_path):
     convert_export(_export(history), output)
     assert not stale.exists()
     assert len(load_okf_bundle(output)["memories"]) == 1
+
+
+def test_committed_sample_bundle_matches_adapter(tmp_path):
+    root = Path(__file__).parents[1] / "examples" / "migrations" / "open_webui"
+    data = json.loads((root / "sample-export.json").read_text(encoding="utf-8"))
+    generated = tmp_path / "sample-okf"
+    convert_export(data, generated, "sample-export.json")
+
+    def files(directory):
+        return {
+            path.relative_to(directory): path.read_bytes()
+            for path in directory.rglob("*")
+            if path.is_file()
+        }
+
+    assert files(generated) == files(root / "sample-okf")

--- a/tests/test_open_webui_okf_adapter.py
+++ b/tests/test_open_webui_okf_adapter.py
@@ -1,0 +1,139 @@
+import json
+
+import pytest
+
+from examples.migrations.open_webui.adapter import (
+    ExportError,
+    convert_export,
+    current_branch,
+)
+from memanto.cli.migrate.mappers import map_okf
+from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+
+def _export(history, **extra):
+    return [
+        {
+            "id": "chat-1",
+            "created_at": 1_700_000_000,
+            "meta": {"tags": ["project"]},
+            "chat": {"title": "Release plan", "history": history},
+            **extra,
+        }
+    ]
+
+
+def test_selected_branch_excludes_abandoned_response(tmp_path):
+    history = {
+        "currentId": "current",
+        "messages": {
+            "root": {
+                "role": "user",
+                "content": "Release on Friday",
+                "parentId": None,
+                "childrenIds": ["abandoned", "current"],
+                "timestamp": 1,
+            },
+            "abandoned": {
+                "role": "assistant",
+                "content": "Release on Thursday",
+                "parentId": "root",
+                "childrenIds": [],
+                "timestamp": 2,
+            },
+            "current": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Release on Friday confirmed"}],
+                "parentId": "root",
+                "childrenIds": [],
+                "timestamp": 3,
+                "model": "qwen3",
+            },
+        },
+    }
+    output = tmp_path / "bundle"
+    manifest = convert_export(_export(history), output)
+
+    assert manifest["conversations"] == 1
+    assert manifest["messages"] == 2
+    rows = map_okf(load_okf_bundle(output))
+    assert len(rows) == 1
+    assert rows[0]["type"] == "artifact"
+    assert rows[0]["source"] == "open-webui"
+    assert "Release on Friday confirmed" in rows[0]["content"]
+    assert "Release on Thursday" not in rows[0]["content"]
+    assert set(rows[0]["tags"]) == {"open-webui", "conversation", "project"}
+
+
+def test_missing_current_id_chooses_newest_leaf():
+    history = {
+        "messages": {
+            "root": {
+                "role": "user",
+                "content": "x",
+                "parentId": None,
+                "childrenIds": ["a", "b"],
+            },
+            "a": {
+                "role": "assistant",
+                "content": "old",
+                "parentId": "root",
+                "childrenIds": [],
+                "timestamp": 10,
+            },
+            "b": {
+                "role": "assistant",
+                "content": "new",
+                "parentId": "root",
+                "childrenIds": [],
+                "timestamp": 20,
+            },
+        }
+    }
+    assert [message["id"] for message in current_branch(history)] == ["root", "b"]
+
+
+def test_cycle_and_missing_parent_fail_closed():
+    with pytest.raises(ExportError, match="cycle"):
+        current_branch({"currentId": "a", "messages": {"a": {"parentId": "a"}}})
+    with pytest.raises(ExportError, match="missing parent"):
+        current_branch({"currentId": "a", "messages": {"a": {"parentId": "gone"}}})
+
+
+def test_legacy_envelope_and_empty_chat_count(tmp_path):
+    data = {
+        "chats": [
+            {
+                "title": "Legacy",
+                "history": {
+                    "currentId": "u",
+                    "messages": {
+                        "u": {"role": "user", "content": "", "parentId": None}
+                    },
+                },
+            }
+        ]
+    }
+    manifest = convert_export(data, tmp_path / "bundle")
+    assert manifest["conversations"] == 0
+    assert manifest["skipped_empty"] == 1
+    assert (
+        json.loads((tmp_path / "bundle" / "migration-manifest.json").read_text())[
+            "messages"
+        ]
+        == 0
+    )
+
+
+def test_repeated_conversion_replaces_stale_files(tmp_path):
+    history = {
+        "currentId": "u",
+        "messages": {"u": {"role": "user", "content": "kept", "parentId": None}},
+    }
+    output = tmp_path / "bundle"
+    convert_export(_export(history), output)
+    stale = output / "memories" / "artifact" / "stale.md"
+    stale.write_text("stale", encoding="utf-8")
+    convert_export(_export(history), output)
+    assert not stale.exists()
+    assert len(load_okf_bundle(output)["memories"]) == 1


### PR DESCRIPTION
## Summary

Adds an Open WebUI chat-export to OKF migration adapter for bounty #1609 (Path B / new migration source).

- consumes Open WebUI's built-in **Settings > Data Controls > Export Chats** JSON without a server or API key
- follows `history.currentId` back to the root so abandoned regenerated/edited response branches are not imported as contradictory long-term memory
- fails closed on cycles and missing parents, with a deterministic newest-leaf fallback for legacy exports without `currentId`
- writes one inspectable `artifact` memory per conversation with source chat/message IDs, models, tags, timestamps, and provenance
- replaces stale output atomically and emits an exact migration manifest
- includes a runnable sample, mapping documentation, and focused regression coverage

This direction is distinct from the existing ChatGPT, Claude, Hindsight, LangGraph, LangMem, and OKF metadata submissions.

## Verification

- `uv run pytest tests -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run python examples/migrations/open_webui/adapter.py examples/migrations/open_webui/sample-export.json .tmp-open-webui-okf`
- loaded the generated bundle through `load_okf_bundle` + `map_okf` and verified one `artifact` row with `source=open-webui`

Full test result: all repository tests passed; 24 live Moorcheh E2E tests were skipped by the upstream test suite because no real `MOORCHEH_API_KEY` is configured.

Closes #1609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Open WebUI chat-export adapter that generates OKF bundles with Markdown conversation artifacts, an index, and a `migration-manifest.json`.
  * Selects the active message branch when available, with deterministic fallback.
  * Validates inputs, fail-fast on invalid/cyclic histories, and cleanly replaces existing output.
* **Documentation**
  * Added migration guidance, field mapping, and sample export/bundle.
  * Notes that attachments/binary assets aren’t embedded.
* **Tests**
  * Added coverage for branch selection, legacy/empty chats, tag handling, output replacement, and a byte-for-byte snapshot against the committed sample bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->