### PR TITLE
fix: unify as_of date parsing to handle all ISO 8601 date formats [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -191,7 +191,7 @@ class RecallAsOfRequest(BaseModel):
             if "T" not in v and " " not in v:
                 try:
                     return datetime.combine(
-                        date.fromisoformat(v), time(23, 59, 59), tzinfo=timezone.utc
+                        date.fromisoformat(v), time.max, tzinfo=timezone.utc
                     )
                 except ValueError:
                     pass

--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -45,7 +45,7 @@ def parse_as_of_timestamp(ts_str: str) -> datetime:
     Normalizing at the service boundary keeps every caller consistent without
     changing the meaning of full ISO timestamps.
     """
-    if len(ts_str) == 10 and ts_str[4] == "-" and ts_str[7] == "-":
+    if "T" not in ts_str and " " not in ts_str:
         try:
             return datetime.combine(
                 date.fromisoformat(ts_str), time.max, tzinfo=timezone.utc

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -84,3 +84,19 @@ def test_parse_as_of_timestamp_preserves_explicit_time():
     parsed = parse_as_of_timestamp("2026-01-15T13:30:00Z")
 
     assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"
+
+
+def test_parse_as_of_timestamp_handles_basic_iso_format():
+    """ISO 8601 basic format (no hyphens) should be treated as end of day."""
+    parsed = parse_as_of_timestamp("20260726")
+
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.isoformat() == "2026-07-26T23:59:59.999999+00:00"
+
+
+def test_parse_as_of_timestamp_handles_iso_week_date():
+    """ISO 8601 week date format should also be treated as end of day."""
+    parsed = parse_as_of_timestamp("2026-W30-7")
+
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.isoformat() == "2026-07-26T23:59:59.999999+00:00"


### PR DESCRIPTION
## Summary

Fixes the `as_of` date parsing inconsistency where ISO 8601 basic format dates (e.g., `20260726`) were treated differently depending on which entry point you used.

### The Bug

`parse_as_of_timestamp` in `temporal_helpers.py` used hyphen-shape detection to identify date-only inputs, missing basic format dates like `20260726`. These fell through to `parse_iso_timestamp`, returning start-of-day (midnight) instead of end-of-day.

The REST route validator (`RecallAsOfRequest`) correctly handled all date-only formats using a time-component check.

### The Fix

1. Replaced the hyphen-shape check with the time-component check in `parse_as_of_timestamp`
2. Used `time.max` consistently in both paths to eliminate the 0.999999s sub-second gap

### Tests Added

- `test_parse_as_of_timestamp_handles_basic_iso_format`: Ensures `20260726` is treated as end of day
- `test_parse_as_of_timestamp_handles_iso_week_date`: Ensures `2026-W30-7` is also treated as end of day

Closes #1655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “as-of” date handling across supported ISO 8601 formats.
  * Date-only values now consistently resolve to the final microsecond of the specified UTC day.
* **Tests**
  * Added coverage for compact calendar dates and ISO week-date formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->