### PR TITLE
fix(validation): _supersede drops expires_at, ttl_seconds, source_ref fields

### DIFF
--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -4,7 +4,7 @@ Memory Validation Service
 Write-time contradiction detection and resolution for memory records.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -218,7 +218,7 @@ class MemoryValidationService:
             old_id = str(old_item.get("id"))
             namespace = new_memory.namespace()
 
-            now_iso = datetime.utcnow().isoformat()
+            now_iso = datetime.now(timezone.utc).isoformat()
             document: dict[str, Any] = {
                 "id": old_id,
                 "text": old_item.get("text") or "",
@@ -237,6 +237,12 @@ class MemoryValidationService:
             tags = old_item.get("tags")
             if tags:
                 document["tags"] = ",".join(tags) if isinstance(tags, list) else tags
+            if old_item.get("source_ref"):
+                document["source_ref"] = old_item["source_ref"]
+            if old_item.get("expires_at"):
+                document["expires_at"] = old_item["expires_at"]
+            if old_item.get("ttl_seconds"):
+                document["ttl_seconds"] = old_item["ttl_seconds"]
 
             from moorcheh_sdk.types.document import Document
 


### PR DESCRIPTION
## Bug

When `_supersede()` rewrites a contradicted memory, the new document silently discards three fields from the original record:

- `expires_at` — TTL-based expiry is lost, so superseded memories may never expire (or expire prematurely depending on downstream defaults)
- `ttl_seconds` — same class of bug
- `source_ref` — provenance link to the originating conversation/artifact is severed

## Fix

Preserve all three fields on the superseded document when present. Also replaces deprecated `datetime.utcnow()` with timezone-aware `datetime.now(timezone.utc)` to avoid naive-timestamp comparison issues in `_filter_expired_memories`.

## Reproduction

1. Store a memory with `ttl_seconds=3600` and `source_ref="conv-42"`
2. Store a contradicting memory that triggers supersede
3. Fetch the superseded document → `expires_at`, `ttl_seconds`, `source_ref` are all missing

Relates to #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contradiction handling by using consistent timezone-aware timestamps.
  * Preserved existing source references and expiration settings when superseding memory records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->