### PR TITLE
fix(export): split comma-separated tags in OKF export [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -283,9 +283,21 @@ class OkfExportService:
         if description:
             frontmatter["description"] = description
 
-        tags = mem.get("tags") or []
-        if tags:
-            frontmatter["tags"] = list(tags)
+        # Tags arrive in two shapes depending on where the record came from:
+        # Moorcheh serializes the flat ``tags`` field as a comma-separated string,
+        # while the in-memory recall path already hands back a list.  Normalize so
+        # the OKF frontmatter always carries one list entry per tag instead of
+        # splitting a comma-joined string character-by-character (e.g.
+        # ``["project", "db"]`` was previously written as
+        # ``["p", "r", "o", "j", "e", "c", "t", ",", "d", "b"]``).
+        raw_tags = mem.get("tags") or []
+        if raw_tags:
+            if isinstance(raw_tags, str):
+                frontmatter["tags"] = [
+                    t.strip() for t in raw_tags.split(",") if t.strip()
+                ]
+            else:
+                frontmatter["tags"] = list(raw_tags)
 
         created_at = mem.get("created_at")
         if created_at:

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -12,6 +12,8 @@ from memanto.app.services.okf_export_service import OkfExportService
 from memanto.cli.migrate.mappers import map_okf
 from memanto.cli.migrate.okf_loader import load_okf_bundle
 
+import yaml  # type: ignore[import-untyped]
+
 
 def _mem(mem_id, title, content, **extra):
     base = {
@@ -186,3 +188,44 @@ def test_loader_splits_stacked_file(tmp_path):
     assert {m["title"] for m in export["memories"]} == {
         f"Standup {i}" for i in range(5)
     }
+
+
+def test_okf_export_splits_comma_separated_tags(tmp_path):
+    """Tags serialized by Moorcheh arrive as a comma-separated string. The
+    export must emit one frontmatter list entry per tag, not split the string
+    character-by-character.
+
+    Regression for BountyHub #770: with tags='project,db' the old
+    ``list(tags)`` wrote ["p", "r", "o", "j", "e", "c", "t", ",", "d", "b"].
+    """
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    # Moorcheh wire format: flat ``tags`` field is a comma-joined string.
+    memories_by_type = {
+        "fact": [
+            _mem("f1", "Postgres", "Use PG 16.", tags="project, db, prod"),
+        ],
+    }
+    result = svc.write_okf_bundle("agent1", memories_by_type, split="file")
+    fact_md = (
+        svc.exports_dir / "agent1_okf" / "memories" / "fact" / "postgres.md"
+    )
+    front = fact_md.read_text(encoding="utf-8").split("---", 2)[1]
+    fm = yaml.safe_load(front)
+    assert set(fm["tags"]) == {"project", "db", "prod"}
+
+
+def test_okf_export_preserves_list_tags(tmp_path):
+    """Tags from the in-memory recall path arrive as a list; the export must
+    still emit a proper frontmatter list of those tags (unchanged behaviour)."""
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    memories_by_type = {
+        "fact": [
+            _mem("f1", "A fact", "Body.", tags=["infra", "db"]),
+        ],
+    }
+    svc.write_okf_bundle("agent1", memories_by_type, split="file")
+    fact_md = (
+        svc.exports_dir / "agent1_okf" / "memories" / "fact" / "a-fact.md"
+    )
+    fm = yaml.safe_load(fact_md.read_text(encoding="utf-8").split("---", 2)[1])
+    assert set(fm["tags"]) == {"infra", "db"}


### PR DESCRIPTION
## 🏭 Bounty #770: Bug and Exploit Challenge

### The bug: multi-tag OKF export is garbled into one-character tokens

OkfExportService._render_okf_doc normalizes memory tags into the OKF
frontmatter `tags` list.  The in-memory recall path hands back tags as a
Python **list**, but documents read straight from Moorcheh store the flat
`tags` field as a **comma-separated string** (e.g. `"project, db, prod"`).

The code did `list(tags)`, so a string input was split **character-by-character**,
emitting garbage one-character tokens and wiping the real tag values.

Before (with tags="project, db"):
```yaml
tags: [p, r, o, j, e, c, t, ',', ' ', d, b]   # garbage
```
After:
```yaml
tags: [project, db]                             # correct
```

### Impact
Every `moorcheh` `memory export --okf` on a multi-tag memory corrupts the
tags list in the exported bundle.  Memanto to OKF to Memanto round-trips
therefore lose the original tags, and any OKF consumer (e.g. Google
Knowledge Catalog tooling) sees nonsense tags.

### Fix
Normalize in _render_okf_doc:
- str  -> split on comma, strip, drop empties
- list -> list() pass-through (preserves current recall-path behaviour)

### Testing
- New test_okf_export_splits_comma_separated_tags: fails on the old code,
  passes on the fix (verified round-trip).
- New test_okf_export_preserves_list_tags: confirms the in-memory list path
  is unchanged.
- Full tests/test_okf.py (7 tests) green.

    pytest tests/test_okf.py -q
    # 7 passed

Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OKF export handling for comma-separated tags.
  * Preserved tag lists correctly when exporting frontmatter.
  * Ensured exported tags appear as properly formatted YAML lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->