### PR TITLE
fix(migrate): use valid source for imported memories

### DIFF
--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -11,7 +11,7 @@ accepted by ``SdkClient.batch_remember``:
         "type": str | None,     # None lets the parsing service auto-classify
         "tags": list[str],
         "confidence": float,
-        "source": str,          # provider name ("mem0", "letta", ...)
+        "source": "tool",       # valid MemoryRecord source for external imports
         "source_ref": str,      # original record id
         "provenance": "imported",
         "created_at": datetime, # original source timestamp (when present)
@@ -20,9 +20,11 @@ accepted by ``SdkClient.batch_remember``:
 
 Mappers extract every useful field from the source. Anything that maps
 naturally onto Memanto's schema (id, created_at, tags) goes into the right
-slot. Everything else (provider metadata, scope ids, hashes, scores) gets
-packed into a bounded ``[Supporting data]`` markdown block appended to the
-content, so it stays searchable and visible without bloating the schema.
+slot. Imported provider data uses the valid ``tool`` source; provider identity
+stays in ``source_ref`` and the supporting-data footer. Everything else
+(provider metadata, scope ids, hashes, scores) gets packed into a bounded
+``[Supporting data]`` markdown block appended to the content, so it stays
+searchable and visible without bloating the schema.
 
 Adding a new provider: write a ``map_<provider>`` function returning
 ``list[dict]``, register it in ``MAPPERS``, and add a per-provider source
@@ -57,6 +59,7 @@ _MEM0_CATEGORY_TO_TYPE: dict[str, str] = {
 _DEFAULT_TITLE_CHARS = 80
 _MAX_CONTENT_CHARS = 10000  # MemoryRecord.content max_length
 _MAX_FOOTER_CHARS = 800  # cap supporting-data footer so it never dominates
+_VALID_SOURCE_TYPES = {"user", "agent", "tool", "system"}
 
 
 def _title_from(content: str) -> str:
@@ -71,6 +74,21 @@ def _coerce_type(raw: str | None) -> str | None:
         return None
     t = raw.strip().lower()
     return t if t in VALID_MEMORY_TYPES else None
+
+
+def _coerce_source(raw: Any) -> str:
+    """Map imported provenance onto ``MemoryRecord.source``.
+
+    Provider names such as ``mem0`` and ``letta`` are not valid
+    ``MemoryRecord`` source values. Imported records come from an external
+    tool, while provider-specific identity remains available in
+    ``source_ref`` and the supporting-data footer.
+    """
+    if isinstance(raw, str):
+        source = raw.strip().lower()
+        if source in _VALID_SOURCE_TYPES:
+            return source
+    return "tool"
 
 
 def _scope_tag(scope: dict[str, Any] | None) -> str | None:
@@ -225,7 +243,7 @@ def map_mem0(export: dict[str, Any]) -> list[dict[str, Any]]:
                 "type": memory_type,
                 "tags": tags,
                 "confidence": 0.8,
-                "source": "mem0",
+                "source": "tool",
                 "source_ref": str(mem.get("id")) if mem.get("id") else None,
                 "provenance": "imported",
                 "created_at": created_at,
@@ -284,7 +302,7 @@ def map_letta(export: dict[str, Any]) -> list[dict[str, Any]]:
                 "type": "observation",
                 "tags": tags,
                 "confidence": 0.8,
-                "source": "letta",
+                "source": "tool",
                 "source_ref": str(passage.get("id")) if passage.get("id") else None,
                 "provenance": "imported",
                 "created_at": created_at,
@@ -346,7 +364,7 @@ def map_supermemory(export: dict[str, Any]) -> list[dict[str, Any]]:
                 "type": None,
                 "tags": tags,
                 "confidence": 0.8,
-                "source": "supermemory",
+                "source": "tool",
                 "source_ref": str(mem.get("id")) if mem.get("id") else None,
                 "provenance": "imported",
                 "created_at": created_at,
@@ -394,7 +412,7 @@ def map_supermemory(export: dict[str, Any]) -> list[dict[str, Any]]:
                     "type": "artifact",
                     "tags": doc_tags,
                     "confidence": 0.7,
-                    "source": "supermemory",
+                    "source": "tool",
                     "source_ref": (f"{doc_id}:{chunk.get('id')}" if doc_id else None),
                     "provenance": "imported",
                     "created_at": doc_created,
@@ -451,7 +469,7 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
             confidence = 0.8
         confidence = min(1.0, max(0.0, confidence))
 
-        source = x_memanto.get("source") or "okf"
+        source = _coerce_source(x_memanto.get("source"))
         created_at = _parse_dt(entry.get("timestamp"))
 
         footer_items: list[tuple[str, Any]] = [

--- a/tests/test_migration_source_validation.py
+++ b/tests/test_migration_source_validation.py
@@ -1,0 +1,63 @@
+"""Regression coverage for migration rows crossing the MemoryRecord boundary."""
+
+import pytest
+
+from memanto.app.core import MemoryRecord
+from memanto.cli.migrate.mappers import (
+    map_letta,
+    map_mem0,
+    map_okf,
+    map_supermemory,
+)
+
+
+def _as_memory_record(row):
+    """Mirror the batch clients, which omit absent optional timestamp fields."""
+    kwargs = {
+        key: value for key, value in row.items() if value is not None or key == "type"
+    }
+    return MemoryRecord(**kwargs, agent_id="agent-1", actor_id="agent-1")
+
+
+@pytest.mark.parametrize(
+    ("mapper", "export"),
+    [
+        (map_mem0, {"memories": [{"id": "m1", "memory": "Prefers tea"}]}),
+        (map_letta, {"passages": [{"id": "l1", "text": "Prefers tea"}]}),
+        (
+            map_supermemory,
+            {"memories": [{"id": "s1", "content": "Prefers tea"}]},
+        ),
+        (
+            map_okf,
+            {"memories": [{"title": "Preference", "body": "Prefers tea"}]},
+        ),
+    ],
+)
+def test_provider_rows_are_valid_memory_records(mapper, export):
+    """Every shipped provider must produce rows the batch clients can store."""
+    row = mapper(export)[0]
+
+    record = _as_memory_record(row)
+
+    assert record.source == "tool"
+    assert record.provenance == "imported"
+
+
+def test_okf_round_trip_preserves_valid_memanto_source():
+    """A Memanto-authored OKF bundle keeps a valid original source."""
+    row = map_okf(
+        {
+            "memories": [
+                {
+                    "title": "Preference",
+                    "body": "Prefers tea",
+                    "x_memanto": {"source": "user"},
+                }
+            ]
+        }
+    )[0]
+
+    record = _as_memory_record(row)
+
+    assert record.source == "user"

--- a/tests/test_migration_source_validation.py
+++ b/tests/test_migration_source_validation.py
@@ -29,8 +29,31 @@ def _as_memory_record(row):
             {"memories": [{"id": "s1", "content": "Prefers tea"}]},
         ),
         (
+            map_supermemory,
+            {
+                "documents": [
+                    {
+                        "id": "d1",
+                        "chunks": [{"id": "c1", "content": "Prefers tea"}],
+                    }
+                ]
+            },
+        ),
+        (
             map_okf,
             {"memories": [{"title": "Preference", "body": "Prefers tea"}]},
+        ),
+        (
+            map_okf,
+            {
+                "memories": [
+                    {
+                        "title": "Preference",
+                        "body": "Prefers tea",
+                        "x_memanto": {"source": "okf"},
+                    }
+                ]
+            },
         ),
     ],
 )

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -162,7 +162,7 @@ def test_foreign_okf_bundle_is_lossless(tmp_path):
 
     row = map_okf(export)[0]
     assert row["type"] is None  # free-form type -> auto-classify
-    assert row["source"] == "okf"
+    assert row["source"] == "tool"
     assert row["source_ref"] == "https://console.cloud.google.com/bigquery?t=orders"
     assert row["provenance"] == "imported"
     assert "One row per completed customer order." in row["content"]  # description


### PR DESCRIPTION
## Summary

- map Mem0, Letta, Supermemory, and foreign OKF imports to the valid `tool` source
- preserve a valid original Memanto source when it is present in `x_memanto`
- add regression coverage that constructs `MemoryRecord` objects from every shipped provider mapper

## Root cause and impact

All four shipped migration paths produced source values that the storage model rejects:

| Provider | Mapper output | Allowed by `MemoryRecord.source` |
| --- | --- | --- |
| Mem0 | `mem0` | no |
| Letta | `letta` | no |
| Supermemory | `supermemory` | no |
| foreign OKF | `okf` | no |

Both batch clients construct every mapped row as a `MemoryRecord` before storage. Pydantic therefore raised `Input should be 'user', 'agent', 'tool' or 'system'`, preventing a normal migration from importing even its first record.

External provider data now uses `tool`, which matches the existing source contract. Provider identity is still preserved in `source_ref` and the supporting-data footer. Memanto-authored OKF bundles retain valid original values such as `user`.

## Reproduction

Before this patch, each of these mapper outputs failed the same model boundary:

```python
row = map_mem0({"memories": [{"id": "m1", "memory": "Prefers tea"}]})[0]
MemoryRecord(**row, agent_id="agent-1", actor_id="agent-1")
```

Equivalent inputs for `map_letta`, `map_supermemory`, and `map_okf` failed as well.

## Validation

```text
uv run ruff check memanto/cli/migrate/mappers.py tests/test_migration_source_validation.py tests/test_okf.py
uv run ruff format --check memanto/cli/migrate/mappers.py tests/test_migration_source_validation.py tests/test_okf.py
uv run mypy memanto/cli/migrate/mappers.py
uv run pytest -q
```

Result: lint, formatting, and mypy passed; the full unit suite passed. The existing live Moorcheh E2E tests were skipped because no API key was configured.

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized migrated/imported records to use a `tool` source designation for provider data.
  * Preserved Memanto-authored OKF provenance when a valid original source value is provided.
  * Improved validation/coercion of missing or invalid source information during migration, while retaining provider details in supporting metadata for reference and searchability.
* **Tests**
  * Added regression coverage for source/provenance handling across multiple migration formats.
  * Updated OKF bundle loader expectations to match the new `tool` source behavior for imported data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->