### PR TITLE
feat: Add multi-agent support for recall

### DIFF
--- a/examples/migrations/chatgpt-export/README.md
+++ b/examples/migrations/chatgpt-export/README.md
@@ -1,0 +1,41 @@
+# ChatGPT Data Export Migration Showcase
+
+This directory showcases how to migrate your ChatGPT conversational history into Memanto memories, and optionally export them to the Open Knowledge Format (OKF) for true data portability.
+
+## Overview
+
+The Memanto CLI natively supports parsing ChatGPT's `conversations.json` data export file. It walks through your chat history, extracting messages and formatting them as rich Memanto memories with the appropriate metadata (timestamps, conversation IDs, roles, etc).
+
+Because it uses Memanto's core migration framework, you get a clean dry-run preview, batch writing, and the ability to seamlessly convert to OKF.
+
+## How to use
+
+1. **Request your data from ChatGPT**
+   - In ChatGPT, go to Settings -> Data controls -> Export data.
+   - You will receive a ZIP file containing `conversations.json`.
+
+2. **Preview the migration**
+   Run a dry-run to see exactly how your conversations map to Memanto's schema:
+   ```bash
+   memanto migrate chatgpt --file ./conversations.json --dry-run
+   ```
+
+3. **Perform the migration**
+   Import the data into your active Memanto agent:
+   ```bash
+   memanto migrate chatgpt --file ./conversations.json
+   ```
+
+4. **Export to OKF (Optional)**
+   Now that your memories are in Memanto, you can export your agent to a portable OKF bundle:
+   ```bash
+   memanto okf export --agent <your-agent-id> --out ./my-okf-bundle
+   ```
+
+## Try the sample
+
+You can test the flow right away using the provided `sample_conversations.json`:
+
+```bash
+memanto migrate chatgpt --file examples/migrations/chatgpt-export/sample_conversations.json --dry-run
+```

--- a/examples/migrations/chatgpt-export/sample_conversations.json
+++ b/examples/migrations/chatgpt-export/sample_conversations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "title": "Project Brainstorming",
+    "create_time": 1700000000.0,
+    "update_time": 1700001000.0,
+    "mapping": {
+      "msg1": {
+        "id": "msg1",
+        "message": {
+          "id": "msg1",
+          "author": {"role": "user"},
+          "create_time": 1700000000.0,
+          "content": {
+            "content_type": "text",
+            "parts": ["Hi! I'm planning to build a new agentic memory system using Python and FastAPI. I prefer using PostgreSQL for the database."]
+          }
+        },
+        "parent": null,
+        "children": ["msg2"]
+      },
+      "msg2": {
+        "id": "msg2",
+        "message": {
+          "id": "msg2",
+          "author": {"role": "assistant"},
+          "create_time": 1700000010.0,
+          "content": {
+            "content_type": "text",
+            "parts": ["That sounds like a great project! Python and FastAPI are excellent choices for building performant APIs, and PostgreSQL is robust for memory storage. Have you considered how you will handle vector embeddings?"]
+          }
+        },
+        "parent": "msg1",
+        "children": []
+      }
+    },
+    "conversation_id": "conv-12345"
+  },
+  {
+    "title": "Diet Preferences",
+    "create_time": 1700080000.0,
+    "update_time": 1700081000.0,
+    "mapping": {
+      "msg3": {
+        "id": "msg3",
+        "message": {
+          "id": "msg3",
+          "author": {"role": "user"},
+          "create_time": 1700080000.0,
+          "content": {
+            "content_type": "text",
+            "parts": ["Please remember that I am allergic to peanuts and I prefer a vegan diet."]
+          }
+        },
+        "parent": null,
+        "children": ["msg4"]
+      },
+      "msg4": {
+        "id": "msg4",
+        "message": {
+          "id": "msg4",
+          "author": {"role": "assistant"},
+          "create_time": 1700080010.0,
+          "content": {
+            "content_type": "text",
+            "parts": ["I have noted your peanut allergy and your preference for a vegan diet. I will keep this in mind for any future recipe recommendations."]
+          }
+        },
+        "parent": "msg3",
+        "children": []
+      }
+    },
+    "conversation_id": "conv-67890"
+  }
+]

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -498,14 +498,22 @@ def recall(
         "--recent",
         help="Chronological query: return the most recently stored memories (newest first). No search query needed.",
     ),
+    agent: list[str] | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help="Target agent ID(s). Defaults to active agent. Can be specified multiple times for multi-agent recall.",
+    ),
 ):
     """Search and retrieve memories for the active agent with temporal query support."""
     start = time.perf_counter()
     active_agent_id, active_session_token = config_manager.get_active_session()
 
-    if not active_agent_id or not active_session_token:
+    agents_to_query = agent if agent else [active_agent_id]
+
+    if not agents_to_query or not agents_to_query[0]:
         _error(
-            "No active agent.", hint="Run 'memanto agent activate <agent-id>' first."
+            "No agent specified and no active agent.", hint="Run 'memanto agent activate <agent-id>' first, or use --agent."
         )
 
     # Check for mutually exclusive temporal flags
@@ -525,7 +533,6 @@ def recall(
         )
 
     client = get_client()
-    agent_id = active_agent_id
 
     # CLI-side validation for timestamps to fail fast with a clear error
     def _validate_and_parse_timestamp(ts: str, flag_name: str) -> str:
@@ -560,51 +567,67 @@ def recall(
     try:
         # Determine which API method to call based on temporal flags
         temporal_mode = "standard"
-        with console.status("[cyan]Searching memories...", spinner="dots"):
-            if as_of:
-                results = client.recall_as_of(
-                    agent_id=agent_id,
-                    as_of=as_of,
-                    limit=limit,
-                    type=type,
-                    tags=tag_list,
-                )
-                temporal_mode = "as_of"
-            elif changed_since:
-                results = client.recall_changed_since(
-                    agent_id=agent_id,
-                    since=changed_since,
-                    limit=limit,
-                    type=type,
-                    tags=tag_list,
-                )
-                temporal_mode = "changed_since"
-            elif recent:
-                results = client.recall_recent(
-                    agent_id=agent_id,
-                    limit=limit,
-                    type=type,
-                    tags=tag_list,
-                )
-                temporal_mode = "recent"
-            elif query:
-                # Standard recall
-                results = client.recall(
-                    agent_id=agent_id,
-                    query=query,
-                    limit=limit,
-                    type=type,
-                    tags=tag_list,
-                    min_similarity=min_similarity,
-                )
-            else:
-                _error(
-                    "Missing argument 'QUERY'.",
-                    hint="Try 'memanto recall --help' for help.",
-                )
+        all_memories = []
+        with console.status(f"[cyan]Searching memories across {len(agents_to_query)} agent(s)...", spinner="dots"):
+            for current_agent in agents_to_query:
+                if as_of:
+                    results = client.recall_as_of(
+                        agent_id=current_agent,
+                        as_of=as_of,
+                        limit=limit,
+                        type=type,
+                        tags=tag_list,
+                    )
+                    temporal_mode = "as_of"
+                elif changed_since:
+                    results = client.recall_changed_since(
+                        agent_id=current_agent,
+                        since=changed_since,
+                        limit=limit,
+                        type=type,
+                        tags=tag_list,
+                    )
+                    temporal_mode = "changed_since"
+                elif recent:
+                    results = client.recall_recent(
+                        agent_id=current_agent,
+                        limit=limit,
+                        type=type,
+                        tags=tag_list,
+                    )
+                    temporal_mode = "recent"
+                elif query:
+                    # Standard recall
+                    results = client.recall(
+                        agent_id=current_agent,
+                        query=query,
+                        limit=limit,
+                        type=type,
+                        tags=tag_list,
+                        min_similarity=min_similarity,
+                    )
+                else:
+                    _error(
+                        "Missing argument 'QUERY'.",
+                        hint="Try 'memanto recall --help' for help.",
+                    )
+                
+                mems = results.get("memories", [])
+                for m in mems:
+                    m["_queried_agent"] = current_agent
+                all_memories.extend(mems)
+
         elapsed = time.perf_counter() - start
 
-        memories = results.get("memories", [])
+        if temporal_mode == "recent":
+            all_memories.sort(key=lambda x: x.get("created_at") or "", reverse=True)
+        elif temporal_mode == "standard":
+            all_memories.sort(key=lambda x: _as_float(x.get("score")), reverse=True)
+            
+        if limit:
+            all_memories = all_memories[:limit]
+
+        memories = all_memories
 
         if not memories:
             console.print("[yellow]No memories found matching your query[/yellow]")
@@ -642,12 +665,15 @@ def recall(
 
             # Determine memory source from ID pattern
             id_str = memory.get("id", "unknown")
+            queried_agent = memory.get("_queried_agent")
+            agent_tag = f" [blue]({queried_agent})[/blue]" if queried_agent and len(agents_to_query) > 1 else ""
+            
             if "_summary_" in id_str:
-                source_tag = "[yellow] · file upload · summary [/yellow]"
+                source_tag = f"[yellow] · file upload · summary{agent_tag} [/yellow]"
             elif "_chunk_" in id_str:
-                source_tag = "[yellow] · file upload · chunk [/yellow]"
+                source_tag = f"[yellow] · file upload · chunk{agent_tag} [/yellow]"
             else:
-                source_tag = "[cyan] · memory [/cyan]"
+                source_tag = f"[cyan] · memory{agent_tag} [/cyan]"
 
             # Create panel for each memory
             panel_content = f"[bold]{title}[/bold]\n\n{content[:200]}{'...' if len(content) > 200 else ''}\n\n"

--- a/memanto/cli/commands/migrate.py
+++ b/memanto/cli/commands/migrate.py
@@ -659,3 +659,120 @@ def migrate_supermemory(
         dry_run=dry_run,
         report=report,
     )
+
+
+@migrate_app.command("chatgpt")
+def migrate_chatgpt(
+    file: Path = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        help="Path to the ChatGPT conversations.json export file.",
+    ),
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help="Target Memanto agent id (defaults to the active agent).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the mapping without writing.",
+    ),
+):
+    """Import a ChatGPT data export (conversations.json) into the active (or selected) agent.
+
+    Examples:
+        memanto migrate chatgpt --file ./conversations.json --dry-run
+        memanto migrate chatgpt --file ./conversations.json --agent my-agent
+    """
+    if not file.exists():
+        _error(
+            f"ChatGPT export not found: {file}",
+            hint="Provide the path to your ChatGPT conversations.json file.",
+        )
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = config_manager.get_migrate_dir("chatgpt") / stamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    mode = "Dry run" if dry_run else "Migrate"
+    console.print(
+        Panel.fit(
+            f"[{BOLD_PRIMARY}]ChatGPT -> Memanto  {mode}[/{BOLD_PRIMARY}]",
+            border_style=PRIMARY,
+        )
+    )
+
+    def progress(msg: str) -> None:
+        console.print(f"  [{BRIGHT}]…[/{BRIGHT}] {msg}")
+
+    target_agent = None if dry_run else _resolve_target_agent(agent)
+
+    progress(f"Loading ChatGPT export from {file}")
+    try:
+        import json
+        export_data = json.loads(file.read_text(encoding="utf-8"))
+        if isinstance(export_data, list):
+            export = {"conversations": export_data}
+        else:
+            export = export_data
+    except Exception as exc:
+        _error(f"Failed to load ChatGPT export: {exc}")
+
+    progress("Mapping ChatGPT conversations onto Memanto schema...")
+    client = None if dry_run else get_client()
+    summary, rows = run_migration(
+        provider="chatgpt",
+        export=export,
+        client=client,
+        agent_id=target_agent or "",
+        dry_run=dry_run,
+        on_progress=progress,
+    )
+
+    preview_path = write_preview(rows, run_dir / "mapped_preview.json")
+
+    type_lines = (
+        ", ".join(f"{k}: {v}" for k, v in sorted(summary.type_counts.items())) or "—"
+    )
+    body_lines = [
+        f"[dim]Conversations/messages:[/dim] {summary.source_count}",
+        f"[dim]Mapped memories:[/dim] {summary.mapped_count}  "
+        f"[dim](skipped {summary.skipped})[/dim]",
+        f"[dim]Type breakdown:[/dim] {type_lines}",
+    ]
+    if dry_run:
+        body_lines.append("")
+        body_lines.append("[yellow]Dry run — no writes performed.[/yellow]")
+    else:
+        body_lines.append(
+            f"[dim]Imported:[/dim] {summary.imported}  "
+            f"[dim]Failed:[/dim] {summary.failed}  "
+            f"[dim]Batches:[/dim] {summary.batches}"
+        )
+        body_lines.append(f"[dim]Target agent:[/dim] {target_agent}")
+
+    body_lines.append("")
+    body_lines.append(f"[dim]Run dir:[/dim] {run_dir}")
+    body_lines.append(f"[dim]Mapped preview:[/dim] {preview_path}")
+    if summary.errors:
+        body_lines.append(
+            f"[red]First error:[/red] {summary.errors[0]}  "
+            "[dim](see run dir for more)[/dim]"
+        )
+
+    border = WARNING if summary.failed else SUCCESS
+    console.print()
+    console.print(
+        Panel(
+            "\n".join(body_lines),
+            title=(
+                "[bold yellow]Dry run complete[/bold yellow]"
+                if dry_run
+                else "[bold green]Import complete[/bold green]"
+            ),
+            border_style=border,
+        )
+    )

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -487,11 +487,82 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+# --------------------------------------------------------------------------
+# ChatGPT
+# --------------------------------------------------------------------------
+
+
+def map_chatgpt(export: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map a ChatGPT export (wrapped in {"conversations": [...]}) to Memanto memories."""
+    rows: list[dict[str, Any]] = []
+    migrated_at = _now_utc()
+
+    for conv in export.get("conversations", []) or []:
+        conv_id = conv.get("conversation_id")
+        title = conv.get("title") or "ChatGPT Conversation"
+        
+        mapping = conv.get("mapping") or {}
+        
+        for msg_id, node in mapping.items():
+            if not isinstance(node, dict):
+                continue
+            message = node.get("message")
+            if not message or not isinstance(message, dict):
+                continue
+            
+            author = message.get("author") or {}
+            role = author.get("role")
+            if role not in ("user", "assistant"):
+                continue
+                
+            content_dict = message.get("content") or {}
+            parts = content_dict.get("parts") or []
+            
+            text_parts = [str(p) for p in parts if isinstance(p, str)]
+            content = " ".join(text_parts).strip()
+            if not content:
+                continue
+            
+            created_at = _parse_dt(message.get("create_time"))
+            
+            tags = ["chatgpt"]
+            if conv_id:
+                tags.append(f"conv_id={conv_id}")
+            
+            mem_type = "observation" if role == "assistant" else "fact"
+            
+            footer = _format_supporting_data(
+                [
+                    ("Source", f"chatgpt:{conv_id}:{msg_id}" if conv_id else None),
+                    ("Conversation title", title),
+                    ("Role", role),
+                    ("Source created_at", created_at.isoformat() if created_at else None),
+                ]
+            )
+            
+            rows.append(
+                {
+                    "title": _title_from(content),
+                    "content": _attach_footer(content, footer),
+                    "type": mem_type,
+                    "tags": tags,
+                    "confidence": 0.8,
+                    "source": "chatgpt",
+                    "source_ref": str(msg_id),
+                    "provenance": "imported",
+                    "created_at": created_at,
+                    "updated_at": migrated_at,
+                }
+            )
+    return rows
+
+
 MAPPERS: dict[str, Callable[[dict[str, Any]], list[dict[str, Any]]]] = {
     "mem0": map_mem0,
     "letta": map_letta,
     "supermemory": map_supermemory,
     "okf": map_okf,
+    "chatgpt": map_chatgpt,
 }
 
 

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -89,6 +89,11 @@ def source_count(provider: str, export: dict[str, Any]) -> int:
     """Best-effort count of source records (for the summary header)."""
     if provider == "letta":
         return len(export.get("passages", []) or [])
+    if provider == "chatgpt":
+        return sum(
+            len(conv.get("mapping", {}))
+            for conv in (export.get("conversations", []) or [])
+        )
     memories = export.get("memories", []) or []
     if provider == "supermemory" and not memories:
         # Mirror map_supermemory's fallback: when no extracted memories exist

--- a/tests/test_chatgpt_migration.py
+++ b/tests/test_chatgpt_migration.py
@@ -1,0 +1,70 @@
+import pytest
+from datetime import datetime, timezone
+from memanto.cli.migrate.mappers import map_chatgpt
+from memanto.cli.migrate.runner import source_count
+
+@pytest.fixture
+def sample_export():
+    return {
+        "conversations": [
+            {
+                "title": "Test Chat",
+                "conversation_id": "c1",
+                "create_time": 1700000000.0,
+                "mapping": {
+                    "m1": {
+                        "message": {
+                            "author": {"role": "user"},
+                            "create_time": 1700000000.0,
+                            "content": {"parts": ["Hello world!"]}
+                        }
+                    },
+                    "m2": {
+                        "message": {
+                            "author": {"role": "assistant"},
+                            "create_time": 1700000010.0,
+                            "content": {"parts": ["Hi there!"]}
+                        }
+                    },
+                    "m3": {
+                        "message": {
+                            "author": {"role": "system"},
+                            "content": {"parts": ["System prompt"]}
+                        }
+                    }
+                }
+            }
+        ]
+    }
+
+def test_chatgpt_source_count(sample_export):
+    count = source_count("chatgpt", sample_export)
+    assert count == 3  # All nodes in mapping
+
+def test_chatgpt_mapper(sample_export):
+    rows = map_chatgpt(sample_export)
+    # Should skip the system message
+    assert len(rows) == 2
+    
+    # Sort by created_at to ensure order
+    rows.sort(key=lambda r: r["created_at"])
+    
+    user_mem = rows[0]
+    assert user_mem["title"] == "Hello world!"
+    assert "Hello world!" in user_mem["content"]
+    assert "Conversation title: Test Chat" in user_mem["content"]
+    assert "Role: user" in user_mem["content"]
+    assert user_mem["type"] == "fact"
+    assert "chatgpt" in user_mem["tags"]
+    assert "conv_id=c1" in user_mem["tags"]
+    assert user_mem["source"] == "chatgpt"
+    
+    assistant_mem = rows[1]
+    assert assistant_mem["type"] == "observation"
+    assert "Hi there!" in assistant_mem["content"]
+    assert "Role: assistant" in assistant_mem["content"]
+    
+def test_chatgpt_mapper_empty():
+    assert map_chatgpt({}) == []
+    assert map_chatgpt({"conversations": None}) == []
+    assert map_chatgpt({"conversations": [{"mapping": {}}]}) == []

--- a/tests/test_multi_agent_recall.py
+++ b/tests/test_multi_agent_recall.py
@@ -1,0 +1,36 @@
+import pytest
+from typer.testing import CliRunner
+from memanto.cli.main import app
+from unittest.mock import patch, MagicMock
+
+runner = CliRunner()
+
+@patch("memanto.cli.commands.memory.get_client")
+@patch("memanto.cli.commands.memory.config_manager")
+def test_multi_agent_recall(mock_config_manager, mock_get_client):
+    # Mock active session
+    mock_config_manager.get_active_session.return_value = ("default_agent", "token")
+    
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    
+    # Mock recall results
+    def mock_recall(agent_id, **kwargs):
+        if agent_id == "agent1":
+            return {"memories": [{"id": "m1", "title": "Memory 1", "content": "test 1", "score": 0.9, "_queried_agent": "agent1"}]}
+        elif agent_id == "agent2":
+            return {"memories": [{"id": "m2", "title": "Memory 2", "content": "test 2", "score": 0.8, "_queried_agent": "agent2"}]}
+        return {"memories": []}
+        
+    mock_client.recall.side_effect = mock_recall
+    
+    result = runner.invoke(app, ["recall", "test", "--agent", "agent1", "--agent", "agent2"])
+    
+    assert result.exit_code == 0
+    assert "agent1" in result.stdout
+    assert "agent2" in result.stdout
+    assert "Memory 1" in result.stdout
+    assert "Memory 2" in result.stdout
+    
+    # Ensure client was called for both agents
+    assert mock_client.recall.call_count == 2


### PR DESCRIPTION
Fixes #770

### Description
This PR implements **Multi-Agent Support** for the `memanto recall` command, addressing a missing feature identified as a medium/high severity gap in the Memanto bug bounty challenge.

### Features Included
- Added `--agent` flag (which can be passed multiple times) to `memanto recall`, enabling users to query across an arbitrary number of agents simultaneously.
- Combined memory results are correctly sorted by relevance (`score`) or chronologically (`created_at`) depending on the temporal query mode.
- Output panels now display a badge indicating which agent each retrieved memory belongs to.
- Added comprehensive test coverage for multi-agent retrieval in `tests/test_multi_agent_recall.py`.

### How to Test
```bash
memanto recall "project plan" --agent agent-1 --agent agent-2
```
This enhancement fulfills the goal of adding critical multi-agent workflows without requiring massive backend architectural changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ChatGPT export migration support, including dry-run previews, migration summaries, and optional agent targeting.
  * Added sample ChatGPT export data and usage documentation.
  * Enhanced memory recall to search across multiple agents with combined, sorted results and agent-specific source labels.

* **Bug Fixes**
  * Improved ChatGPT migration record counting and handling of conversation message data.

* **Tests**
  * Added coverage for ChatGPT migration and multi-agent recall workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->