### PR TITLE
Integrations/merge prs

### DIFF
--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -102,10 +102,14 @@ class RememberInput(BaseModel):
     )
     title: str = Field(
         ...,
+        min_length=1,
+        max_length=100,
         description="Short title for the memory (max 100 characters).",
     )
     content: str = Field(
         ...,
+        min_length=1,
+        max_length=10000,
         description="The memory content to store (max 10000 characters). Be concise and atomic.",
     )
     confidence: float = Field(

--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -104,13 +104,13 @@ class RememberInput(BaseModel):
         ...,
         min_length=1,
         max_length=100,
-        description="Short title for the memory (max 100 characters).",
+        description="Short title for the memory (1-100 characters).",
     )
     content: str = Field(
         ...,
         min_length=1,
         max_length=10000,
-        description="The memory content to store (max 10000 characters). Be concise and atomic.",
+        description="The memory content to store (1-10000 characters). Be concise and atomic.",
     )
     confidence: float = Field(
         ...,

--- a/integrations/crewai/tests/test_tools.py
+++ b/integrations/crewai/tests/test_tools.py
@@ -1,11 +1,14 @@
 from unittest.mock import MagicMock
 
+import pytest
 from crewai_memanto.tools import (
     MemantoAnswerTool,
     MemantoRecallTool,
     MemantoRememberTool,
     MemantoSetup,
+    RememberInput,
 )
+from pydantic import ValidationError
 
 from memanto.app.utils.errors import AgentAlreadyExistsError
 
@@ -73,6 +76,28 @@ def test_memanto_remember_tool():
         source="crewai-agent",
         provenance="explicit_statement",
     )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("title", ""),
+        ("title", "t" * 101),
+        ("content", ""),
+        ("content", "c" * 10001),
+    ],
+)
+def test_memanto_remember_input_enforces_documented_limits(field, value):
+    payload = {
+        "memory_type": "fact",
+        "title": "Valid title",
+        "content": "Valid content",
+        "confidence": 0.9,
+    }
+    payload[field] = value
+
+    with pytest.raises(ValidationError):
+        RememberInput.model_validate(payload)
 
 
 def test_memanto_recall_tool_success():

--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -138,20 +138,6 @@ def _as_bool(value: Any, default: bool) -> bool:
     return default
 
 
-def _sanitize_agent_id(raw: str) -> str:
-    """Coerce to Memanto's id charset (letters, digits, ``-``, ``_``)."""
-    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "-", raw or "")
-    cleaned = re.sub(r"-+", "-", cleaned).strip("-")
-    if not cleaned:
-        return "hermes"
-    if len(cleaned) <= _MAX_AGENT_ID_LENGTH:
-        return cleaned
-
-    digest = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:10]
-    prefix_len = _MAX_AGENT_ID_LENGTH - len(digest) - 1
-    prefix = cleaned[:prefix_len].rstrip("-_") or "hermes"
-    return f"{prefix}-{digest}"
-
 
 def _detect_memory_type(text: str) -> str:
     lowered = text.lower()
@@ -529,8 +515,7 @@ class MemantoMemoryProvider(MemoryProvider):
         sanitized = dict(values or {})
         sanitized.pop("api_key", None)
         # Keep the {identity} template intact; only sanitize concrete ids.
-        if "agent_id" in sanitized and "{identity}" not in str(sanitized["agent_id"]):
-            sanitized["agent_id"] = _sanitize_agent_id(str(sanitized["agent_id"]))
+        
         if "pattern" in sanitized:
             pattern = str(sanitized["pattern"]).strip().lower()
             sanitized["pattern"] = (
@@ -548,7 +533,7 @@ class MemantoMemoryProvider(MemoryProvider):
         raw_id = (
             os.environ.get("MEMANTO_AGENT_ID", "").strip() or self._config["agent_id"]
         )
-        self._agent_id = _sanitize_agent_id(raw_id.replace("{identity}", identity))
+        self._agent_id = raw_id.replace("{identity}", identity)
 
         self._auto_recall = self._config["auto_recall"]
         self._auto_capture = self._config["auto_capture"]

--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -26,6 +26,7 @@ provider stays inert.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -65,6 +66,16 @@ _MIN_CAPTURE_LENGTH = 10
 _MAX_TITLE_LENGTH = 100
 _MAX_AGENT_ID_LENGTH = 64
 _ACTIVATION_RETRY_COOLDOWN = 60.0
+
+
+def _sanitize_agent_id(raw: str) -> str:
+    """Sanitize charset and append a stable hash if over 64 chars."""
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", raw)
+    if len(sanitized) > _MAX_AGENT_ID_LENGTH:
+        suffix = hashlib.sha256(raw.encode()).hexdigest()[:8]
+        sanitized = sanitized[: _MAX_AGENT_ID_LENGTH - len(suffix) - 1] + "-" + suffix
+    return sanitized
+
 
 # Memory taxonomy mirrored from memanto.app.constants.VALID_MEMORY_TYPES so the
 # tool schema matches what the backend validates. Kept as a literal list to
@@ -531,7 +542,7 @@ class MemantoMemoryProvider(MemoryProvider):
         raw_id = (
             os.environ.get("MEMANTO_AGENT_ID", "").strip() or self._config["agent_id"]
         )
-        self._agent_id = raw_id.replace("{identity}", identity)
+        self._agent_id = _sanitize_agent_id(raw_id.replace("{identity}", identity))
 
         self._auto_recall = self._config["auto_recall"]
         self._auto_capture = self._config["auto_capture"]

--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -26,7 +26,6 @@ provider stays inert.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
@@ -136,7 +135,6 @@ def _as_bool(value: Any, default: bool) -> bool:
         if lowered in {"false", "0", "no", "n", "off"}:
             return False
     return default
-
 
 
 def _detect_memory_type(text: str) -> str:
@@ -515,7 +513,7 @@ class MemantoMemoryProvider(MemoryProvider):
         sanitized = dict(values or {})
         sanitized.pop("api_key", None)
         # Keep the {identity} template intact; only sanitize concrete ids.
-        
+
         if "pattern" in sanitized:
             pattern = str(sanitized["pattern"]).strip().lower()
             sanitized["pattern"] = (

--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -26,6 +26,7 @@ provider stays inert.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -141,8 +142,15 @@ def _sanitize_agent_id(raw: str) -> str:
     """Coerce to Memanto's id charset (letters, digits, ``-``, ``_``)."""
     cleaned = re.sub(r"[^a-zA-Z0-9_-]", "-", raw or "")
     cleaned = re.sub(r"-+", "-", cleaned).strip("-")
-    cleaned = cleaned[:_MAX_AGENT_ID_LENGTH].strip("-")
-    return cleaned or "hermes"
+    if not cleaned:
+        return "hermes"
+    if len(cleaned) <= _MAX_AGENT_ID_LENGTH:
+        return cleaned
+
+    digest = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:10]
+    prefix_len = _MAX_AGENT_ID_LENGTH - len(digest) - 1
+    prefix = cleaned[:prefix_len].rstrip("-_") or "hermes"
+    return f"{prefix}-{digest}"
 
 
 def _detect_memory_type(text: str) -> str:

--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -712,7 +712,7 @@ class MemantoMemoryProvider(MemoryProvider):
         if self._write_thread and self._write_thread.is_alive():
             self._write_thread.join(timeout=2.0)
         self._write_thread = threading.Thread(
-            target=_run, daemon=False, name="memanto-memory-write"
+            target=_run, daemon=True, name="memanto-memory-write"
         )
         self._write_thread.start()
 

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -459,6 +459,13 @@ def test_on_memory_write_mirrors_to_memanto(provider):
     assert provider._client.remember_calls[0]["source"] == "hermes-memory"
 
 
+def test_on_memory_write_uses_daemon_thread(provider):
+    provider.on_memory_write("add", "memory", "The deploy pipeline lives in gh actions")
+    assert provider._write_thread is not None
+    assert provider._write_thread.daemon is True
+    provider._write_thread.join(timeout=1)
+
+
 def test_on_memory_write_user_target_is_preference(provider):
     provider.on_memory_write("add", "user", "Name is Jordan")
     provider._write_thread.join(timeout=1)

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -15,7 +15,6 @@ from hermes_memanto.provider import (
     _detect_memory_type,
     _format_recall_block,
     _load_memanto_config,
-    _sanitize_agent_id,
     _save_memanto_config,
 )
 
@@ -125,23 +124,6 @@ def test_is_available_false_when_import_missing(monkeypatch):
 # -- Helpers ------------------------------------------------------------------
 
 
-def test_sanitize_agent_id_coerces_charset():
-    assert _sanitize_agent_id("Hermes Coder!@#") == "Hermes-Coder"
-    assert _sanitize_agent_id("") == "hermes"
-    long_id = _sanitize_agent_id("a" * 100)
-    assert len(long_id) == 64
-    assert long_id.startswith("a" * 53 + "-")
-
-
-def test_sanitize_agent_id_avoids_truncation_collisions():
-    first = _sanitize_agent_id("hermes-" + "a" * 80)
-    second = _sanitize_agent_id("hermes-" + "a" * 79 + "b")
-
-    assert first != second
-    assert len(first) <= 64
-    assert len(second) <= 64
-
-
 def test_detect_memory_type():
     assert _detect_memory_type("User prefers dark mode") == "preference"
     assert _detect_memory_type("We decided to use Postgres") == "decision"
@@ -158,13 +140,6 @@ def test_load_and_save_config_round_trip(tmp_path):
     assert cfg["auto_capture"] is False
     assert cfg["auto_recall"] is True
     assert cfg["pattern"] == "tool"
-
-
-def test_save_config_sanitizes_concrete_agent_id(tmp_path):
-    p = MemantoMemoryProvider()
-    p.save_config({"agent_id": "My Agent!"}, str(tmp_path))
-    cfg = _load_memanto_config(str(tmp_path))
-    assert cfg["agent_id"] == "My-Agent"
 
 
 def test_save_config_preserves_identity_template(tmp_path):

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -128,7 +128,18 @@ def test_is_available_false_when_import_missing(monkeypatch):
 def test_sanitize_agent_id_coerces_charset():
     assert _sanitize_agent_id("Hermes Coder!@#") == "Hermes-Coder"
     assert _sanitize_agent_id("") == "hermes"
-    assert _sanitize_agent_id("a" * 100) == "a" * 64
+    long_id = _sanitize_agent_id("a" * 100)
+    assert len(long_id) == 64
+    assert long_id.startswith("a" * 53 + "-")
+
+
+def test_sanitize_agent_id_avoids_truncation_collisions():
+    first = _sanitize_agent_id("hermes-" + "a" * 80)
+    second = _sanitize_agent_id("hermes-" + "a" * 79 + "b")
+
+    assert first != second
+    assert len(first) <= 64
+    assert len(second) <= 64
 
 
 def test_detect_memory_type():

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -232,11 +232,12 @@ class MemantoStore(BaseStore):
         raw_content = value.pop("content", None)
         if raw_content is None:
             raw_content = self._stringify(value)
+        content = str(raw_content)
 
         title = value.pop("title", None)
         if not title:
-            title = raw_content if len(raw_content) <= 80 else raw_content[:77] + "..."
-        title = title[:100]
+            title = content if len(content) <= 80 else content[:77] + "..."
+        title = str(title)[:100]
 
         confidence = float(value.pop("confidence", 0.8))
         confidence = max(0.0, min(1.0, confidence))
@@ -252,7 +253,7 @@ class MemantoStore(BaseStore):
             agent_id=agent_id,
             memory_type=memory_type,
             title=title,
-            content=str(raw_content),
+            content=content,
             confidence=confidence,
             tags=all_tags,
             source="langgraph-store",

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -307,7 +307,10 @@ class MemantoStore(BaseStore):
                 if time.time() - ts < self._CACHE_TTL_S:
                     return items
 
-        fetch_limit = max(1, min(op.limit, self._MEMANTO_RECALL_CAP))
+        if min_confidence is not None:
+            fetch_limit = self._MEMANTO_RECALL_CAP
+        else:
+            fetch_limit = max(1, min(op.limit, self._MEMANTO_RECALL_CAP))
         rate_limited = False
 
         client, agent_id = self._ensure_client(op.namespace_prefix)
@@ -431,7 +434,6 @@ class MemantoStore(BaseStore):
                 return t[len(_KEY_TAG_PREFIX) :]
         return None
 
-    @staticmethod
     @staticmethod
     def _passes_min_confidence(mem: dict[str, Any], min_confidence: Any) -> bool:
         try:

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -17,7 +17,8 @@ Mapping between abstractions
     value["tags"]                     ->  user tags (non-reserved)
     SearchOp.query                    ->  recall query   (``recall_recent`` if ``"*"``)
     SearchOp.filter["type"]           ->  type filter
-    SearchOp.filter["min_confidence"] ->  min_similarity
+    SearchOp.filter["min_similarity"] ->  semantic similarity threshold
+    SearchOp.filter["min_confidence"] ->  memory confidence threshold
 
 Documented limitations
 ----------------------
@@ -105,7 +106,7 @@ class MemantoStore(BaseStore):
         self._lock = threading.RLock()
         self._client_pool: dict[str, SdkClient] = {}
         self._agent_prefix = "langgraph_"
-        # (namespace, query, limit, type, min_sim) -> (timestamp, list[SearchItem])
+        # (namespace, query, limit, tags, type, min_sim, min_conf) -> (timestamp, items)
         self._search_cache: dict[tuple, tuple[float, list[SearchItem]]] = {}
         # Survives 429s without flashing the UI panel to zero.
         self._last_good: dict[tuple[str, ...], list[SearchItem]] = {}
@@ -286,8 +287,8 @@ class MemantoStore(BaseStore):
         type_filter = filter_dict.get("type") or filter_dict.get("kind")
         if isinstance(type_filter, str):
             type_filter = [type_filter]
-        # SearchOp uses "min_confidence"; SdkClient.recall() uses "min_similarity"
-        min_similarity = filter_dict.get("min_confidence")
+        min_similarity = filter_dict.get("min_similarity")
+        min_confidence = filter_dict.get("min_confidence")
         extra_tags = self._normalize_tags(filter_dict.get("tags"))
 
         cache_key = (
@@ -297,6 +298,7 @@ class MemantoStore(BaseStore):
             tuple(extra_tags),
             tuple(type_filter) if type_filter else None,
             min_similarity,
+            min_confidence,
         )
         with self._lock:
             cached = self._search_cache.get(cache_key)
@@ -346,6 +348,10 @@ class MemantoStore(BaseStore):
         for mem in result.get("memories", []):
             tags = self._normalize_tags(mem.get("tags"))
             if extra_tags and not all(t in tags for t in extra_tags):
+                continue
+            if min_confidence is not None and not self._passes_min_confidence(
+                mem, min_confidence
+            ):
                 continue
             key = self._tags_to_key(tags) or mem.get("id", "")
             out.append(self._memory_to_search_item(mem, op.namespace_prefix, key))
@@ -424,6 +430,19 @@ class MemantoStore(BaseStore):
             if t.startswith(_KEY_TAG_PREFIX):
                 return t[len(_KEY_TAG_PREFIX) :]
         return None
+
+    @staticmethod
+    @staticmethod
+    def _passes_min_confidence(mem: dict[str, Any], min_confidence: Any) -> bool:
+        try:
+            threshold = float(min_confidence)
+        except (TypeError, ValueError):
+            return False
+        try:
+            confidence = float(mem.get("confidence"))
+        except (TypeError, ValueError):
+            return threshold <= 0
+        return confidence >= threshold
 
     @staticmethod
     def _normalize_tags(raw: Any) -> list[str]:

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -46,7 +46,8 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
                 client.activate_agent(agent_id, duration_hours=6)
             except Exception:
                 pass
-            _setup_done = True
+            else:
+                _setup_done = True
 
     @tool
     def memanto_remember(

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -65,13 +65,17 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
         title: Annotated[
             str,
             Field(
-                description="Short title for the memory (max 100 characters).",
+                min_length=1,
+                max_length=100,
+                description="Short title for the memory (1-100 characters).",
             ),
         ],
         content: Annotated[
             str,
             Field(
-                description="The memory content to store (max 10000 characters). Be concise and atomic.",
+                min_length=1,
+                max_length=10000,
+                description="The memory content to store (1-10000 characters). Be concise and atomic.",
             ),
         ],
         confidence: Annotated[

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -214,6 +214,26 @@ def test_tags_to_key_unescapes_encoded_key_tags():
     )
 
 
+def test_do_put_stringifies_non_string_content(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    op = PutOp(namespace=("my_ns",), key="answer", value={"content": 42})
+    store._do_put(op)
+
+    client_instance.remember.assert_called_once_with(
+        agent_id="langgraph_my_ns",
+        memory_type=None,
+        title="42",
+        content="42",
+        confidence=0.8,
+        tags=["lg:key:answer"],
+        source="langgraph-store",
+        provenance="explicit_statement",
+    )
+
+
 def test_do_put_delete_not_supported(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     op = PutOp(namespace=("my_ns",), key="my_key", value=None)

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -341,6 +341,78 @@ def test_do_search_semantic(mock_sdk_client):
     )
 
 
+def test_do_search_filters_min_confidence_without_changing_similarity(
+    mock_sdk_client,
+):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall.return_value = {
+        "memories": [
+            {
+                "id": "mem-high",
+                "tags": ["lg:key:key-high"],
+                "type": "fact",
+                "content": "high confidence",
+                "confidence": 0.95,
+            },
+            {
+                "id": "mem-low",
+                "tags": ["lg:key:key-low"],
+                "type": "fact",
+                "content": "low confidence",
+                "confidence": 0.4,
+            },
+        ]
+    }
+
+    op = SearchOp(
+        namespace_prefix=("my_ns",),
+        query="test query",
+        filter={"min_confidence": 0.9, "min_similarity": 0.2},
+        limit=10,
+    )
+    items = store._do_search(op)
+
+    assert [item.key for item in items] == ["key-high"]
+    client_instance.recall.assert_called_once_with(
+        agent_id="langgraph_my_ns",
+        query="test query",
+        limit=10,
+        type=None,
+        tags=None,
+        min_similarity=0.2,
+    )
+
+
+def test_do_search_min_confidence_zero_keeps_legacy_memories(mock_sdk_client):
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+
+    client_instance.recall_recent.return_value = {
+        "memories": [
+            {
+                "id": "legacy-memory",
+                "tags": ["lg:key:legacy"],
+                "type": "fact",
+                "content": "stored before confidence existed",
+            }
+        ]
+    }
+
+    op = SearchOp(
+        namespace_prefix=("my_ns",),
+        query="*",
+        filter={"min_confidence": 0.0},
+        limit=10,
+    )
+    items = store._do_search(op)
+
+    assert [item.key for item in items] == ["legacy"]
+
+
 def test_do_search_accepts_string_tag_filter(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()
@@ -398,6 +470,7 @@ def test_do_search_recovers_key_from_comma_separated_tags(mock_sdk_client):
     assert len(items) == 1
     assert items[0].key == "key2"
     assert items[0].value["tags"] == ["urgent"]
+>>>>>>> origin/integrations/merge-prs
 
 
 def test_batch_execution(mock_sdk_client):

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
 
+import pytest
 from langgraph_memanto.tools import create_memanto_tools
+from pydantic import ValidationError
 
 
 def test_create_memanto_tools_returns_all_tools():
@@ -68,6 +70,34 @@ def test_memanto_remember_tool_setup_fallback():
     assert client.remember.call_count == 2
     client.create_agent.assert_called_once_with(agent_id="test-agent", pattern="tool")
     client.activate_agent.assert_called_once_with("test-agent", duration_hours=6)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("title", ""),
+        ("title", "t" * 101),
+        ("content", ""),
+        ("content", "c" * 10001),
+    ],
+)
+def test_memanto_remember_tool_enforces_documented_limits(field, value):
+    client = MagicMock()
+    tools = create_memanto_tools(client, "test-agent")
+    remember_tool = next(t for t in tools if t.name == "memanto_remember")
+    payload = {
+        "memory_type": "fact",
+        "title": "Valid title",
+        "content": "Valid content",
+        "confidence": 0.9,
+        "tags": "",
+    }
+    payload[field] = value
+
+    with pytest.raises(ValidationError):
+        remember_tool.invoke(payload)
+
+    client.remember.assert_not_called()
 
 
 def test_memanto_recall_tool_success():

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -72,6 +72,52 @@ def test_memanto_remember_tool_setup_fallback():
     client.activate_agent.assert_called_once_with("test-agent", duration_hours=6)
 
 
+def test_memanto_remember_retries_setup_after_activation_failure():
+    client = MagicMock()
+    activated = False
+    activation_attempts = 0
+
+    def activate_agent(*_args, **_kwargs):
+        nonlocal activated, activation_attempts
+        activation_attempts += 1
+        if activation_attempts == 1:
+            raise Exception("Activation failed")
+        activated = True
+
+    def remember(**_kwargs):
+        if not activated:
+            raise Exception("Not initialized")
+        return {"memory_id": "mem-789"}
+
+    client.activate_agent.side_effect = activate_agent
+    client.remember.side_effect = remember
+
+    tools = create_memanto_tools(client, "test-agent")
+    remember_tool = next(t for t in tools if t.name == "memanto_remember")
+    payload = {
+        "memory_type": "goal",
+        "title": "Test Goal",
+        "content": "This is a test goal.",
+        "confidence": 1.0,
+        "tags": "",
+    }
+
+    with pytest.raises(Exception, match="Not initialized"):
+        remember_tool.invoke(payload)
+
+    result = remember_tool.invoke(payload)
+
+    assert result == "Memory stored: mem-789"
+    assert client.create_agent.call_count == 2
+    assert client.activate_agent.call_count == 2
+
+    fast_path_result = remember_tool.invoke(payload)
+
+    assert fast_path_result == "Memory stored: mem-789"
+    assert client.create_agent.call_count == 2
+    assert client.activate_agent.call_count == 2
+
+
 @pytest.mark.parametrize(
     "field,value",
     [

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -41,8 +41,10 @@ class MemantoLifecycle:
     """Owns the long-lived SdkClient and per-agent session bookkeeping."""
 
     def __init__(self, settings: MCPServerSettings) -> None:
+        """Initialize admin and per-agent client state."""
         self._settings = settings
-        self._client = SdkClient(api_key=settings.api_key_value())
+        self._admin_client = SdkClient(api_key=settings.api_key_value())
+        self._clients: dict[str, SdkClient] = {}
         self._activated_agents: set[str] = set()
         self._ensured_agents: set[str] = set()
         self._lock = threading.Lock()
@@ -53,8 +55,8 @@ class MemantoLifecycle:
 
     @property
     def client(self) -> SdkClient:
-        """The shared Memanto SDK client."""
-        return self._client
+        """An SDK client for agent administration calls."""
+        return self._admin_client
 
     @property
     def settings(self) -> MCPServerSettings:
@@ -76,25 +78,35 @@ class MemantoLifecycle:
             "configured. Either pass agent_id explicitly or set the env var."
         )
 
-    def ensure_ready(self, agent_id: str) -> str:
+    def ensure_ready(self, agent_id: str) -> SdkClient:
         """Make sure the agent exists and a session is active for it.
 
-        Returns the resolved agent_id (mostly a convenience so callers can
-        chain ``ensure_ready(resolve_agent_id(...))``).
+        Returns an agent-scoped SDK client. ``SdkClient`` stores the active
+        session token on the instance, so sharing one client across multiple
+        concurrent MCP tool calls can make agents overwrite each other's
+        session state.
         """
         with self._lock:
+            client = self._clients.get(agent_id)
+            is_new_client = client is None
+            if is_new_client:
+                client = SdkClient(api_key=self._settings.api_key_value())
+
             if agent_id not in self._ensured_agents:
-                self._ensure_agent_exists_locked(agent_id)
+                self._ensure_agent_exists_locked(client, agent_id)
                 self._ensured_agents.add(agent_id)
 
             if (
                 agent_id not in self._activated_agents
-                or self._client.agent_id != agent_id
+                or client.agent_id != agent_id
             ):
-                self._activate_locked(agent_id)
+                self._activate_locked(client, agent_id)
                 self._activated_agents.add(agent_id)
 
-        return agent_id
+            if is_new_client:
+                self._clients[agent_id] = client
+
+        return client
 
     def shutdown(self) -> None:
         """Best-effort cleanup. Sessions can outlive the process safely."""
@@ -107,9 +119,10 @@ class MemantoLifecycle:
     # Internals
     # ------------------------------------------------------------------ #
 
-    def _ensure_agent_exists_locked(self, agent_id: str) -> None:
+    def _ensure_agent_exists_locked(self, client: SdkClient, agent_id: str) -> None:
+        """Verify an agent exists, auto-creating it when configured."""
         try:
-            self._client.get_agent(agent_id)
+            client.get_agent(agent_id)
             logger.debug("Agent '%s' exists.", agent_id)
             return
         except AgentNotFoundError:
@@ -128,7 +141,7 @@ class MemantoLifecycle:
             self._settings.agent_pattern,
         )
         try:
-            self._client.create_agent(
+            client.create_agent(
                 agent_id=agent_id,
                 pattern=self._settings.agent_pattern,
                 description="Auto-created by memanto-mcp",
@@ -137,9 +150,10 @@ class MemantoLifecycle:
             # Race: another caller created it between our get_agent and create.
             logger.debug("Agent '%s' was created concurrently.", agent_id)
 
-    def _activate_locked(self, agent_id: str) -> None:
+    def _activate_locked(self, client: SdkClient, agent_id: str) -> None:
+        """Activate a Memanto session on the provided agent-scoped client."""
         try:
-            self._client.activate_agent(
+            client.activate_agent(
                 agent_id=agent_id,
                 duration_hours=self._settings.session_duration_hours,
             )

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -96,10 +96,7 @@ class MemantoLifecycle:
                 self._ensure_agent_exists_locked(client, agent_id)
                 self._ensured_agents.add(agent_id)
 
-            if (
-                agent_id not in self._activated_agents
-                or client.agent_id != agent_id
-            ):
+            if agent_id not in self._activated_agents or client.agent_id != agent_id:
                 self._activate_locked(client, agent_id)
                 self._activated_agents.add(agent_id)
 

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -139,12 +139,16 @@ class AnswerResult(BaseModel):
 
 
 class BatchRememberItemResult(BaseModel):
+    """Result for one item in a batch memory write."""
+
     id: str | None = None
     status: str
     error: str | None = None
 
 
 class BatchRememberResult(BaseModel):
+    """Response returned by the batch_remember MCP tool."""
+
     status: str
     agent_id: str
     namespace: str | None = None
@@ -156,6 +160,8 @@ class BatchRememberResult(BaseModel):
 
 
 class AgentInfoResult(BaseModel):
+    """Agent metadata returned by MCP admin tools."""
+
     status: str
     agent_id: str | None = None
     namespace: str | None = None
@@ -166,6 +172,8 @@ class AgentInfoResult(BaseModel):
 
 
 class AgentListResult(BaseModel):
+    """Collection response for listing Memanto agents."""
+
     status: str
     count: int = 0
     agents: list[dict[str, Any]] = Field(default_factory=list)
@@ -325,14 +333,16 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = "mcp-agent",
         agent_id: AgentIdField = None,
     ) -> RememberResult:
+        """Store a single memory for the resolved agent."""
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
             resolved_title = title or (
                 content[: _MAX_TITLE_LENGTH - 3] + "..."
                 if len(content) > _MAX_TITLE_LENGTH
                 else content
             )
-            result = lifecycle.client.remember(
+            result = client.remember(
                 agent_id=resolved,
                 memory_type=type,
                 title=resolved_title,
@@ -386,8 +396,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ],
         agent_id: AgentIdField = None,
     ) -> BatchRememberResult:
+        """Validate and store multiple memories for the resolved agent."""
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved = lifecycle.resolve_agent_id(agent_id)
             # Validate before round-trip so we fail fast with a clear error.
             normalized_memories: list[dict[str, Any]] = []
             for i, item in enumerate(memories):
@@ -415,7 +426,8 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 normalized_item["tags"] = _normalize_tags(item.get("tags"))
                 normalized_memories.append(normalized_item)
 
-            result = lifecycle.client.batch_remember(
+            client = lifecycle.ensure_ready(resolved)
+            result = client.batch_remember(
                 agent_id=resolved,
                 memories=normalized_memories,
             )
@@ -499,9 +511,11 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Search memories semantically for the resolved agent."""
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.recall(
                 agent_id=resolved,
                 query=query,
                 limit=limit,
@@ -553,9 +567,11 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Return the most recent memories for the resolved agent."""
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_recent(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.recall_recent(
                 agent_id=resolved,
                 limit=limit,
                 type=list(type) if type else None,
@@ -608,9 +624,11 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Recall memories that were valid at a point in time."""
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_as_of(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.recall_as_of(
                 agent_id=resolved,
                 as_of=as_of,
                 limit=limit,
@@ -664,9 +682,11 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = None,
         agent_id: AgentIdField = None,
     ) -> RecallResult:
+        """Recall memories changed after the supplied timestamp."""
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_changed_since(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.recall_changed_since(
                 agent_id=resolved,
                 since=since,
                 limit=limit,
@@ -739,9 +759,11 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         ] = False,
         agent_id: AgentIdField = None,
     ) -> AnswerResult:
+        """Answer a question using memories from the resolved agent."""
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.answer(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.ensure_ready(resolved)
+            result = client.answer(
                 agent_id=resolved,
                 question=question,
                 limit=limit,
@@ -805,6 +827,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             Field(default=None, description="Optional human-readable description."),
         ] = None,
     ) -> AgentInfoResult:
+        """Create a Memanto agent through the admin client."""
         try:
             agent = lifecycle.client.create_agent(
                 agent_id=agent_id, pattern=pattern, description=description
@@ -836,6 +859,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         description="List every Memanto agent visible to the current API key.",
     )
     def list_agents() -> AgentListResult:
+        """List available Memanto agents through the admin client."""
         try:
             agents = lifecycle.client.list_agents()
             return AgentListResult(status="ok", count=len(agents), agents=agents)
@@ -852,6 +876,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             str, Field(description="Agent id to look up.", min_length=1)
         ],
     ) -> AgentInfoResult:
+        """Fetch one Memanto agent by identifier."""
         try:
             agent = lifecycle.client.get_agent(agent_id)
             return AgentInfoResult(
@@ -887,6 +912,7 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             str, Field(description="Agent id to delete.", min_length=1)
         ],
     ) -> AgentInfoResult:
+        """Delete one Memanto agent by identifier."""
         try:
             lifecycle.client.delete_agent(agent_id)
             return AgentInfoResult(status="ok", agent_id=agent_id, message="deleted")

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -1,0 +1,188 @@
+"""Lifecycle tests for agent-scoped MCP clients."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from memanto.app.utils.errors import AgentNotFoundError
+
+from memanto_mcp.config import MCPServerSettings
+from memanto_mcp.lifecycle import MemantoLifecycle
+from memanto_mcp.tools import register_tools
+
+
+class FakeSdkClient:
+    """Small stateful stand-in for SdkClient.
+
+    The real SdkClient stores ``agent_id`` and ``session_token`` on the client
+    instance. These tests make that mutable state visible without hitting the
+    network.
+    """
+
+    instances: list[FakeSdkClient] = []
+    missing_agents: set[str] = set()
+    fail_activate_agents: set[str] = set()
+
+    def __init__(self, api_key: str) -> None:
+        """Record constructor calls and initialize mutable session state."""
+        self.api_key = api_key
+        self.agent_id: str | None = None
+        self.session_token: str | None = None
+        self.created_agents: list[str] = []
+        self.activated_agents: list[str] = []
+        FakeSdkClient.instances.append(self)
+
+    def get_agent(self, agent_id: str) -> dict[str, str]:
+        """Pretend the requested agent exists unless configured missing."""
+        if agent_id in FakeSdkClient.missing_agents:
+            raise AgentNotFoundError(f"Agent '{agent_id}' not found")
+        return {"agent_id": agent_id}
+
+    def create_agent(
+        self, agent_id: str, pattern: str = "tool", description: str | None = None
+    ) -> dict[str, str]:
+        """Record auto-created agents for future assertions."""
+        self.created_agents.append(agent_id)
+        return {"agent_id": agent_id, "pattern": pattern}
+
+    def activate_agent(
+        self, agent_id: str, duration_hours: int | None = None
+    ) -> dict[str, str]:
+        """Mutate instance session state like the real SdkClient does."""
+        if agent_id in FakeSdkClient.fail_activate_agents:
+            raise RuntimeError("activation failed")
+        self.agent_id = agent_id
+        self.session_token = f"token-for-{agent_id}"
+        self.activated_agents.append(agent_id)
+        return {"agent_id": agent_id, "session_token": self.session_token}
+
+    def remember(self, *, agent_id: str, **_: Any) -> dict[str, str]:
+        """Fail if a memory call uses a client scoped to another agent."""
+        if self.agent_id != agent_id:
+            raise AssertionError(
+                f"client for {self.agent_id!r} used for {agent_id!r}"
+            )
+        return {"memory_id": f"mem-{agent_id}", "status": "ok"}
+
+
+class ToolRegistry:
+    """Tiny FastMCP stand-in that captures decorated tool functions."""
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, name: str, description: str):
+        """Return a decorator that stores the tool by name."""
+
+        def decorator(fn):
+            """Store one decorated tool function and return it unchanged."""
+            self.tools[name] = fn
+            return fn
+
+        return decorator
+
+
+def test_ensure_ready_uses_distinct_clients_per_agent(
+    fake_api_key: str, monkeypatch
+) -> None:
+    """Different MCP agents must not share SdkClient session state."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = set()
+    FakeSdkClient.fail_activate_agents = set()
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    agent_a_client = lifecycle.ensure_ready("agent-a")
+    agent_b_client = lifecycle.ensure_ready("agent-b")
+
+    assert agent_a_client is not agent_b_client
+    assert agent_a_client.agent_id == "agent-a"
+    assert agent_b_client.agent_id == "agent-b"
+    assert agent_a_client.remember(agent_id="agent-a")["memory_id"] == "mem-agent-a"
+    assert agent_b_client.remember(agent_id="agent-b")["memory_id"] == "mem-agent-b"
+
+
+def test_repeated_agent_reuses_its_scoped_client(fake_api_key: str, monkeypatch) -> None:
+    """Repeated calls for one agent should reuse that agent's client."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = set()
+    FakeSdkClient.fail_activate_agents = set()
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    first = lifecycle.ensure_ready("agent-a")
+    second = lifecycle.ensure_ready("agent-a")
+
+    assert first is second
+    assert first.activated_agents == ["agent-a"]
+
+
+def test_missing_agent_is_created_with_scoped_client(
+    fake_api_key: str, monkeypatch
+) -> None:
+    """Auto-create should happen on the same scoped client returned later."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = {"agent-a"}
+    FakeSdkClient.fail_activate_agents = set()
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    client = lifecycle.ensure_ready("agent-a")
+
+    assert client.created_agents == ["agent-a"]
+    assert client.activated_agents == ["agent-a"]
+    assert lifecycle.ensure_ready("agent-a") is client
+
+
+def test_failed_first_activation_does_not_cache_new_client(
+    fake_api_key: str, monkeypatch
+) -> None:
+    """A failed readiness check should not leave a new scoped client cached."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = set()
+    FakeSdkClient.fail_activate_agents = {"agent-a"}
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    with pytest.raises(Exception, match="Failed to activate Memanto session"):
+        lifecycle.ensure_ready("agent-a")
+
+    failed_client = FakeSdkClient.instances[-1]
+    FakeSdkClient.fail_activate_agents = set()
+    recovered_client = lifecycle.ensure_ready("agent-a")
+    cached_client = lifecycle.ensure_ready("agent-a")
+
+    assert recovered_client is not failed_client
+    assert cached_client is recovered_client
+    assert recovered_client.activated_agents == ["agent-a"]
+
+
+def test_batch_remember_validates_before_lifecycle_side_effects(
+    fake_api_key: str, monkeypatch
+) -> None:
+    """Invalid batch payloads should fail before creating or activating agents."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = set()
+    FakeSdkClient.fail_activate_agents = set()
+
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+    registry = ToolRegistry()
+    register_tools(registry, lifecycle)
+
+    result = registry.tools["batch_remember"](
+        memories=[{"content": "   "}],
+        agent_id="agent-a",
+    )
+
+    assert result.status == "error"
+    # Only the admin client from lifecycle construction should exist.
+    assert len(FakeSdkClient.instances) == 1
+    assert FakeSdkClient.instances[0].created_agents == []
+    assert FakeSdkClient.instances[0].activated_agents == []

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -57,7 +57,9 @@ class FakeSdkClient:
         self.activated_agents.append(agent_id)
         return {"agent_id": agent_id, "session_token": self.session_token}
 
-    def remember(self, *, agent_id: str, **_: Any) -> dict[str, str]:
+    def remember(
+        self, content: str, role: str, *, agent_id: str, **_: Any
+    ) -> dict[str, str]:
         """Fail if a memory call uses a client scoped to another agent."""
         if self.agent_id != agent_id:
             raise AssertionError(f"client for {self.agent_id!r} used for {agent_id!r}")
@@ -99,8 +101,14 @@ def test_ensure_ready_uses_distinct_clients_per_agent(
     assert agent_a_client is not agent_b_client
     assert agent_a_client.agent_id == "agent-a"
     assert agent_b_client.agent_id == "agent-b"
-    assert agent_a_client.remember(agent_id="agent-a")["memory_id"] == "mem-agent-a"
-    assert agent_b_client.remember(agent_id="agent-b")["memory_id"] == "mem-agent-b"
+    assert (
+        agent_a_client.remember("test", "user", agent_id="agent-a")["memory_id"]
+        == "mem-agent-a"
+    )
+    assert (
+        agent_b_client.remember("test", "user", agent_id="agent-b")["memory_id"]
+        == "mem-agent-b"
+    )
 
 
 def test_repeated_agent_reuses_its_scoped_client(

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -60,9 +60,7 @@ class FakeSdkClient:
     def remember(self, *, agent_id: str, **_: Any) -> dict[str, str]:
         """Fail if a memory call uses a client scoped to another agent."""
         if self.agent_id != agent_id:
-            raise AssertionError(
-                f"client for {self.agent_id!r} used for {agent_id!r}"
-            )
+            raise AssertionError(f"client for {self.agent_id!r} used for {agent_id!r}")
         return {"memory_id": f"mem-{agent_id}", "status": "ok"}
 
 
@@ -105,7 +103,9 @@ def test_ensure_ready_uses_distinct_clients_per_agent(
     assert agent_b_client.remember(agent_id="agent-b")["memory_id"] == "mem-agent-b"
 
 
-def test_repeated_agent_reuses_its_scoped_client(fake_api_key: str, monkeypatch) -> None:
+def test_repeated_agent_reuses_its_scoped_client(
+    fake_api_key: str, monkeypatch
+) -> None:
     """Repeated calls for one agent should reuse that agent's client."""
     monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
     FakeSdkClient.instances = []

--- a/integrations/mcp/tests/test_tools.py
+++ b/integrations/mcp/tests/test_tools.py
@@ -46,8 +46,8 @@ class FakeLifecycle:
     def resolve_agent_id(self, agent_id: str | None) -> str:
         return agent_id or self.settings.default_agent_id
 
-    def ensure_ready(self, agent_id: str) -> str:
-        return agent_id
+    def ensure_ready(self, agent_id: str) -> Any:
+        return self.client
 
 
 def test_batch_remember_normalizes_comma_separated_tags() -> None:

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -280,10 +280,10 @@ class DirectClient:
         locally.
         """
         if self._moorcheh is None:
-            from memanto.app.clients.moorcheh import get_moorcheh_client
+            from memanto.app.clients.moorcheh import moorcheh_client
 
             logger.debug("Initializing Moorcheh client via backend dispatcher")
-            self._moorcheh = get_moorcheh_client()
+            self._moorcheh = moorcheh_client.get_client(api_key=self.api_key)
         return self._moorcheh
 
     def _get_write_service(self):

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -7,6 +7,7 @@ Calls the Moorcheh API directly through existing service classes
 import json
 import logging
 import os
+import re
 import shutil
 import urllib.error
 import urllib.request
@@ -429,6 +430,12 @@ class DirectClient:
             ValueError: If *pattern* is invalid.
             AgentAlreadyExistsError: If agent already exists.
         """
+        if not agent_id:
+            raise ValueError("agent_id must not be empty")
+        if not re.fullmatch(r"^[a-zA-Z0-9_-]+$", agent_id):
+            raise ValueError(
+                f"Invalid agent_id: '{agent_id}'. Only alphanumeric characters, hyphens, and underscores are allowed."
+            )
         if pattern not in _VALID_PATTERNS:
             raise ValueError(
                 f"Invalid pattern '{pattern}'. Must be one of: {', '.join(sorted(_VALID_PATTERNS))}"

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -112,10 +112,10 @@ class SdkClient:
         either way.
         """
         if self._moorcheh is None:
-            from memanto.app.clients.moorcheh import get_moorcheh_client
+            from memanto.app.clients.moorcheh import moorcheh_client
 
             logger.debug("Initializing Moorcheh client via backend dispatcher")
-            self._moorcheh = get_moorcheh_client()
+            self._moorcheh = moorcheh_client.get_client(api_key=self.api_key)
         return self._moorcheh
 
     def _get_write_service(self):

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -6,6 +6,7 @@ Uses the official moorcheh_sdk to interact with Moorcheh API.
 
 import json
 import logging
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -261,6 +262,12 @@ class SdkClient:
             ValueError: If *pattern* is invalid.
             AgentAlreadyExistsError: If agent already exists.
         """
+        if not agent_id:
+            raise ValueError("agent_id must not be empty")
+        if not re.fullmatch(r"^[a-zA-Z0-9_-]+$", agent_id):
+            raise ValueError(
+                f"Invalid agent_id: '{agent_id}'. Only alphanumeric characters, hyphens, and underscores are allowed."
+            )
         if pattern not in _VALID_PATTERNS:
             raise ValueError(
                 f"Invalid pattern '{pattern}'. Must be one of: {', '.join(sorted(_VALID_PATTERNS))}"

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -233,6 +233,12 @@ def _remove_instructions(
 
     # For dedicated files (cline, roo, continue, augment, cursor)
     if agent.instruction_is_dir or agent.instruction_format == "mdc":
+        try:
+            existing = instr_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return None
+        if MEMANTO_SENTINEL not in existing:
+            return None
         instr_path.unlink()
         # Clean up empty parent dirs
         parent = instr_path.parent

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -1,0 +1,39 @@
+from memanto.cli.connect.agent_registry import AGENT_REGISTRY
+from memanto.cli.connect.engine import _remove_instructions
+from memanto.cli.connect.templates import get_instruction_content
+
+
+def test_remove_dedicated_instruction_preserves_unmanaged_file(tmp_path):
+    agent = AGENT_REGISTRY["cursor"]
+    rules_path = tmp_path / ".cursor" / "rules" / "memanto.mdc"
+    rules_path.parent.mkdir(parents=True)
+    rules_path.write_text("User-owned Cursor rules\n", encoding="utf-8")
+
+    result = _remove_instructions(agent, tmp_path, is_global=False)
+
+    assert result is None
+    assert rules_path.read_text(encoding="utf-8") == "User-owned Cursor rules\n"
+
+
+def test_remove_dedicated_instruction_preserves_non_utf8_unmanaged_file(tmp_path):
+    agent = AGENT_REGISTRY["cursor"]
+    rules_path = tmp_path / ".cursor" / "rules" / "memanto.mdc"
+    rules_path.parent.mkdir(parents=True)
+    rules_path.write_bytes(b"\xff\xfeuser-owned rules")
+
+    result = _remove_instructions(agent, tmp_path, is_global=False)
+
+    assert result is None
+    assert rules_path.read_bytes() == b"\xff\xfeuser-owned rules"
+
+
+def test_remove_dedicated_instruction_deletes_memanto_managed_file(tmp_path):
+    agent = AGENT_REGISTRY["cursor"]
+    rules_path = tmp_path / ".cursor" / "rules" / "memanto.mdc"
+    rules_path.parent.mkdir(parents=True)
+    rules_path.write_text(get_instruction_content("cursor"), encoding="utf-8")
+
+    result = _remove_instructions(agent, tmp_path, is_global=False)
+
+    assert result == "Removed memanto.mdc"
+    assert not rules_path.exists()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -741,6 +741,41 @@ class TestMemoryReadServiceVersionSelection:
         assert result["results"][0]["change_type"] == "updated"
 
 
+class TestClientApiKeyDispatch:
+    """CLI clients must honor the api_key supplied to the client instance."""
+
+    @pytest.mark.parametrize(
+        "client_cls_path",
+        [
+            "memanto.cli.client.direct_client.DirectClient",
+            "memanto.cli.client.sdk_client.SdkClient",
+        ],
+    )
+    def test_clients_pass_instance_api_key_to_backend_dispatcher(
+        self, monkeypatch, client_cls_path
+    ):
+        from memanto.app.clients import moorcheh as moorcheh_mod
+
+        calls = []
+        fake_backend = object()
+
+        class Recorder:
+            def get_client(self, api_key=None):
+                calls.append(api_key)
+                return fake_backend
+
+        module_name, class_name = client_cls_path.rsplit(".", 1)
+        module = __import__(module_name, fromlist=[class_name])
+        client_cls = getattr(module, class_name)
+
+        monkeypatch.setattr(moorcheh_mod, "moorcheh_client", Recorder())
+
+        client = client_cls(api_key="mk_instance_specific_key")
+
+        assert client._get_moorcheh() is fake_backend
+        assert calls == ["mk_instance_specific_key"]
+
+
 class TestForgetEndToEnd:
     """End-to-end ``forget`` flow through ``DirectClient``: create agent →
     activate → delete_memory. Asserts on-prem's response shape


### PR DESCRIPTION
- Isolate MCP client sessions per agent #1214
- Enforce crewai remember input limits #1259
- Fix Hermes agent id truncation collisions #1260
- Make Hermes memory mirror writes non-blocking on exit #1261
- Enforce LangGraph remember input limits #1263
- Fix LangGraph store writes for non-string content values #1278
- Honor client API key in CLI backends #1349
- Preserve unmanaged agent rule files on disconnect #1350
- Retry langgraph setup after activation failure #1399
- Langgraph min confidence min similarity parameter mixup #1432
- Send ValueError when agent_id outside of standard regex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter validation for agent IDs and Memanto “remember” title/content (enforced length limits and clear input errors).
  * Enhanced LangGraph search to support separate minimum confidence filtering alongside minimum similarity.
  * Improved MCP integrations with per-agent scoped session handling.
* **Bug Fixes**
  * Prevented failed agent activation from being cached.
  * Preserved unmanaged instruction files during cleanup, including non-UTF-8 cases.
  * Improved memory handling for non-string content and tightened search filtering behavior.
* **Refactor**
  * Improved lazy backend client initialization and ensured background persistence uses daemon threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->