### PR TITLE
fix(write): batch supersede executes before replacements are stored

### DIFF
--- a/memanto/app/services/memory_validation_service.py
+++ b/memanto/app/services/memory_validation_service.py
@@ -45,6 +45,7 @@ class MemoryValidationService:
         context: dict[str, Any] | None = None,
         *,
         prefetched_conflicts: list[dict[str, Any]] | None | object = _MISSING,
+        defer_supersede: bool = False,
     ) -> dict[str, Any]:
         """Validate a memory against existing records, resolving contradictions.
 
@@ -53,6 +54,11 @@ class MemoryValidationService:
 
         When ``prefetched_conflicts`` is supplied by batch prefetch, the
         lookup is skipped. ``None`` means the prefetch lookup failed.
+
+        When ``defer_supersede`` is True, contradictions are detected but
+        ``_supersede`` is NOT called. The conflict items are returned under
+        ``pending_supersedes`` so the caller can execute them after confirming
+        the replacement documents were stored (batch atomicity).
         """
         memory_type = memory.type or "fact"
         if memory_type not in settings.REQUIRE_VALIDATION_FOR:
@@ -83,6 +89,13 @@ class MemoryValidationService:
             return {
                 "action": "store",
                 "reason": "validated: no contradicting memories found",
+            }
+
+        if defer_supersede:
+            return {
+                "action": "store",
+                "reason": f"contradiction detected: {len(conflicts)} conflict(s) pending supersede",
+                "pending_supersedes": conflicts,
             }
 
         superseded: list[str] = []

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -212,6 +212,8 @@ class MemoryWriteService:
                 to_validate
             )
 
+            deferred_supersedes: list[tuple[dict[str, Any], MemoryRecord]] = []
+
             for memory in prepared:
                 try:
                     batch_note = superseded_in_batch.get(memory.id)
@@ -225,14 +227,18 @@ class MemoryWriteService:
                             memory,
                             context,
                             prefetched_conflicts=prefetched_conflicts[memory.id],
+                            defer_supersede=True,
                         )
                     else:
                         validation_result = self.validation_service.validate_memory(
-                            memory, context
+                            memory, context, defer_supersede=True
                         )
                         # Use validated memory if modified
                         if "memory" in validation_result:
                             memory = cast(MemoryRecord, validation_result["memory"])
+
+                    for old_item in validation_result.get("pending_supersedes", []):
+                        deferred_supersedes.append((old_item, memory))
 
                     from moorcheh_sdk.types.document import Document
 
@@ -290,6 +296,11 @@ class MemoryWriteService:
                             result["error"] = (
                                 f"Batch upload returned status '{moorcheh_status}'"
                             )
+
+                # Execute deferred supersedes only after replacements are stored
+                if moorcheh_status in _SUCCESSFUL_UPLOAD_STATUSES:
+                    for old_item, new_memory in deferred_supersedes:
+                        self.validation_service._supersede(old_item, new_memory)
 
             # Count successes, failures, and namespace-rejected items separately
             # so that successful + failed + rejected == total_submitted always.


### PR DESCRIPTION
## Bug

`batch_store_memories` calls `_supersede()` (which uploads immediately) during the validation loop, but the replacement documents are uploaded later in a single batch call. If the batch upload fails or returns a non-success status, the old memories are already marked `superseded` in Moorcheh but no replacement exists — silent, irreversible knowledge loss.

## Reproduction

1. Store memory A (active)
2. Call `batch_store_memories([B])` where B contradicts A
3. Validation supersedes A immediately (uploads A with status=superseded)
4. Batch upload of B fails (network error, quota, etc.)
5. Result: A is superseded, B never stored. Agent has lost knowledge.

## Fix

- `validate_memory` gains `defer_supersede=True` parameter: detects conflicts but returns them as `pending_supersedes` without executing
- `batch_store_memories` collects deferred supersedes and executes them only after the batch upload confirms success
- Single-memory `store_memory` path is unaffected (still supersedes immediately, which is correct since the new doc is uploaded in the same call)

Relates to #770