### PR TITLE
fix: use timezone-aware datetime throughout validation, logging, timestamp coercion, and OKF export [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -46,6 +46,8 @@ def _coerce_timestamp_str(value: Any) -> Any:
         except (OverflowError, OSError, ValueError):
             return None
     if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
         return value.isoformat()
     return value
 

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -45,6 +45,8 @@ def _coerce_timestamp_str(value: Any) -> Any:
             return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
         except (OverflowError, OSError, ValueError):
             return None
+    if isinstance(value, datetime):
+        return value.isoformat()
     return value
 
 

--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -4,7 +4,7 @@ Memory Validation Service
 Write-time contradiction detection and resolution for memory records.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -218,7 +218,7 @@ class MemoryValidationService:
             old_id = str(old_item.get("id"))
             namespace = new_memory.namespace()
 
-            now_iso = datetime.utcnow().isoformat()
+            now_iso = datetime.now(timezone.utc).isoformat()
             document: dict[str, Any] = {
                 "id": old_id,
                 "text": old_item.get("text") or "",

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -23,7 +23,7 @@ frontmatter keys.
 
 import re
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -339,7 +339,7 @@ class OkfExportService:
         self, directory: Path, title: str, heading: str, links: list[tuple[str, str]]
     ) -> None:
         """Write a navigational ``index.md`` (skipped on import)."""
-        now = datetime.now().isoformat(timespec="seconds")
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         lines = [
             "---",
             "type: index",
@@ -357,7 +357,7 @@ class OkfExportService:
     def _write_root_index(
         self, base: Path, agent_id: str, sections: dict[str, str]
     ) -> None:
-        now = datetime.now().isoformat(timespec="seconds")
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         lines = [
             "---",
             "type: index",

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -269,7 +269,7 @@ class OkfExportService:
                 return datetime.fromisoformat(text)
             except ValueError:
                 pass
-        return datetime.now()
+        return datetime.now(timezone.utc)
 
     # Rendering helpers
     def _render_okf_doc(self, mem: dict[str, Any], mem_type: str) -> str:

--- a/memanto/app/utils/logging.py
+++ b/memanto/app/utils/logging.py
@@ -8,7 +8,7 @@ import logging
 import time
 import uuid
 from contextvars import ContextVar
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps
 from typing import Any
 
@@ -54,7 +54,7 @@ class MemantoLogger:
     ):
         """Log core request information"""
         log_entry = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "level": "INFO",
             "logger": "memanto.request",
             "request_id": request_id,
@@ -96,7 +96,7 @@ class MemantoLogger:
     ):
         """Log memory write operation"""
         log_entry = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "level": "INFO",
             "logger": "memanto.memory.write",
             "request_id": request_id,
@@ -129,7 +129,7 @@ class MemantoLogger:
     ):
         """Log memory read operation"""
         log_entry = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "level": "INFO",
             "logger": "memanto.memory.read",
             "request_id": request_id,
@@ -153,7 +153,7 @@ class MemantoLogger:
     ):
         """Log memory delete operation"""
         log_entry = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "level": "INFO",
             "logger": "memanto.memory.delete",
             "request_id": request_id,
@@ -174,7 +174,7 @@ class MemantoLogger:
     ):
         """Log Moorcheh SDK calls"""
         log_entry = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "level": "INFO" if success else "ERROR",
             "logger": "memanto.moorcheh",
             "request_id": request_id,


### PR DESCRIPTION
This PR fixes several datetime-related issues for Python 3.12+ compatibility and timestamp consistency:

**Changes:**

1. **memory_validation_service.py**: Replace `datetime.utcnow().isoformat()` (naive, deprecated in Python 3.12) with `datetime.now(timezone.utc).isoformat()` (timezone-aware) in the `_supersede` method.

2. **memory_read_service.py**: Fix `_coerce_timestamp_str` to convert `datetime` objects to ISO strings via `.isoformat()` instead of returning them as-is, preventing potential serialization issues.

3. **okf_export_service.py**: Replace `datetime.now().isoformat(...)` (naive) with `datetime.now(timezone.utc).isoformat(...)` (timezone-aware) in index file generation.

4. **logging.py**: Replace all 5 occurrences of `datetime.utcnow().isoformat()` (naive, deprecated) with `datetime.now(timezone.utc).isoformat()` (timezone-aware).

**Rationale:**
- `datetime.utcnow()` is deprecated in Python 3.12+ and produces a `DeprecationWarning`
- Naive timestamps (without timezone info) are inconsistent with the rest of the codebase, which uses timezone-aware timestamps via `MemoryRecord.to_moorcheh_document()` and `_coerce_timestamp_str`
- Timezone-aware timestamps ensure correct sorting, filtering, and comparison across the stack

**Testing:**
- All tests pass (existing flaky timing test `test_prefetch_contradictions_runs_parallel_lookups` is a pre-existing issue unrelated to this PR)
- All modified files compile without syntax errors

Bounty: #770