### PR TITLE
State management/merge prs

### DIFF
--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -108,8 +108,6 @@ class MemantoStore(BaseStore):
         self._agent_prefix = "langgraph_"
         # (namespace, query, limit, tags, type, min_sim, min_conf) -> (timestamp, items)
         self._search_cache: dict[tuple, tuple[float, list[SearchItem]]] = {}
-        # Survives 429s without flashing the UI panel to zero.
-        self._last_good: dict[tuple[str, ...], list[SearchItem]] = {}
 
     def _ensure_client(self, namespace: tuple[str, ...]) -> tuple[SdkClient, str]:
         ns_str = "_".join(namespace) or "default"
@@ -311,7 +309,6 @@ class MemantoStore(BaseStore):
             fetch_limit = self._MEMANTO_RECALL_CAP
         else:
             fetch_limit = max(1, min(op.limit, self._MEMANTO_RECALL_CAP))
-        rate_limited = False
 
         client, agent_id = self._ensure_client(op.namespace_prefix)
 
@@ -334,18 +331,7 @@ class MemantoStore(BaseStore):
                 )
         except Exception as exc:
             logger.warning("MemantoStore._do_search recall failed: %s", exc)
-            err = str(exc)
-            if any(
-                m in err
-                for m in (
-                    "429",
-                    "Limit Exceeded",
-                )
-            ):
-                rate_limited = True
-                result = {"memories": []}
-            else:
-                return []
+            raise
 
         out: list[SearchItem] = []
         for mem in result.get("memories", []):
@@ -362,16 +348,8 @@ class MemantoStore(BaseStore):
         out = out[: op.limit]
 
         with self._lock:
-            if not out and rate_limited and op.namespace_prefix in self._last_good:
-                logger.info(
-                    "MemantoStore: rate-limited, returning last-good for %r",
-                    op.namespace_prefix,
-                )
-                return self._last_good[op.namespace_prefix]
-
-            if out and not rate_limited:
+            if out:
                 self._search_cache[cache_key] = (time.time(), out)
-                self._last_good[op.namespace_prefix] = out
 
         return out
 

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -30,6 +30,9 @@ Documented limitations
 * **_do_get** is best-effort: uses ``recall_recent`` (unbiased by query)
   up to the 100-result cap, then a semantic fallback. A key stored long
   ago beyond the cap window may not be found.
+* **Cross-process puts** rely on backend coordination. This adapter serializes
+  puts for the same key within one ``MemantoStore`` instance, including
+  concurrent ``abatch`` calls, but cannot make separate processes atomic.
 """
 
 from __future__ import annotations
@@ -161,7 +164,7 @@ class MemantoStore(BaseStore):
     # GET                                                                #
     # ------------------------------------------------------------------ #
 
-    def _do_get(self, op: GetOp) -> Item | None:
+    def _do_get(self, op: GetOp, *, strict: bool = False) -> Item | None:
         """Lookup a single memory by key.
 
         Uses ``recall_recent`` first (no semantic bias) so the target memory
@@ -191,6 +194,10 @@ class MemantoStore(BaseStore):
                 tags=[key_tag],
             )
         except Exception as exc:
+            if strict:
+                raise RuntimeError(
+                    f"Cannot safely determine whether key {op.key!r} exists"
+                ) from exc
             logger.warning("MemantoStore._do_get fallback recall failed: %s", exc)
             return None
 
@@ -248,23 +255,44 @@ class MemantoStore(BaseStore):
         all_tags = user_tags + [self._key_to_tag(op.key)]
 
         client, agent_id = self._ensure_client(op.namespace)
-        client.remember(
-            agent_id=agent_id,
-            memory_type=memory_type,
-            title=title,
-            content=content,
-            confidence=confidence,
-            tags=all_tags,
-            source="langgraph-store",
-            provenance="explicit_statement",
+        existing = self._do_get(
+            GetOp(namespace=op.namespace, key=op.key), strict=True
         )
+        existing_id = existing.value.get("memory_id") if existing else None
+
+        if existing_id:
+            updates: dict[str, Any] = {
+                "title": title,
+                "content": str(raw_content),
+                "confidence": confidence,
+                "tags": all_tags,
+                "source": "langgraph-store",
+            }
+            if memory_type is not None:
+                updates["type"] = memory_type
+            client.update_memory(
+                agent_id=agent_id,
+                memory_id=str(existing_id),
+                updates=updates,
+            )
+        else:
+            client.remember(
+                agent_id=agent_id,
+                memory_type=memory_type,
+                title=title,
+                content=str(raw_content),
+                confidence=confidence,
+                tags=all_tags,
+                source="langgraph-store",
+                provenance="explicit_statement",
+            )
 
         # Invalidate cached searches for this namespace
         prefix = op.namespace
         with self._lock:
             self._search_cache = {
-                k: v for k, v in self._search_cache.items() if k[0] != prefix
-            }
+                    k: v for k, v in self._search_cache.items() if k[0] != prefix
+                }
 
     # ------------------------------------------------------------------ #
     # SEARCH                                                             #

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -107,6 +107,7 @@ class MemantoStore(BaseStore):
         """Initialize MemantoStore with an API key."""
         self.api_key = api_key
         self._lock = threading.RLock()
+        self._key_locks: dict[tuple[tuple[str, ...], str], threading.Lock] = {}
         self._client_pool: dict[str, SdkClient] = {}
         self._agent_prefix = "langgraph_"
         # (namespace, query, limit, tags, type, min_sim, min_conf) -> (timestamp, items)
@@ -255,44 +256,52 @@ class MemantoStore(BaseStore):
         all_tags = user_tags + [self._key_to_tag(op.key)]
 
         client, agent_id = self._ensure_client(op.namespace)
-        existing = self._do_get(
-            GetOp(namespace=op.namespace, key=op.key), strict=True
-        )
-        existing_id = existing.value.get("memory_id") if existing else None
 
-        if existing_id:
-            updates: dict[str, Any] = {
-                "title": title,
-                "content": str(raw_content),
-                "confidence": confidence,
-                "tags": all_tags,
-                "source": "langgraph-store",
-            }
-            if memory_type is not None:
-                updates["type"] = memory_type
-            client.update_memory(
-                agent_id=agent_id,
-                memory_id=str(existing_id),
-                updates=updates,
-            )
-        else:
-            client.remember(
-                agent_id=agent_id,
-                memory_type=memory_type,
-                title=title,
-                content=str(raw_content),
-                confidence=confidence,
-                tags=all_tags,
-                source="langgraph-store",
-                provenance="explicit_statement",
-            )
+        lock_key = (op.namespace, op.key)
+        with self._lock:
+            if lock_key not in self._key_locks:
+                self._key_locks[lock_key] = threading.Lock()
+            key_lock = self._key_locks[lock_key]
 
-        # Invalidate cached searches for this namespace
+        with key_lock:
+            existing = self._do_get(
+                GetOp(namespace=op.namespace, key=op.key), strict=True
+            )
+            existing_id = existing.value.get("memory_id") if existing else None
+
+            if existing_id:
+                updates: dict[str, Any] = {
+                    "title": title,
+                    "content": str(raw_content),
+                    "confidence": confidence,
+                    "tags": all_tags,
+                    "source": "langgraph-store",
+                }
+                if memory_type is not None:
+                    updates["type"] = memory_type
+                client.update_memory(
+                    agent_id=agent_id,
+                    memory_id=str(existing_id),
+                    updates=updates,
+                )
+            else:
+                client.remember(
+                    agent_id=agent_id,
+                    memory_type=memory_type,
+                    title=title,
+                    content=str(raw_content),
+                    confidence=confidence,
+                    tags=all_tags,
+                    source="langgraph-store",
+                    provenance="explicit_statement",
+                )
+
+        # Invalidate search cache for this namespace because we mutated it
         prefix = op.namespace
         with self._lock:
             self._search_cache = {
-                    k: v for k, v in self._search_cache.items() if k[0] != prefix
-                }
+                k: v for k, v in self._search_cache.items() if k[0] != prefix
+            }
 
     # ------------------------------------------------------------------ #
     # SEARCH                                                             #

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -1,3 +1,5 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -173,6 +175,8 @@ def test_do_put_success(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()
     mock_sdk_client.return_value = client_instance
+    client_instance.recall_recent.return_value = {"memories": []}
+    client_instance.recall.return_value = {"memories": []}
 
     op = PutOp(
         namespace=("my_ns",),
@@ -212,6 +216,32 @@ def test_tags_to_key_unescapes_encoded_key_tags():
     assert MemantoStore._tags_to_key(["lg:key:v1:thread%2Ccheckpoint"]) == (
         "thread,checkpoint"
     )
+
+
+def test_do_put_upsert_behavior(mock_sdk_client):
+    """LangGraph put acts as an upsert, preserves existing types, and fails safe."""
+    store = MemantoStore(api_key="test_key")
+    client_instance = MagicMock()
+    mock_sdk_client.return_value = client_instance
+    
+    # 1. Test update
+    client_instance.recall_recent.return_value = {
+        "memories": [{"id": "mem-1", "tags": ["lg:key:my_key"], "type": "fact"}]
+    }
+    store._do_put(PutOp(namespace=("my_ns",), key="my_key", value={"content": "new"}))
+    client_instance.update_memory.assert_called_once()
+    assert "type" not in client_instance.update_memory.call_args.kwargs["updates"]
+    client_instance.remember.assert_not_called()
+
+    # 2. Test failure safe
+    client_instance.reset_mock()
+    client_instance.recall_recent.return_value = {"memories": []}
+    client_instance.recall.side_effect = RuntimeError("backend down")
+    import pytest
+    with pytest.raises(RuntimeError, match="Cannot safely determine"):
+        store._do_put(PutOp(namespace=("my_ns",), key="my_key", value={"content": "x"}))
+    client_instance.update_memory.assert_not_called()
+    client_instance.remember.assert_not_called()
 
 
 def test_do_put_stringifies_non_string_content(mock_sdk_client):

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -379,7 +379,7 @@ def test_do_search_filters_min_confidence_without_changing_similarity(
     client_instance.recall.assert_called_once_with(
         agent_id="langgraph_my_ns",
         query="test query",
-        limit=10,
+        limit=100,
         type=None,
         tags=None,
         min_similarity=0.2,

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -1,5 +1,3 @@
-import threading
-from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -223,7 +221,7 @@ def test_do_put_upsert_behavior(mock_sdk_client):
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()
     mock_sdk_client.return_value = client_instance
-    
+
     # 1. Test update
     client_instance.recall_recent.return_value = {
         "memories": [{"id": "mem-1", "tags": ["lg:key:my_key"], "type": "fact"}]
@@ -238,6 +236,7 @@ def test_do_put_upsert_behavior(mock_sdk_client):
     client_instance.recall_recent.return_value = {"memories": []}
     client_instance.recall.side_effect = RuntimeError("backend down")
     import pytest
+
     with pytest.raises(RuntimeError, match="Cannot safely determine"):
         store._do_put(PutOp(namespace=("my_ns",), key="my_key", value={"content": "x"}))
     client_instance.update_memory.assert_not_called()

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -123,7 +123,7 @@ All config is via environment variables (load order: process env →
 | `MOORCHEH_API_KEY` | **yes** | — | Moorcheh API key. |
 | `MEMANTO_DEFAULT_AGENT_ID` | recommended | _none_ | Default agent. When set, tool calls may omit `agent_id`. |
 | `MEMANTO_AGENT_PATTERN` | no | `tool` | Pattern (`support`/`project`/`tool`) used when auto-creating the default agent. |
-| `MEMANTO_AGENT_AUTO_CREATE` | no | `true` | Create the default agent on first use if missing. |
+| `MEMANTO_AGENT_AUTO_CREATE` | no | `true` | Create the default agent on first use if missing. Explicit non-default agents must already exist. |
 | `MEMANTO_SESSION_DURATION_HOURS` | no | server default (6) | Session lifetime in hours. |
 | `MEMANTO_EXPOSE_ADMIN` | no | `false` | Register the 4 agent-management tools. |
 | `MEMANTO_MCP_TRANSPORT` | no | `stdio` | `stdio`, `sse`, or `streamable-http`. |

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -132,6 +132,13 @@ class MemantoLifecycle:
                 f"{agent_id}` or via the create_agent tool."
             )
 
+        if agent_id != self._settings.default_agent_id:
+            raise AgentNotFoundError(
+                f"Agent '{agent_id}' does not exist. Only the configured default agent "
+                "may be auto-created; create other agents explicitly with "
+                f"`memanto agent create {agent_id}` or the gated create_agent tool."
+            )
+
         logger.info(
             "Auto-creating agent '%s' with pattern '%s'.",
             agent_id,

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -138,6 +138,7 @@ def test_missing_agent_is_created_with_scoped_client(
     FakeSdkClient.missing_agents = {"agent-a"}
     FakeSdkClient.fail_activate_agents = set()
 
+    monkeypatch.setenv("MEMANTO_DEFAULT_AGENT_ID", "agent-a")
     lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
 
     client = lifecycle.ensure_ready("agent-a")
@@ -194,3 +195,28 @@ def test_batch_remember_validates_before_lifecycle_side_effects(
     assert len(FakeSdkClient.instances) == 1
     assert FakeSdkClient.instances[0].created_agents == []
     assert FakeSdkClient.instances[0].activated_agents == []
+
+
+def test_auto_create_is_limited_to_default_agent(
+    fake_api_key: str, monkeypatch
+) -> None:
+    """Only the configured default agent can be auto-created; arbitrary IDs fail."""
+    monkeypatch.setattr("memanto_mcp.lifecycle.SdkClient", FakeSdkClient)
+    FakeSdkClient.instances = []
+    FakeSdkClient.missing_agents = {"project-agent", "attacker-agent"}
+    FakeSdkClient.fail_activate_agents = set()
+
+    monkeypatch.setenv("MEMANTO_DEFAULT_AGENT_ID", "project-agent")
+    lifecycle = MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+    # 1. Arbitrary agent fails and does not auto-create
+    with pytest.raises(AgentNotFoundError, match="Only the configured default agent"):
+        lifecycle.ensure_ready("attacker-agent")
+
+    # Ensure no client recorded the creation of "attacker-agent"
+    assert not any("attacker-agent" in c.created_agents for c in FakeSdkClient.instances)
+
+    # 2. Configured default agent succeeds and auto-creates
+    client = lifecycle.ensure_ready("project-agent")
+    assert client.created_agents == ["project-agent"]
+    assert client.activated_agents == ["project-agent"]

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -214,7 +214,9 @@ def test_auto_create_is_limited_to_default_agent(
         lifecycle.ensure_ready("attacker-agent")
 
     # Ensure no client recorded the creation of "attacker-agent"
-    assert not any("attacker-agent" in c.created_agents for c in FakeSdkClient.instances)
+    assert not any(
+        "attacker-agent" in c.created_agents for c in FakeSdkClient.instances
+    )
 
     # 2. Configured default agent succeeds and auto-creates
     client = lifecycle.ensure_ready("project-agent")

--- a/memanto/app/clients/moorcheh.py
+++ b/memanto/app/clients/moorcheh.py
@@ -12,6 +12,7 @@ backends expose it.
 
 from typing import Any
 
+from fastapi import Header
 from moorcheh_sdk import AsyncMoorchehClient, MoorchehClient
 
 from memanto.app.clients.backend import Backend, parse_backend
@@ -118,11 +119,15 @@ class MoorchehClientSingleton:
 moorcheh_client = MoorchehClientSingleton()
 
 
-def get_moorcheh_client(api_key: str | None = None) -> Any:
+def get_moorcheh_client(
+    api_key: str | None = Header(None, alias="X-Api-Key"),
+) -> Any:
     """Dependency injection function (cloud or on-prem)."""
     return moorcheh_client.get_client(api_key=api_key)
 
 
-def get_async_moorcheh_client(api_key: str | None = None) -> Any:
+def get_async_moorcheh_client(
+    api_key: str | None = Header(None, alias="X-Api-Key"),
+) -> Any:
     """Dependency injection function for async client (cloud or on-prem)."""
     return moorcheh_client.get_async_client(api_key=api_key)

--- a/memanto/app/clients/moorcheh.py
+++ b/memanto/app/clients/moorcheh.py
@@ -118,11 +118,11 @@ class MoorchehClientSingleton:
 moorcheh_client = MoorchehClientSingleton()
 
 
-def get_moorcheh_client() -> Any:
+def get_moorcheh_client(api_key: str | None = None) -> Any:
     """Dependency injection function (cloud or on-prem)."""
-    return moorcheh_client.get_client()
+    return moorcheh_client.get_client(api_key=api_key)
 
 
-def get_async_moorcheh_client() -> Any:
+def get_async_moorcheh_client(api_key: str | None = None) -> Any:
     """Dependency injection function for async client (cloud or on-prem)."""
-    return moorcheh_client.get_async_client()
+    return moorcheh_client.get_async_client(api_key=api_key)

--- a/memanto/app/models/session.py
+++ b/memanto/app/models/session.py
@@ -144,3 +144,4 @@ class AgentList(BaseModel):
 
     agents: list[AgentInfo]
     count: int
+    warnings: list[str] = Field(default_factory=list)

--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -16,6 +16,7 @@ from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import get_data_dir
 from memanto.app.core import agent_namespace
 from memanto.app.models.session import AgentCreate, AgentInfo, AgentList
+from memanto.app.utils.atomic_write import atomic_write_text
 from memanto.app.utils.errors import AgentAlreadyExistsError, AgentNotFoundError
 from memanto.app.utils.temporal_helpers import as_utc_aware
 from memanto.app.utils.validation import validate_safe_id
@@ -221,10 +222,11 @@ class AgentService:
 
     def _save_agent(self, agent: AgentInfo) -> None:
         """Save agent metadata to file"""
-        self.agents_dir.mkdir(parents=True, exist_ok=True)
         agent_file = self._get_agent_file(agent.agent_id)
-        with open(agent_file, "w") as f:
-            json.dump(agent.model_dump(mode="json"), f, indent=2)
+        atomic_write_text(
+            agent_file,
+            json.dumps(agent.model_dump(mode="json"), indent=2),
+        )
 
     def _load_agent_file(self, agent_file: Path) -> AgentInfo | None:
         """Load one agent metadata file. Raises exception if file is corrupted."""

--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -5,10 +5,12 @@ Handles agent creation, listing, and lifecycle management.
 """
 
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
 from moorcheh_sdk.exceptions import ConflictError
+from pydantic import ValidationError
 
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import get_data_dir
@@ -17,6 +19,8 @@ from memanto.app.models.session import AgentCreate, AgentInfo, AgentList
 from memanto.app.utils.errors import AgentAlreadyExistsError, AgentNotFoundError
 from memanto.app.utils.temporal_helpers import as_utc_aware
 from memanto.app.utils.validation import validate_safe_id
+
+logger = logging.getLogger(__name__)
 
 
 class AgentService:
@@ -122,9 +126,11 @@ class AgentService:
         if not agent_file.exists():
             return None
 
-        with open(agent_file) as f:
-            data = json.load(f)
-            return AgentInfo(**data)
+        try:
+            return self._load_agent_file(agent_file)
+        except (OSError, json.JSONDecodeError, TypeError, ValidationError) as exc:
+            logger.warning("Skipping invalid agent file %s: %s", agent_file, exc)
+            return None
 
     def list_agents(self) -> AgentList:
         """
@@ -134,18 +140,23 @@ class AgentService:
             AgentList with all agents
         """
         agents: list[AgentInfo] = []
+        warnings: list[str] = []
         if not self.agents_dir.exists():
-            return AgentList(agents=agents, count=0)
+            return AgentList(agents=agents, count=0, warnings=warnings)
 
         for agent_file in self.agents_dir.glob("*.json"):
-            with open(agent_file) as f:
-                data = json.load(f)
-                agents.append(AgentInfo(**data))
+            try:
+                agent = self._load_agent_file(agent_file)
+                if agent is not None:
+                    agents.append(agent)
+            except (OSError, json.JSONDecodeError, TypeError, ValidationError) as exc:
+                logger.warning("Skipping invalid agent file %s: %s", agent_file, exc)
+                warnings.append(f"Could not load agent file '{agent_file.name}': {exc}")
 
         # Sort by created_at (newest first); normalize for legacy naive timestamps.
         agents.sort(key=lambda a: as_utc_aware(a.created_at), reverse=True)
 
-        return AgentList(agents=agents, count=len(agents))
+        return AgentList(agents=agents, count=len(agents), warnings=warnings)
 
     def update_agent_stats(
         self,
@@ -214,3 +225,12 @@ class AgentService:
         agent_file = self._get_agent_file(agent.agent_id)
         with open(agent_file, "w") as f:
             json.dump(agent.model_dump(mode="json"), f, indent=2)
+
+    def _load_agent_file(self, agent_file: Path) -> AgentInfo | None:
+        """Load one agent metadata file. Raises exception if file is corrupted."""
+        if not agent_file.exists():
+            return None
+
+        with open(agent_file) as f:
+            data = json.load(f)
+        return AgentInfo(**data)

--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -66,59 +66,50 @@ class AgentService:
             AgentAlreadyExistsError: If agent already exists
         """
         agent_file = self._get_agent_file(agent_create.agent_id)
-        
-        # Atomic lock: Create the file exclusively to prevent TOCTOU race conditions.
-        # This guarantees only one thread can claim this agent ID.
+        self.agents_dir.mkdir(parents=True, exist_ok=True)
+
+        # Atomically claim the agent ID before creating its namespace.
         try:
-            with open(agent_file, "x") as f:
+            with open(agent_file, "x"):
                 pass
         except FileExistsError:
             raise AgentAlreadyExistsError(
                 f"Agent '{agent_create.agent_id}' already exists"
             )
 
-        namespace = self._generate_namespace(agent_create.agent_id)
-
-        # Create namespace in Moorcheh - CRITICAL: Must succeed.
-        # ``moorcheh_api_key`` is honored on cloud; ignored on on-prem.
-        client = get_moorcheh_client()
-
         try:
-            # Use Moorcheh SDK to create namespace with type="text"
-            client.namespaces.create(namespace, type="text")
-            print(f"[OK] Namespace created in Moorcheh: {namespace}")
-        except ConflictError:
-            # Namespace already exists - this is OK, agent might have been created before
-            print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
-        except Exception as e:
-            # On-prem raises moorcheh.errors.MoorchehApiError (HTTP 409) rather
-            # than the cloud SDK's typed ConflictError when the namespace
-            # already exists. Match on message so both backends behave the same.
-            msg = str(e).lower()
-            if ("namespace" in msg and "already exists" in msg) or "conflict" in msg:
+            namespace = self._generate_namespace(agent_create.agent_id)
+            client = get_moorcheh_client(api_key=moorcheh_api_key)
+
+            try:
+                client.namespaces.create(namespace, type="text")
+                print(f"[OK] Namespace created in Moorcheh: {namespace}")
+            except ConflictError:
                 print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
-            else:
-                raise Exception(
-                    f"Failed to create namespace '{namespace}' in Moorcheh: {str(e)}"
-                )
+            except Exception as exc:
+                message = str(exc).lower()
+                if ("namespace" in message and "already exists" in message) or "conflict" in message:
+                    print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
+                else:
+                    raise Exception(
+                        f"Failed to create namespace '{namespace}' in Moorcheh: {exc}"
+                    )
 
-        # Create agent metadata
-        agent = AgentInfo(
-            agent_id=agent_create.agent_id,
-            namespace=namespace,
-            pattern=agent_create.pattern,
-            description=agent_create.description,
-            created_at=datetime.now(timezone.utc),
-            memory_count=0,
-            session_count=0,
-            status="ready",
-        )
-
-        # Save agent metadata
-        self._save_agent(agent)
-
-        return agent
-
+            agent = AgentInfo(
+                agent_id=agent_create.agent_id,
+                namespace=namespace,
+                pattern=agent_create.pattern,
+                description=agent_create.description,
+                created_at=datetime.now(timezone.utc),
+                memory_count=0,
+                session_count=0,
+                status="ready",
+            )
+            self._save_agent(agent)
+            return agent
+        except Exception:
+            agent_file.unlink(missing_ok=True)
+            raise
     def get_agent(self, agent_id: str) -> AgentInfo | None:
         """
         Get agent by ID

--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -66,11 +66,17 @@ class AgentService:
             AgentAlreadyExistsError: If agent already exists
         """
         agent_file = self._get_agent_file(agent_create.agent_id)
+        if agent_file.exists():
+            raise AgentAlreadyExistsError(
+                f"Agent '{agent_create.agent_id}' already exists"
+            )
+
+        lock_file = agent_file.with_suffix(".json.lock")
         self.agents_dir.mkdir(parents=True, exist_ok=True)
 
         # Atomically claim the agent ID before creating its namespace.
         try:
-            with open(agent_file, "x"):
+            with open(lock_file, "x"):
                 pass
         except FileExistsError:
             raise AgentAlreadyExistsError(
@@ -88,7 +94,9 @@ class AgentService:
                 print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
             except Exception as exc:
                 message = str(exc).lower()
-                if ("namespace" in message and "already exists" in message) or "conflict" in message:
+                if (
+                    "namespace" in message and "already exists" in message
+                ) or "conflict" in message:
                     print(f"[OK] Namespace already exists in Moorcheh: {namespace}")
                 else:
                     raise Exception(
@@ -107,9 +115,9 @@ class AgentService:
             )
             self._save_agent(agent)
             return agent
-        except Exception:
-            agent_file.unlink(missing_ok=True)
-            raise
+        finally:
+            lock_file.unlink(missing_ok=True)
+
     def get_agent(self, agent_id: str) -> AgentInfo | None:
         """
         Get agent by ID
@@ -126,7 +134,13 @@ class AgentService:
 
         try:
             return self._load_agent_file(agent_file)
-        except (OSError, json.JSONDecodeError, TypeError, ValidationError) as exc:
+        except (
+            OSError,
+            json.JSONDecodeError,
+            TypeError,
+            ValidationError,
+            UnicodeDecodeError,
+        ) as exc:
             logger.warning("Skipping invalid agent file %s: %s", agent_file, exc)
             return None
 
@@ -147,7 +161,13 @@ class AgentService:
                 agent = self._load_agent_file(agent_file)
                 if agent is not None:
                     agents.append(agent)
-            except (OSError, json.JSONDecodeError, TypeError, ValidationError) as exc:
+            except (
+                OSError,
+                json.JSONDecodeError,
+                TypeError,
+                ValidationError,
+                UnicodeDecodeError,
+            ) as exc:
                 logger.warning("Skipping invalid agent file %s: %s", agent_file, exc)
                 warnings.append(f"Could not load agent file '{agent_file.name}': {exc}")
 

--- a/memanto/app/services/agent_service.py
+++ b/memanto/app/services/agent_service.py
@@ -66,7 +66,13 @@ class AgentService:
             AgentAlreadyExistsError: If agent already exists
         """
         agent_file = self._get_agent_file(agent_create.agent_id)
-        if agent_file.exists():
+        
+        # Atomic lock: Create the file exclusively to prevent TOCTOU race conditions.
+        # This guarantees only one thread can claim this agent ID.
+        try:
+            with open(agent_file, "x") as f:
+                pass
+        except FileExistsError:
             raise AgentAlreadyExistsError(
                 f"Agent '{agent_create.agent_id}' already exists"
             )

--- a/memanto/app/services/memory_export_service.py
+++ b/memanto/app/services/memory_export_service.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from memanto.app.config import get_data_dir
 from memanto.app.utils.validation import validate_output_path, validate_safe_id
 
 # Memory type metadata: (label, emoji, description)
@@ -89,7 +90,7 @@ class MemoryExportService:
     """Formats and writes a structured memory.md for an agent."""
 
     def __init__(self, exports_dir: Path | None = None):
-        self.exports_dir = exports_dir or (Path.home() / ".memanto" / "exports")
+        self.exports_dir = exports_dir or (get_data_dir() / "exports")
 
     # Public API
     def format_memory_md(
@@ -201,8 +202,8 @@ class MemoryExportService:
         Args:
             agent_id: Agent identifier.
             memories_by_type: Dict mapping memory type -> list of memory dicts.
-            output_path: Custom output path. Defaults to
-                ``~/.memanto/exports/{agent_id}_memory.md``.
+            output_path: Custom output path. Defaults to the active backend's
+                export directory with filename ``{agent_id}_memory.md``.
 
         Returns:
             Absolute Path to the written file.

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -25,6 +25,7 @@ from memanto.app.models.session import (
     SessionSummary,
     SessionToken,
 )
+from memanto.app.utils.atomic_write import atomic_write_text
 from memanto.app.utils.errors import (
     InvalidSessionTokenError,
     SessionExpiredError,
@@ -386,10 +387,11 @@ class SessionService:
     def _save_session(self, session: Session) -> None:
         """Save session to file"""
         validate_safe_id(session.agent_id, "agent_id")
-        self.sessions_dir.mkdir(parents=True, exist_ok=True)
         session_file = self.sessions_dir / f"{session.agent_id}.json"
-        with open(session_file, "w") as f:
-            json.dump(session.model_dump(mode="json"), f, indent=2)
+        atomic_write_text(
+            session_file,
+            json.dumps(session.model_dump(mode="json"), indent=2),
+        )
 
     def _load_session_file(self, session_file: Path) -> Session | None:
         """Load one session file, treating corrupt local state as absent."""

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -1381,7 +1381,8 @@
 
             .charts-row,
             .form-row,
-            .conflict-memories {
+            .conflict-memories,
+            .hh-stats {
                 grid-template-columns: 1fr;
             }
         }

--- a/memanto/app/utils/atomic_write.py
+++ b/memanto/app/utils/atomic_write.py
@@ -1,0 +1,42 @@
+"""Crash-safe helpers for replacing small local state files."""
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Replace *path* only after a complete same-directory write.
+
+    Writing the temporary file next to the destination keeps ``os.replace``
+    atomic on the same filesystem. Restrictive permissions are applied before
+    the file becomes visible at its final path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+
+        try:
+            tmp_path.chmod(0o600)
+        except OSError:
+            pass  # Windows may not support POSIX permission bits
+        os.replace(tmp_path, path)
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1576,9 +1576,8 @@ class DirectClient:
         """
         Sync agent memories to a project directory's MEMORY.md.
 
-        Uses the cached export at ``~/.memanto/exports/{agent_id}_memory.md``
-        when available. Falls back to a fresh export if
-        the cache file does not exist.
+        Always refreshes the export first so project-local ``MEMORY.md`` files
+        cannot silently lag behind newly written memories.
 
         Args:
             agent_id: Target agent.
@@ -1590,32 +1589,15 @@ class DirectClient:
             (``"cache"`` or ``"fresh"``).
         """
 
-        cache_path = Path.home() / ".memanto" / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if cache_path.exists():
-            # Fast path: copy cached export
-            shutil.copy2(str(cache_path), str(target_path))
-            # Count memories from the cached file
-            content = cache_path.read_text(encoding="utf-8")
-            mem_count = content.count("### ")
-            return {
-                "output_path": str(target_path.resolve()),
-                "total_memories": mem_count,
-                "source": "cache",
-            }
-
-        # Fallback: run a fresh export to the default location, then copy
-        logger.debug(
-            "No cached export found, generating fresh export for '%s'", agent_id
-        )
+        logger.debug("Refreshing memory export before syncing '%s'", agent_id)
         export_result = self.export_memory_md(
             agent_id=agent_id,
             limit_per_type=limit_per_type,
         )
 
-        # Now copy the freshly generated export to the project
         exported_path = Path(export_result["output_path"])
         if exported_path.exists():
             shutil.copy2(str(exported_path), str(target_path))

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
+from memanto.app.config import get_data_dir
 from memanto.app.constants import (
     ALLOWED_UPDATE_FIELDS as _ALLOWED_UPDATE_FIELDS,
 )
@@ -1537,7 +1538,7 @@ class DirectClient:
         Args:
             agent_id: Target agent.
             output_path: Custom output path. Defaults to
-                ``~/.memanto/exports/{agent_id}_memory.md``.
+                the active backend's export directory.
             limit_per_type: Max memories per type (default 25).
 
         Returns:
@@ -1576,8 +1577,9 @@ class DirectClient:
         """
         Sync agent memories to a project directory's MEMORY.md.
 
-        Always refreshes the export first so project-local ``MEMORY.md`` files
-        cannot silently lag behind newly written memories.
+        Uses the cached export in the active backend's data directory
+        when available. Falls back to a fresh export if
+        the cache file does not exist.
 
         Args:
             agent_id: Target agent.
@@ -1589,8 +1591,20 @@ class DirectClient:
             (``"cache"`` or ``"fresh"``).
         """
 
+        cache_path = get_data_dir() / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if cache_path.exists():
+            # Fast path: copy cached export without an API-backed refresh.
+            shutil.copy2(str(cache_path), str(target_path))
+            content = cache_path.read_text(encoding="utf-8")
+            mem_count = content.count("### ")
+            return {
+                "output_path": str(target_path.resolve()),
+                "total_memories": mem_count,
+                "source": "cache",
+            }
 
         logger.debug("Refreshing memory export before syncing '%s'", agent_id)
         export_result = self.export_memory_md(

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -47,6 +47,7 @@ from memanto.app.utils.validation import (
     InputLimits,
     is_successful_write_result,
     validate_recall_limit,
+    validate_safe_id,
 )
 from memanto.cli.config.manager import ConfigManager
 
@@ -1591,6 +1592,7 @@ class DirectClient:
             (``"cache"`` or ``"fresh"``).
         """
 
+        validate_safe_id(agent_id, "agent_id")
         cache_path = get_data_dir() / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -457,15 +457,15 @@ class DirectClient:
         agent_info = self._get_agent_service().create_agent(agent_create, self.api_key)
         return cast(dict[str, Any], agent_info.model_dump(mode="json"))
 
-    def list_agents(self) -> list[dict[str, Any]]:
+    def list_agents(self) -> dict[str, Any]:
         """
         List all registered agents.
 
         Returns:
-            List of agent info dicts.
+            Dictionary with 'agents', 'count', and 'warnings'.
         """
         agent_list = self._get_agent_service().list_agents()
-        return [a.model_dump(mode="json") for a in agent_list.agents]
+        return cast(dict[str, Any], agent_list.model_dump(mode="json"))
 
     def get_agent(self, agent_id: str) -> dict[str, Any]:
         """

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
+from memanto.app.config import get_data_dir
 from memanto.app.constants import (
     ALLOWED_UPDATE_FIELDS as _ALLOWED_UPDATE_FIELDS,
 )
@@ -1448,9 +1449,20 @@ class SdkClient:
             (``"cache"``, ``"fresh"``, or ``"stale-cache"`` if a refresh
             failed and a previous export was reused instead).
         """
-        cache_path = Path.home() / ".memanto" / "exports" / f"{agent_id}_memory.md"
+        cache_path = get_data_dir() / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if cache_path.exists():
+            # Fast path: copy cached export without an API-backed refresh.
+            shutil.copy2(str(cache_path), str(target_path))
+            content = cache_path.read_text(encoding="utf-8")
+            mem_count = content.count("### ")
+            return {
+                "output_path": str(target_path.resolve()),
+                "total_memories": mem_count,
+                "source": "cache",
+            }
 
         try:
             # Run export function first (ensures ~/.memanto/exports/... is fresh)
@@ -1469,9 +1481,9 @@ class SdkClient:
                 }
             raise
 
-        if cache_path.exists():
-            # Copy freshly updated cache to project
-            shutil.copy2(str(cache_path), str(target_path))
+        exported_path = Path(export_result["output_path"])
+        if exported_path.exists():
+            shutil.copy2(str(exported_path), str(target_path))
 
         return {
             "output_path": str(target_path.resolve()),

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1454,7 +1454,7 @@ class SdkClient:
 
         try:
             # Run export function first (ensures ~/.memanto/exports/... is fresh)
-            self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
+            export_result = self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
         except ConnectionError:
             if cache_path.exists():
                 # Backend unreachable, but we have a previously good export —
@@ -1472,17 +1472,10 @@ class SdkClient:
         if cache_path.exists():
             # Copy freshly updated cache to project
             shutil.copy2(str(cache_path), str(target_path))
-            content = cache_path.read_text(encoding="utf-8")
-            mem_count = content.count("### ")
-            return {
-                "output_path": str(target_path.resolve()),
-                "total_memories": mem_count,
-                "source": "cache",
-            }
 
         return {
             "output_path": str(target_path.resolve()),
-            "total_memories": 0,
+            "total_memories": export_result.get("total_memories", 0),
             "source": "fresh",
         }
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -44,6 +44,7 @@ from memanto.app.utils.validation import (
     InputLimits,
     is_successful_write_result,
     validate_recall_limit,
+    validate_safe_id,
 )
 from memanto.cli.config.manager import ConfigManager
 
@@ -1449,6 +1450,7 @@ class SdkClient:
             (``"cache"``, ``"fresh"``, or ``"stale-cache"`` if a refresh
             failed and a previous export was reused instead).
         """
+        validate_safe_id(agent_id, "agent_id")
         cache_path = get_data_dir() / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1466,7 +1468,9 @@ class SdkClient:
 
         try:
             # Run export function first (ensures ~/.memanto/exports/... is fresh)
-            export_result = self.export_memory_md(agent_id=agent_id, limit_per_type=limit_per_type)
+            export_result = self.export_memory_md(
+                agent_id=agent_id, limit_per_type=limit_per_type
+            )
         except ConnectionError:
             if cache_path.exists():
                 # Backend unreachable, but we have a previously good export —

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -289,15 +289,15 @@ class SdkClient:
         agent_info = self._get_agent_service().create_agent(agent_create, self.api_key)
         return cast(dict[str, Any], agent_info.model_dump(mode="json"))
 
-    def list_agents(self) -> list[dict[str, Any]]:
+    def list_agents(self) -> dict[str, Any]:
         """
         List all registered agents.
 
         Returns:
-            List of agent info dicts.
+            Dictionary with 'agents', 'count', and 'warnings'.
         """
         agent_list = self._get_agent_service().list_agents()
-        return [a.model_dump(mode="json") for a in agent_list.agents]
+        return cast(dict[str, Any], agent_list.model_dump(mode="json"))
 
     def get_agent(self, agent_id: str) -> dict[str, Any]:
         """

--- a/memanto/cli/commands/agent.py
+++ b/memanto/cli/commands/agent.py
@@ -66,7 +66,13 @@ def agent_list():
     client = get_client()
 
     try:
-        agents = client.list_agents()
+        response = client.list_agents()
+        agents = response.get("agents", [])
+        warnings = response.get("warnings", [])
+
+        if warnings:
+            for w in warnings:
+                console.print(f"[yellow]Warning: {w}[/yellow]")
 
         if not agents:
             console.print(

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -16,6 +16,7 @@ from urllib.parse import urlsplit, urlunsplit
 from dotenv import load_dotenv, set_key
 
 from memanto.app.clients.backend import Backend, parse_backend
+from memanto.app.utils.atomic_write import atomic_write_text
 from memanto.app.utils.validation import validate_recall_limit
 from memanto.cli.schedule_time import normalize_schedule_time
 
@@ -255,10 +256,9 @@ class ConfigManager:
     def set_onprem_state(self, **updates) -> None:
         """Merge ``updates`` into the on-prem state.json (creates dir if needed)."""
         p = self._onprem_state_path()
-        p.parent.mkdir(parents=True, exist_ok=True)
         data = self.get_onprem_state()
         data.update({k: v for k, v in updates.items() if v is not None})
-        p.write_text(json.dumps(data, indent=2))
+        atomic_write_text(p, json.dumps(data, indent=2))
 
     def get_onprem_config(self) -> dict:
         """Get on-prem config dict (url, embedding_provider, llm_model, ...).
@@ -578,15 +578,10 @@ class ConfigManager:
 
     def _save_connections(self, data: dict) -> None:
         """Atomically write the connections registry."""
-        self.config_dir.mkdir(parents=True, exist_ok=True)
-        tmp = self.connections_file.with_suffix(".json.tmp")
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, sort_keys=True)
-        os.replace(tmp, self.connections_file)
-        try:
-            self.connections_file.chmod(0o600)
-        except OSError:
-            pass
+        atomic_write_text(
+            self.connections_file,
+            json.dumps(data, indent=2, sort_keys=True),
+        )
 
     def add_connection(
         self, agent_name: str, project_dir: str | None, is_global: bool

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -9,6 +9,7 @@ Handles configuration persistence:
 
 import importlib
 import json
+import math
 import os
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
@@ -84,7 +85,7 @@ def _validate_float_range(name: str, value, minimum: float, maximum: float) -> f
         validated = float(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{name} must be between {minimum} and {maximum}") from exc
-    if validated < minimum or validated > maximum:
+    if not math.isfinite(validated) or validated < minimum or validated > maximum:
         raise ValueError(f"{name} must be between {minimum} and {maximum}")
     return validated
 

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 from dotenv import load_dotenv, set_key
+from filelock import FileLock
 
 from memanto.app.clients.backend import Backend, parse_backend
 from memanto.app.utils.atomic_write import atomic_write_text
@@ -257,9 +258,12 @@ class ConfigManager:
     def set_onprem_state(self, **updates) -> None:
         """Merge ``updates`` into the on-prem state.json (creates dir if needed)."""
         p = self._onprem_state_path()
-        data = self.get_onprem_state()
-        data.update({k: v for k, v in updates.items() if v is not None})
-        atomic_write_text(p, json.dumps(data, indent=2))
+        p.parent.mkdir(parents=True, exist_ok=True)
+        lock = FileLock(str(p) + ".lock")
+        with lock:
+            data = self.get_onprem_state()
+            data.update({k: v for k, v in updates.items() if v is not None})
+            atomic_write_text(p, json.dumps(data, indent=2))
 
     def get_onprem_config(self) -> dict:
         """Get on-prem config dict (url, embedding_provider, llm_model, ...).
@@ -588,29 +592,39 @@ class ConfigManager:
         self, agent_name: str, project_dir: str | None, is_global: bool
     ) -> None:
         """Record that ``agent_name`` was installed at ``project_dir`` (or globally)."""
-        data = self.load_connections()
-        entry = data.setdefault(agent_name, {"projects": [], "installed_global": False})
-        if is_global:
-            entry["installed_global"] = True
-        elif project_dir:
-            abs_path = str(Path(project_dir).resolve())
-            if abs_path not in entry["projects"]:
-                entry["projects"].append(abs_path)
-        self._save_connections(data)
+        self.connections_file.parent.mkdir(parents=True, exist_ok=True)
+        lock = FileLock(str(self.connections_file) + ".lock")
+        with lock:
+            data = self.load_connections()
+            entry = data.setdefault(
+                agent_name, {"projects": [], "installed_global": False}
+            )
+            if is_global:
+                entry["installed_global"] = True
+            elif project_dir:
+                abs_path = str(Path(project_dir).resolve())
+                if abs_path not in entry["projects"]:
+                    entry["projects"].append(abs_path)
+            self._save_connections(data)
 
     def remove_connection(
         self, agent_name: str, project_dir: str | None, is_global: bool
     ) -> None:
         """Inverse of ``add_connection``."""
-        data = self.load_connections()
-        if agent_name not in data:
-            return
-        entry = data[agent_name]
-        if is_global:
-            entry["installed_global"] = False
-        elif project_dir:
-            abs_path = str(Path(project_dir).resolve())
-            entry["projects"] = [p for p in entry.get("projects", []) if p != abs_path]
-        if not entry.get("projects") and not entry.get("installed_global"):
-            del data[agent_name]
-        self._save_connections(data)
+        self.connections_file.parent.mkdir(parents=True, exist_ok=True)
+        lock = FileLock(str(self.connections_file) + ".lock")
+        with lock:
+            data = self.load_connections()
+            if agent_name not in data:
+                return
+            entry = data[agent_name]
+            if is_global:
+                entry["installed_global"] = False
+            elif project_dir:
+                abs_path = str(Path(project_dir).resolve())
+                entry["projects"] = [
+                    p for p in entry.get("projects", []) if p != abs_path
+                ]
+            if not entry.get("projects") and not entry.get("installed_global"):
+                del data[agent_name]
+            self._save_connections(data)

--- a/memanto/cli/connect/agent_registry.py
+++ b/memanto/cli/connect/agent_registry.py
@@ -73,9 +73,18 @@ class AgentDef:
         if is_global:
             if self.config_global_dir:
                 base = Path.home() / self.config_global_dir.lstrip("~/")
+                instruction_path = Path(self.instruction_file)
+                if self.config_local_dir:
+                    try:
+                        instruction_path = instruction_path.relative_to(
+                            self.config_local_dir
+                        )
+                    except ValueError:
+                        pass
             else:
                 base = Path.home()
-            return base / self.instruction_file
+                instruction_path = Path(self.instruction_file)
+            return base / instruction_path
         return project_dir / self.instruction_file
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "rich>=13.0.0",
     "python-multipart>=0.0.7",
     "rapidfuzz>=3.0.0",
+    "filelock>=3.13.0",
 ]
 
 [project.urls]

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -88,6 +88,22 @@
             }
           },
           {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
+            }
+          },
+          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -171,6 +187,22 @@
             "schema": {
               "type": "string",
               "title": "Agent Id"
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
             }
           },
           {
@@ -269,6 +301,22 @@
             }
           },
           {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
+            }
+          },
+          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -360,6 +408,22 @@
             }
           },
           {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
+            }
+          },
+          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -431,6 +495,22 @@
             "schema": {
               "type": "string",
               "title": "Agent Id"
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
             }
           },
           {
@@ -601,6 +681,22 @@
             "schema": {
               "type": "string",
               "title": "Agent Id"
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
             }
           },
           {
@@ -1118,6 +1214,22 @@
             }
           },
           {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
+            }
+          },
+          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -1204,6 +1316,22 @@
             }
           },
           {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
+            }
+          },
+          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -1287,6 +1415,22 @@
             "schema": {
               "type": "string",
               "title": "Agent Id"
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
             }
           },
           {
@@ -2723,6 +2867,13 @@
           "count": {
             "type": "integer",
             "title": "Count"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings"
           }
         },
         "type": "object",

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -88,22 +88,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -117,6 +101,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -190,22 +190,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -219,6 +203,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -301,22 +301,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -330,6 +314,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -408,22 +408,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -437,6 +421,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -498,22 +498,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -527,6 +511,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -684,22 +684,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -713,6 +697,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -1214,22 +1214,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -1243,6 +1227,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -1316,22 +1316,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -1345,6 +1329,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -1418,22 +1418,6 @@
             }
           },
           {
-            "name": "api_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Api Key"
-            }
-          },
-          {
             "name": "x-session-token",
             "in": "header",
             "required": false,
@@ -1447,6 +1431,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -298,3 +298,46 @@ class TestDataDirRouting:
         result = app_config.get_data_dir()
         assert result == tmp_path / ".memanto" / "on-prem"
         assert result.exists()
+
+
+class TestExportDataDirRouting:
+    def test_export_cache_is_isolated_by_backend(self, tmp_path, monkeypatch):
+        from memanto.app import config as app_config
+        from memanto.app.services.memory_export_service import MemoryExportService
+        from memanto.cli.client.direct_client import DirectClient
+        from memanto.cli.client.sdk_client import SdkClient
+
+        monkeypatch.setattr(app_config.settings, "MEMANTO_BACKEND", "on-prem")
+        monkeypatch.setattr(app_config.Path, "home", classmethod(lambda cls: tmp_path))
+
+        cloud_cache = tmp_path / ".memanto" / "exports" / "agent-1_memory.md"
+        cloud_cache.parent.mkdir(parents=True)
+        cloud_cache.write_text("# cloud export", encoding="utf-8")
+
+        on_prem_cache = (
+            tmp_path / ".memanto" / "on-prem" / "exports" / "agent-1_memory.md"
+        )
+        on_prem_cache.parent.mkdir(parents=True)
+        on_prem_cache.write_text("# on-prem export", encoding="utf-8")
+
+        assert MemoryExportService().exports_dir == on_prem_cache.parent
+
+        for client_cls in (DirectClient, SdkClient):
+            client = client_cls(api_key="dummy-key")
+            export_calls = []
+            monkeypatch.setattr(
+                client,
+                "export_memory_md",
+                lambda export_calls=export_calls, **kwargs: export_calls.append(kwargs)
+                or {"output_path": str(on_prem_cache)},
+            )
+            project_dir = tmp_path / "projects" / client_cls.__name__
+
+            result = client.sync_memory_to_project("agent-1", str(project_dir))
+
+            assert result["source"] == "cache"
+            assert not export_calls
+            assert (project_dir / "MEMORY.md").read_text(encoding="utf-8") == (
+                "# on-prem export"
+            )
+            assert cloud_cache.read_text(encoding="utf-8") == "# cloud export"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,10 +180,13 @@ class TestMEMANTOCLI:
 
     def test_agent_list(self, mock_all_clients):
         """Test 'memanto agent list'"""
-        mock_all_clients.list_agents.return_value = [
-            {"agent_id": "agent-1", "pattern": "support", "description": "Desc 1"},
-            {"agent_id": "agent-2", "pattern": "tool", "description": "Desc 2"},
-        ]
+        mock_all_clients.list_agents.return_value = {
+            "agents": [
+                {"agent_id": "agent-1", "pattern": "support", "description": "Desc 1"},
+                {"agent_id": "agent-2", "pattern": "tool", "description": "Desc 2"},
+            ],
+            "warnings": [],
+        }
 
         result = runner.invoke(app, ["agent", "list"])
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,8 +131,18 @@ class TestMEMANTOCLI:
         assert result.exit_code == 0
         assert "Memory that AI Agents Love!" in result.stdout
 
-    def test_status_command(self, mock_all_clients):
+    @patch("memanto.cli.commands.core.httpx.get")
+    def test_status_command(self, mock_get, mock_all_clients):
         """Test 'memanto status'"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "healthy",
+            "version": "1.0.0",
+            "moorcheh_connected": True,
+        }
+        mock_get.return_value = mock_response
+
         # Status command might use helper functions, let's just check it runs
         result = runner.invoke(app, ["status"])
         assert result.exit_code == 0

--- a/tests/test_config_manager_setters.py
+++ b/tests/test_config_manager_setters.py
@@ -1,3 +1,5 @@
+import pytest
+
 from memanto.cli.config.manager import ConfigManager
 
 
@@ -41,3 +43,18 @@ def test_config_setters_recover_malformed_sections(tmp_path):
     assert data["answer"]["model"] == "local-model"
     assert data["answer"]["temperature"] == 0.2
     assert data["recall"] == {"limit": 7, "min_similarity": 0.4}
+
+
+@pytest.mark.parametrize("value", [float("nan"), "nan", float("inf"), "-inf"])
+def test_config_setters_reject_non_finite_floats(tmp_path, value):
+    manager = ConfigManager(config_dir=tmp_path)
+    manager.config_file.write_text("memanto:\n  recall:\n    limit: 7\n")
+    original_config = manager.config_file.read_text()
+
+    with pytest.raises(ValueError, match="temperature must be between"):
+        manager.set_answer_config(temperature=value)
+    assert manager.config_file.read_text() == original_config
+
+    with pytest.raises(ValueError, match="min_similarity must be between"):
+        manager.set_recall_config(min_similarity=value)
+    assert manager.config_file.read_text() == original_config

--- a/tests/test_export_resilience.py
+++ b/tests/test_export_resilience.py
@@ -88,6 +88,7 @@ class TestSyncUsesCacheFastPath:
             agent_id="test-agent", project_dir=str(project_dir)
         )
 
+        client.recall.assert_not_called()
         assert result["source"] == "cache"
         assert result["total_memories"] == 1
         written = (project_dir / "MEMORY.md").read_text(encoding="utf-8")
@@ -110,7 +111,13 @@ class TestSyncUsesCacheFastPath:
     ):
         client = _build_client(client_cls, monkeypatch, tmp_path)
 
+        # Patch get_data_dir in the specific client module to prove it's never reached
+        mock_get_data_dir = MagicMock()
+        monkeypatch.setattr(f"{client_cls.__module__}.get_data_dir", mock_get_data_dir)
+
         with pytest.raises(ValueError, match="invalid characters"):
             client.sync_memory_to_project(
                 agent_id="../outside", project_dir=str(tmp_path / "project")
             )
+
+        mock_get_data_dir.assert_not_called()

--- a/tests/test_export_resilience.py
+++ b/tests/test_export_resilience.py
@@ -69,14 +69,10 @@ class TestExportMemoryMdRefusesEmptyOnTotalFailure:
         assert result["total_memories"] > 0
 
 
-class TestSyncFallsBackToStaleCacheOnOutage:
-    """``sync_memory_to_project`` (SdkClient) always re-exports before
-    copying its cache. When the backend is briefly unreachable, it must
-    reuse the last good export rather than propagate the now-empty write —
-    or, if there is no prior export at all, surface the outage instead of
-    creating an empty ``MEMORY.md``."""
+class TestSyncUsesCacheFastPath:
+    """A cached export is copied without requiring a reachable backend."""
 
-    def test_stale_cache_used_when_backend_down(self, monkeypatch, tmp_path):
+    def test_cache_used_when_backend_down(self, monkeypatch, tmp_path):
         client = _build_client(SdkClient, monkeypatch, tmp_path)
 
         cache_file = tmp_path / ".memanto" / "exports" / "test-agent_memory.md"
@@ -92,7 +88,7 @@ class TestSyncFallsBackToStaleCacheOnOutage:
             agent_id="test-agent", project_dir=str(project_dir)
         )
 
-        assert result["source"] == "stale-cache"
+        assert result["source"] == "cache"
         assert result["total_memories"] == 1
         written = (project_dir / "MEMORY.md").read_text(encoding="utf-8")
         assert "good content" in written
@@ -106,4 +102,15 @@ class TestSyncFallsBackToStaleCacheOnOutage:
         with pytest.raises(ConnectionError):
             client.sync_memory_to_project(
                 agent_id="test-agent", project_dir=str(tmp_path / "project")
+            )
+
+    @pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+    def test_rejects_path_traversal_before_cache_lookup(
+        self, client_cls, monkeypatch, tmp_path
+    ):
+        client = _build_client(client_cls, monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="invalid characters"):
+            client.sync_memory_to_project(
+                agent_id="../outside", project_dir=str(tmp_path / "project")
             )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -345,6 +345,29 @@ class TestAgentService:
 
         print(f"✅ Listed {agent_list.count} agents")
 
+    def test_invalid_agent_metadata_handling(self, agent_service):
+        """Corrupt or invalid agent files must not hide valid agents, should report warnings, and behave like absent local state for lookups."""
+        agent_service.create_agent(
+            AgentCreate(agent_id="valid-agent", pattern=AgentPattern.SUPPORT),
+            settings.MOORCHEH_API_KEY,
+        )
+        
+        # JSONDecodeError (corrupt JSON)
+        (agent_service.agents_dir / "broken-agent.json").write_text("{")
+        assert agent_service.get_agent("broken-agent") is None
+
+        # ValidationError (missing required fields)
+        (agent_service.agents_dir / "broken-schema-agent.json").write_text('{"description": "missing agent_id and pattern"}')
+        assert agent_service.get_agent("broken-schema-agent") is None
+
+        agent_list = agent_service.list_agents()
+
+        assert agent_list.count == 1
+        assert [agent.agent_id for agent in agent_list.agents] == ["valid-agent"]
+        assert len(agent_list.warnings) == 2
+        assert any("broken-agent.json" in w for w in agent_list.warnings)
+        assert any("broken-schema-agent.json" in w for w in agent_list.warnings)
+
     def test_get_agent(self, agent_service):
         """Test getting agent info"""
         # Create agent

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
+from pathlib import Path
 
 from memanto.app.config import settings
 from memanto.app.core import MemoryRecord
@@ -1471,3 +1472,47 @@ def test_batch_upload_error_counts_each_pending_memory_as_failed():
     assert all(
         "Batch upload returned status" in item["error"] for item in result["results"]
     )
+def test_direct_sync_refreshes_cached_export_before_copy(tmp_path, monkeypatch):
+    from memanto.cli.client.direct_client import DirectClient
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    cache_dir = tmp_path / ".memanto" / "exports"
+    cache_dir.mkdir(parents=True)
+    cache_path = cache_dir / "agent-1_memory.md"
+    cache_path.write_text("# MEMORY\n\n### stale memory\n", encoding="utf-8")
+
+    client = DirectClient.__new__(DirectClient)
+    export_calls = []
+
+    def fresh_export(*, agent_id, limit_per_type):
+        export_calls.append((agent_id, limit_per_type))
+        cache_path.write_text(
+            "# MEMORY\n\n### current memory\n\n### newer memory\n",
+            encoding="utf-8",
+        )
+        return {
+            "output_path": str(cache_path),
+            "total_memories": 2,
+            "per_type_counts": {"learning": 2},
+        }
+
+    monkeypatch.setattr(client, "export_memory_md", fresh_export)
+
+    project_dir = tmp_path / "project"
+    result = client.sync_memory_to_project(
+        agent_id="agent-1",
+        project_dir=str(project_dir),
+        limit_per_type=7,
+    )
+
+    target = project_dir / "MEMORY.md"
+    assert export_calls == [("agent-1", 7)]
+    assert target.read_text(encoding="utf-8") == cache_path.read_text(encoding="utf-8")
+    assert "current memory" in target.read_text(encoding="utf-8")
+    assert "stale memory" not in target.read_text(encoding="utf-8")
+    assert result == {
+        "output_path": str(target.resolve()),
+        "total_memories": 2,
+        "source": "fresh",
+    }

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5,6 +5,7 @@ Tests the session and agent services directly without HTTP layer.
 """
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import jwt
@@ -1408,6 +1409,33 @@ class TestValidateSafeId:
         assert not (tmp_path / "etc").exists()
 
 
+
+@pytest.mark.parametrize(
+    ("agent_name", "is_global", "expected_suffix"),
+    [
+        ("cursor", True, ".cursor/rules/memanto.mdc"),
+        ("claude-code", True, ".claude/CLAUDE.md"),
+        ("windsurf", True, ".codeium/windsurf/.windsurfrules"),
+        ("cursor", False, "project/.cursor/rules/memanto.mdc"),
+    ],
+)
+def test_resolve_instruction_file_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    agent_name: str,
+    is_global: bool,
+    expected_suffix: str,
+) -> None:
+    """Test resolution of instruction file paths."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    from memanto.cli.connect.agent_registry import AGENT_REGISTRY
+    
+    project_dir = tmp_path / "project"
+    resolved = AGENT_REGISTRY[agent_name].resolve_instruction_file(project_dir, is_global=is_global)
+    
+    assert resolved == tmp_path / expected_suffix
+
+
 def test_memory_edit_rejects_oversized_source():
     from pydantic import ValidationError
 
@@ -1567,3 +1595,4 @@ def test_onprem_state_survives_interrupted_replace(tmp_path):
         "embedding_provider": "openai",
         "embedding_model": "text-embedding-3-small",
     }
+

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1539,3 +1539,31 @@ def test_direct_sync_refreshes_cached_export_before_copy(tmp_path, monkeypatch):
         "total_memories": 2,
         "source": "fresh",
     }
+
+def test_onprem_state_survives_interrupted_replace(tmp_path):
+    """An interrupted state replacement must preserve the previous file."""
+    from memanto.cli.config.manager import ConfigManager
+    from unittest.mock import patch
+    
+    manager = ConfigManager(tmp_path)
+    manager.set_onprem_state(
+        embedding_provider="openai",
+        embedding_model="text-embedding-3-small",
+    )
+    state_path = manager._onprem_state_path()
+    original = state_path.read_text(encoding="utf-8")
+
+    with (
+        patch(
+            "memanto.app.utils.atomic_write.os.replace",
+            side_effect=OSError("simulated interruption"),
+        ),
+        pytest.raises(OSError, match="simulated interruption"),
+    ):
+        manager.set_onprem_state(llm_model="qwen3:8b")
+
+    assert state_path.read_text(encoding="utf-8") == original
+    assert manager.get_onprem_state() == {
+        "embedding_provider": "openai",
+        "embedding_model": "text-embedding-3-small",
+    }

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
-from pathlib import Path
 
 from memanto.app.config import settings
 from memanto.app.core import MemoryRecord
@@ -352,13 +351,15 @@ class TestAgentService:
             AgentCreate(agent_id="valid-agent", pattern=AgentPattern.SUPPORT),
             settings.MOORCHEH_API_KEY,
         )
-        
+
         # JSONDecodeError (corrupt JSON)
         (agent_service.agents_dir / "broken-agent.json").write_text("{")
         assert agent_service.get_agent("broken-agent") is None
 
         # ValidationError (missing required fields)
-        (agent_service.agents_dir / "broken-schema-agent.json").write_text('{"description": "missing agent_id and pattern"}')
+        (agent_service.agents_dir / "broken-schema-agent.json").write_text(
+            '{"description": "missing agent_id and pattern"}'
+        )
         assert agent_service.get_agent("broken-schema-agent") is None
 
         agent_list = agent_service.list_agents()
@@ -1409,7 +1410,6 @@ class TestValidateSafeId:
         assert not (tmp_path / "etc").exists()
 
 
-
 @pytest.mark.parametrize(
     ("agent_name", "is_global", "expected_suffix"),
     [
@@ -1429,10 +1429,12 @@ def test_resolve_instruction_file_paths(
     """Test resolution of instruction file paths."""
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     from memanto.cli.connect.agent_registry import AGENT_REGISTRY
-    
+
     project_dir = tmp_path / "project"
-    resolved = AGENT_REGISTRY[agent_name].resolve_instruction_file(project_dir, is_global=is_global)
-    
+    resolved = AGENT_REGISTRY[agent_name].resolve_instruction_file(
+        project_dir, is_global=is_global
+    )
+
     assert resolved == tmp_path / expected_suffix
 
 
@@ -1523,7 +1525,9 @@ def test_batch_upload_error_counts_each_pending_memory_as_failed():
     assert all(
         "Batch upload returned status" in item["error"] for item in result["results"]
     )
-def test_direct_sync_refreshes_cached_export_before_copy(tmp_path, monkeypatch):
+
+
+def test_direct_sync_uses_cached_export_fast_path(tmp_path, monkeypatch):
     from memanto.cli.client.direct_client import DirectClient
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -1558,21 +1562,22 @@ def test_direct_sync_refreshes_cached_export_before_copy(tmp_path, monkeypatch):
     )
 
     target = project_dir / "MEMORY.md"
-    assert export_calls == [("agent-1", 7)]
+    assert export_calls == []
     assert target.read_text(encoding="utf-8") == cache_path.read_text(encoding="utf-8")
-    assert "current memory" in target.read_text(encoding="utf-8")
-    assert "stale memory" not in target.read_text(encoding="utf-8")
+    assert "stale memory" in target.read_text(encoding="utf-8")
     assert result == {
         "output_path": str(target.resolve()),
-        "total_memories": 2,
-        "source": "fresh",
+        "total_memories": 1,
+        "source": "cache",
     }
+
 
 def test_onprem_state_survives_interrupted_replace(tmp_path):
     """An interrupted state replacement must preserve the previous file."""
-    from memanto.cli.config.manager import ConfigManager
     from unittest.mock import patch
-    
+
+    from memanto.cli.config.manager import ConfigManager
+
     manager = ConfigManager(tmp_path)
     manager.set_onprem_state(
         embedding_provider="openai",
@@ -1595,4 +1600,3 @@ def test_onprem_state_survives_interrupted_replace(tmp_path):
         "embedding_provider": "openai",
         "embedding_model": "text-embedding-3-small",
     }
-


### PR DESCRIPTION
- Stack history stat cards on narrow viewports (mobile) #1386
- Surface corrupted agent files as warnings in list payload #1404 
- fix: isolate export caches between on-prem and cloud #1460
- Make config persistence crash-safe #1484
- Avoid duplicated global instruction paths (e.g .cursor/.cursor) #1486
- Langgraph remove rate-limit fallback to error instead
- Update repeated store keys over duplicating #1495
- MCP restrict automatic agent creation for non-default agents #1503
- Clean up typescript lifecycle signal listeners (memory leaks, hangs) #1522 
- Fix agent creation race condition for multiple threads #1641 
- Reject NaN and infinity in persisted float configuration #1682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory saves now update existing entries (upsert) instead of creating duplicates.
  * Project memory syncing uses cached exports first for faster results.
  * Agent listings can include warnings for invalid or unreadable metadata.
  * API operations accept the API key via `X-Api-Key` header when provided.
  * Local state and configuration persistence is now more crash-safe.

* **Bug Fixes**
  * Restricted automatic agent creation to the configured default agent.
  * Improved handling of corrupted agent metadata and more resilient writes.
  * Added validation against unsafe agent identifiers and non-finite numeric settings.
  * Improved mobile display by hiding secondary history statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->