### PR TITLE
fix(write): preserve active facts until replacements are stored (#770)

### DIFF
--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -45,6 +45,7 @@ class MemoryValidationService:
         context: dict[str, Any] | None = None,
         *,
         prefetched_conflicts: list[dict[str, Any]] | None | object = _MISSING,
+        resolve_conflicts: bool = True,
     ) -> dict[str, Any]:
         """Validate a memory against existing records, resolving contradictions.
 
@@ -85,6 +86,19 @@ class MemoryValidationService:
                 "reason": "validated: no contradicting memories found",
             }
 
+        if not resolve_conflicts:
+            return {
+                "action": "store",
+                "reason": f"validated: {len(conflicts)} contradiction(s) found",
+                "conflicts": conflicts,
+            }
+
+        return self.resolve_contradictions(memory, conflicts)
+
+    def resolve_contradictions(
+        self, memory: MemoryRecord, conflicts: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Supersede conflicts after the replacement memory is safely stored."""
         superseded: list[str] = []
         failed: list[str] = []
         for old_item in conflicts:

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -93,7 +93,12 @@ class MemoryWriteService:
             namespace = memory.namespace()
 
             # Validate memory (write-time contradiction resolution)
-            validation_result = self.validation_service.validate_memory(memory, context)
+            # Detect contradictions before writing, but do not deactivate the
+            # existing active memories until the replacement is confirmed.
+            # Otherwise a failed replacement upload leaves no active truth.
+            validation_result = self.validation_service.validate_memory(
+                memory, context, resolve_conflicts=False
+            )
             # Use validated memory if modified
             if "memory" in validation_result:
                 memory = validation_result["memory"]
@@ -107,6 +112,17 @@ class MemoryWriteService:
             result = self.client.documents.upload(
                 namespace_name=namespace, documents=[document]
             )
+            upload_status = str(result.get("status", "unknown")).lower()
+            if upload_status not in SUCCESSFUL_UPLOAD_STATUSES:
+                raise MemoryError(
+                    f"Memory upload returned unsuccessful status '{upload_status}'"
+                )
+
+            conflicts = validation_result.pop("conflicts", [])
+            if conflicts:
+                validation_result = self.validation_service.resolve_contradictions(
+                    memory, conflicts
+                )
 
             response = {
                 "id": memory.id,
@@ -152,6 +168,8 @@ class MemoryWriteService:
             results = []
             validated_documents = []
             prepared: list[MemoryRecord] = []
+            deferred_conflicts: dict[str, list[dict[str, Any]]] = {}
+            memories_by_id: dict[str, MemoryRecord] = {}
 
             # Enforce server-side timestamps for batch (single timestamp for all)
             now = datetime.now(timezone.utc)
@@ -225,14 +243,25 @@ class MemoryWriteService:
                             memory,
                             context,
                             prefetched_conflicts=prefetched_conflicts[memory.id],
+                            resolve_conflicts=False,
                         )
                     else:
                         validation_result = self.validation_service.validate_memory(
-                            memory, context
+                            memory, context, resolve_conflicts=False
                         )
                         # Use validated memory if modified
                         if "memory" in validation_result:
                             memory = cast(MemoryRecord, validation_result["memory"])
+
+                    raw_conflicts: Any = validation_result.pop("conflicts", [])
+                    pending_conflicts = (
+                        cast(list[dict[str, Any]], raw_conflicts)
+                        if isinstance(raw_conflicts, list)
+                        else []
+                    )
+                    if pending_conflicts:
+                        deferred_conflicts[str(memory.id)] = pending_conflicts
+                    memories_by_id[str(memory.id)] = memory
 
                     from moorcheh_sdk.types.document import Document
 
@@ -290,6 +319,24 @@ class MemoryWriteService:
                             result["error"] = (
                                 f"Batch upload returned status '{moorcheh_status}'"
                             )
+
+                # Only supersede pre-existing contradictions for documents
+                # whose replacements were confirmed by the batch upload.
+                for result in results:
+                    result_id = str(result.get("id", ""))
+                    if (
+                        str(result.get("status", "")).lower()
+                        not in SUCCESSFUL_UPLOAD_STATUSES
+                        or result_id not in deferred_conflicts
+                    ):
+                        continue
+                    resolution = self.validation_service.resolve_contradictions(
+                        memories_by_id[result_id], deferred_conflicts[result_id]
+                    )
+                    result["action"] = resolution.get("action", result["action"])
+                    result["reason"] = resolution.get("reason", result["reason"])
+                    if resolution.get("superseded_ids"):
+                        result["superseded_ids"] = resolution["superseded_ids"]
 
             # Count successes, failures, and namespace-rejected items separately
             # so that successful + failed + rejected == total_submitted always.

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,8 +1,11 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from memanto.app.core import MemoryRecord
 from memanto.app.services.memory_validation_service import MemoryValidationService
 from memanto.app.services.memory_write_service import MemoryWriteService
+from memanto.app.utils.errors import MemoryError
 
 
 def make_memory(**overrides):
@@ -131,14 +134,14 @@ class TestContradictionHandling:
         client.documents.delete.assert_not_called()
         uploads = client.documents.upload.call_args_list
         assert len(uploads) == 2
-        superseded_doc = uploads[0].kwargs["documents"][0]
+        new_doc = uploads[0].kwargs["documents"][0]
+        assert new_doc["id"] == memory.id
+        assert new_doc["status"] == "active"
+        superseded_doc = uploads[1].kwargs["documents"][0]
         assert superseded_doc["id"] == "old-1"
         assert superseded_doc["status"] == "superseded"
         assert superseded_doc["superseded_by"] == memory.id
         assert "superseded_at" in superseded_doc
-        new_doc = uploads[1].kwargs["documents"][0]
-        assert new_doc["id"] == memory.id
-        assert new_doc["status"] == "active"
 
     def test_duplicate_content_is_not_a_contradiction(self):
         """Identical content under the same title is a duplicate, not a conflict."""
@@ -155,8 +158,8 @@ class TestContradictionHandling:
         """Failed supersede upload must not delete the original document."""
         client = make_client(search_results=[existing_doc()])
         client.documents.upload.side_effect = [
-            {"status": "failed"},
             {"status": "success"},
+            {"status": "failed"},
         ]
         write_service = MemoryWriteService(client)
 
@@ -165,6 +168,25 @@ class TestContradictionHandling:
         assert result.get("superseded_ids", []) == []
         assert "failed to supersede old-1" in result["reason"]
         client.documents.delete.assert_not_called()
+
+    def test_failed_replacement_upload_leaves_existing_memory_active(self):
+        """A failed replacement must not supersede the last active truth."""
+        client = make_client(search_results=[existing_doc()])
+        client.documents.upload.return_value = {"status": "failed"}
+        write_service = MemoryWriteService(client)
+
+        memory = make_memory()
+        with pytest.raises(
+            MemoryError, match="Memory upload returned unsuccessful status 'failed'"
+        ):
+            write_service.store_memory(memory)
+
+        uploads = client.documents.upload.call_args_list
+        assert len(uploads) == 1
+        attempted_doc = uploads[0].kwargs["documents"][0]
+        assert attempted_doc["id"] == memory.id
+        assert attempted_doc["status"] == "active"
+        assert all(call.kwargs["documents"][0]["id"] != "old-1" for call in uploads)
 
     def test_exempt_type_skips_conflict_check(self):
         """Types outside REQUIRE_VALIDATION_FOR store directly, without search."""
@@ -203,6 +225,22 @@ class TestContradictionHandling:
             assert res.get("reason") != "MVP direct store", (
                 "Contradiction validation is skipped for batch storage (MVP direct store)."
             )
+
+    def test_failed_batch_replacement_leaves_existing_memory_active(self):
+        """A failed batch upload must not supersede pre-existing active truth."""
+        client = make_client(search_results=[existing_doc()])
+        client.documents.upload.return_value = {"status": "failed"}
+        write_service = MemoryWriteService(client)
+
+        result = write_service.batch_store_memories([make_memory()])
+
+        assert result["failed"] == 1
+        uploads = client.documents.upload.call_args_list
+        assert len(uploads) == 1
+        attempted_docs = uploads[0].kwargs["documents"]
+        assert len(attempted_docs) == 1
+        assert attempted_docs[0]["status"] == "active"
+        assert all(document["id"] != "old-1" for document in attempted_docs)
 
     def test_batch_resolves_contradictions_within_batch(self):
         """Contradicting memories submitted together resolve to last-wins,


### PR DESCRIPTION
## Bounty #770 submission

### Summary

The newly merged write-time contradiction resolver can erase the last active version of a fact when a replacement upload fails.

`store_memory()` currently resolves a contradiction in this order:

1. Find the existing active memory.
2. Rewrite it as `status="superseded"`.
3. Upload the replacement.

If step 3 raises or returns `{"status": "failed"}`, the old fact is already inactive and the replacement does not exist. The same ordering is used by `batch_store_memories()`, so one failed batch can deactivate several trusted facts at once.

This is a memory-integrity failure in the challenge's highest-priority category: a transient backend failure causes permanent, silent timeline amnesia.

### Reproduction

The regression tests use the real write/validation services with a deterministic fake Moorcheh client:

1. Seed an active fact: `Favorite Color = blue`.
2. Store a same-title contradictory replacement: `Favorite Color = red`.
3. Make the replacement upload return `status="failed"`.
4. Inspect the upload calls.

On `main`:

- The first upload rewrites `old-1` as superseded.
- The replacement upload fails.
- `store_memory()` does not raise for the failed status.
- No active version is guaranteed to remain.

The batch path reproduces the same issue: the old document is superseded before the aggregate batch upload reports failure.

The added regression tests fail on untouched `origin/main`; the baseline run reports four failures, including:

- `test_failed_replacement_upload_leaves_existing_memory_active`
- `test_failed_batch_replacement_leaves_existing_memory_active`

### Root cause

`MemoryValidationService.validate_memory()` both detects and mutates contradictions. The write services therefore cannot validate before upload without also superseding the current truth before the replacement is durable.

The single-write path also accepts any backend response as a completed write, even an explicit unsuccessful status.

### Fix

- Split contradiction detection from contradiction resolution.
- Detect conflicts before writing, but defer mutation.
- Upload the replacement first.
- Reject explicit unsuccessful upload statuses.
- Only after a successful replacement upload, supersede the pre-existing conflicts.
- Apply the same deferred ordering per successful document in batch writes.

If the replacement fails, the old active memory is untouched. If superseding later fails, the replacement is still active and the existing honest failure reporting remains in place; the system may temporarily retain two active facts, but it no longer loses both.

### Verification

```text
uv run pytest tests/test_contradiction.py -q
12 passed

uv run pytest -o addopts='' -q
461 passed, 24 skipped

uv run ruff check memanto/app/services/memory_validation_service.py \
  memanto/app/services/memory_write_service.py tests/test_contradiction.py
All checks passed

uv run ruff format --check memanto/app/services/memory_validation_service.py \
  memanto/app/services/memory_write_service.py tests/test_contradiction.py
3 files already formatted

uv run mypy memanto/app/services/memory_validation_service.py \
  memanto/app/services/memory_write_service.py
Success: no issues found
```

The 24 skipped tests are the repository's live Moorcheh E2E cases, which require `MOORCHEH_API_KEY`; all local tests pass.

Fixes #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contradictory memories are now superseded only after a successful upload.
  * Failed replacement uploads no longer alter or supersede existing active memories.
  * Single and batch memory writes now report upload failures consistently.
  * Batch processing safely applies contradiction updates only to successfully uploaded memories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->