### PR TITLE
feat: add ChatGPT conversation memory adapter (OKF migration path) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/examples/migrations/chatgpt-memory/README.md
+++ b/examples/migrations/chatgpt-memory/README.md
@@ -1,0 +1,130 @@
+# ChatGPT → OKF → Memanto
+
+A migration adapter that extracts durable **user memories** out of a ChatGPT
+conversation history, packages them as a portable [OKF](https://docs.memanto.ai/integrations/okf)
+bundle, and hands them off to Memanto with:
+
+```bash
+memanto migrate okf ./chatgpt-memory/
+```
+
+## What this is for
+
+When a chat assistant has been talking with you for weeks, it has quietly
+built a model of *you* — preferences, the stack you run, the decisions you've
+made. When that context window rolls off, or if you switch assistants, that
+memory vanishes. This adapter makes that memory portable.
+
+**What we do:** read a ChatGPT-style JSON export and emit a small set of
+plain-Markdown OKF documents, one per durable user memory, tagged by category
+(`preference`, `fact`, `decision`, `goal`).
+
+**What we deliberately do not do:** dump every raw assistant turn. We extract
+only the user-facing knowledge that's worth remembering, so the bundle stays
+small, readable, and actually useful as a migration target.
+
+## Quick start
+
+```bash
+# 1. Produce a ChatGPT-style export (your own tooling, or use the sample).
+#    Expected shape: a JSON array of {"thread_id", "title", "messages": [...]}
+
+# 2. Extract memories into an OKF bundle
+python3 extract_memories.py chatgpt_export.json ./chatgpt-memory/
+
+# 3. Inspect — plain Markdown with YAML frontmatter
+cat ./chatgpt-memory/*.md
+
+# 4. Import into Memanto (requires MOORCHEH_API_KEY in your environment)
+memanto migrate okf ./chatgpt-memory/
+```
+
+## Run the sample end-to-end
+
+This folder ships `sample_export.json` (3 realistic threads) and the script:
+
+```bash
+python3 extract_memories.py sample_export.json sample_bundle/
+# -> 6 memory documents across preference / fact / decision / goal
+```
+
+Open any `.md` in `sample_bundle/` — it's valid OKF that Memanto's
+`memanto migrate okf` importer reads losslessly.
+
+## Input format
+
+A JSON array of threads. Each thread is an object with:
+
+| Key | Required | Example |
+|---|---|---|
+| `thread_id` | yes | `"thread-abc123"` |
+| `title` | yes | `"Project planning session"` |
+| `messages` | yes | `[{"role": "user", "content": "...", "timestamp": "2026-05-01T10:00:00Z"}, ...]` |
+
+Only `role: "user"` messages are scanned; assistant replies are treated as
+context and ignored. User messages under ~30 characters (greetings, one-liners)
+are skipped.
+
+## Output
+
+One `.md` file per extracted memory, plus an `index.md` navigation file
+(skipped by the importer). Each document has YAML frontmatter conforming to
+OKF:
+
+```yaml
+---
+type: preference
+title: "I prefer Kotlin over Java."
+tags:
+  - preference
+  - chatgpt-import
+  - thread:thread-abc12
+timestamp: "2026-05-01T10:00:00Z"
+resource: chatgpt://thread/thread-abc123def456
+x_memanto:
+  type: preference
+  source: chatgpt
+---
+
+Extracted from thread **Project planning session** (thread-abc123def).
+
+First surfaced: `2026-05-01T10:00:00Z`
+
+I prefer Kotlin over Java because the null-safety model keeps me sane...
+```
+
+## How it works
+
+1. Walk every `user` message in every thread.
+2. Classify with keyword/signal regexes (see `SIGNAL_PATTERNS` in
+   `extract_memories.py`) into one of `preference`, `fact`, `decision`,
+   `goal`. Messages with no strong signal are dropped.
+3. Write each surviving memory as an OKF Markdown document with full
+   provenance (`thread_id`, `timestamp`, `resource` URI).
+4. De-duplicate identical bodies within the same thread so repeat utterances
+   don't pollute the bundle.
+
+The extraction is **fully deterministic and offline** — no LLM call — so the
+same export always produces byte-stable output. Easy to review, easy to CI,
+easy to prove round-trip fidelity.
+
+## Reusability
+
+This adapter lives in `examples/migrations/chatgpt-memory/` so it ships with
+the repo and a reviewer can run it in under 15 minutes. The design follows
+the pattern used by the existing provider adapters (`letta`, `mem0`,
+`supermemory`): a thin script that emits an OKF bundle, which Memanto's
+standard `memanto migrate okf` importer consumes.
+
+To add another source (Zep, Graphiti, LangMem, LangGraph checkpoints), write
+a companion `extract_<source>.py` that emits the same OKF shape and drop it
+into this folder — the import step is already done.
+
+## Testing
+
+```bash
+python3 -m pytest test_extract_memories.py -v
+```
+
+18 tests covering category inference, message filtering, deduplication, and
+OKF frontmatter validity.

--- a/examples/migrations/chatgpt-memory/extract_memories.py
+++ b/examples/migrations/chatgpt-memory/extract_memories.py
@@ -123,6 +123,17 @@ DEFAULT_OKF_TYPE = "preference"
 
 @dataclass
 class Memory:
+    """A single extracted memory fragment with its metadata.
+
+    Attributes:
+        category: Memory category (preference, fact, decision, goal, context).
+        title: Short human-readable title.
+        body: Full text of the memory.
+        thread_id: Source conversation thread identifier.
+        thread_title: Human-readable thread name.
+        sources: Timestamped citation strings for provenance tracking.
+    """
+
     category: str
     title: str
     body: str

--- a/examples/migrations/chatgpt-memory/extract_memories.py
+++ b/examples/migrations/chatgpt-memory/extract_memories.py
@@ -1,0 +1,295 @@
+"""
+Export ChatGPT conversation memory into an OKF bundle for Memanto.
+
+Background
+----------
+When you have a long-running ChatGPT (or any chat assistant) conversation,
+the assistant gradually builds a mental model of you: your preferences, the
+decisions you made, facts you told it, recurring themes. Once that context
+window is pruned, or if you switch assistants, that accumulated "memory of
+you" vanishes.
+
+This adapter treats each conversation **thread** as a memory source and
+extracts the assistant's accumulated context about the user into a portable
+OKF (Open Knowledge Format) bundle: plain, human-readable Markdown that
+Memanto can ingest with ``memanto migrate okf <bundle>``.
+
+What this adapter does
+----------------------
+1. Reads a ChatGPT-style conversation export (JSON produced by the
+   ``export_conversation.py`` helper or by any tool that emits the same
+   shape: a list of threads, each a list of messages with ``role``,
+   ``content``, and ``timestamp``).
+2. From each thread, distills a small set of **user-relevant memories**:
+   facts, preferences, decisions, goals, and themes the user has surfaced,
+   written as plain Markdown OKF documents with YAML frontmatter.
+3. Writes the bundle to a directory. Memanto can then import it losslessly:
+
+       memanto migrate okf ./chatgpt-memory/
+
+Why this shape
+--------------
+We do **not** dump every raw turn (which would be mostly assistant
+reasoning, not memory). Instead we surface only the durable user-facing
+knowledge — the kind of things you would want any new assistant to
+remember about you. That keeps the bundle small, readable, and actually
+useful as a migration target.
+
+Reproducibility
+---------------
+The export step is deterministic given the input JSON. The memory
+distillation is keyword/signal based (not a live LLM call) so it runs
+offline and produces byte-stable output — ideal for CI and for reviewers
+to verify.
+
+Input format (chatgpt_export.json)
+----------------------------------
+    [
+      {
+        "thread_id": "thread-abc123",
+        "title": "Project planning session",
+        "messages": [
+          {"role": "user",      "content": "I'm using Python 3.12 with pytest.",
+           "timestamp": "2026-05-01T10:00:00Z"},
+          {"role": "assistant", "content": "Great choice. Python 3.12 with
+           pytest is a solid combo...",
+           "timestamp": "2026-05-01T10:00:12Z"},
+          ...
+        ]
+      },
+      ...
+    ]
+
+Usage
+-----
+    python extract_memories.py chatgpt_export.json ./chatgpt-memory/
+
+    # Then into Memanto (requires a MOORCHEH_API_KEY):
+    memanto migrate okf ./chatgpt-memory/
+
+The sample ``sample_export.json`` and ``sample_bundle/`` in this folder
+demonstrate the full round trip with realistic synthetic data.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Domain concepts
+# ---------------------------------------------------------------------------
+
+# Keywords that signal a *user* attribute rather than a generic assistant reply.
+# Patterns match against user messages (lower-cased).
+SIGNAL_PATTERNS: dict[str, list[re.Pattern]] = {
+    "preference": [
+        re.compile(r"\bI (prefer|like|don'?t like|love|hate|always|never)\b", re.I),
+        re.compile(r"\bI am (a|an)\b"),
+        re.compile(r"\bmy (favorite|preferred|default)\b", re.I),
+    ],
+    "fact": [
+        re.compile(r"\bI (live|work|study|commute) (in|at|to|for)\b", re.I),
+        re.compile(r"\bI (use|am using|run)\b", re.I),
+        re.compile(r"\bI (work with|build with|operate on)\b", re.I),
+        re.compile(r"\bmy (name|age|role|job|title|team|stack|language|os|distro)\b", re.I),
+        re.compile(r"\b(?:python|javascript|java|go|rust|kotlin|swift)\b", re.I),
+        re.compile(r"\b(?:docker|kubernetes|linux|windows|macos|ubuntu|arch)\b", re.I),
+        re.compile(r"\b(?:github|gitlab|ci|cd|ci/cd|k8s|wayland|hyprland|postgre?)\b", re.I),
+        re.compile(r"\b(?:arch linux|ubuntu|debian|fedora|k3s)\b", re.I),
+    ],
+    "decision": [
+        re.compile(r"\bI (chose|choose|decided|will (use|go with|stick to))\b", re.I),
+        re.compile(r"\bwe (went with|picked|settled on)\b", re.I),
+    ],
+    "goal": [
+        re.compile(r"\bI (want|would like|plan to|am trying to|aim to|need to)\b", re.I),
+        re.compile(r"\bmy goal is\b", re.I),
+    ],
+}
+
+# Type labels used as OKF ``type`` and as ``x_memanto.type``.
+# ``x_memanto.type`` carries the real category; OKF top-level ``type`` is fixed
+# so the bundle stays importable by Memanto's ``map_okf`` mapper.
+DEFAULT_OKF_TYPE = "preference"
+
+
+@dataclass
+class Memory:
+    category: str
+    title: str
+    body: str
+    thread_id: str
+    thread_title: str
+    sources: list[str] = field(default_factory=list)  # timestamped citations
+
+
+def _iso(s: str | None) -> str | None:
+    if not s:
+        return None
+    return s if s.endswith("Z") or "+" in s else s + "Z"
+
+
+def _first_match(text: str, patterns: list[re.Pattern]) -> list[re.Match]:
+    return [m for p in patterns for m in [p.search(text)] if m]
+
+
+def _infer_category(text: str) -> str:
+    """Return the strongest category whose pattern list hits *text*, else 'context'.
+
+    Priority order: ``preference`` is checked first because an explicit
+    preference phrase ("I prefer / I like / I hate") is a stronger signal than
+    a coincidental fact keyword (e.g. "Kotlin" in "I prefer Kotlin"). The
+    remaining categories follow in order of intent specificity.
+    """
+    for cat in ("preference", "decision", "goal", "fact"):
+        if _first_match(text, SIGNAL_PATTERNS[cat]):
+            return cat
+    return "context"
+
+
+def _safe_filename(s: str) -> str:
+    s = re.sub(r"[^\w\-]+", "-", s.strip()).strip("-").lower()
+    return s[:90] or "untitled"
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+def extract_memories(threads: list[dict[str, Any]]) -> list[Memory]:
+    """Extract durable user memories from a list of chat threads."""
+    memories: list[Memory] = []
+    seen: set[tuple[str, str]] = set()
+    for thread in threads:
+        tid = str(thread.get("thread_id", "unknown"))
+        ttitle = str(thread.get("title", "Untitled thread")).strip()
+        messages = thread.get("messages") or []
+
+        for msg in messages:
+            role = str(msg.get("role", "")).lower()
+            if role != "user":
+                continue
+            text = str(msg.get("content", ""))
+            if not text.strip():
+                continue
+            if len(text) < 30:
+                continue  # skip greetings / one-liners that aren't durable
+
+            category = _infer_category(text)
+            if category == "context":
+                continue
+
+            ts = _iso(str(msg.get("timestamp", "")).strip())
+            # Title = first sentence, capped.
+            first_sent = re.split(r"[.\n]", text, maxsplit=1)[0].strip()
+            title = first_sent[:95] if first_sent else f"User {category} from {ttitle[:40]}"
+            if not title.endswith("."):
+                title += "."
+
+            m = Memory(
+                category=category,
+                title=title,
+                body=text.strip(),
+                thread_id=tid,
+                thread_title=ttitle,
+                sources=[ts] if ts else [],
+            )
+            key = (tid, text.strip())
+            if key not in seen:
+                seen.add(key)
+                memories.append(m)
+
+    return memories
+
+# ---------------------------------------------------------------------------
+# OKF bundle writer
+# ---------------------------------------------------------------------------
+
+def write_okf_bundle(memories: list[Memory], out: Path) -> Path:
+    """Write an OKF bundle directory of Markdown documents."""
+    out.mkdir(parents=True, exist_ok=True)
+    written = 0
+    # Deduplicate identical bodies within the same category per thread, while
+    # keeping a citation trail so nothing is silently lost.
+    seen: set[tuple[str, str]] = set()
+    written = 0
+
+    # Counter for safe filenames within a (category, thread) bucket.
+    counter: dict[str, int] = defaultdict(int)
+
+    for m in memories:
+        key = (m.thread_id, m.body)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        counter[m.category] += 1
+        name = _safe_filename(m.title) or f"{m.category}-{counter[m.category]}"
+
+        frontmatter = {
+            "type": DEFAULT_OKF_TYPE,
+            "title": m.title,
+            "tags": [m.category, "chatgpt-import", f"thread:{m.thread_id[:12]}"],
+            "timestamp": m.sources[0] if m.sources else None,
+            "resource": f"chatgpt://thread/{m.thread_id}",
+            "x_memanto": {"type": m.category, "source": "chatgpt"},
+        }
+        body = f"Extracted from thread **{m.thread_title}** ({m.thread_id[:16]}).\n\n"
+        if m.sources:
+            body += f"First surfaced: `{m.sources[0]}`\n\n"
+        body += m.body
+
+        doc = "---\n" + yaml.safe_dump(frontmatter, sort_keys=False).strip() + "\n---\n\n" + body
+        (out / f"{name}.md").write_text(doc, encoding="utf-8")
+        written += 1
+
+    # index.md navigation file (skipped by memanto's loader)
+    idx = (out / "index.md")
+    idx.write_text(
+        "---\ntype: index\ntitle: ChatGPT Memory Export\n---\n\n"
+        f"Auto-generated bundle of {written} user memory fragments extracted "
+        "from ChatGPT conversation history. Import with:\n\n"
+        "    memanto migrate okf ./chatgpt-memory/\n",
+        encoding="utf-8",
+    )
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv or sys.argv[1:]
+    if len(args) < 2:
+        print("Usage: extract_memories.py <chatgpt_export.json> <output_dir>", file=sys.stderr)
+        return 2
+
+    src = Path(args[0])
+    out = Path(args[1])
+
+    with src.open(encoding="utf-8") as f:
+        threads = json.load(f)
+
+    if not isinstance(threads, list):
+        print("Error: expected a JSON array of threads", file=sys.stderr)
+        return 2
+
+    memories = extract_memories(threads)
+    write_okf_bundle(memories, out)
+
+    print(f"Exported {len(memories)} memory documents -> {out.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/migrations/chatgpt-memory/extract_memories.py
+++ b/examples/migrations/chatgpt-memory/extract_memories.py
@@ -132,12 +132,22 @@ class Memory:
 
 
 def _iso(s: str | None) -> str | None:
+    """Normalize a timestamp to ISO 8601 format with trailing Z.
+
+    Appends a ``Z`` suffix to timestamps that lack one (unless they already
+    contain a timezone offset), ensuring consistency in the OKF output.
+    """
     if not s:
         return None
     return s if s.endswith("Z") or "+" in s else s + "Z"
 
 
 def _first_match(text: str, patterns: list[re.Pattern]) -> list[re.Match]:
+    """Return all pattern matches found in *text*.
+
+    Iterates the given pattern list and collects every match. An empty
+    list means no signal was detected.
+    """
     return [m for p in patterns for m in [p.search(text)] if m]
 
 
@@ -156,6 +166,12 @@ def _infer_category(text: str) -> str:
 
 
 def _safe_filename(s: str) -> str:
+    """Convert a string into a safe, lowercase filename fragment.
+
+    Replaces non-alphanumeric characters (except hyphens) with hyphens,
+    truncates to 90 characters, and falls back to ``\"untitled\"`` if the
+    result is empty.
+    """
     s = re.sub(r"[^\w\-]+", "-", s.strip()).strip("-").lower()
     return s[:90] or "untitled"
 
@@ -269,6 +285,7 @@ def write_okf_bundle(memories: list[Memory], out: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: parse args, extract memories, write OKF bundle."""
     args = argv or sys.argv[1:]
     if len(args) < 2:
         print("Usage: extract_memories.py <chatgpt_export.json> <output_dir>", file=sys.stderr)

--- a/examples/migrations/chatgpt-memory/sample_bundle/i-chose-kotlin-spring-boot-3.md
+++ b/examples/migrations/chatgpt-memory/sample_bundle/i-chose-kotlin-spring-boot-3.md
@@ -1,0 +1,19 @@
+---
+type: preference
+title: I chose Kotlin, Spring Boot 3.
+tags:
+- decision
+- chatgpt-import
+- thread:thread-abc12
+timestamp: '2026-05-01T10:05:00Z'
+resource: chatgpt://thread/thread-abc123def456
+x_memanto:
+  type: decision
+  source: chatgpt
+---
+
+Extracted from thread **Project planning session** (thread-abc123def).
+
+First surfaced: `2026-05-01T10:05:00Z`
+
+I chose Kotlin, Spring Boot 3.3, PostgreSQL 16, Ktor for the mesh, Flyway for migrations, and I plan to deploy via Docker Compose into Kubernetes on k3s when the MVP is stable.

--- a/examples/migrations/chatgpt-memory/sample_bundle/i-live-in-berlin-i-work-remotely-and-i-m-trying-to-ship-the-mvp-by-august.md
+++ b/examples/migrations/chatgpt-memory/sample_bundle/i-live-in-berlin-i-work-remotely-and-i-m-trying-to-ship-the-mvp-by-august.md
@@ -1,0 +1,19 @@
+---
+type: preference
+title: I live in Berlin, I work remotely, and I'm trying to ship the MVP by August.
+tags:
+- goal
+- chatgpt-import
+- thread:thread-abc12
+timestamp: '2026-05-01T10:02:20Z'
+resource: chatgpt://thread/thread-abc123def456
+x_memanto:
+  type: goal
+  source: chatgpt
+---
+
+Extracted from thread **Project planning session** (thread-abc123def).
+
+First surfaced: `2026-05-01T10:02:20Z`
+
+I live in Berlin, I work remotely, and I'm trying to ship the MVP by August. The team uses PostgreSQL 16 and I want to make sure migration is handled with Flyway from day one.

--- a/examples/migrations/chatgpt-memory/sample_bundle/i-m-building-a-spring-boot-backend-for-a-saas-product.md
+++ b/examples/migrations/chatgpt-memory/sample_bundle/i-m-building-a-spring-boot-backend-for-a-saas-product.md
@@ -1,0 +1,19 @@
+---
+type: preference
+title: I'm building a Spring Boot backend for a SaaS product.
+tags:
+- preference
+- chatgpt-import
+- thread:thread-abc12
+timestamp: '2026-05-01T10:00:00Z'
+resource: chatgpt://thread/thread-abc123def456
+x_memanto:
+  type: preference
+  source: chatgpt
+---
+
+Extracted from thread **Project planning session** (thread-abc123def).
+
+First surfaced: `2026-05-01T10:00:00Z`
+
+I'm building a Spring Boot backend for a SaaS product. I prefer Kotlin over Java because the null-safety model keeps me sane, and I always use Ktor for the internal service-to-service mesh.

--- a/examples/migrations/chatgpt-memory/sample_bundle/i-use-arch-linux-on-the-desktop-ubuntu-on-the-server-and-i-m-an-arch-enthusiast-who-runs-w.md
+++ b/examples/migrations/chatgpt-memory/sample_bundle/i-use-arch-linux-on-the-desktop-ubuntu-on-the-server-and-i-m-an-arch-enthusiast-who-runs-w.md
@@ -1,0 +1,20 @@
+---
+type: preference
+title: I use Arch Linux on the desktop, Ubuntu on the server, and I'm an Arch enthusiast
+  who runs wayl.
+tags:
+- fact
+- chatgpt-import
+- thread:thread-zzz-r
+timestamp: '2026-05-10T09:20:00Z'
+resource: chatgpt://thread/thread-zzz-remote-life
+x_memanto:
+  type: fact
+  source: chatgpt
+---
+
+Extracted from thread **Remote work and travel** (thread-zzz-remot).
+
+First surfaced: `2026-05-10T09:20:00Z`
+
+I use Arch Linux on the desktop, Ubuntu on the server, and I'm an Arch enthusiast who runs wayland with Hyprland.

--- a/examples/migrations/chatgpt-memory/sample_bundle/i-work-from-a-home-office-with-a-standing-desk-and-i-hate-noisy-coworking-spaces.md
+++ b/examples/migrations/chatgpt-memory/sample_bundle/i-work-from-a-home-office-with-a-standing-desk-and-i-hate-noisy-coworking-spaces.md
@@ -1,0 +1,19 @@
+---
+type: preference
+title: I work from a home office with a standing desk and I hate noisy coworking spaces.
+tags:
+- preference
+- chatgpt-import
+- thread:thread-zzz-r
+timestamp: '2026-05-10T09:05:00Z'
+resource: chatgpt://thread/thread-zzz-remote-life
+x_memanto:
+  type: preference
+  source: chatgpt
+---
+
+Extracted from thread **Remote work and travel** (thread-zzz-remot).
+
+First surfaced: `2026-05-10T09:05:00Z`
+
+I work from a home office with a standing desk and I hate noisy coworking spaces. I always need a second monitor and I prefer mechanical keyboards, Cherry MX Browns specifically.

--- a/examples/migrations/chatgpt-memory/sample_bundle/index.md
+++ b/examples/migrations/chatgpt-memory/sample_bundle/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: ChatGPT Memory Export
+---
+
+Auto-generated bundle of 6 user memory fragments extracted from ChatGPT conversation history. Import with:
+
+    memanto migrate okf ./chatgpt-memory/

--- a/examples/migrations/chatgpt-memory/sample_bundle/my-goal-is-to-spend-3-months-a-year-working-from-abroad.md
+++ b/examples/migrations/chatgpt-memory/sample_bundle/my-goal-is-to-spend-3-months-a-year-working-from-abroad.md
@@ -1,0 +1,19 @@
+---
+type: preference
+title: My goal is to spend 3 months a year working from abroad.
+tags:
+- goal
+- chatgpt-import
+- thread:thread-zzz-r
+timestamp: '2026-05-10T09:12:00Z'
+resource: chatgpt://thread/thread-zzz-remote-life
+x_memanto:
+  type: goal
+  source: chatgpt
+---
+
+Extracted from thread **Remote work and travel** (thread-zzz-remot).
+
+First surfaced: `2026-05-10T09:12:00Z`
+
+My goal is to spend 3 months a year working from abroad. I want a setup that works from a laptop on 4G, and I'm using Tailscale for the mesh and Obsidian for notes.

--- a/examples/migrations/chatgpt-memory/sample_export.json
+++ b/examples/migrations/chatgpt-memory/sample_export.json
@@ -1,0 +1,85 @@
+[
+  {
+    "thread_id": "thread-abc123def456",
+    "title": "Project planning session",
+    "messages": [
+      {
+        "role": "user",
+        "content": "I'm building a Spring Boot backend for a SaaS product. I prefer Kotlin over Java because the null-safety model keeps me sane, and I always use Ktor for the internal service-to-service mesh.",
+        "timestamp": "2026-05-01T10:00:00Z"
+      },
+      {
+        "role": "assistant",
+        "content": "Kotlin and Spring Boot are a great pairing. Kotlin's null-safety and coroutines work especially well alongside Ktor for the internal mesh. Here's a starter layout...",
+        "timestamp": "2026-05-01T10:00:14Z"
+      },
+      {
+        "role": "user",
+        "content": "I live in Berlin, I work remotely, and I'm trying to ship the MVP by August. The team uses PostgreSQL 16 and I want to make sure migration is handled with Flyway from day one.",
+        "timestamp": "2026-05-01T10:02:20Z"
+      },
+      {
+        "role": "assistant",
+        "content": "Got it — Berlin, remote, PostgreSQL 16, Flyway-driven migrations, August MVP. That gives us a clear picture to size the architecture around...",
+        "timestamp": "2026-05-01T10:02:41Z"
+      },
+      {
+        "role": "user",
+        "content": "I chose Kotlin, Spring Boot 3.3, PostgreSQL 16, Ktor for the mesh, Flyway for migrations, and I plan to deploy via Docker Compose into Kubernetes on k3s when the MVP is stable.",
+        "timestamp": "2026-05-01T10:05:00Z"
+      },
+      {
+        "role": "assistant",
+        "content": "Great decisions. To summarize your stack: Kotlin + Spring Boot 3.3, PostgreSQL 16 with Flyway, Ktor service mesh, Docker Compose -> k3s. That's a solid, modern path...",
+        "timestamp": "2026-05-01T10:05:18Z"
+      }
+    ]
+  },
+  {
+    "thread_id": "thread-zzz-remote-life",
+    "title": "Remote work and travel",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hi there!",
+        "timestamp": "2026-05-10T09:00:00Z"
+      },
+      {
+        "role": "user",
+        "content": "I work from a home office with a standing desk and I hate noisy coworking spaces. I always need a second monitor and I prefer mechanical keyboards, Cherry MX Browns specifically.",
+        "timestamp": "2026-05-10T09:05:00Z"
+      },
+      {
+        "role": "assistant",
+        "content": "Standing desk, second monitor, mechanical keyboard with MX Browns — a very thoughtful setup. I'll remember those preferences when suggesting hardware or workspace configurations...",
+        "timestamp": "2026-05-10T09:05:22Z"
+      },
+      {
+        "role": "user",
+        "content": "My goal is to spend 3 months a year working from abroad. I want a setup that works from a laptop on 4G, and I'm using Tailscale for the mesh and Obsidian for notes.",
+        "timestamp": "2026-05-10T09:12:00Z"
+      },
+      {
+        "role": "user",
+        "content": "I use Arch Linux on the desktop, Ubuntu on the server, and I'm an Arch enthusiast who runs wayland with Hyprland.",
+        "timestamp": "2026-05-10T09:20:00Z"
+      }
+    ]
+  },
+  {
+    "thread_id": "thread-decisions-2026",
+    "title": "Year decisions",
+    "messages": [
+      {
+        "role": "user",
+        "content": "We decided to stick with PostgreSQL instead of moving to a document store. The relational model plus JSONB gives us everything we need without adding a second datastore.",
+        "timestamp": "2026-06-01T14:00:00Z"
+      },
+      {
+        "role": "assistant",
+        "content": "Solid reasoning. JSONB on PostgreSQL is often the pragmatic sweet spot — you keep referential integrity and still get document flexibility...",
+        "timestamp": "2026-06-01T14:00:25Z"
+      }
+    ]
+  }
+]

--- a/examples/migrations/chatgpt-memory/test_extract_memories.py
+++ b/examples/migrations/chatgpt-memory/test_extract_memories.py
@@ -31,18 +31,23 @@ class TestCategoryInference:
     """Test _infer_category classification logic."""
 
     def test_preference_signal(self):
+        """An explicit 'I prefer' phrase is classified as preference."""
         assert _infer_category("I prefer Kotlin over Java.") == "preference"
 
     def test_fact_signal(self):
+        """A 'work with / use' phrase is classified as fact."""
         assert _infer_category("I work with Kubernetes on Linux.") == "fact"
 
     def test_decision_signal(self):
+        """A 'we went with' phrase is classified as decision."""
         assert _infer_category("We went with PostgreSQL.") == "decision"
 
     def test_goal_signal(self):
+        """A 'I want to' phrase is classified as goal."""
         assert _infer_category("I want to ship by August.") == "goal"
 
     def test_fallback_to_context(self):
+        """A message with no signal phrase falls back to context."""
         assert _infer_category("How are you doing today?") == "context"
 
 
@@ -50,6 +55,7 @@ class TestExtractMemories:
     """Test extract_memories extraction logic, filters, and dedup."""
 
     def test_skips_assistant_messages(self):
+        """Assistant messages are ignored while valid user memories are kept."""
         # User message must be >=30 chars to be considered durable.
         mems = extract_memories(
             _threads([_user("I like Rust a lot and prefer it to Go."), _assistant("Rust is great.")])
@@ -58,14 +64,17 @@ class TestExtractMemories:
         assert all(m.thread_id == "t1" for m in mems)
 
     def test_skips_greetings_and_one_liners(self):
+        """Very short user messages are dropped as non-durable."""
         mems = extract_memories(_threads([_user("Hi there!"), _user("ok")]))
         assert mems == []
 
     def test_skips_empty_content(self):
+        """Messages with empty content produce no memories."""
         mems = extract_memories(_threads([_user("")]))
         assert mems == []
 
     def test_captures_preference(self):
+        """A preference user message is captured with the correct category."""
         mems = extract_memories(
             _threads([_user("I prefer Kotlin, I always use Ktor, and I hate messy code.")])
         )
@@ -75,6 +84,7 @@ class TestExtractMemories:
         assert mems[0].sources == ["2026-01-01T00:00:00Z"]
 
     def test_captures_fact(self):
+        """A fact user message is captured with the correct category."""
         mems = extract_memories(
             _threads(
                 [
@@ -88,6 +98,7 @@ class TestExtractMemories:
         assert mems[0].category == "fact"
 
     def test_deduplicates_identical_body_same_thread(self):
+        """Duplicate messages within one thread yield a single memory."""
         mems = extract_memories(
             _threads(
                 [
@@ -99,13 +110,16 @@ class TestExtractMemories:
         assert len(mems) == 1
 
     def test_empty_threads(self):
+        """Empty thread lists, or threads with no messages, return no memories."""
         assert extract_memories([]) == []
         assert extract_memories([{"thread_id": "x", "messages": []}]) == []
 
     def test_non_list_messages(self):
+        """A thread with a non-list messages field is handled safely."""
         assert extract_memories([{"thread_id": "x", "messages": None}]) == []
 
     def test_thread_identity(self):
+        """The produced memory retains the source thread title and content."""
         mems = extract_memories(
             _threads([_user("I live in Berlin and I work remotely.")])
         )
@@ -118,6 +132,7 @@ class TestOkfBundle:
     """Test write_okf_bundle output format, frontmatter, and index."""
 
     def _write_and_load(self, messages) -> tuple[Path, dict]:
+        """Run extraction and bundle write, then reload each document."""
         mems = extract_memories(_threads(messages))
         out = Path(f"/tmp/test_okf_bundle_chatgpt_{id(self)}_{id(messages)}")
         out.mkdir(exist_ok=True)
@@ -137,6 +152,7 @@ class TestOkfBundle:
         return out, docs
 
     def test_writes_valid_frontmatter(self):
+        """Each document has valid frontmatter with the expected keys."""
         _, docs = self._write_and_load([_user("I prefer Kotlin and I use Arch Linux.")])
         assert len(docs) == 1
         fm, body = next(iter(docs.values()))
@@ -146,11 +162,13 @@ class TestOkfBundle:
         assert fm["resource"].startswith("chatgpt://thread/")
 
     def test_index_is_type_index(self):
+        """The generated index.md is marked with type: index."""
         out, _ = self._write_and_load([_user("I prefer Kotlin and I use Arch Linux.")])
         idx = (out / "index.md").read_text()
         assert "---\ntype: index\n" in idx
 
     def test_bundle_count_matches_extraction(self):
+        """The number of bundle documents matches the number of extracted memories."""
         out, docs = self._write_and_load(
             [
                 _user("I prefer Kotlin and I work with Kubernetes on Linux."),
@@ -160,6 +178,7 @@ class TestOkfBundle:
         assert len(docs) == 2
 
     def test_no_body_memory_produces_title(self):
+        """Exercise the safe-filename helper directly for edge cases."""
         # Edge case: empty body but we already skip empties in extract; cover
         # the safe-filename helper instead.
         assert _safe_filename("  ") == "untitled"

--- a/examples/migrations/chatgpt-memory/test_extract_memories.py
+++ b/examples/migrations/chatgpt-memory/test_extract_memories.py
@@ -13,18 +13,23 @@ from extract_memories import (
 
 
 def _threads(messages) -> list[dict]:
+    """Build a single-thread wrapper around a message list."""
     return [{"thread_id": "t1", "title": "T1", "messages": messages}]
 
 
 def _user(text: str, ts: str = "2026-01-01T00:00:00Z") -> dict:
+    """Build a user message dict with role, content, and timestamp."""
     return {"role": "user", "content": text, "timestamp": ts}
 
 
 def _assistant(text: str) -> dict:
+    """Build an assistant message dict with role, content, and timestamp."""
     return {"role": "assistant", "content": text, "timestamp": "2026-01-01T00:00:01Z"}
 
 
 class TestCategoryInference:
+    """Test _infer_category classification logic."""
+
     def test_preference_signal(self):
         assert _infer_category("I prefer Kotlin over Java.") == "preference"
 
@@ -42,6 +47,8 @@ class TestCategoryInference:
 
 
 class TestExtractMemories:
+    """Test extract_memories extraction logic, filters, and dedup."""
+
     def test_skips_assistant_messages(self):
         # User message must be >=30 chars to be considered durable.
         mems = extract_memories(
@@ -108,6 +115,8 @@ class TestExtractMemories:
 
 
 class TestOkfBundle:
+    """Test write_okf_bundle output format, frontmatter, and index."""
+
     def _write_and_load(self, messages) -> tuple[Path, dict]:
         mems = extract_memories(_threads(messages))
         out = Path(f"/tmp/test_okf_bundle_chatgpt_{id(self)}_{id(messages)}")

--- a/examples/migrations/chatgpt-memory/test_extract_memories.py
+++ b/examples/migrations/chatgpt-memory/test_extract_memories.py
@@ -1,0 +1,158 @@
+"""Tests for the ChatGPT memory OKF adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from extract_memories import (
+    _infer_category,
+    _safe_filename,
+    extract_memories,
+    write_okf_bundle,
+)
+
+
+def _threads(messages) -> list[dict]:
+    return [{"thread_id": "t1", "title": "T1", "messages": messages}]
+
+
+def _user(text: str, ts: str = "2026-01-01T00:00:00Z") -> dict:
+    return {"role": "user", "content": text, "timestamp": ts}
+
+
+def _assistant(text: str) -> dict:
+    return {"role": "assistant", "content": text, "timestamp": "2026-01-01T00:00:01Z"}
+
+
+class TestCategoryInference:
+    def test_preference_signal(self):
+        assert _infer_category("I prefer Kotlin over Java.") == "preference"
+
+    def test_fact_signal(self):
+        assert _infer_category("I work with Kubernetes on Linux.") == "fact"
+
+    def test_decision_signal(self):
+        assert _infer_category("We went with PostgreSQL.") == "decision"
+
+    def test_goal_signal(self):
+        assert _infer_category("I want to ship by August.") == "goal"
+
+    def test_fallback_to_context(self):
+        assert _infer_category("How are you doing today?") == "context"
+
+
+class TestExtractMemories:
+    def test_skips_assistant_messages(self):
+        # User message must be >=30 chars to be considered durable.
+        mems = extract_memories(
+            _threads([_user("I like Rust a lot and prefer it to Go."), _assistant("Rust is great.")])
+        )
+        assert len(mems) == 1
+        assert all(m.thread_id == "t1" for m in mems)
+
+    def test_skips_greetings_and_one_liners(self):
+        mems = extract_memories(_threads([_user("Hi there!"), _user("ok")]))
+        assert mems == []
+
+    def test_skips_empty_content(self):
+        mems = extract_memories(_threads([_user("")]))
+        assert mems == []
+
+    def test_captures_preference(self):
+        mems = extract_memories(
+            _threads([_user("I prefer Kotlin, I always use Ktor, and I hate messy code.")])
+        )
+        assert len(mems) == 1
+        assert mems[0].category == "preference"
+        assert "Kotlin" in mems[0].body
+        assert mems[0].sources == ["2026-01-01T00:00:00Z"]
+
+    def test_captures_fact(self):
+        mems = extract_memories(
+            _threads(
+                [
+                    _user(
+                        "I work with Kubernetes on Arch Linux and my stack is Python 3.12."
+                    )
+                ]
+            )
+        )
+        assert len(mems) == 1
+        assert mems[0].category == "fact"
+
+    def test_deduplicates_identical_body_same_thread(self):
+        mems = extract_memories(
+            _threads(
+                [
+                    _user("I like Go. I like Go. I like Go."),
+                    _user("I like Go. I like Go. I like Go."),
+                ]
+            )
+        )
+        assert len(mems) == 1
+
+    def test_empty_threads(self):
+        assert extract_memories([]) == []
+        assert extract_memories([{"thread_id": "x", "messages": []}]) == []
+
+    def test_non_list_messages(self):
+        assert extract_memories([{"thread_id": "x", "messages": None}]) == []
+
+    def test_thread_identity(self):
+        mems = extract_memories(
+            _threads([_user("I live in Berlin and I work remotely.")])
+        )
+        m = mems[0]
+        assert m.thread_title == "T1"
+        assert "Berlin" in m.body
+
+
+class TestOkfBundle:
+    def _write_and_load(self, messages) -> tuple[Path, dict]:
+        mems = extract_memories(_threads(messages))
+        out = Path(f"/tmp/test_okf_bundle_chatgpt_{id(self)}_{id(messages)}")
+        out.mkdir(exist_ok=True)
+        write_okf_bundle(mems, out)
+
+        import yaml
+
+        docs = {}
+        for f in sorted(out.glob("*.md")):
+            if f.name == "index.md":
+                continue
+            text = f.read_text()
+            parts = text.split("---", 2)
+            fm = yaml.safe_load(parts[1])
+            body = parts[2].strip()
+            docs[f.name] = (fm, body)
+        return out, docs
+
+    def test_writes_valid_frontmatter(self):
+        _, docs = self._write_and_load([_user("I prefer Kotlin and I use Arch Linux.")])
+        assert len(docs) == 1
+        fm, body = next(iter(docs.values()))
+        assert fm["type"] == "preference"
+        assert "x_memanto" in fm
+        assert fm["x_memanto"]["source"] == "chatgpt"
+        assert fm["resource"].startswith("chatgpt://thread/")
+
+    def test_index_is_type_index(self):
+        out, _ = self._write_and_load([_user("I prefer Kotlin and I use Arch Linux.")])
+        idx = (out / "index.md").read_text()
+        assert "---\ntype: index\n" in idx
+
+    def test_bundle_count_matches_extraction(self):
+        out, docs = self._write_and_load(
+            [
+                _user("I prefer Kotlin and I work with Kubernetes on Linux."),
+                _user("I want to ship the MVP by August."),
+            ]
+        )
+        assert len(docs) == 2
+
+    def test_no_body_memory_produces_title(self):
+        # Edge case: empty body but we already skip empties in extract; cover
+        # the safe-filename helper instead.
+        assert _safe_filename("  ") == "untitled"
+        assert _safe_filename("A & B!") == "a-b"
+        assert _safe_filename("normal").isascii()


### PR DESCRIPTION
## Summary

Adds a new **Path B migration adapter** for `memanto migrate`: a ChatGPT conversation-memory exporter that turns assistant-built user memories into a portable OKF bundle, importable with the existing `memanto migrate okf ./chatgpt-memory/`.

This is a new, supported migration path that did not exist before — it feeds the shipped CLI rather than reimplementing it, per the bounty's "do not reinvent the wheel" guideline.

## What it does

1. Reads a ChatGPT-style JSON export (array of threads, each a list of user/assistant messages with timestamps).
2. Extracts durable **user-facing memories** (skips assistant reasoning and greetings) and classifies them into `preference`, `fact`, `decision`, `goal`.
3. Writes a valid **OKF** Markdown bundle with YAML frontmatter (`type`, `tags`, `timestamp`, `resource`, `x_memanto` extension block) plus an `index.md` nav file.
4. A user imports with the standard shipped command: `memanto migrate okf ./chatgpt-memory/`.

The extraction is **fully deterministic and offline** — keyword/signal regexes, no LLM call — so the same export produces byte-stable output. Easy to review, easy to CI, easy to prove round-trip fidelity.

## Files

- `examples/migrations/chatgpt-memory/extract_memories.py` — the adapter (CLI + library).
- `examples/migrations/chatgpt-memory/test_extract_memories.py` — 18 tests (inference, filtering, dedup, OKF validity).
- `examples/migrations/chatgpt-memory/sample_export.json` — realistic synthetic ChatGPT threads (3 threads).
- `examples/migrations/chatgpt-memory/sample_bundle/` — exported OKF bundle (6 docs), verified importable and lint-clean.
- `examples/migrations/chatgpt-memory/README.md` — usage guide.

## Verification

- `ruff` — all checks passed (clean).
- `pytest` — 18 / 18 passed.
- OKF bundle — 6 docs, all with valid YAML frontmatter and bodies; `index.md` is correctly typed `type: index`.
- Round trip: bundle conforms to the shape consumed by `memanto.cli.migrate.okf_loader.load_okf_bundle`.

## Reproducibility

    python3 extract_memories.py chatgpt_export.json ./chatgpt-memory/
    memanto migrate okf ./chatgpt-memory/

Plug-and-play; a reviewer can run the full path in under 15 minutes.

## Demo video

*(To be posted by the bounty deadline; placeholder for now.)*

## Checklist

- [x] No modification to the shipped `memanto migrate` / OKF tooling — this is an adapter that feeds it.
- [x] New adapter lives under `/examples/migrations/<name>/` as the bounty requests.
- [x] Tests included, passing.
- [x] README documents input format, output, and import command.
- [x] Lint clean.

Fixes #1609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI migration tool to convert ChatGPT-style JSON exports into an importable Markdown OKF bundle.
  * Extracts durable user memories, assigns them to preference/fact/decision/goal categories, normalizes timestamps, deduplicates within threads, and generates a bundle index.
  * Included example exported JSON and sample generated memory records.

* **Documentation**
  * Added a full README with input shape expectations, filtering rules, and exact export/import command examples.

* **Tests**
  * Added pytest coverage for extraction, categorization, deduplication, OKF frontmatter/index output, and filename formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->