### PR TITLE
feat(migration): add ChatGPT conversations migration adapter

### DIFF
--- a/memanto/cli/analyze/chatgpt_compare.py
+++ b/memanto/cli/analyze/chatgpt_compare.py
@@ -1,0 +1,228 @@
+"""
+Compare a ChatGPT account export against Memanto.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from memanto.cli.analyze.ingestion_cost import (
+    DEFAULT_INPUT_USD_PER_1M,
+    DEFAULT_OUTPUT_USD_PER_1M,
+    DEFAULT_SOURCE_MULTIPLIER,
+    estimate_ingestion_cost,
+)
+
+ASSUMPTIONS: dict[str, Any] = {
+    "chars_per_token": 4,
+    "vector_bytes_float32": 4096,
+    "vector_bytes_memanto": 128,
+    "compression_ratio": 32,
+    # ChatGPT does not run on local agentic memory; read latency over vast history is simulated.
+    "chatgpt_read_ms": 600,
+    "memanto_read_ms": 90,
+    "extraction_usd_per_1m_input_tokens": DEFAULT_INPUT_USD_PER_1M,
+    "extraction_usd_per_1m_output_tokens": DEFAULT_OUTPUT_USD_PER_1M,
+    "extraction_source_multiplier": DEFAULT_SOURCE_MULTIPLIER,
+}
+
+
+def _human_bytes(num: float) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(num) < 1024.0:
+            return f"{num:.2f} {unit}"
+        num /= 1024.0
+    return f"{num:.2f} PB"
+
+
+def compute_metrics(export: dict[str, Any]) -> dict[str, Any]:
+    """Compute deterministic comparison metrics from a ChatGPT export."""
+    conversations = export.get("conversations", []) or []
+    conv_count = len(conversations)
+
+    total_chars = 0
+    message_count = 0
+
+    for conv in conversations:
+        mapping = conv.get("mapping") or {}
+        for node in mapping.values():
+            if not isinstance(node, dict):
+                continue
+            message = node.get("message")
+            if not message:
+                continue
+            message_count += 1
+            content = message.get("content") or {}
+            parts = content.get("parts") or []
+            for part in parts:
+                if isinstance(part, str):
+                    total_chars += len(part)
+
+    cpt = ASSUMPTIONS["chars_per_token"]
+    content_tokens = total_chars // cpt if cpt else 0
+    output_tokens = content_tokens
+    multiplier = float(ASSUMPTIONS["extraction_source_multiplier"])
+    input_tokens = int(content_tokens * multiplier)
+    ingestion = estimate_ingestion_cost(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        assumptions=ASSUMPTIONS,
+    )
+
+    # Reconstructed memories count (one per conversation)
+    vector_count = conv_count
+    storage_chatgpt_bytes = total_chars  # Raw JSON text representation
+    storage_memanto_bytes = vector_count * ASSUMPTIONS["vector_bytes_memanto"]
+    storage_saved_bytes = max(0, storage_chatgpt_bytes - storage_memanto_bytes)
+
+    read_ms_chatgpt = ASSUMPTIONS["chatgpt_read_ms"]
+    read_ms_memanto = ASSUMPTIONS["memanto_read_ms"]
+    latency_speedup = (
+        round(read_ms_chatgpt / read_ms_memanto, 1) if read_ms_memanto else 0
+    )
+
+    return {
+        "volume": {
+            "conversations": conv_count,
+            "messages": message_count,
+            "estimated_content_tokens": content_tokens,
+            "estimated_input_tokens": input_tokens,
+            "estimated_output_tokens": output_tokens,
+            "vector_count": vector_count,
+        },
+        "ingestion_tax": {
+            "chatgpt_input_tokens": input_tokens,
+            "chatgpt_output_tokens": output_tokens,
+            "chatgpt_input_cost_usd": ingestion["input_cost_usd"],
+            "chatgpt_output_cost_usd": ingestion["output_cost_usd"],
+            "chatgpt_extraction_cost_usd": ingestion["total_cost_usd"],
+            "tokens_saved": input_tokens + output_tokens,
+        },
+        "storage": {
+            "chatgpt_raw": storage_chatgpt_bytes,
+            "chatgpt_human": _human_bytes(storage_chatgpt_bytes),
+            "memanto_raw": storage_memanto_bytes,
+            "memanto_human": _human_bytes(storage_memanto_bytes),
+            "saved_raw": storage_saved_bytes,
+            "saved_human": _human_bytes(storage_saved_bytes),
+            "compression_ratio": ASSUMPTIONS["compression_ratio"],
+        },
+        "latency": {
+            "chatgpt_read_ms": read_ms_chatgpt,
+            "memanto_read_ms": read_ms_memanto,
+            "speedup_x": latency_speedup,
+            "ms_saved_per_query": max(0, read_ms_chatgpt - read_ms_memanto),
+        },
+    }
+
+
+def build_llm_prompt(metrics: dict[str, Any]) -> str:
+    v = metrics["volume"]
+    t = metrics["ingestion_tax"]
+    s = metrics["storage"]
+    lat = metrics["latency"]
+
+    return (
+        "Write a structured technical brief comparing ChatGPT raw history to Memanto.\n\n"
+        "=== MEASURED INPUT METRICS ===\n"
+        f"- Conversations: {v['conversations']}\n"
+        f"- Total Messages: {v['messages']}\n"
+        f"- Estimated content tokens: {v['estimated_content_tokens']:,}\n\n"
+        "=== PROJECTED MEMANTO IMPACT ===\n"
+        f"1. Ingestion/Extraction Cost — ChatGPT raw history ingest is modeled as "
+        f"~{t['chatgpt_input_tokens']:,} input tokens + {t['chatgpt_output_tokens']:,} output tokens "
+        f"≈ ${t['chatgpt_extraction_cost_usd']} extraction cost. Memanto maps each conversation "
+        f"into a single structured memory record, skipping redundant text extraction.\n"
+        f"2. Latency — Traversing or querying raw JSON history is ~{lat['chatgpt_read_ms']}ms. "
+        f"Memanto exact-match bitwise recall delivers <{lat['memanto_read_ms']}ms read time "
+        f"({lat['speedup_x']}x faster).\n"
+        f"3. Storage — Raw text stores {s['chatgpt_human']}. Memanto vector/Hamming representation "
+        f"stores {s['memanto_human']} (saving {s['saved_human']}).\n\n"
+        "Write a concise, professional markdown brief with these sections:\n"
+        "## Executive summary (2-3 sentences)\n"
+        "## What you could save by migrating (bullet points with numbers)\n"
+        "## What could improve in your memory layer (search speed, recall precision)\n"
+        "## Migration considerations\n"
+        "Use third person and professional tense."
+    )
+
+
+def build_report_markdown(
+    *,
+    metrics: dict[str, Any],
+    narrative: str,
+    export_path: str,
+    llm_model: str,
+    llm_method: str,
+    exported_at: str | None,
+) -> str:
+    v = metrics["volume"]
+    t = metrics["ingestion_tax"]
+    s = metrics["storage"]
+    lat = metrics["latency"]
+    generated = datetime.now(timezone.utc).isoformat()
+
+    lines: list[str] = []
+    lines.append("# Memanto vs. ChatGPT — Memory Analysis Report")
+    lines.append("")
+    lines.append(f"_Generated: {generated}_")
+    if exported_at:
+        lines.append(f"_ChatGPT export: {exported_at}_")
+    lines.append("")
+    lines.append("## Your ChatGPT footprint (measured)")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("| --- | --- |")
+    lines.append(f"| Conversations | {v['conversations']:,} |")
+    lines.append(f"| Total Messages | {v['messages']:,} |")
+    lines.append(f"| Estimated content tokens | {v['estimated_content_tokens']:,} |")
+    lines.append("")
+    lines.append("## Projected impact of migrating to Memanto")
+    lines.append("")
+    lines.append("### 1. Ingestion tax (token savings)")
+    lines.append("")
+    lines.append("| | ChatGPT | Memanto |")
+    lines.append("| --- | --- | --- |")
+    lines.append(f"| Ingest/content input tokens (estimated) | {t['chatgpt_input_tokens']:,} | 0 |")
+    lines.append(f"| AI extraction output tokens | {t['chatgpt_output_tokens']:,} | 0 |")
+    lines.append(f"| **Total extraction cost** | **${t['chatgpt_extraction_cost_usd']}** | **$0.00** |")
+    lines.append("")
+    lines.append(
+        f"**You could save ~{t['tokens_saved']:,} extraction tokens** "
+        f"if you migrate — Memanto's structural migration stores mapped conversation history directly."
+    )
+    lines.append("")
+    lines.append("### 2. Latency & indexing")
+    lines.append("")
+    lines.append("| | ChatGPT | Memanto |")
+    lines.append("| --- | --- | --- |")
+    lines.append(f"| Read latency | ~{lat['chatgpt_read_ms']}ms | <{lat['memanto_read_ms']}ms |")
+    lines.append("| Write availability | parsing delay | 0ms (instant) |")
+    lines.append("")
+    lines.append(f"**Reads could be ~{lat['speedup_x']}x faster**.")
+    lines.append("")
+    lines.append("### 3. Storage footprint")
+    lines.append("")
+    lines.append("| | ChatGPT | Memanto |")
+    lines.append("| --- | --- | --- |")
+    lines.append(f"| Vector storage | {s['chatgpt_human']} | {s['memanto_human']} |")
+    lines.append("")
+    lines.append(f"**Storage could be smaller** — freeing {s['saved_human']}.")
+    lines.append("")
+    lines.append("## Analysis")
+    lines.append("")
+    lines.append(narrative.strip() if narrative else "_(LLM narrative unavailable.)_")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## Method & assumptions")
+    lines.append("")
+    lines.append(f"- **LLM:** {llm_model}")
+    lines.append(f"- **How compared:** {llm_method}")
+    lines.append(f"- **Source export:** `{export_path}`")
+    lines.append("- **Assumptions used:**")
+    for key, value in ASSUMPTIONS.items():
+        lines.append(f"  - `{key}` = {value}")
+    lines.append("")
+    return "\n".join(lines)

--- a/memanto/cli/commands/migrate.py
+++ b/memanto/cli/commands/migrate.py
@@ -69,6 +69,15 @@ from memanto.cli.analyze.supermemory_compare import (
     compute_metrics as compute_supermemory_metrics,
 )
 from memanto.cli.analyze.supermemory_export import run_supermemory_export
+from memanto.cli.analyze.chatgpt_compare import (
+    build_llm_prompt as build_chatgpt_llm_prompt,
+)
+from memanto.cli.analyze.chatgpt_compare import (
+    build_report_markdown as build_chatgpt_report_markdown,
+)
+from memanto.cli.analyze.chatgpt_compare import (
+    compute_metrics as compute_chatgpt_metrics,
+)
 from memanto.cli.commands._shared import (
     BOLD_PRIMARY,
     BRIGHT,
@@ -118,6 +127,7 @@ _PROVIDER_BUNDLES: dict[str, dict[str, Any]] = {
         "report": build_supermemory_report_markdown,
         "export_filename": "supermemory_export.json",
     },
+<<<<<<< HEAD
     # Langfuse carries no savings report: it is an observability backend, not
     # a memory store to benchmark Memanto against. It also runs its own flow
     # (`_run_langfuse_flow`) because it reconciles against a sync ledger, so
@@ -126,6 +136,15 @@ _PROVIDER_BUNDLES: dict[str, dict[str, Any]] = {
         "label": "Langfuse",
         "exporter": run_langfuse_export,
         "export_filename": "langfuse_export.json",
+=======
+    "chatgpt": {
+        "label": "ChatGPT",
+        "exporter": None,
+        "metrics": compute_chatgpt_metrics,
+        "prompt": build_chatgpt_llm_prompt,
+        "report": build_chatgpt_report_markdown,
+        "export_filename": "conversations.json",
+>>>>>>> 29b5915 (feat(migration): add ChatGPT conversations migration adapter)
     },
 }
 
@@ -307,6 +326,9 @@ def _load_or_export(
     if file is not None:
         progress(f"Loading export from {file}")
         return file, load_export(file)
+
+    if provider == "chatgpt":
+        _error("ChatGPT migration requires a --file parameter.")
 
     key = _resolve_provider_key(provider, api_key)
     try:
@@ -685,6 +707,7 @@ def migrate_supermemory(
     )
 
 
+<<<<<<< HEAD
 # --------------------------------------------------------------------------
 # Langfuse — a repeatable sync, so it runs its own reconciling flow.
 # --------------------------------------------------------------------------
@@ -1153,4 +1176,44 @@ def migrate_langfuse(
             ),
             border_style=border,
         )
+    )
+
+
+@migrate_app.command("chatgpt")
+def migrate_chatgpt(
+    file: Path = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to the official ChatGPT conversations.json export file.",
+    ),
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help="Target Memanto agent id (defaults to the active agent).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the mapping and savings report without writing.",
+    ),
+    report: bool = typer.Option(
+        False,
+        "--report",
+        help="Also write the token/latency/storage savings report on a real run.",
+    ),
+):
+    """Migrate ChatGPT conversations history into the active (or selected) Memanto agent."""
+    _run_migrate_flow(
+        provider="chatgpt",
+        api_key=None,
+        file=file,
+        agent=agent,
+        dry_run=dry_run,
+        report=report,
     )

--- a/memanto/cli/commands/migrate.py
+++ b/memanto/cli/commands/migrate.py
@@ -127,7 +127,6 @@ _PROVIDER_BUNDLES: dict[str, dict[str, Any]] = {
         "report": build_supermemory_report_markdown,
         "export_filename": "supermemory_export.json",
     },
-<<<<<<< HEAD
     # Langfuse carries no savings report: it is an observability backend, not
     # a memory store to benchmark Memanto against. It also runs its own flow
     # (`_run_langfuse_flow`) because it reconciles against a sync ledger, so
@@ -136,7 +135,7 @@ _PROVIDER_BUNDLES: dict[str, dict[str, Any]] = {
         "label": "Langfuse",
         "exporter": run_langfuse_export,
         "export_filename": "langfuse_export.json",
-=======
+    },
     "chatgpt": {
         "label": "ChatGPT",
         "exporter": None,
@@ -144,7 +143,6 @@ _PROVIDER_BUNDLES: dict[str, dict[str, Any]] = {
         "prompt": build_chatgpt_llm_prompt,
         "report": build_chatgpt_report_markdown,
         "export_filename": "conversations.json",
->>>>>>> 29b5915 (feat(migration): add ChatGPT conversations migration adapter)
     },
 }
 
@@ -707,7 +705,6 @@ def migrate_supermemory(
     )
 
 
-<<<<<<< HEAD
 # --------------------------------------------------------------------------
 # Langfuse — a repeatable sync, so it runs its own reconciling flow.
 # --------------------------------------------------------------------------

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -491,10 +491,103 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
 # memories, so one incident collapses into a single grouped payload rather
 # than mapping row-for-row. That needs the user's capture settings, which
 # this registry's signature cannot carry — see ``langfuse_rules.build_rows``.
+
+
+def map_chatgpt(export: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map a ChatGPT conversation export to rich Memanto memory payloads.
+
+    Reconstructs the active branch of dialogues using a leaf-to-root tree-trace
+    of conversation message mappings.
+    """
+    rows: list[dict[str, Any]] = []
+    migrated_at = _now_utc()
+
+    for conv in export.get("conversations", []) or []:
+        title = (conv.get("title") or "").strip()
+        conv_id = conv.get("id") or conv.get("id")
+
+        mapping = conv.get("mapping") or {}
+        nodes = []
+        for k, v in mapping.items():
+            if not isinstance(v, dict):
+                continue
+            msg = v.get("message")
+            if not msg:
+                continue
+            nodes.append(v)
+
+        if not nodes:
+            continue
+
+        parent_ids = {n.get("parent") for n in nodes if n.get("parent")}
+        leaves = [n for n in nodes if n.get("id") and n.get("id") not in parent_ids]
+
+        if not leaves:
+            try:
+                nodes.sort(key=lambda x: x.get("message", {}).get("create_time") or 0)
+            except Exception:
+                pass
+            active_nodes = nodes
+        else:
+            leaf = leaves[0]
+            active_nodes = []
+            curr = leaf
+            while curr:
+                active_nodes.append(curr)
+                parent_id = curr.get("parent")
+                curr = mapping.get(parent_id) if parent_id else None
+            active_nodes.reverse()
+
+        lines = []
+        for node in active_nodes:
+            msg = node.get("message") or {}
+            author = msg.get("author") or {}
+            role = str(author.get("role") or "").capitalize()
+            content_obj = msg.get("content") or {}
+            parts = content_obj.get("parts") or []
+            text = "".join(str(p) for p in parts if p).strip()
+            if text and role:
+                lines.append(f"**{role}**: {text}")
+
+        content = "\n\n".join(lines).strip()
+        if not content:
+            continue
+
+        # Extract timestamps
+        created_at_val = conv.get("create_time")
+        created_at = _parse_dt(created_at_val)
+
+        # Pack metadata into the footer
+        footer = _format_supporting_data(
+            [
+                ("Source", f"chatgpt:{conv_id}" if conv_id else None),
+                ("Conversation title", title),
+                ("Message count", len(active_nodes)),
+                ("Source created_at", created_at.isoformat() if created_at else None),
+            ]
+        )
+
+        rows.append(
+            {
+                "title": title or _title_from(content),
+                "content": _attach_footer(content, footer),
+                "type": "observation",
+                "tags": ["chatgpt", "conversation"],
+                "confidence": 0.8,
+                "source": "chatgpt",
+                "source_ref": str(conv_id) if conv_id else None,
+                "provenance": "imported",
+                "created_at": created_at,
+                "updated_at": migrated_at,
+            }
+        )
+    return rows
+
 MAPPERS: dict[str, Callable[[dict[str, Any]], list[dict[str, Any]]]] = {
     "mem0": map_mem0,
     "letta": map_letta,
     "supermemory": map_supermemory,
+    "chatgpt": map_chatgpt,
     "okf": map_okf,
 }
 

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -252,6 +252,8 @@ def source_count(provider: str, export: dict[str, Any]) -> int:
     if provider == "langfuse":
         # Observations, not memories — many collapse into one signature.
         return len(export.get("observations", []) or [])
+    if provider == "chatgpt":
+        return len(export.get("conversations", []) or [])
     memories = export.get("memories", []) or []
     if provider == "supermemory" and not memories:
         # Mirror map_supermemory's fallback: when no extracted memories exist

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1552,6 +1552,65 @@ class TestMEMANTOCLI:
         assert "Executive summary" in report_text
         assert "Method & assumptions" in report_text
 
+    def test_migrate_chatgpt_dry_run(self, mock_all_clients, tmp_path):
+        """'memanto migrate chatgpt --file ... --dry-run' maps and renders a report."""
+        export = {
+            "conversations": [
+                {
+                    "title": "Test Conversation 1",
+                    "id": "conv-123",
+                    "create_time": 1700000000.0,
+                    "mapping": {
+                        "node-1": {
+                            "id": "node-1",
+                            "parent": None,
+                            "message": {
+                                "author": {"role": "user"},
+                                "content": {"parts": ["Hello assistant"]},
+                                "create_time": 1700000000.0,
+                            }
+                        },
+                        "node-2": {
+                            "id": "node-2",
+                            "parent": "node-1",
+                            "message": {
+                                "author": {"role": "assistant"},
+                                "content": {"parts": ["Hello user, how can I help?"]},
+                                "create_time": 1700000005.0,
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+        export_file = self._write_export_file(tmp_path, "conversations.json", export)
+
+        mock_all_clients.answer.return_value = {
+            "answer": "## Executive summary\nMigrating from ChatGPT saves tokens.",
+        }
+
+        with patch("memanto.cli.commands.migrate.config_manager") as mock_cfg:
+            mock_cfg.get_migrate_dir.return_value = tmp_path
+            mock_cfg.get_active_session.return_value = ("test-agent", "test-token")
+            mock_cfg.get_answer_config.return_value = {
+                "model": "anthropic.claude-sonnet-4-6"
+            }
+
+            result = runner.invoke(
+                app,
+                ["migrate", "chatgpt", "--file", str(export_file), "--dry-run"],
+            )
+
+        assert result.exit_code == 0, result.stdout
+        assert "Dry run complete" in result.stdout
+
+        reports = list(tmp_path.glob("*/migrate-report.md"))
+        assert len(reports) == 1
+        report_text = reports[0].read_text(encoding="utf-8")
+        assert "Memanto vs. ChatGPT" in report_text
+        assert "Executive summary" in report_text
+        assert "Method & assumptions" in report_text
+
     def test_migrate_narrative_retries_on_invalid_session(
         self, mock_all_clients, tmp_path
     ):


### PR DESCRIPTION
Added a migration adapter for ChatGPT exports (`conversations.json`). It traverses the message node tree (following parent/child linkages) to reconstruct and map user/assistant conversations into Memanto memories. Includes a full token, latency, and storage savings compare report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ChatGPT conversation export migration through the CLI.
  * Converts conversation history into Memanto memories while preserving timestamps, source details, and conversation metadata.
  * Added dry-run previews and optional reports comparing usage, cost, latency, and storage.
  * Reports include calculation methods, assumptions, and migration impact estimates.
  * Requires a ChatGPT `conversations.json` export file and supports selecting a target agent.

* **Bug Fixes**
  * ChatGPT records are now counted correctly during migration, including exports without memories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->