### PR TITLE
fix(read): search_as_of returns superseded memories, corrupting point-in-time recall (#770)

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -304,6 +304,21 @@ class MemoryReadService:
                     except (ValueError, AttributeError):
                         pass
 
+                # Skip if superseded before as_of_date. A superseded memory's
+                # updated_at is set to the supersede timestamp by _supersede().
+                # If it was superseded after as_of_date it was still active then.
+                if (memory.get("status") or "active") == "superseded":
+                    updated_at = memory.get("updated_at")
+                    if updated_at:
+                        try:
+                            updated_dt = parse_iso_timestamp(updated_at)
+                            if updated_dt <= as_of_dt:
+                                continue
+                        except (ValueError, AttributeError):
+                            pass
+                    else:
+                        continue
+
                 valid_memories.append(memory)
 
             # Apply limit

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -316,8 +316,6 @@ class MemoryReadService:
                                 continue
                         except (ValueError, AttributeError):
                             pass
-                    else:
-                        continue
 
                 valid_memories.append(memory)
 

--- a/tests/test_memory_read_as_of.py
+++ b/tests/test_memory_read_as_of.py
@@ -122,4 +122,47 @@ def test_search_as_of_includes_superseded_after_cutoff():
 
     ids = [m["id"] for m in result["results"]]
     assert "old-fact" in ids
-    assert "replacement" in ids
+    assert "replacement" not in ids
+
+
+def _superseded_no_timestamp(memory_id: str, created_at: str) -> dict:
+    return {
+        "id": memory_id,
+        "text": f"[FACT] {memory_id}\n\nOld fact",
+        "memory_type": "fact",
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "superseded",
+        "created_at": created_at,
+        "updated_at": None,
+    }
+
+
+class _FakeDocumentsNoTimestamp:
+    def fetch_text_data(self, **kwargs):
+        return {
+            "items": [
+                _superseded_no_timestamp("no-ts", "2026-01-01T10:00:00Z"),
+            ],
+            "pagination": {"has_more": False},
+        }
+
+
+class _FakeClientNoTimestamp:
+    documents = _FakeDocumentsNoTimestamp()
+
+
+def test_search_as_of_fail_open_missing_updated_at():
+    """Superseded memory with no updated_at is included (fail-open)."""
+    service = MemoryReadService(_FakeClientNoTimestamp())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15T00:00:00Z",
+        agent_id="agent-1",
+        limit=None,
+    )
+
+    ids = [m["id"] for m in result["results"]]
+    assert "no-ts" in ids

--- a/tests/test_memory_read_as_of.py
+++ b/tests/test_memory_read_as_of.py
@@ -57,3 +57,69 @@ def test_search_as_of_full_timestamp_keeps_exact_cutoff():
     )
 
     assert [memory["id"] for memory in result["results"]] == ["morning"]
+
+
+def _superseded_memory(
+    memory_id: str, created_at: str, superseded_at: str
+) -> dict:
+    return {
+        "id": memory_id,
+        "text": f"[FACT] {memory_id}\n\nOld contradicted fact",
+        "memory_type": "fact",
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "superseded",
+        "created_at": created_at,
+        "updated_at": superseded_at,
+        "superseded_by": "replacement",
+        "superseded_at": superseded_at,
+    }
+
+
+class _FakeDocumentsWithSuperseded:
+    def fetch_text_data(self, **kwargs):
+        return {
+            "items": [
+                _superseded_memory(
+                    "old-fact", "2026-01-01T10:00:00Z", "2026-01-10T12:00:00Z"
+                ),
+                _memory("replacement", "2026-01-10T12:00:00Z"),
+            ],
+            "pagination": {"has_more": False},
+        }
+
+
+class _FakeClientWithSuperseded:
+    documents = _FakeDocumentsWithSuperseded()
+
+
+def test_search_as_of_excludes_superseded_before_cutoff():
+    """A memory superseded on Jan 10 must NOT appear in a Jan 15 as_of query."""
+    service = MemoryReadService(_FakeClientWithSuperseded())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15T00:00:00Z",
+        agent_id="agent-1",
+        limit=None,
+    )
+
+    ids = [m["id"] for m in result["results"]]
+    assert "old-fact" not in ids
+    assert "replacement" in ids
+
+
+def test_search_as_of_includes_superseded_after_cutoff():
+    """A memory superseded on Jan 10 WAS still active on Jan 5 — include it."""
+    service = MemoryReadService(_FakeClientWithSuperseded())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-05T00:00:00Z",
+        agent_id="agent-1",
+        limit=None,
+    )
+
+    ids = [m["id"] for m in result["results"]]
+    assert "old-fact" in ids
+    assert "replacement" in ids


### PR DESCRIPTION
## Bug: `search_as_of` returns already-superseded memories

**Severity: HIGH** — Point-in-time queries return contradicted/stale facts alongside their replacements, making historical context reconstruction unreliable.

### Reproduction

1. Store memory "user prefers Python" (created Jan 1)
2. Store contradicting "user prefers Rust" (created Jan 10) → first memory gets `status: superseded`
3. Query `search_as_of("2026-01-15")`
4. **Expected:** only "user prefers Rust" (what was true on Jan 15)
5. **Actual (before fix):** BOTH memories returned — contradicted fact leaks through

### Root Cause

`search_as_of` filters by `created_at <= as_of` and `expires_at > as_of`, but never checks whether a memory was already **superseded** at the queried point in time. The `_supersede()` method sets `updated_at` to the supersede timestamp, but `search_as_of` ignores this.

### Fix

After the existing expiry filter, exclude memories with `status == "superseded"` whose `updated_at <= as_of_date` (they were already invalidated). Memories superseded AFTER the cutoff were still active at the queried time and remain included.

### Impact

Any agent using temporal recall (`/recall/as-of`) to reconstruct historical context gets polluted results — both the old contradicted fact AND its replacement appear, making it impossible to determine what was actually true at that point in time. This defeats the purpose of point-in-time queries.

### Tests

Two regression tests added:
- `test_search_as_of_excludes_superseded_before_cutoff` — superseded memory excluded when supersede happened before as_of
- `test_search_as_of_includes_superseded_after_cutoff` — superseded memory included when it was still active at as_of time

Bounty: #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Historical memory searches now exclude superseded memories when they were superseded on or before the specified date, while still including their replacements.
  * Memories are included when searching a point in time prior to when they were superseded.
  * Improved behavior when `updated_at` is missing or cannot be parsed, preventing unintended exclusions.

* **Tests**
  * Added extended test coverage for superseded memories, replacements, and cutoff semantics (including fail-open behavior for missing timestamps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->