### PR TITLE
fix(migrate): update Mem0 export to v3 API

### DIFF
--- a/memanto/cli/analyze/mem0_export.py
+++ b/memanto/cli/analyze/mem0_export.py
@@ -7,7 +7,11 @@ ships a new version.
 
 Endpoints (Mem0 Platform REST API — https://docs.mem0.ai/api-reference):
     GET  /v1/entities/                                 list users/agents/apps/runs
-    GET  /v1/memories/?<scope>&page=&page_size=        list memories scoped to one entity
+    POST /v3/memories/?page=&page_size=                list memories scoped to one entity
+
+Mem0 v3 requires entity identifiers inside a JSON ``filters`` object. Passing
+them as top-level query parameters, as the retired v1 endpoint allowed, is
+rejected by the current Platform API.
 
 Auth: ``Authorization: Token <api_key>`` (Mem0's convention — not Bearer).
 """
@@ -51,6 +55,19 @@ def _get_json(
     resp = client.get(path, params=params or {})
     if resp.status_code >= 400:
         raise RuntimeError(f"GET {path} -> {resp.status_code}: {resp.text[:500]}")
+    return resp.json() if resp.content else {}
+
+
+def _post_json(
+    client: httpx.Client,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json: dict[str, Any] | None = None,
+) -> Any:
+    resp = client.post(path, params=params or {}, json=json or {})
+    if resp.status_code >= 400:
+        raise RuntimeError(f"POST {path} -> {resp.status_code}: {resp.text[:500]}")
     return resp.json() if resp.content else {}
 
 
@@ -122,8 +139,13 @@ def paginate_memories(
     last_page: dict[str, Any] = {}
 
     while True:
-        params = {**filters, "page": page, "page_size": page_size}
-        response = _get_json(client, "/v1/memories/", params=params)
+        params = {"page": page, "page_size": page_size}
+        response = _post_json(
+            client,
+            "/v3/memories/",
+            params=params,
+            json={"filters": filters},
+        )
         last_page = response if isinstance(response, dict) else {}
         batch = last_page.get("results") or []
         if not batch:

--- a/tests/test_mem0_export.py
+++ b/tests/test_mem0_export.py
@@ -1,0 +1,72 @@
+"""Unit tests for the live Mem0 export transport."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from memanto.cli.analyze.mem0_export import paginate_memories
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.status_code = 200
+        self.text = ""
+        self.content = b"{}"
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = iter(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def post(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any],
+        json: dict[str, Any],
+    ) -> _FakeResponse:
+        self.calls.append({"path": path, "params": params, "json": json})
+        return _FakeResponse(next(self._responses))
+
+
+def test_paginate_memories_uses_v3_filter_body_for_every_page() -> None:
+    client = _FakeClient(
+        [
+            {
+                "count": 3,
+                "next": "https://api.mem0.ai/v3/memories/?page=2&page_size=2",
+                "results": [{"id": "m1"}, {"id": "m2"}],
+            },
+            {
+                "count": 3,
+                "next": None,
+                "results": [{"id": "m3"}],
+            },
+        ]
+    )
+
+    memories, pagination = paginate_memories(
+        client,  # type: ignore[arg-type]
+        {"user_id": "alice"},
+        page_size=2,
+    )
+
+    assert [memory["id"] for memory in memories] == ["m1", "m2", "m3"]
+    assert pagination["count"] == 3
+    assert client.calls == [
+        {
+            "path": "/v3/memories/",
+            "params": {"page": 1, "page_size": 2},
+            "json": {"filters": {"user_id": "alice"}},
+        },
+        {
+            "path": "/v3/memories/",
+            "params": {"page": 2, "page_size": 2},
+            "json": {"filters": {"user_id": "alice"}},
+        },
+    ]


### PR DESCRIPTION
## Summary

Updates Memanto's live Mem0 migration exporter to use Mem0's current paginated Get Memories API.

## Root cause and impact

`memanto migrate mem0` discovers account entities correctly through `GET /v1/entities/`, but then fetches each entity's memories with the retired request shape:

```text
GET /v1/memories/?user_id=alice&page=1&page_size=200
```

Mem0's current Platform API requires `POST /v3/memories/`, keeps `page` and `page_size` as query parameters, and requires entity identifiers inside a JSON `filters` object. Top-level entity filters are rejected. As a result, a live Mem0 export fails before Memanto can map or import any memories.

Current upstream request contract: https://docs.mem0.ai/api-reference/memory/get-memories

## Fix

- Send paginated memory requests to `POST /v3/memories/`.
- Preserve `page` and `page_size` as query parameters.
- Send each discovered entity scope as `{"filters": {<entity key>: <entity id>}}`.
- Keep the existing response parsing, deduplication, progress reporting, and migration mapping unchanged.

## Regression coverage

The new transport test simulates a two-page Mem0 response and asserts that every page uses the v3 endpoint and JSON filter body while returning all records in order.

## Validation

- `uv run pytest -q` — 473 passed, 24 live credential-dependent tests skipped
- `uv run ruff check memanto/cli/analyze/mem0_export.py tests/test_mem0_export.py`
- `uv run ruff format --check memanto/cli/analyze/mem0_export.py tests/test_mem0_export.py`
- `uv run mypy memanto/cli/analyze/mem0_export.py`
- `git diff --check`

Refs #770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Mem0 memory exports to use the current v3 API.
  * Improved scoped memory retrieval across multiple pages.
  * Added consistent handling for request errors.

* **Tests**
  * Added coverage to verify pagination, filtering, request paths, and page parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->