### PR TITLE
fix: migrate deprecated Pydantic V1 @validator to V2 @field_validator

### DIFF
--- a/memanto/app/utils/validation.py
+++ b/memanto/app/utils/validation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import HTTPException
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class InputLimits:
@@ -113,11 +113,13 @@ class ValidatedMemoryWriteRequest(BaseModel):
     text: str = Field(..., description="Memory text content")
     metadata: dict[str, Any] = Field(default_factory=dict)
 
-    @validator("text")
+    @field_validator("text")
+    @classmethod
     def validate_text(cls, v):
         return CostGuard.validate_text_length(v, "text")
 
-    @validator("metadata")
+    @field_validator("metadata")
+    @classmethod
     def validate_metadata(cls, v):
         return CostGuard.validate_metadata_size(v)
 
@@ -128,11 +130,13 @@ class ValidatedMemoryReadRequest(BaseModel):
     query: str = Field(..., description="Search query")
     k: int = Field(default=10, ge=1, description="Number of results")
 
-    @validator("query")
+    @field_validator("query")
+    @classmethod
     def validate_query(cls, v):
         return CostGuard.validate_query_length(v)
 
-    @validator("k")
+    @field_validator("k")
+    @classmethod
     def validate_k(cls, v):
         return CostGuard.validate_k_limit(v)
 
@@ -142,7 +146,8 @@ class ValidatedMemoryAnswerRequest(BaseModel):
 
     question: str = Field(..., description="Question to answer")
 
-    @validator("question")
+    @field_validator("question")
+    @classmethod
     def validate_question(cls, v):
         return CostGuard.validate_query_length(v)
 


### PR DESCRIPTION
## Description

Migrates 5 deprecated Pydantic V1 `@validator` decorators to V2 `@field_validator` in `memanto/app/utils/validation.py`.

Pydantic V1 validators emit deprecation warnings in V2 and will be removed in V3. This change is forward-compatible with V2+ while preserving identical runtime behavior.

### Changes
- `memanto/app/utils/validation.py`: Replaced 5 `@validator` with `@field_validator` (classmethod pattern)

### Verification
- 459 tests pass, 24 skipped (E2E needs API key)
- 0 warnings with `python -W error`
- No behavioral changes — all validators produce identical results

### Related
References #770 (Memanto Bug & Exploit Challenge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated request validation to use the current validation approach, improving compatibility with the latest Pydantic version.
  * Preserved existing cost and input validation behavior for memory requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->