### PR TITLE
fix: resolve session deletion issue in client delete_agent Closes #770

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -486,6 +486,7 @@ class DirectClient:
         """
         logger.debug("Deleting agent '%s'", agent_id)
         self._get_agent_service().delete_agent(agent_id)
+        self._get_session_service().delete_session(agent_id)
         if self.agent_id == agent_id:
             self.session_token = None
             self.agent_id = None

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -318,6 +318,7 @@ class SdkClient:
         """
         logger.debug("Deleting agent '%s'", agent_id)
         self._get_agent_service().delete_agent(agent_id)
+        self._get_session_service().delete_session(agent_id)
         if self.agent_id == agent_id:
             self.session_token = None
             self.agent_id = None

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1389,3 +1389,46 @@ def test_batch_upload_error_counts_each_pending_memory_as_failed():
     assert all(
         "Batch upload returned status" in item["error"] for item in result["results"]
     )
+
+
+def test_client_delete_agent_clears_session_state(
+    tmp_path, monkeypatch, mock_moorcheh_for_tests
+):
+    """Deleting an agent via DirectClient and SdkClient clears persisted session state."""
+    from memanto.app.services.session_service import get_session_service
+    from memanto.cli.client import direct_client as direct_mod
+    from memanto.cli.client.direct_client import DirectClient
+    from memanto.cli.client.sdk_client import SdkClient
+
+    monkeypatch.setattr(
+        "memanto.app.services.agent_service.get_data_dir", lambda: tmp_path
+    )
+    monkeypatch.setattr(
+        "memanto.app.services.session_service.get_data_dir", lambda: tmp_path
+    )
+    monkeypatch.setattr(
+        direct_mod, "MoorchehClient", lambda **_: mock_moorcheh_for_tests
+    )
+
+    session_svc = get_session_service()
+
+    # Test DirectClient
+    d_client = DirectClient(api_key="test-key")
+    d_client._moorcheh = mock_moorcheh_for_tests
+    d_client.create_agent("agent-d", "tool", "direct client test")
+    d_client.activate_agent("agent-d")
+    assert session_svc.get_session("agent-d") is not None
+    assert session_svc.get_active_session() is not None
+
+    d_client.delete_agent("agent-d")
+    assert session_svc.get_session("agent-d") is None
+    assert session_svc.get_active_session() is None
+
+    # Test SdkClient
+    s_client = SdkClient(api_key="test-key")
+    s_client.create_agent("agent-s", "tool", "sdk client test")
+    s_client.activate_agent("agent-s")
+    assert session_svc.get_session("agent-s") is not None
+
+    s_client.delete_agent("agent-s")
+    assert session_svc.get_session("agent-s") is None


### PR DESCRIPTION
This PR resolves Issue #770 where deleting an agent via the CLI/Client (`SdkClient` or `DirectClient`) only deleted the agent metadata and failed to clear the active/persisted session files, leading to inconsistent behavior compared to the FastAPI delete route.

We integrated `delete_session` into both client implementations and added corresponding unit tests in `tests/test_unit.py`. All 460 tests and pre-commit checks have passed successfully.

Closes #770
/claim #770
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting an agent now also removes its persisted session data.
  * Active client session state continues to be cleared when the deleted agent is currently selected.

* **Tests**
  * Added regression coverage verifying session cleanup for both supported client workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->