### PR TITLE
Harden invalid session marker cleanup

### DIFF
--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -426,6 +426,18 @@ class SessionService:
                 # or remove the marker while this process holds its local lock.
                 if active_link.is_symlink():
                     target = active_link.readlink()
+                    if target.is_absolute() or target.parent != Path("."):
+                        logger.warning(
+                            "Clearing invalid active session symlink: %s", target
+                        )
+                        self._clear_active_session()
+                        return None
+                    if target.suffix != ".json" or target.name != f"{target.stem}.json":
+                        logger.warning(
+                            "Clearing invalid active session symlink: %s", target
+                        )
+                        self._clear_active_session()
+                        return None
                     agent_id = target.stem
                 else:
                     with open(active_link) as f:
@@ -435,13 +447,16 @@ class SessionService:
 
             try:
                 session = self.get_session(agent_id)
-            except ValueError:
+            except ValueError as exc:
                 # An empty or malformed marker (e.g. a crash between unlink and
                 # the fallback write in _set_active_session) fails validate_safe_id.
                 # An unreadable marker means "no active session", exactly as the
                 # OSError path above already treats it.
+                logger.warning("Clearing invalid active session marker: %s", exc)
+                self._clear_active_session()
                 return None
             if not session:
+                self._clear_active_session()
                 return None
 
             # If session is expired, clear the stale marker and return None.

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -452,16 +452,7 @@ class SessionService:
             except OSError:
                 return None
 
-            try:
-                session = self.get_session(agent_id)
-            except ValueError as exc:
-                # An empty or malformed marker (e.g. a crash between unlink and
-                # the fallback write in _set_active_session) fails validate_safe_id.
-                # An unreadable marker means "no active session", exactly as the
-                # OSError path above already treats it.
-                logger.warning("Clearing invalid active session marker: %s", exc)
-                self._clear_active_session()
-                return None
+            session = self.get_session(agent_id)
             if not session:
                 self._clear_active_session()
                 return None

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -411,6 +411,26 @@ class SessionService:
         session_file = self.sessions_dir / f"{agent_id}.json"
         return self._load_session_file(session_file)
 
+    @staticmethod
+    def _read_active_agent_id(active_link: Path) -> str:
+        """Read and validate the agent id stored in the active marker."""
+        if active_link.is_symlink():
+            target = active_link.readlink()
+            if (
+                target.is_absolute()
+                or target.parent != Path(".")
+                or target.suffix != ".json"
+                or target.name != f"{target.stem}.json"
+            ):
+                raise ValueError(f"Invalid active session symlink target: {target}")
+            agent_id = target.stem
+        else:
+            with open(active_link) as f:
+                agent_id = f.read().strip()
+
+        validate_safe_id(agent_id, "agent_id")
+        return agent_id
+
     def get_active_session(self) -> Session | None:
         """
         Get currently active session
@@ -424,24 +444,11 @@ class SessionService:
             try:
                 # Read symlink (or file on Windows). Another process can replace
                 # or remove the marker while this process holds its local lock.
-                if active_link.is_symlink():
-                    target = active_link.readlink()
-                    if target.is_absolute() or target.parent != Path("."):
-                        logger.warning(
-                            "Clearing invalid active session symlink: %s", target
-                        )
-                        self._clear_active_session()
-                        return None
-                    if target.suffix != ".json" or target.name != f"{target.stem}.json":
-                        logger.warning(
-                            "Clearing invalid active session symlink: %s", target
-                        )
-                        self._clear_active_session()
-                        return None
-                    agent_id = target.stem
-                else:
-                    with open(active_link) as f:
-                        agent_id = f.read().strip()
+                agent_id = self._read_active_agent_id(active_link)
+            except ValueError as exc:
+                logger.warning("Clearing invalid active session marker: %s", exc)
+                self._clear_active_session()
+                return None
             except OSError:
                 return None
 
@@ -831,11 +838,10 @@ class SessionService:
             active_agent_id: str | None = None
 
             try:
-                if active_link.is_symlink():
-                    active_agent_id = active_link.readlink().stem
-                else:
-                    with open(active_link) as f:
-                        active_agent_id = f.read().strip()
+                active_agent_id = self._read_active_agent_id(active_link)
+            except ValueError as exc:
+                logger.warning("Clearing invalid active session marker: %s", exc)
+                self._clear_active_session()
             except OSError as exc:
                 # Best-effort: a missing or unreadable active marker must not
                 # block deleting this agent's persisted session state. Leaving

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -586,6 +586,47 @@ class TestSessionService:
         assert session_service.delete_session("test-agent") is True
         assert not (session_service.sessions_dir / "test-agent.json").exists()
 
+    def test_get_active_session_clears_invalid_active_marker(self, session_service):
+        """A malformed active marker should not crash session recovery."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.parent.mkdir(parents=True, exist_ok=True)
+        active_marker.write_text("../outside")
+
+        assert session_service.get_active_session() is None
+        assert not active_marker.exists()
+
+    def test_get_active_session_clears_traversal_symlink(self, session_service):
+        """A traversal symlink target should not be treated as an agent id."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            active_marker.symlink_to("../outside.json")
+        except OSError as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        assert session_service.get_active_session() is None
+        assert not active_marker.exists()
+
+    def test_get_active_session_clears_missing_session_marker(self, session_service):
+        """A stale active marker should be removed when its session is gone."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.parent.mkdir(parents=True, exist_ok=True)
+        active_marker.write_text("missing-agent")
+
+        assert session_service.get_active_session() is None
+        assert not active_marker.exists()
+
+    def test_delete_session_rejects_path_traversal_agent_id(self, session_service):
+        """delete_session must not delete files outside the sessions directory."""
+        session_service.sessions_dir.mkdir(parents=True, exist_ok=True)
+        outside = session_service.sessions_dir.parent / "outside.json"
+        outside.write_text("keep me", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="agent_id"):
+            session_service.delete_session("../outside")
+
+        assert outside.read_text(encoding="utf-8") == "keep me"
+
     def test_list_sessions_skips_invalid_session_files(self, session_service):
         """One corrupt session record must not hide all valid sessions."""
         valid_session = session_service.create_session(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -605,7 +605,7 @@ class TestSessionService:
             pytest.skip(f"symlink creation unavailable: {exc}")
 
         assert session_service.get_active_session() is None
-        assert not active_marker.exists()
+        assert not os.path.lexists(active_marker)
 
     def test_get_active_session_clears_dangling_symlink(self, session_service):
         """A dangling active symlink should be removed during session recovery."""
@@ -617,7 +617,7 @@ class TestSessionService:
             pytest.skip(f"symlink creation unavailable: {exc}")
 
         assert session_service.get_active_session() is None
-        assert not active_marker.exists()
+        assert not os.path.lexists(active_marker)
 
     def test_get_active_session_clears_missing_session_marker(self, session_service):
         """A stale active marker should be removed when its session is gone."""
@@ -638,6 +638,20 @@ class TestSessionService:
             session_service.delete_session("../outside")
 
         assert outside.read_text(encoding="utf-8") == "keep me"
+
+    def test_delete_session_clears_traversal_active_marker(self, session_service):
+        """Deleting a session should also discard an invalid active symlink."""
+        session_service.create_session("test-agent")
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.unlink()
+        try:
+            active_marker.symlink_to("../other-agent.json")
+        except OSError as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        assert session_service.delete_session("test-agent") is True
+        assert not os.path.lexists(active_marker)
+        assert not (session_service.sessions_dir / "test-agent.json").exists()
 
     def test_list_sessions_skips_invalid_session_files(self, session_service):
         """One corrupt session record must not hide all valid sessions."""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -607,6 +607,18 @@ class TestSessionService:
         assert session_service.get_active_session() is None
         assert not active_marker.exists()
 
+    def test_get_active_session_clears_dangling_symlink(self, session_service):
+        """A dangling active symlink should be removed during session recovery."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            active_marker.symlink_to("missing-agent.json")
+        except OSError as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        assert session_service.get_active_session() is None
+        assert not active_marker.exists()
+
     def test_get_active_session_clears_missing_session_marker(self, session_service):
         """A stale active marker should be removed when its session is gone."""
         active_marker = session_service.sessions_dir / "active"


### PR DESCRIPTION
## Summary

Bounty submission for #770.

This hardens local session recovery and cleanup around malformed or stale agent ids:

- `get_active_session()` now clears and ignores invalid `active` session markers instead of letting `validate_safe_id()` raise during status/session recovery.
- Symlink active markers are accepted only when they point to a local `<agent_id>.json` target; traversal-style symlinks such as `../outside.json` are cleared.
- `get_active_session()` also clears stale markers that point to missing session files, avoiding repeated bad-state reads on every status check.
- `delete_session()` now validates `agent_id` before building a filesystem path, preventing direct service-layer calls with traversal-like ids from deleting files outside the sessions directory.
- Added regression tests for malformed active markers, traversal symlink markers, stale missing-session markers, and traversal-style delete input.

## Reproduction

Before this change, writing `../outside` into the local `sessions/active` marker could make `get_active_session()` raise instead of gracefully treating the active session as absent. A symlinked active marker pointing at `../outside.json` was not rejected before deriving the agent id. Writing an otherwise valid but missing agent id left the stale marker in place, so every later status check repeated the bad lookup. Directly calling `delete_session("../outside")` could also resolve to a sibling `outside.json` path.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_unit.py::TestSessionService::test_get_active_session_clears_traversal_symlink tests\test_unit.py::TestSessionService::test_get_active_session_clears_invalid_active_marker tests\test_unit.py::TestSessionService::test_get_active_session_clears_missing_session_marker tests\test_unit.py::TestSessionService::test_delete_session_rejects_path_traversal_agent_id -q`
- `.\.venv\Scripts\python.exe -m pytest tests\test_unit.py -q`
- `.\.venv\Scripts\python.exe -m ruff check memanto\app\services\session_service.py tests\test_unit.py`

This PR was prepared with AI assistance under the account owner's direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of active-session markers, including malformed values and unsafe symlink targets.
  * Automatically clears invalid, dangling, or stale markers when sessions are missing or inaccessible.
  * Prevented unsafe session identifiers from affecting files outside the sessions directory.

* **Tests**
  * Expanded coverage for marker cleanup, invalid symlinks, missing sessions, and path-traversal protection during session deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->