### PR TITLE
fix(okf): ensure valid ISO 8601 timestamp in OKF export when created_at is a datetime object [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -24,6 +24,17 @@ frontmatter keys.
 import re
 import shutil
 from datetime import datetime
+
+
+def format_okf_timestamp(created_at):
+    """Return a valid ISO 8601 timestamp string."""
+    if isinstance(created_at, datetime):
+        return created_at.isoformat()
+    if isinstance(created_at, str):
+        return created_at
+    return None
+
+
 from pathlib import Path
 from typing import Any
 
@@ -289,10 +300,7 @@ class OkfExportService:
 
         created_at = mem.get("created_at")
         if created_at:
-            if isinstance(created_at, datetime):
-                frontmatter["timestamp"] = created_at.isoformat()
-            else:
-                frontmatter["timestamp"] = str(created_at)
+            frontmatter["timestamp"] = format_okf_timestamp(created_at)
 
         source_ref = mem.get("source_ref")
         if source_ref:

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -289,7 +289,10 @@ class OkfExportService:
 
         created_at = mem.get("created_at")
         if created_at:
-            frontmatter["timestamp"] = str(created_at)
+            if isinstance(created_at, datetime):
+                frontmatter["timestamp"] = created_at.isoformat()
+            else:
+                frontmatter["timestamp"] = str(created_at)
 
         source_ref = mem.get("source_ref")
         if source_ref:


### PR DESCRIPTION
### Bug

When `created_at` is a `datetime` object (not a pre-serialized string), `str(created_at)` produces `2026-07-26 12:00:00+00:00` which is **not valid ISO 8601** — the 'T' separator between date and time is missing.

### Fix

Use `.isoformat()` when the value is a `datetime` object, so the timestamp is always a proper ISO 8601 string like `2026-07-26T12:00:00+00:00`.

### Impact

This edge case affects OKF bundle exports when memory records come from non-standard sources (e.g., direct tests, OKF imports, or manually constructed records) where timestamps are not pre-serialized to strings.

Fixes #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp formatting in exported OKF documents by using standardized ISO 8601 formatting for datetime values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->