### PR TITLE
fix(migrate): OKF round-trip resurrects superseded memories as active

### DIFF
--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -586,6 +586,10 @@ class SdkClient:
                 if val is not None:
                     kwargs[opt_key] = val
 
+            raw_status = item.get("status")
+            if raw_status in ("active", "superseded", "deleted", "provisional"):
+                kwargs["status"] = raw_status
+
             memory = MemoryRecord(**kwargs)
             memory_records.append(memory)
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -587,7 +587,12 @@ class SdkClient:
                     kwargs[opt_key] = val
 
             raw_status = item.get("status")
-            if raw_status in ("active", "superseded", "deleted", "provisional"):
+            if raw_status is not None:
+                if raw_status not in ("active", "superseded", "deleted", "provisional"):
+                    raise ValueError(
+                        f"Unsupported memory status {raw_status!r}; "
+                        f"expected one of: active, superseded, deleted, provisional"
+                    )
                 kwargs["status"] = raw_status
 
             memory = MemoryRecord(**kwargs)

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -452,6 +452,7 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
         confidence = min(1.0, max(0.0, confidence))
 
         source = x_memanto.get("source") or "okf"
+        status = x_memanto.get("status") or "active"
         created_at = _parse_dt(entry.get("timestamp"))
 
         footer_items: list[tuple[str, Any]] = [
@@ -480,6 +481,7 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
                 "source": source,
                 "source_ref": str(resource) if resource else None,
                 "provenance": "imported",
+                "status": status,
                 "created_at": created_at,
                 "updated_at": migrated_at,
             }

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -31,11 +31,16 @@ count helper in ``runner.py``.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
 from memanto.app.constants import VALID_MEMORY_TYPES
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_STATUSES = frozenset({"active", "superseded", "deleted", "provisional"})
 
 # Mem0 ships category labels per memory. Map the common ones to Memanto's
 # typed primitives; everything else falls through to None (auto-classify).
@@ -452,7 +457,18 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
         confidence = min(1.0, max(0.0, confidence))
 
         source = x_memanto.get("source") or "okf"
-        status = x_memanto.get("status") or "active"
+        raw_status = x_memanto.get("status")
+        if raw_status is None:
+            status = "active"
+        elif raw_status in _SUPPORTED_STATUSES:
+            status = raw_status
+        else:
+            logger.warning(
+                "Skipping entry with unsupported status %r: %s",
+                raw_status,
+                content[:80],
+            )
+            continue
         created_at = _parse_dt(entry.get("timestamp"))
 
         footer_items: list[tuple[str, Any]] = [


### PR DESCRIPTION
## Bug

The OKF export explicitly preserves `status` in the `x_memanto` frontmatter block (documented as lossless round-trip support). But on import:

1. `map_okf` never reads `x_memanto.status`
2. `batch_remember` never passes `status` to `MemoryRecord`

Result: `memanto memory export --okf` followed by `memanto migrate okf ./bundle` silently resurrects every superseded/deleted/provisional memory as `"active"`, re-injecting invalidated knowledge into the agent's live recall.

## Reproduction

1. Store memory A, then contradict it (A becomes `status: superseded`)
2. `memanto memory export --okf` → A's frontmatter has `x_memanto.status: superseded`
3. `memanto migrate okf ./bundle` → A is re-stored with `status: active`
4. Agent recall now returns the dead memory as live truth

## Fix

- `map_okf`: read `x_memanto.get("status")` and include it in the mapped row
- `batch_remember`: validate and forward `status` to `MemoryRecord`

Relates to #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch memory submissions now support a per-item `status` field (active, superseded, deleted, provisional) and preserve it into stored records.
  * OKF migrations now retain memory status via `status`, defaulting to active when omitted.
* **Bug Fixes**
  * Unsupported per-item statuses are now rejected for batch submissions, and unsupported statuses encountered during OKF mapping are skipped to prevent invalid imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->