### PR TITLE
fix: remove duplicate SUCCESSFUL_UPLOAD_STATUSES constant [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -31,9 +31,6 @@ _REMOVED_TRUST_FIELDS = frozenset(
     }
 )
 
-_SUCCESSFUL_UPLOAD_STATUSES = {"queued", "success", "ok"}
-
-
 class MemoryWriteService:
     """Persist memory records to Moorcheh-backed namespaces."""
 
@@ -283,7 +280,7 @@ class MemoryWriteService:
                 moorcheh_status = str(upload_result.get("status", "unknown")).lower()
                 for result in results:
                     if result["status"] == "pending":
-                        if moorcheh_status in _SUCCESSFUL_UPLOAD_STATUSES:
+                        if moorcheh_status in SUCCESSFUL_UPLOAD_STATUSES:
                             result["status"] = moorcheh_status
                         else:
                             result["status"] = "failed"


### PR DESCRIPTION
## Summary

`SUCCESSFUL_UPLOAD_STATUSES = {"queued", "success", "ok"}` was defined twice in `memory_write_service.py`:
- Line 18 as a module-level constant
- Line 34 as a private copy with the same value

**Fix:** Removed the duplicate at line 34 and updated the sole reference from `_SUCCESSFUL_UPLOAD_STATUSES` to `SUCCESSFUL_UPLOAD_STATUSES`.

## Testing

All 459 tests pass (0 failed, 24 skipped).

Closes #770