### PR TITLE
[#770] Reject NaN and infinity in persisted float configuration

### DIFF
--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -9,6 +9,7 @@ Handles configuration persistence:
 
 import importlib
 import json
+import math
 import os
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
@@ -83,7 +84,7 @@ def _validate_float_range(name: str, value, minimum: float, maximum: float) -> f
         validated = float(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{name} must be between {minimum} and {maximum}") from exc
-    if validated < minimum or validated > maximum:
+    if not math.isfinite(validated) or validated < minimum or validated > maximum:
         raise ValueError(f"{name} must be between {minimum} and {maximum}")
     return validated
 

--- a/tests/test_config_manager_setters.py
+++ b/tests/test_config_manager_setters.py
@@ -48,11 +48,13 @@ def test_config_setters_recover_malformed_sections(tmp_path):
 @pytest.mark.parametrize("value", [float("nan"), "nan", float("inf"), "-inf"])
 def test_config_setters_reject_non_finite_floats(tmp_path, value):
     manager = ConfigManager(config_dir=tmp_path)
+    manager.config_file.write_text("memanto:\n  recall:\n    limit: 7\n")
+    original_config = manager.config_file.read_text()
 
     with pytest.raises(ValueError, match="temperature must be between"):
         manager.set_answer_config(temperature=value)
+    assert manager.config_file.read_text() == original_config
 
     with pytest.raises(ValueError, match="min_similarity must be between"):
         manager.set_recall_config(min_similarity=value)
-
-    assert not manager.config_file.exists()
+    assert manager.config_file.read_text() == original_config

--- a/tests/test_config_manager_setters.py
+++ b/tests/test_config_manager_setters.py
@@ -1,3 +1,5 @@
+import pytest
+
 from memanto.cli.config.manager import ConfigManager
 
 
@@ -41,3 +43,16 @@ def test_config_setters_recover_malformed_sections(tmp_path):
     assert data["answer"]["model"] == "local-model"
     assert data["answer"]["temperature"] == 0.2
     assert data["recall"] == {"limit": 7, "min_similarity": 0.4}
+
+
+@pytest.mark.parametrize("value", [float("nan"), "nan", float("inf"), "-inf"])
+def test_config_setters_reject_non_finite_floats(tmp_path, value):
+    manager = ConfigManager(config_dir=tmp_path)
+
+    with pytest.raises(ValueError, match="temperature must be between"):
+        manager.set_answer_config(temperature=value)
+
+    with pytest.raises(ValueError, match="min_similarity must be between"):
+        manager.set_recall_config(min_similarity=value)
+
+    assert not manager.config_file.exists()


### PR DESCRIPTION
## Summary

Rejects non-finite values in Memanto's shared float range validator and adds regression coverage for both answer temperature and recall similarity configuration.

## Bug and reproduction

Python's IEEE-754 NaN compares false to both bounds. As a result, the previous check `validated < minimum or validated > maximum` accepted `float("nan")` and the string `"nan"`. Those values could then be persisted through `set_answer_config` or `set_recall_config`, poisoning later threshold comparisons and producing non-standard serialized configuration. Infinity is rejected explicitly by the same finite-number rule.

Minimal reproduction before this patch:

```python
manager.set_recall_config(min_similarity=float("nan"))
assert manager.load_yaml()["recall"]["min_similarity"] != manager.load_yaml()["recall"]["min_similarity"]
```

## Fix

Use `math.isfinite` immediately after numeric conversion, before the existing inclusive range check. This keeps the public validation error unchanged and applies consistently to every caller of `_validate_float_range`.

## Verification

- `.venv/bin/python -m pytest tests/test_config_manager_setters.py -q` — 5 passed
- `.venv/bin/python -m pytest tests/test_schedule_time_validation.py tests/test_memory_read_filter_sanitization.py -q` — 10 passed
- `.venv/bin/ruff check memanto/cli/config/manager.py tests/test_config_manager_setters.py` — clean

The parameterized regression covers numeric NaN, string NaN, positive infinity, and string negative infinity for both configuration paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation to reject non-finite numeric values (such as `NaN`, `Infinity`, and `-Infinity`) for float settings.
  * Ensured invalid inputs no longer result in configuration files being created or updated.

* **Tests**
  * Added parametrized test coverage to verify setters correctly reject non-finite values for temperature and similarity settings, and that persisted config content remains unchanged after failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->