### PR TITLE
fix: date only end of day recall bounds drop the final subsecond of the day

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -137,15 +137,19 @@ class RecallRequest(BaseModel):
 
 
 def _parse_recall_temporal_bound(v: object, *, end_of_day: bool) -> datetime:
+    # End-of-day must be time.max (23:59:59.999999), matching
+    # parse_as_of_timestamp: the temporal filter compares with a strict `>`,
+    # so a 23:59:59 bound silently drops memories created in the final
+    # sub-second of the requested day.
     if isinstance(v, datetime):
         return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
     if isinstance(v, date):
-        boundary = time(23, 59, 59) if end_of_day else time(0, 0, 0)
+        boundary = time.max if end_of_day else time(0, 0, 0)
         return datetime.combine(v, boundary, tzinfo=timezone.utc)
     if isinstance(v, str):
         if "T" not in v and " " not in v:
             try:
-                boundary = time(23, 59, 59) if end_of_day else time(0, 0, 0)
+                boundary = time.max if end_of_day else time(0, 0, 0)
                 return datetime.combine(
                     date.fromisoformat(v), boundary, tzinfo=timezone.utc
                 )
@@ -185,13 +189,14 @@ class RecallAsOfRequest(BaseModel):
         if isinstance(v, datetime):
             return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
         if isinstance(v, date):
-            return datetime.combine(v, time(23, 59, 59), tzinfo=timezone.utc)
+            return datetime.combine(v, time.max, tzinfo=timezone.utc)
         if isinstance(v, str):
-            # Date-only (no time component) → end of day
+            # Date-only (no time component) → end of day (time.max, matching
+            # parse_as_of_timestamp — see _parse_recall_temporal_bound)
             if "T" not in v and " " not in v:
                 try:
                     return datetime.combine(
-                        date.fromisoformat(v), time(23, 59, 59), tzinfo=timezone.utc
+                        date.fromisoformat(v), time.max, tzinfo=timezone.utc
                     )
                 except ValueError:
                     pass

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -2,7 +2,11 @@ from datetime import timezone
 
 import pytest
 
-from memanto.app.routes.memory import RecallRequest
+from memanto.app.routes.memory import (
+    RecallAsOfRequest,
+    RecallRecentRequest,
+    RecallRequest,
+)
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.utils.temporal_helpers import (
     build_temporal_query,
@@ -84,3 +88,42 @@ def test_parse_as_of_timestamp_preserves_explicit_time():
     parsed = parse_as_of_timestamp("2026-01-15T13:30:00Z")
 
     assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"
+
+
+def test_recall_date_only_created_before_covers_the_whole_day():
+    request = RecallRequest.model_validate(
+        {"query": "notes", "created_before": "2026-06-30"}
+    )
+
+    assert request.created_before is not None
+    assert request.created_before.isoformat() == "2026-06-30T23:59:59.999999+00:00"
+
+
+def test_recall_date_only_created_before_keeps_final_subsecond_memory():
+    # A memory created at 23:59:59.5 on the boundary day is still "that day";
+    # a 23:59:59 bound (pre-fix) wrongly excluded it via the strict `>` filter.
+    request = RecallRequest.model_validate(
+        {"query": "notes", "created_before": "2026-06-30"}
+    )
+    service = MemoryReadService(object())
+
+    results = [{"id": "late", "created_at": "2026-06-30T23:59:59.500000+00:00"}]
+    filtered = service._apply_temporal_filter(
+        results, created_before=request.created_before.isoformat()
+    )
+
+    assert [memory["id"] for memory in filtered] == ["late"]
+
+
+def test_recall_recent_date_only_created_before_covers_the_whole_day():
+    request = RecallRecentRequest.model_validate({"created_before": "2026-06-30"})
+
+    assert request.created_before is not None
+    assert request.created_before.isoformat() == "2026-06-30T23:59:59.999999+00:00"
+
+
+def test_recall_as_of_date_only_matches_service_helper_end_of_day():
+    request = RecallAsOfRequest.model_validate({"as_of": "2026-06-30"})
+
+    assert request.as_of == parse_as_of_timestamp("2026-06-30")
+    assert request.as_of.isoformat() == "2026-06-30T23:59:59.999999+00:00"


### PR DESCRIPTION
Submitted for the Bug & Exploit Challenge (#770).

### What's the bug?

The recall routes document date only temporal bounds as covering "the end of that day":

- `POST /api/v2/agents/{agent_id}/recall` — `created_before`
- `POST /api/v2/agents/{agent_id}/recall/recent` — `created_before`
- `POST /api/v2/agents/{agent_id}/recall/as-of` — `as_of`

But `_parse_recall_temporal_bound` and `RecallAsOfRequest.parse_as_of` in
`memanto/app/routes/memory.py` parse a date only value (e.g. `2026-06-30`) as
`23:59:59` — while the service layer's own `parse_as_of_timestamp` (and the
`get_today_range`/`get_yesterday_range` helpers in `temporal_helpers.py`) use
`time.max` = `23:59:59.999999`.

Since `MemoryReadService._apply_temporal_filter` excludes with a strict `>`
comparison, and `created_at` timestamps carry microsecond precision
(`datetime.now(timezone.utc)`), any memory created in the final sub-second of
the requested day is silently dropped from recall.

### Reproduction

```python
from memanto.app.routes.memory import _parse_recall_temporal_bound
from memanto.app.services.memory_read_service import MemoryReadService
from memanto.app.utils.temporal_helpers import parse_as_of_timestamp

bound = _parse_recall_temporal_bound("2026-06-30", end_of_day=True)
# pre-fix: 2026-06-30T23:59:59+00:00
# parse_as_of_timestamp("2026-06-30") -> 2026-06-30T23:59:59.999999+00:00 (inconsistent)

mem = {"id": "late", "created_at": "2026-06-30T23:59:59.500000+00:00"}
kept = MemoryReadService(object())._apply_temporal_filter([mem], created_before=bound.isoformat())
# pre-fix: [] — the memory is on 2026-06-30 but gets excluded
```

### Fix

Use `time.max` for the end of day boundary in both route level parsers,
matching `parse_as_of_timestamp` and the documented field semantics.
Two files changed: the two parse sites in `memanto/app/routes/memory.py`,
plus four regression tests in `tests/test_temporal_helpers.py` covering
`RecallRequest`, `RecallRecentRequest`, and `RecallAsOfRequest` date only
bounds (including an end-to-end check through `_apply_temporal_filter`).

`pytest`: 392 passed, 24 skipped (skips are the live-Moorcheh E2E tests).

---

I used AI tooling (Claude Code) to help find and analyze this; the fix and
submission were reviewed, tested, and are owned by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-only temporal filters to include memories created throughout the entire specified day.
  * Fixed end-of-day recall and point-in-time filtering so entries created during the final fraction of a second are not unintentionally excluded.

* **Tests**
  * Added coverage for date-only `created_before` and `as_of` requests, including end-of-day boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->