### PR TITLE
fix(rate_limiting): fail-closed on unknown operations; unify memory id validation (#1438)

### DIFF
--- a/memanto/app/legacy/safe_deletion.py
+++ b/memanto/app/legacy/safe_deletion.py
@@ -2,6 +2,8 @@
 Safer Deletion with Audit Logging for MEMANTO
 """
 
+from memanto.app.utils.ids import is_valid_memory_id
+
 import json
 import re
 from dataclasses import asdict, dataclass
@@ -145,7 +147,7 @@ class SafeDeletion:
             )
 
         # 4. Validate ID format
-        invalid_ids = [id for id in ids if not SafeDeletion._is_valid_memory_id(id)]
+        invalid_ids = [id for id in ids if not is_valid_memory_id(id)]
         if invalid_ids:
             raise HTTPException(
                 status_code=400,
@@ -155,16 +157,6 @@ class SafeDeletion:
                     "invalid_ids": invalid_ids[:10],  # Limit error response size
                 },
             )
-
-    @staticmethod
-    def _is_valid_memory_id(memory_id: str) -> bool:
-        """Validate memory ID format"""
-        if not memory_id or len(memory_id) < 4:
-            return False
-
-        # Should match our ID generation pattern
-
-        return bool(re.match(r"^[a-zA-Z0-9_-]+$", memory_id))
 
     @staticmethod
     def perform_safe_deletion(

--- a/memanto/app/utils/rate_limiting.py
+++ b/memanto/app/utils/rate_limiting.py
@@ -50,7 +50,15 @@ class RateLimiter:
         Returns: (allowed, retry_after_seconds)
         """
         if operation not in self.limits:
-            return True, None
+            # Fail-closed: unknown operations must not silently bypass rate
+            # limiting. Previously this returned (True, None), which let
+            # `enforce_namespace_rate_limit(op, agent_id)` (which builds
+            # keys like `namespace_<op>`) pass through unrestricted.
+            # See issue #1438.
+            raise ValueError(
+                f"Unknown rate-limit operation '{operation}'. "
+                f"Allowed: {sorted(self.limits)}"
+            )
 
         limit = self.limits[operation]
         key = self._get_key(operation, agent_id)

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -48,5 +48,4 @@ class TestSafeDeletionUsesCanonicalValidator:
 
     def test_safe_deletion_no_longer_defines_private_validator(self):
         import memanto.app.legacy.safe_deletion as sd
-        assert not hasattr(sd.SafeDeletion, "_is_valid_memory_id") or \
-            sd.SafeDeletion._is_valid_memory_id.__module__ == "memanto.app.utils.ids"
+        assert not hasattr(sd.SafeDeletion, "_is_valid_memory_id")

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,0 +1,52 @@
+"""Tests for memanto.app.utils.ids (Finding 2 in #1438).
+
+The canonical `is_valid_memory_id` is now the single source of truth.
+Safe-deletion paths must use the same check as everywhere else, so a
+memory ID can't pass one gate and fail another.
+"""
+
+import pytest
+
+from memanto.app.utils.ids import generate_memory_id, is_valid_memory_id
+
+
+class TestIsValidMemoryId:
+    def test_generated_ids_are_valid(self):
+        # The ID generator should always produce IDs that pass validation.
+        for _ in range(50):
+            mid = generate_memory_id()
+            assert is_valid_memory_id(mid), f"generated id {mid!r} failed validation"
+
+    def test_ids_with_underscore_are_valid(self):
+        assert is_valid_memory_id("mem_abc123")
+        assert is_valid_memory_id("any_thing_here")
+
+    def test_ids_without_underscore_are_invalid(self):
+        # `abc-123` previously passed deletion validation but failed the
+        # general check. After the fix both reject it.
+        assert not is_valid_memory_id("abc-123")
+        assert not is_valid_memory_id("abcdef")
+
+    def test_short_ids_are_invalid(self):
+        assert not is_valid_memory_id("a_b")
+        assert not is_valid_memory_id("")
+        assert not is_valid_memory_id(None)  # type: ignore[arg-type]
+
+
+class TestSafeDeletionUsesCanonicalValidator:
+    """The legacy safe_deletion module previously had its own private
+    `_is_valid_memory_id` whose rules diverged from the canonical one.
+    After the fix it must import from `memanto.app.utils.ids`, so the
+    two paths cannot disagree."""
+
+    def test_safe_deletion_imports_canonical(self):
+        import memanto.app.legacy.safe_deletion as sd
+        # `is_valid_memory_id` should be re-exported from the ids module
+        # rather than defined locally.
+        from memanto.app.utils.ids import is_valid_memory_id as canonical
+        assert sd.is_valid_memory_id is canonical
+
+    def test_safe_deletion_no_longer_defines_private_validator(self):
+        import memanto.app.legacy.safe_deletion as sd
+        assert not hasattr(sd.SafeDeletion, "_is_valid_memory_id") or \
+            sd.SafeDeletion._is_valid_memory_id.__module__ == "memanto.app.utils.ids"

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -8,7 +8,7 @@ makes the limiter fail-closed.
 
 import pytest
 
-from memanto.app.utils.rate_limiting import RateLimiter
+from memanto.app.utils.rate_limiting import RateLimiter, enforce_namespace_rate_limit
 
 
 class TestRateLimiterFailClosed:
@@ -30,7 +30,7 @@ class TestRateLimiterFailClosed:
         limiter (e.g. `list`) bypassed rate limiting entirely. After the
         fix it raises."""
         with pytest.raises(ValueError):
-            self.limiter.check_rate_limit("namespace_list", "agent-1")
+            enforce_namespace_rate_limit("list", "agent-1")
 
     def test_known_operation_still_passes_under_limit(self):
         # Sanity check: registered operations are not broken by the fix.

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,49 @@
+"""Tests for memanto.app.utils.rate_limiting (Finding 1 in #1438).
+
+Before the fix, `check_rate_limit` silently returned `(True, None)` for
+unknown operations, which let `enforce_namespace_rate_limit(op, agent_id)`
+bypass rate limiting whenever the operation wasn't registered. The fix
+makes the limiter fail-closed.
+"""
+
+import pytest
+
+from memanto.app.utils.rate_limiting import RateLimiter
+
+
+class TestRateLimiterFailClosed:
+    """Unknown operations must NOT silently pass."""
+
+    def setup_method(self):
+        self.limiter = RateLimiter()
+
+    def test_unknown_operation_raises_value_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            self.limiter.check_rate_limit("nonexistent_op", "agent-1")
+        assert "nonexistent_op" in str(exc_info.value)
+        # Allowed operations are listed in the error to aid debugging.
+        assert "memory_write" in str(exc_info.value)
+
+    def test_namespace_prefix_bypass_no_longer_works(self):
+        """`enforce_namespace_rate_limit(op, agent_id)` builds keys like
+        `namespace_<op>`. Before the fix, any operation unknown to the
+        limiter (e.g. `list`) bypassed rate limiting entirely. After the
+        fix it raises."""
+        with pytest.raises(ValueError):
+            self.limiter.check_rate_limit("namespace_list", "agent-1")
+
+    def test_known_operation_still_passes_under_limit(self):
+        # Sanity check: registered operations are not broken by the fix.
+        allowed, retry = self.limiter.check_rate_limit("memory_write", "agent-1")
+        assert allowed is True
+        assert retry is None
+
+    def test_known_operation_still_blocks_over_limit(self):
+        # Saturate the bucket then assert the limiter blocks instead of raising.
+        for _ in range(self.limiter.limits["memory_write"].requests):
+            allowed, _ = self.limiter.check_rate_limit("memory_write", "agent-2")
+            assert allowed is True
+        allowed, retry = self.limiter.check_rate_limit("memory_write", "agent-2")
+        assert allowed is False
+        assert retry is not None
+        assert retry >= 1


### PR DESCRIPTION
Closes part of #1438 (Findings 1 and 2).

## Finding 1 — Rate limiter fail-open (security, Severity: Medium per #1438)

`RateLimiter.check_rate_limit` silently returned `(True, None)` for any operation not in `self.limits`. `enforce_namespace_rate_limit(op, agent_id)` builds keys as `namespace_<op>`, so calling it with any unregistered operation (e.g. `list`) created an unknown key and bypassed rate limiting entirely — confirmed by the PoC in #1438.

Switch to fail-closed: unknown operations raise `ValueError`, listing the allowed set in the message so debugging stays easy.

```diff
-        if operation not in self.limits:
-            return True, None
+        if operation not in self.limits:
+            # Fail-closed: unknown operations must not silently bypass rate
+            # limiting. See issue #1438.
+            raise ValueError(
+                f"Unknown rate-limit operation '{operation}'. "
+                f"Allowed: {sorted(self.limits)}"
+            )
```

## Finding 2 — Inconsistent `is_valid_memory_id`

`memanto/app/utils/ids.py` and `memanto/app/legacy/safe_deletion.py` had two different validators for the same thing. The legacy regex `^[a-zA-Z0-9_-]+$` accepted IDs like `abc-123` that the canonical checker (which requires `_`) rejected, so an ID could pass one gate and fail another.

Make `memanto.app.utils.ids.is_valid_memory_id` the single source of truth and have `safe_deletion.SafeDeletion` import it directly. The private `_is_valid_memory_id` method is removed from `SafeDeletion`.

## Tests

- `tests/test_rate_limiting.py` (new, 4 tests) — fail-closed behavior, namespace prefix bypass no longer works, registered operations still pass under limit and block over limit.
- `tests/test_ids.py` (new, 6 tests) — generated IDs validate, the canonical check rejects underscore-free IDs, and `safe_deletion` now uses the same function (verified via identity check).

```
$ pytest tests/test_rate_limiting.py tests/test_ids.py tests/test_unit.py
99 passed in 2.68s
```

Broader run (excluding e2e/cli/api/backend that need a server / CLI key):

```
$ pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_cli.py \
                --ignore=tests/test_api.py --ignore=tests/test_backend.py
244 passed, 1 warning in 4.30s
```

## Finding 3 — left for a separate PR

Finding 3 in #1438 (`SourceType = str` lacking validation) needs wider discussion about which values to allow (the existing comment hints at arbitrary `agent_name` values, not just the four enums). Leaving it for a focused follow-up so this PR stays small and reviewable. Happy to take that on next if useful.

## Payout

- Wallet: OKX Web3 Wallet (self-custody)
- **Base USDC address: `0x2a5a559afca0ea453b7c32b6a755254b0a5e6541`** (same address works on every EVM chain)
- Preferred chain: Base — USDC contract `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
- Payout routing per #770 / BountyHub — the rate-limiter bypass is a Medium-severity security finding, so I believe it qualifies for bounty scoring under the existing rubric.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory deletion now uses the shared, canonical memory-id validation (including supported underscore-containing IDs).
  * Rate limiting is now fail-closed for unknown operations, raising an error instead of bypassing enforcement.
  * Known operations still succeed within configured limits and are blocked once the quota is reached.

* **Tests**
  * Added unit tests for canonical memory-id validation and to ensure legacy deletion logic no longer uses a private validator.
  * Added unit tests covering fail-closed behavior for unknown rate-limit operations and correct enforcement for known ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->