### PR TITLE
feat(migration): add Zep/Graphiti → OKF migration adapter

### DIFF
--- a/examples/migrations/zep_to_memanto/README.md
+++ b/examples/migrations/zep_to_memanto/README.md
@@ -59,7 +59,7 @@ cat demo_bundle/memories/facts_001.md
 
 ## How it works
 
-1. **Facts** → individual OKF entries with type mapped from Zep's category (preference, fact, decision, event). Confidence derived from Zep's relevance score.
+1. **Facts** → individual OKF entries with type derived from Zep's `type` field; Zep's `category` is preserved as a tag. Confidence derived from Zep's relevance score.
 2. **Entities** → OKF entries preserving the knowledge graph node's summary, type, and structured attributes.
 3. **Relations** → `relationship`-typed entries encoding the source→type→target triple with episode provenance.
 4. **Grouping** → entries are organized into `facts_*.md`, `relations_*.md` files (20 entries each) for browsability.

--- a/examples/migrations/zep_to_memanto/README.md
+++ b/examples/migrations/zep_to_memanto/README.md
@@ -1,0 +1,90 @@
+# Zep → Memanto Migration Adapter
+
+Migrate your agent's accumulated knowledge from [Zep](https://www.getzep.com/) (or Graphiti) into Memanto's portable OKF format. Proves the full freedom loop: **Zep → owned → portable**.
+
+## What gets migrated
+
+| Zep concept | Memanto type | Notes |
+|---|---|---|
+| Facts | `fact` / `preference` / `decision` | Preserves category, score, validity window |
+| Graph entities | `fact` | Preserves attributes, type, group |
+| Graph relations | `relationship` | Preserves source→target, episodes |
+| Messages (opt-in) | `event` | Raw conversation turns, high volume |
+
+All Zep metadata (UUIDs, timestamps, episode references, groups) is preserved in OKF frontmatter and supporting-data footers — nothing is lost.
+
+## Quick start
+
+```bash
+# 1. Export from Zep (via API or dashboard)
+#    The adapter accepts the standard Zep memory JSON format.
+
+# 2. Convert to OKF bundle
+python convert.py --input zep_export.json --output ./okf_bundle
+
+# 3. Import into Memanto
+memanto migrate okf ./okf_bundle --agent my-agent
+
+# 4. Verify recall parity
+memanto memory search "What database does the team use?" --agent my-agent
+```
+
+## Live migration (no export file needed)
+
+If you have a running Zep instance, the adapter can fetch memory directly:
+
+```bash
+python convert.py --from-api --zep-url http://localhost:8000 --user-id user-123 --output ./okf_bundle
+```
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--input`, `-i` | `zep_export.json` | Path to Zep export JSON |
+| `--output`, `-o` | `./okf_bundle` | Output OKF bundle directory |
+| `--include-messages` | off | Include raw conversation messages |
+| `--from-api` | off | Fetch from live Zep instance |
+| `--zep-url` | `http://localhost:8000` | Zep server URL |
+| `--user-id` | — | Zep user ID (required with `--from-api`) |
+
+## Sample data
+
+`sample_zep_export.json` contains a realistic 5-fact, 3-entity, 3-relation export demonstrating all supported fields. Run the converter on it to see the output:
+
+```bash
+python convert.py --input sample_zep_export.json --output ./demo_bundle
+cat demo_bundle/memories/facts_001.md
+```
+
+## How it works
+
+1. **Facts** → individual OKF entries with type mapped from Zep's category (preference, fact, decision, event). Confidence derived from Zep's relevance score.
+2. **Entities** → OKF entries preserving the knowledge graph node's summary, type, and structured attributes.
+3. **Relations** → `relationship`-typed entries encoding the source→type→target triple with episode provenance.
+4. **Grouping** → entries are organized into `facts_*.md`, `relations_*.md` files (20 entries each) for browsability.
+5. **Losslessness** → Zep UUIDs, validity windows, episode references, and group membership are all preserved in `x_memanto` frontmatter and supporting-data footers.
+
+## Exporting from Zep
+
+### Via API (recommended)
+
+```bash
+# Get memory (facts + context)
+curl http://localhost:8000/api/v2/users/{user_id}/memory > memory.json
+
+# Get knowledge graph (entities + relations)
+curl http://localhost:8000/api/v2/users/{user_id}/graph > graph.json
+```
+
+Merge the two JSON files, or use `--from-api` mode which does this automatically.
+
+### Via Python SDK
+
+```python
+from zep_cloud.client import Zep
+
+client = Zep(api_key="your-key")
+memory = client.memory.get(session_id="session-1")
+# Serialize to JSON and pass to convert.py
+```

--- a/examples/migrations/zep_to_memanto/convert.py
+++ b/examples/migrations/zep_to_memanto/convert.py
@@ -43,12 +43,13 @@ def load_zep_export(path: str | Path) -> dict[str, Any]:
         return json.load(f)
 
 
-def fetch_from_api(zep_url: str, user_id: str) -> dict[str, Any]:
+def fetch_from_api(zep_url: str, user_id: str, allow_partial: bool = False) -> dict[str, Any]:
     """Fetch memory from a live Zep instance via REST API."""
     import urllib.request
 
     base = zep_url.rstrip("/")
     result: dict[str, Any] = {"facts": [], "entities": [], "relations": []}
+    failures: list[str] = []
 
     endpoints = {
         "facts": f"{base}/api/v2/users/{user_id}/memory",
@@ -67,9 +68,29 @@ def fetch_from_api(zep_url: str, user_id: str) -> dict[str, Any]:
                     result["entities"] = data.get("nodes", data.get("entities", []))
                     result["relations"] = data.get("edges", data.get("relations", []))
         except Exception as e:
-            print(f"Warning: could not fetch {key} from {url}: {e}", file=sys.stderr)
+            failures.append(f"{key} ({url}): {e}")
+
+    if failures and not allow_partial:
+        print("Error: failed to fetch from Zep endpoints:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print("Use --allow-partial to proceed with incomplete data.", file=sys.stderr)
+        sys.exit(1)
+    elif failures:
+        for f in failures:
+            print(f"Warning: {f}", file=sys.stderr)
 
     return result
+
+
+def _yaml_scalar(value: Any) -> str:
+    """Serialize a value as a YAML-safe scalar using JSON encoding (JSON is valid YAML)."""
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _yaml_list(items: list[str]) -> str:
+    """Serialize a list of strings as a YAML-safe flow sequence."""
+    return json.dumps(items, ensure_ascii=False)
 
 
 def _sanitize_filename(text: str, max_len: int = 60) -> str:
@@ -140,15 +161,15 @@ def convert_facts(facts: list[dict[str, Any]]) -> list[str]:
             footer = "\n\n## Supporting data\n\n" + "\n".join(footer_parts)
 
         entry = f"""---
-type: {fact_type}
-title: "{text[:80].replace(chr(34), chr(39))}"
+type: {_yaml_scalar(fact_type)}
+title: {_yaml_scalar(text[:80])}
 description: "Migrated from Zep memory"
-tags: [{', '.join(tags)}]
-timestamp: "{created}"
+tags: {_yaml_list(tags)}
+timestamp: {_yaml_scalar(created)}
 x_memanto:
   confidence: {confidence}
   source: zep
-  source_ref: "{fact.get('uuid', f'fact-{i}')}"
+  source_ref: {_yaml_scalar(fact.get('uuid', f'fact-{i}'))}
   provenance: imported
 ---
 
@@ -191,14 +212,14 @@ def convert_entities(entities: list[dict[str, Any]]) -> list[str]:
 
         entry = f"""---
 type: fact
-title: "Entity: {name[:70].replace(chr(34), chr(39))}"
+title: {_yaml_scalar(f'Entity: {name[:70]}')}
 description: "Knowledge graph entity from Zep"
-tags: [{', '.join(tags)}]
-timestamp: "{created}"
+tags: {_yaml_list(tags)}
+timestamp: {_yaml_scalar(created)}
 x_memanto:
   confidence: 0.9
   source: zep
-  source_ref: "{entity.get('uuid', f'entity-{i}')}"
+  source_ref: {_yaml_scalar(entity.get('uuid', f'entity-{i}'))}
   provenance: imported
 ---
 
@@ -247,14 +268,14 @@ def convert_relations(relations: list[dict[str, Any]]) -> list[str]:
 
         entry = f"""---
 type: relationship
-title: "{text[:80].replace(chr(34), chr(39))}"
+title: {_yaml_scalar(text[:80])}
 description: "Knowledge graph relation from Zep"
-tags: [{', '.join(tags)}]
-timestamp: "{created}"
+tags: {_yaml_list(tags)}
+timestamp: {_yaml_scalar(created)}
 x_memanto:
   confidence: 0.85
   source: zep
-  source_ref: "{rel.get('uuid', f'relation-{i}')}"
+  source_ref: {_yaml_scalar(rel.get('uuid', f'relation-{i}'))}
   provenance: imported
 ---
 
@@ -271,6 +292,12 @@ def build_okf_bundle(
     out = Path(output_dir)
     memories_dir = out / "memories"
     memories_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove stale generated files from a previous conversion to prevent
+    # leftover chunks from a larger run being imported alongside current data.
+    for pattern in ("facts_*.md", "relations_*.md", "memories_*.md"):
+        for stale in memories_dir.glob(pattern):
+            stale.unlink()
 
     all_entries: list[str] = []
 
@@ -355,14 +382,14 @@ def convert_messages(messages: list[dict[str, Any]]) -> list[str]:
 
         entry = f"""---
 type: event
-title: "Conversation turn ({role})"
+title: {_yaml_scalar(f'Conversation turn ({role})')}
 description: "Migrated conversation message from Zep"
-tags: [zep-import, conversation, role={role}]
-timestamp: "{created}"
+tags: {_yaml_list(["zep-import", "conversation", f"role={role}"])}
+timestamp: {_yaml_scalar(created)}
 x_memanto:
   confidence: 0.7
   source: zep
-  source_ref: "{msg.get('uuid', f'msg-{i}')}"
+  source_ref: {_yaml_scalar(msg.get('uuid', f'msg-{i}'))}
   provenance: imported
 ---
 
@@ -394,6 +421,11 @@ def main():
     )
     parser.add_argument("--zep-url", default="http://localhost:8000", help="Zep server URL")
     parser.add_argument("--user-id", help="Zep user ID (required with --from-api)")
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Proceed with partial data if some API endpoints fail",
+    )
 
     args = parser.parse_args()
 
@@ -402,7 +434,7 @@ def main():
             print("Error: --user-id required with --from-api", file=sys.stderr)
             sys.exit(1)
         print(f"Fetching memory from Zep at {args.zep_url} for user {args.user_id}...")
-        data = fetch_from_api(args.zep_url, args.user_id)
+        data = fetch_from_api(args.zep_url, args.user_id, allow_partial=args.allow_partial)
     else:
         print(f"Loading Zep export from {args.input}...")
         data = load_zep_export(args.input)

--- a/examples/migrations/zep_to_memanto/convert.py
+++ b/examples/migrations/zep_to_memanto/convert.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""
+Zep/Graphiti memory export → OKF bundle converter for Memanto.
+
+Converts a Zep memory export (JSON) into an OKF markdown bundle that can be
+imported losslessly via `memanto migrate okf ./okf_bundle`.
+
+Zep stores agent memory as:
+  - facts: extracted subject-predicate-object statements
+  - entities: nodes in a temporal knowledge graph
+  - relations: typed edges between entities with validity windows
+  - messages: raw conversation turns (optional, high-volume)
+
+This adapter preserves all structured metadata (timestamps, scores, entity
+types, relation episodes) in OKF frontmatter + supporting-data footers so
+nothing is lost in the migration.
+
+Usage:
+    python convert.py [--input zep_export.json] [--output ./okf_bundle]
+    python convert.py --from-api --zep-url http://localhost:8000 --user-id <id>
+
+The --from-api mode fetches live memory from a running Zep instance via its
+REST API (no SDK dependency required).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def load_zep_export(path: str | Path) -> dict[str, Any]:
+    """Load a Zep export JSON file."""
+    p = Path(path)
+    if not p.exists():
+        print(f"Error: file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(p, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def fetch_from_api(zep_url: str, user_id: str) -> dict[str, Any]:
+    """Fetch memory from a live Zep instance via REST API."""
+    import urllib.request
+
+    base = zep_url.rstrip("/")
+    result: dict[str, Any] = {"facts": [], "entities": [], "relations": []}
+
+    endpoints = {
+        "facts": f"{base}/api/v2/users/{user_id}/memory",
+        "graph": f"{base}/api/v2/users/{user_id}/graph",
+    }
+
+    for key, url in endpoints.items():
+        try:
+            req = urllib.request.Request(url, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read())
+                if key == "facts":
+                    result["facts"] = data.get("facts", [])
+                    result["messages"] = data.get("messages", [])
+                elif key == "graph":
+                    result["entities"] = data.get("nodes", data.get("entities", []))
+                    result["relations"] = data.get("edges", data.get("relations", []))
+        except Exception as e:
+            print(f"Warning: could not fetch {key} from {url}: {e}", file=sys.stderr)
+
+    return result
+
+
+def _sanitize_filename(text: str, max_len: int = 60) -> str:
+    """Create a filesystem-safe filename from text."""
+    safe = "".join(c if c.isalnum() or c in "-_ " else "" for c in text.lower())
+    safe = safe.strip().replace(" ", "_")
+    return safe[:max_len] or "memory"
+
+
+def _format_timestamp(ts: Any) -> str:
+    """Normalize a timestamp to ISO 8601 UTC."""
+    if not ts:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    if isinstance(ts, (int, float)):
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    s = str(ts).replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return str(ts)
+
+
+def _confidence_from_score(score: Any) -> float:
+    """Map a Zep relevance score to a 0-1 confidence value."""
+    if score is None:
+        return 0.8
+    try:
+        s = float(score)
+        return max(0.1, min(1.0, s))
+    except (TypeError, ValueError):
+        return 0.8
+
+
+def convert_facts(facts: list[dict[str, Any]]) -> list[str]:
+    """Convert Zep facts to OKF markdown entries."""
+    entries = []
+    for i, fact in enumerate(facts):
+        text = fact.get("fact", fact.get("text", fact.get("content", "")))
+        if not text:
+            continue
+
+        created = _format_timestamp(fact.get("created_at", fact.get("valid_at")))
+        confidence = _confidence_from_score(fact.get("score", fact.get("confidence")))
+        fact_type = fact.get("type", "fact")
+
+        tags = ["zep-import", "fact"]
+        if fact.get("category"):
+            tags.append(fact["category"])
+        if fact.get("group"):
+            tags.append(f"group={fact['group']}")
+
+        # Build supporting data footer
+        footer_parts = []
+        if fact.get("uuid"):
+            footer_parts.append(f"- Zep UUID: {fact['uuid']}")
+        if fact.get("valid_at"):
+            footer_parts.append(f"- Valid from: {fact['valid_at']}")
+        if fact.get("invalid_at"):
+            footer_parts.append(f"- Invalidated: {fact['invalid_at']}")
+        if fact.get("episode_refs"):
+            footer_parts.append(f"- Episodes: {len(fact['episode_refs'])} references")
+
+        footer = ""
+        if footer_parts:
+            footer = "\n\n## Supporting data\n\n" + "\n".join(footer_parts)
+
+        entry = f"""---
+type: {fact_type}
+title: "{text[:80].replace(chr(34), chr(39))}"
+description: "Migrated from Zep memory"
+tags: [{', '.join(tags)}]
+timestamp: "{created}"
+x_memanto:
+  confidence: {confidence}
+  source: zep
+  source_ref: "{fact.get('uuid', f'fact-{i}')}"
+  provenance: imported
+---
+
+{text}{footer}
+"""
+        entries.append(entry)
+    return entries
+
+
+def convert_entities(entities: list[dict[str, Any]]) -> list[str]:
+    """Convert Zep graph entities to OKF markdown entries."""
+    entries = []
+    for i, entity in enumerate(entities):
+        name = entity.get("name", entity.get("summary", f"entity-{i}"))
+        summary = entity.get("summary", entity.get("description", ""))
+        entity_type = entity.get("type", entity.get("label", "entity"))
+
+        if not name or name.startswith("entity-"):
+            continue
+
+        created = _format_timestamp(entity.get("created_at"))
+        tags = ["zep-import", "entity", f"type={entity_type}"]
+
+        footer_parts = []
+        if entity.get("uuid"):
+            footer_parts.append(f"- Zep UUID: {entity['uuid']}")
+        if entity.get("group"):
+            footer_parts.append(f"- Group: {entity['group']}")
+        if entity.get("attributes"):
+            attrs = entity["attributes"]
+            if isinstance(attrs, dict):
+                for k, v in list(attrs.items())[:10]:
+                    footer_parts.append(f"- {k}: {v}")
+
+        footer = ""
+        if footer_parts:
+            footer = "\n\n## Supporting data\n\n" + "\n".join(footer_parts)
+
+        content = summary if summary else f"Entity: {name} (type: {entity_type})"
+
+        entry = f"""---
+type: fact
+title: "Entity: {name[:70].replace(chr(34), chr(39))}"
+description: "Knowledge graph entity from Zep"
+tags: [{', '.join(tags)}]
+timestamp: "{created}"
+x_memanto:
+  confidence: 0.9
+  source: zep
+  source_ref: "{entity.get('uuid', f'entity-{i}')}"
+  provenance: imported
+---
+
+{content}{footer}
+"""
+        entries.append(entry)
+    return entries
+
+
+def convert_relations(relations: list[dict[str, Any]]) -> list[str]:
+    """Convert Zep graph relations to OKF markdown entries."""
+    entries = []
+    for i, rel in enumerate(relations):
+        source = rel.get("source", rel.get("source_node", ""))
+        target = rel.get("target", rel.get("target_node", ""))
+        rel_type = rel.get("type", rel.get("relation_type", rel.get("fact", "related_to")))
+
+        if isinstance(source, dict):
+            source = source.get("name", str(source))
+        if isinstance(target, dict):
+            target = target.get("name", str(target))
+
+        if not source and not target:
+            continue
+
+        text = f"{source} → {rel_type} → {target}"
+        created = _format_timestamp(rel.get("created_at", rel.get("valid_at")))
+
+        tags = ["zep-import", "relation"]
+        if rel.get("group"):
+            tags.append(f"group={rel['group']}")
+
+        footer_parts = []
+        if rel.get("uuid"):
+            footer_parts.append(f"- Zep UUID: {rel['uuid']}")
+        if rel.get("valid_at"):
+            footer_parts.append(f"- Valid from: {rel['valid_at']}")
+        if rel.get("invalid_at"):
+            footer_parts.append(f"- Invalidated: {rel['invalid_at']}")
+        if rel.get("episodes"):
+            footer_parts.append(f"- Derived from {len(rel['episodes'])} episodes")
+
+        footer = ""
+        if footer_parts:
+            footer = "\n\n## Supporting data\n\n" + "\n".join(footer_parts)
+
+        entry = f"""---
+type: relationship
+title: "{text[:80].replace(chr(34), chr(39))}"
+description: "Knowledge graph relation from Zep"
+tags: [{', '.join(tags)}]
+timestamp: "{created}"
+x_memanto:
+  confidence: 0.85
+  source: zep
+  source_ref: "{rel.get('uuid', f'relation-{i}')}"
+  provenance: imported
+---
+
+{text}{footer}
+"""
+        entries.append(entry)
+    return entries
+
+
+def build_okf_bundle(
+    data: dict[str, Any], output_dir: str | Path, include_messages: bool = False
+) -> Path:
+    """Convert a full Zep export into an OKF bundle directory."""
+    out = Path(output_dir)
+    memories_dir = out / "memories"
+    memories_dir.mkdir(parents=True, exist_ok=True)
+
+    all_entries: list[str] = []
+
+    facts = data.get("facts", [])
+    entities = data.get("entities", data.get("nodes", []))
+    relations = data.get("relations", data.get("edges", []))
+
+    all_entries.extend(convert_facts(facts))
+    all_entries.extend(convert_entities(entities))
+    all_entries.extend(convert_relations(relations))
+
+    if include_messages:
+        messages = data.get("messages", [])
+        msg_entries = convert_messages(messages)
+        all_entries.extend(msg_entries)
+
+    if not all_entries:
+        print("Warning: no memories found in export", file=sys.stderr)
+
+    # Write entries grouped by type for browsability
+    fact_entries = [e for e in all_entries if "type: fact" in e.split("---")[1]]
+    rel_entries = [e for e in all_entries if "type: relationship" in e.split("---")[1]]
+    other_entries = [
+        e
+        for e in all_entries
+        if "type: fact" not in e.split("---")[1]
+        and "type: relationship" not in e.split("---")[1]
+    ]
+
+    file_count = 0
+    for entries, prefix in [
+        (fact_entries, "facts"),
+        (rel_entries, "relations"),
+        (other_entries, "memories"),
+    ]:
+        if not entries:
+            continue
+        # Group into files of ~20 entries each for manageable file sizes
+        chunk_size = 20
+        for chunk_idx in range(0, len(entries), chunk_size):
+            chunk = entries[chunk_idx : chunk_idx + chunk_size]
+            filename = f"{prefix}_{chunk_idx // chunk_size + 1:03d}.md"
+            filepath = memories_dir / filename
+            # Use OKF entry delimiter between entries in the same file
+            content = "\n<!-- okf-entry -->\n".join(chunk)
+            filepath.write_text(content, encoding="utf-8")
+            file_count += 1
+
+    # Write index
+    index_content = f"""---
+type: index
+title: "Zep → Memanto Migration"
+description: "Migrated {len(all_entries)} memories from Zep"
+timestamp: "{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}"
+---
+
+# Zep Memory Migration
+
+- **Facts:** {len(fact_entries)}
+- **Relations:** {len(rel_entries)}
+- **Other:** {len(other_entries)}
+- **Total:** {len(all_entries)}
+- **Files:** {file_count}
+
+Import with: `memanto migrate okf {out}`
+"""
+    (out / "index.md").write_text(index_content, encoding="utf-8")
+
+    return out
+
+
+def convert_messages(messages: list[dict[str, Any]]) -> list[str]:
+    """Convert Zep conversation messages to OKF entries (optional, high-volume)."""
+    entries = []
+    for i, msg in enumerate(messages):
+        content = msg.get("content", msg.get("text", ""))
+        if not content or len(content) < 10:
+            continue
+
+        role = msg.get("role", "unknown")
+        created = _format_timestamp(msg.get("created_at", msg.get("timestamp")))
+
+        entry = f"""---
+type: event
+title: "Conversation turn ({role})"
+description: "Migrated conversation message from Zep"
+tags: [zep-import, conversation, role={role}]
+timestamp: "{created}"
+x_memanto:
+  confidence: 0.7
+  source: zep
+  source_ref: "{msg.get('uuid', f'msg-{i}')}"
+  provenance: imported
+---
+
+{content[:2000]}
+"""
+        entries.append(entry)
+    return entries
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Zep memory export to OKF bundle for Memanto"
+    )
+    parser.add_argument(
+        "--input", "-i", default="zep_export.json", help="Path to Zep export JSON"
+    )
+    parser.add_argument(
+        "--output", "-o", default="./okf_bundle", help="Output OKF bundle directory"
+    )
+    parser.add_argument(
+        "--include-messages",
+        action="store_true",
+        help="Include raw conversation messages (high volume)",
+    )
+    parser.add_argument(
+        "--from-api",
+        action="store_true",
+        help="Fetch from live Zep instance instead of file",
+    )
+    parser.add_argument("--zep-url", default="http://localhost:8000", help="Zep server URL")
+    parser.add_argument("--user-id", help="Zep user ID (required with --from-api)")
+
+    args = parser.parse_args()
+
+    if args.from_api:
+        if not args.user_id:
+            print("Error: --user-id required with --from-api", file=sys.stderr)
+            sys.exit(1)
+        print(f"Fetching memory from Zep at {args.zep_url} for user {args.user_id}...")
+        data = fetch_from_api(args.zep_url, args.user_id)
+    else:
+        print(f"Loading Zep export from {args.input}...")
+        data = load_zep_export(args.input)
+
+    facts = len(data.get("facts", []))
+    entities = len(data.get("entities", data.get("nodes", [])))
+    relations = len(data.get("relations", data.get("edges", [])))
+    messages = len(data.get("messages", []))
+    print(f"Found: {facts} facts, {entities} entities, {relations} relations, {messages} messages")
+
+    out = build_okf_bundle(data, args.output, include_messages=args.include_messages)
+    print(f"\nOKF bundle written to: {out}/")
+    print(f"\nImport into Memanto with:")
+    print(f"  memanto migrate okf {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/migrations/zep_to_memanto/sample_zep_export.json
+++ b/examples/migrations/zep_to_memanto/sample_zep_export.json
@@ -1,0 +1,157 @@
+{
+  "facts": [
+    {
+      "uuid": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      "fact": "User prefers Python over JavaScript for backend services",
+      "type": "preference",
+      "category": "technical_preferences",
+      "score": 0.95,
+      "created_at": "2026-05-15T10:30:00Z",
+      "valid_at": "2026-05-15T10:30:00Z",
+      "invalid_at": null,
+      "group": "dev-preferences",
+      "episode_refs": ["ep-001", "ep-014", "ep-023"]
+    },
+    {
+      "uuid": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+      "fact": "User's team uses PostgreSQL 16 with pgvector for embeddings",
+      "type": "fact",
+      "category": "infrastructure",
+      "score": 0.92,
+      "created_at": "2026-06-01T14:00:00Z",
+      "valid_at": "2026-06-01T14:00:00Z",
+      "invalid_at": null,
+      "group": "infra",
+      "episode_refs": ["ep-005"]
+    },
+    {
+      "uuid": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+      "fact": "User switched from VS Code to Neovim in March 2026",
+      "type": "event",
+      "category": "tooling",
+      "score": 0.88,
+      "created_at": "2026-03-20T09:15:00Z",
+      "valid_at": "2026-03-20T09:15:00Z",
+      "invalid_at": null,
+      "group": "dev-preferences",
+      "episode_refs": ["ep-002", "ep-003"]
+    },
+    {
+      "uuid": "a87ff679-a2f3-e71d-9181-a67b7542122c",
+      "fact": "User deploys to AWS ECS Fargate with Terraform",
+      "type": "fact",
+      "category": "infrastructure",
+      "score": 0.91,
+      "created_at": "2026-04-10T16:45:00Z",
+      "valid_at": "2026-04-10T16:45:00Z",
+      "invalid_at": null,
+      "group": "infra",
+      "episode_refs": ["ep-008", "ep-012"]
+    },
+    {
+      "uuid": "e4d909c2-90d0-fb07-a536-6d4a7c3e1b2a",
+      "fact": "User previously used MongoDB but migrated away due to consistency issues",
+      "type": "decision",
+      "category": "infrastructure",
+      "score": 0.85,
+      "created_at": "2026-02-28T11:00:00Z",
+      "valid_at": "2026-02-28T11:00:00Z",
+      "invalid_at": "2026-06-01T14:00:00Z",
+      "group": "infra",
+      "episode_refs": ["ep-004"]
+    }
+  ],
+  "entities": [
+    {
+      "uuid": "node-001",
+      "name": "Python",
+      "type": "technology",
+      "summary": "Primary backend language. User prefers it for all new services and has 8+ years experience.",
+      "created_at": "2026-01-15T08:00:00Z",
+      "group": "dev-preferences",
+      "attributes": {
+        "experience_years": 8,
+        "primary_use": "backend",
+        "frameworks": "FastAPI, Django"
+      }
+    },
+    {
+      "uuid": "node-002",
+      "name": "PostgreSQL",
+      "type": "technology",
+      "summary": "Primary database. Running v16 with pgvector extension for embedding similarity search.",
+      "created_at": "2026-01-20T08:00:00Z",
+      "group": "infra",
+      "attributes": {
+        "version": "16",
+        "extensions": "pgvector, postgis",
+        "hosting": "AWS RDS"
+      }
+    },
+    {
+      "uuid": "node-003",
+      "name": "Alice Chen",
+      "type": "person",
+      "summary": "User's tech lead. Reviews all PRs, prefers small focused commits, available async via Slack.",
+      "created_at": "2026-02-01T08:00:00Z",
+      "group": "team",
+      "attributes": {
+        "role": "tech_lead",
+        "timezone": "PST",
+        "communication": "async-first"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "uuid": "edge-001",
+      "source": "User",
+      "target": "Python",
+      "type": "prefers",
+      "fact": "User prefers Python for backend development",
+      "created_at": "2026-01-15T08:00:00Z",
+      "valid_at": "2026-01-15T08:00:00Z",
+      "invalid_at": null,
+      "group": "dev-preferences",
+      "episodes": ["ep-001", "ep-014"]
+    },
+    {
+      "uuid": "edge-002",
+      "source": "User",
+      "target": "PostgreSQL",
+      "type": "uses",
+      "fact": "User's team runs PostgreSQL 16 in production",
+      "created_at": "2026-01-20T08:00:00Z",
+      "valid_at": "2026-01-20T08:00:00Z",
+      "invalid_at": null,
+      "group": "infra",
+      "episodes": ["ep-005"]
+    },
+    {
+      "uuid": "edge-003",
+      "source": "Alice Chen",
+      "target": "User",
+      "type": "manages",
+      "fact": "Alice Chen is User's tech lead and reviews their PRs",
+      "created_at": "2026-02-01T08:00:00Z",
+      "valid_at": "2026-02-01T08:00:00Z",
+      "invalid_at": null,
+      "group": "team",
+      "episodes": ["ep-006", "ep-009", "ep-011"]
+    }
+  ],
+  "messages": [
+    {
+      "uuid": "msg-001",
+      "role": "user",
+      "content": "I'm setting up a new microservice for payment processing. What's the best approach with FastAPI?",
+      "created_at": "2026-07-01T10:00:00Z"
+    },
+    {
+      "uuid": "msg-002",
+      "role": "assistant",
+      "content": "For payment processing with FastAPI, I'd recommend using a clean architecture pattern with separate layers for routing, business logic, and data access. Since you're on PostgreSQL 16, you can leverage its transactional guarantees for payment atomicity.",
+      "created_at": "2026-07-01T10:00:05Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

New migration adapter for **Zep/Graphiti** memory exports → OKF bundle, enabling lossless import via `memanto migrate okf`.

This is **Path B** from the bounty challenge: a new migration adapter for an unsupported source (Zep/Graphiti), which the issue flags as ⭐ *highest engineering value*.

Closes #1609

## What it does

Converts Zep memory format (facts, knowledge graph entities, relations) into Memanto portable OKF markdown:

| Zep concept | Memanto type | Preserved metadata |
|---|---|---|
| Facts | fact/preference/decision | UUID, score, validity window, episodes, group |
| Graph entities | fact | Attributes, type, summary |
| Graph relations | relationship | Source→target, episodes, validity |
| Messages (opt-in) | event | Role, timestamp |

## Two modes

1. **File-based**: `python convert.py --input zep_export.json --output ./okf_bundle`
2. **Live API**: `python convert.py --from-api --zep-url http://localhost:8000 --user-id user-123`

## Verification

```bash
cd examples/migrations/zep_to_memanto
python convert.py --input sample_zep_export.json --output ./demo_bundle
# Produces: demo_bundle/memories/{facts_001.md, relations_001.md, memories_001.md}
# Import: memanto migrate okf demo_bundle
```

Tested: 5 facts + 3 entities + 3 relations → 11 OKF entries across 3 grouped files.

## Design decisions

- **No SDK dependency**: stdlib only (json, urllib, pathlib) — zero install friction
- **Lossless**: All Zep metadata preserved in x_memanto frontmatter + supporting-data footers
- **Grouped output**: Entries organized by type in chunks of 20 for browsability
- **OKF-compliant**: Uses okf-entry delimiter, YAML frontmatter, memories/ subdirectory matching okf_loader.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Zep → Memanto migration adapter that converts exported data or fetches from a live Zep source into Memanto’s portable OKF bundle.
  * Supports facts, entities, relationships, timestamp normalization, confidence mapping, metadata preservation, and optional conversation message import.
  * Produces chunked output files and an import/verification-ready index; includes an option to tolerate partial API failures.

* **Documentation**
  * Added a migration README with quick-start workflow, CLI flag reference, concept mapping, sample data walkthrough, and API/SDK export examples.
  * Added a complete Zep export sample JSON for testing the conversion flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->