### PR TITLE
fix(conflicts): resolving a conflict from the Web UI deletes another conflict's memories (#770)

### DIFF
--- a/examples/crewai-memory/run_contradiction.py
+++ b/examples/crewai-memory/run_contradiction.py
@@ -116,11 +116,16 @@ def main() -> None:
             print(
                 "Step 6: Resolving conflict (keeping the newer, higher-confidence value)..."
             )
+            # list_conflicts() returns unresolved conflicts only, so address the
+            # report by the conflict_index it hands back — never by position.
+            target = conflicts[0]
             resolve_result = client.resolve_conflict(
                 agent_id=AGENT_ID,
                 date=today,
-                conflict_index=0,
+                conflict_index=target.get("conflict_index", 0),
                 action="keep_new",
+                expected_old_memory_id=target.get("old_memory_id"),
+                expected_new_memory_id=target.get("new_memory_id"),
             )
             print(f"  Resolution: {resolve_result.get('status', 'resolved')}")
         else:

--- a/examples/langgraph-memanto/memanto_base_store/run_contradiction.py
+++ b/examples/langgraph-memanto/memanto_base_store/run_contradiction.py
@@ -111,12 +111,17 @@ async def main() -> None:
         print()
 
         # Step 6: Resolve by keeping the newer memory.
+        # list_conflicts() returns unresolved conflicts only, so address the
+        # report by the conflict_index it hands back — never by position here.
         print("Step 6: Resolve conflict (keep_new - the recent stomach issue)...")
+        target = conflicts[0]
         resolved = client.resolve_conflict(
             agent_id=agent_id,
             date=today,
-            conflict_index=0,
+            conflict_index=target.get("conflict_index", 0),
             action="keep_new",
+            expected_old_memory_id=target.get("old_memory_id"),
+            expected_new_memory_id=target.get("new_memory_id"),
         )
         print(f"  Resolution status: {resolved.get('status', 'resolved')}\n")
 

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -187,7 +187,16 @@ class ExtractMemoriesRequest(BaseModel):
 class ConflictResolveRequest(BaseModel):
     """Request body for resolving a conflict"""
 
-    conflict_index: int = Field(..., ge=0, description="Conflict index to resolve")
+    conflict_index: int = Field(
+        ...,
+        ge=0,
+        description=(
+            "Index of the conflict to resolve. Use the 'conflict_index' field "
+            "of the entry returned by GET /conflicts — that response contains "
+            "only unresolved conflicts, so its own ordering is not the index "
+            "the report is addressed by."
+        ),
+    )
     action: Literal["keep_old", "keep_new", "keep_both", "remove_both", "manual"] = (
         Field(
             ...,
@@ -204,6 +213,18 @@ class ConflictResolveRequest(BaseModel):
     )
     manual_type: str | None = Field(
         None, description="Optional memory type for manual action"
+    )
+    expected_old_memory_id: str | None = Field(
+        None,
+        description=(
+            "Optional guard: the old_memory_id the caller reviewed. When set, "
+            "the resolution is rejected (400) before any memory is deleted if "
+            "the stored conflict does not match."
+        ),
+    )
+    expected_new_memory_id: str | None = Field(
+        None,
+        description="Optional guard for new_memory_id, see expected_old_memory_id.",
     )
 
     @model_validator(mode="after")

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -1149,6 +1149,12 @@ async def resolve_conflict(
     Resolve a conflict for an agent.
 
     Uses the same underlying conflict resolution service used by CLI.
+
+    ``conflict_index`` is the ``conflict_index`` field of an entry returned by
+    ``GET /{agent_id}/conflicts``, not that response's own ordering (it lists
+    unresolved conflicts only). Pass ``expected_old_memory_id`` /
+    ``expected_new_memory_id`` to have the call rejected before any deletion if
+    the index no longer addresses the reviewed conflict.
     """
     enforce_session_scope(session, agent_id)
 
@@ -1163,6 +1169,8 @@ async def resolve_conflict(
             request.action,
             request.manual_content,
             request.manual_type,
+            request.expected_old_memory_id,
+            request.expected_new_memory_id,
         )
         return {
             "agent_id": agent_id,

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -687,6 +687,13 @@ async def resolve_conflict(body: dict, _: None = Depends(_require_local)):
     """
     Resolve a single conflict.
     Expects: {"agent_id": "...", "date": "...", "conflict_index": 0, "action": "keep_old"|"keep_new"|"keep_both"|"remove_both"|"manual", "manual_content": "..."}
+
+    ``conflict_index`` must be the ``conflict_index`` field of the entry from
+    ``GET /api/ui/conflicts`` — that response contains only unresolved
+    conflicts, so its own ordering is not the index the report uses.
+    ``expected_old_memory_id`` / ``expected_new_memory_id`` are optional and
+    make the resolve fail closed if the index no longer points at the conflict
+    the caller reviewed (e.g. the report was regenerated in the meantime).
     """
     agent_id = str(body.get("agent_id", ""))
     date = str(body.get("date", ""))
@@ -698,6 +705,12 @@ async def resolve_conflict(body: dict, _: None = Depends(_require_local)):
     manual_type = body.get("manual_type")
     if manual_type is not None:
         manual_type = str(manual_type)
+    expected_old_memory_id = body.get("expected_old_memory_id")
+    if expected_old_memory_id is not None:
+        expected_old_memory_id = str(expected_old_memory_id)
+    expected_new_memory_id = body.get("expected_new_memory_id")
+    if expected_new_memory_id is not None:
+        expected_new_memory_id = str(expected_new_memory_id)
 
     if not all([agent_id, date, action]) or conflict_index is None:
         raise HTTPException(
@@ -717,6 +730,8 @@ async def resolve_conflict(body: dict, _: None = Depends(_require_local)):
             action=action,
             manual_content=manual_content,
             manual_type=manual_type,
+            expected_old_memory_id=expected_old_memory_id,
+            expected_new_memory_id=expected_new_memory_id,
         )
         return result
     except ValueError as e:

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -4429,9 +4429,17 @@
             const ctype = (c.type || 'conflict').toUpperCase();
             const explanation = c.explanation || c.reason || 'Conflicting information detected.';
 
+            // The conflict report is addressed by position in the FULL list, but
+            // /api/ui/conflicts returns only the unresolved entries. Resolving by
+            // this card's position would delete the memories of a different
+            // conflict as soon as one earlier conflict is resolved, so always use
+            // the server-supplied conflict_index (position is a legacy fallback).
+            const idx = Number.isInteger(c.conflict_index) ? c.conflict_index : i;
+            const expected = { old_memory_id: c.old_memory_id, new_memory_id: c.new_memory_id };
+
             const card = document.createElement('div');
             card.className = 'conflict-card';
-            card.id = `conflict-${i}`;
+            card.id = `conflict-${idx}`;
 
             const header = document.createElement('div');
             header.className = 'conflict-header';
@@ -4446,7 +4454,7 @@
             headerLeft.append(typeSpan, badge);
             const indexSpan = document.createElement('span');
             indexSpan.style.cssText = 'font-size:11px;color:var(--text-dim);font-family:var(--font-mono)';
-            indexSpan.textContent = `#${i}`;
+            indexSpan.textContent = `#${idx}`;
             header.append(headerLeft, indexSpan);
 
             const expl = document.createElement('p');
@@ -4487,22 +4495,22 @@
             const actions = document.createElement('div');
             actions.className = 'conflict-actions';
             actions.append(
-                conflictActionBtn('Keep Old', 'btn-secondary', () => resolveConflict(i, rawAgentId, rawDate, 'keep_old')),
-                conflictActionBtn('Keep New', 'btn-primary', () => resolveConflict(i, rawAgentId, rawDate, 'keep_new')),
-                conflictActionBtn('Keep Both', 'btn-secondary', () => resolveConflict(i, rawAgentId, rawDate, 'keep_both')),
-                conflictActionBtn('Remove Both', 'btn-danger', () => resolveConflict(i, rawAgentId, rawDate, 'remove_both')),
-                conflictActionBtn('Manual', 'btn-secondary', () => showManualResolve(i)),
+                conflictActionBtn('Keep Old', 'btn-secondary', () => resolveConflict(idx, rawAgentId, rawDate, 'keep_old', null, expected)),
+                conflictActionBtn('Keep New', 'btn-primary', () => resolveConflict(idx, rawAgentId, rawDate, 'keep_new', null, expected)),
+                conflictActionBtn('Keep Both', 'btn-secondary', () => resolveConflict(idx, rawAgentId, rawDate, 'keep_both', null, expected)),
+                conflictActionBtn('Remove Both', 'btn-danger', () => resolveConflict(idx, rawAgentId, rawDate, 'remove_both', null, expected)),
+                conflictActionBtn('Manual', 'btn-secondary', () => showManualResolve(idx)),
             );
 
             const manual = document.createElement('div');
-            manual.id = `manual-${i}`;
+            manual.id = `manual-${idx}`;
             manual.style.cssText = 'display:none;margin-top:12px';
             const formGroup = document.createElement('div');
             formGroup.className = 'form-group';
             const manualLabel = document.createElement('label');
             manualLabel.textContent = 'Manual Replacement Content';
             const textarea = document.createElement('textarea');
-            textarea.id = `manualContent-${i}`;
+            textarea.id = `manualContent-${idx}`;
             textarea.placeholder = 'Enter the correct merged content...';
             textarea.style.minHeight = '60px';
             formGroup.append(manualLabel, textarea);
@@ -4513,7 +4521,7 @@
                     textarea.focus();
                     return;
                 }
-                resolveConflict(i, rawAgentId, rawDate, 'manual', content);
+                resolveConflict(idx, rawAgentId, rawDate, 'manual', content, expected);
             });
             manual.append(formGroup, submitBtn);
 
@@ -4579,11 +4587,16 @@
             el.style.display = el.style.display === 'none' ? 'block' : 'none';
         }
 
-        async function resolveConflict(idx, agentId, date, action, manualContent) {
+        async function resolveConflict(idx, agentId, date, action, manualContent, expected) {
             const card = document.getElementById(`conflict-${idx}`);
             try {
                 const body = { agent_id: agentId, date, conflict_index: idx, action };
                 if (manualContent) body.manual_content = manualContent;
+                // Send the memory ids this card was rendered from so the server
+                // refuses the resolve if the report changed under us instead of
+                // deleting memories from a conflict the user never saw.
+                if (expected && expected.old_memory_id) body.expected_old_memory_id = expected.old_memory_id;
+                if (expected && expected.new_memory_id) body.expected_new_memory_id = expected.new_memory_id;
                 await api('POST', '/api/ui/conflicts/resolve', body);
                 toast(`Conflict #${idx} resolved (${action})!`);
                 card.style.opacity = '0.3';

--- a/memanto/app/utils/conflicts.py
+++ b/memanto/app/utils/conflicts.py
@@ -1,0 +1,89 @@
+"""Shared helpers for the conflict report contract.
+
+The conflict report on disk (``~/.memanto/conflicts/{agent}_{date}_conflicts.json``)
+is a positional list: resolutions address a conflict by its index in that
+list. ``list_conflicts`` however returns only the *unresolved* entries, so the
+position of a conflict in a list response is not its index in the report —
+they diverge as soon as one conflict has been resolved.
+
+Resolving a conflict deletes memories and deletion is not reversible, so the
+index has to travel with the data (:func:`attach_conflict_indices`) and the
+destructive call has to be able to verify it is about to act on the conflict
+the caller actually reviewed (:func:`verify_conflict_target`).
+
+Both CLI clients (``DirectClient``, ``SdkClient``) use these helpers so the two
+code paths cannot drift apart.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CONFLICT_INDEX_FIELD = "conflict_index"
+
+
+def attach_conflict_indices(
+    all_conflicts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return the unresolved conflicts, each tagged with its report index.
+
+    The returned dicts are shallow copies, so callers cannot accidentally
+    write the added field back into the report file.
+
+    Any ``conflict_index`` already present in the file is overwritten: the
+    report is generated from LLM output, and a stray key must never be able to
+    redirect a destructive resolve to a different conflict.
+    """
+    return [
+        {**conflict, CONFLICT_INDEX_FIELD: index}
+        for index, conflict in enumerate(all_conflicts)
+        if not conflict.get("resolved", False)
+    ]
+
+
+def verify_conflict_target(
+    conflict: dict[str, Any],
+    conflict_index: int,
+    expected_old_memory_id: str | None = None,
+    expected_new_memory_id: str | None = None,
+) -> None:
+    """Fail closed before a resolution deletes anything.
+
+    Rejects the call when the addressed conflict was already resolved, or when
+    a caller-supplied expected memory id does not match the stored conflict
+    (which means the index no longer points at the reviewed conflict — e.g.
+    the caller numbered a filtered list, or the report was regenerated between
+    listing and resolving).
+
+    Args:
+        conflict: The conflict entry addressed by ``conflict_index``.
+        conflict_index: Index used to address it, for the error message.
+        expected_old_memory_id: Optional expected ``old_memory_id``.
+        expected_new_memory_id: Optional expected ``new_memory_id``.
+
+    Raises:
+        ValueError: If the conflict is already resolved or an expected id
+            does not match.
+    """
+    if conflict.get("resolved", False):
+        raise ValueError(
+            f"Conflict {conflict_index} is already resolved "
+            f"(resolution: {conflict.get('resolution') or 'unknown'}). "
+            "Re-list conflicts and use the 'conflict_index' field of the entry "
+            "you want to resolve."
+        )
+
+    for label, expected in (
+        ("old_memory_id", expected_old_memory_id),
+        ("new_memory_id", expected_new_memory_id),
+    ):
+        if expected is None:
+            continue
+        actual = conflict.get(label)
+        if actual != expected:
+            raise ValueError(
+                f"Conflict {conflict_index} does not match the reviewed conflict: "
+                f"expected {label}={expected!r}, report has {actual!r}. "
+                "Re-list conflicts and use the 'conflict_index' field of the "
+                "entry you want to resolve."
+            )

--- a/memanto/app/utils/conflicts.py
+++ b/memanto/app/utils/conflicts.py
@@ -17,9 +17,66 @@ code paths cannot drift apart.
 
 from __future__ import annotations
 
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 
 CONFLICT_INDEX_FIELD = "conflict_index"
+
+
+@contextmanager
+def conflict_report_lock(json_path: Path) -> Iterator[None]:
+    """Serialize one report's whole resolve transaction across processes.
+
+    Resolution is read-validate-delete-persist. Without a lock two concurrent
+    resolves (two terminals, a CLI call racing the Web UI) can both read
+    ``resolved=False``, both delete memories, and then each write back its own
+    snapshot — so the last writer erases the other's ``resolved`` marker and
+    the already-resolved guard no longer protects a later retry.
+
+    Uses an advisory ``flock`` on a sidecar ``.lock`` file so the lock spans
+    processes, not just threads. Platforms without ``fcntl`` (Windows) fall
+    back to no locking rather than failing the resolve: the guards inside the
+    transaction still apply, they just are not atomic there.
+    """
+    lock_path = json_path.parent / (json_path.name + ".lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "a+")  # noqa: SIM115 - released in finally
+    except OSError:
+        # Cannot create the lock file (read-only dir, etc.) — do not block the
+        # resolve on it; the in-transaction guards are unchanged.
+        yield
+        return
+
+    try:
+        try:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        except (ImportError, OSError):
+            pass
+        yield
+    finally:
+        try:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except (ImportError, OSError):
+            pass
+        handle.close()
+
+
+def conflict_report_lock_path(json_path: Path) -> Path:
+    """Return the sidecar lock path used for ``json_path`` (for tests/cleanup)."""
+    return json_path.parent / (json_path.name + ".lock")
+
+
+def is_conflict_report_locking_available() -> bool:
+    """Whether advisory cross-process locking is available on this platform."""
+    return os.name == "posix"
 
 
 def attach_conflict_indices(

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -34,6 +34,10 @@ from memanto.app.constants import (
 from memanto.app.constants import (
     ProvenanceType as MemoryProvenance,
 )
+from memanto.app.utils.conflicts import (
+    attach_conflict_indices,
+    verify_conflict_target,
+)
 from memanto.app.utils.errors import (
     AgentNotFoundError,
     InvalidSessionTokenError,
@@ -1355,7 +1359,12 @@ class DirectClient:
             date: Date string (YYYY-MM-DD). Defaults to today.
 
         Returns:
-            List of unresolved conflict dicts.
+            List of unresolved conflict dicts. Each dict carries
+            ``conflict_index`` — its position in the *full* report, which is
+            what :meth:`resolve_conflict` expects. Callers must never derive
+            the index from this list's own ordering: resolved conflicts are
+            filtered out here, so the two numberings diverge as soon as one
+            conflict has been resolved.
         """
 
         if not date:
@@ -1371,8 +1380,9 @@ class DirectClient:
         with open(json_path, encoding="utf-8") as f:
             all_conflicts = json.load(f)
 
-        # Return only unresolved conflicts
-        return [c for c in all_conflicts if not c.get("resolved", False)]
+        # Return only unresolved conflicts, each tagged with its authoritative
+        # position in the full report.
+        return attach_conflict_indices(all_conflicts)
 
     def resolve_conflict(
         self,
@@ -1382,6 +1392,8 @@ class DirectClient:
         action: str,
         manual_content: str | None = None,
         manual_type: str | None = None,
+        expected_old_memory_id: str | None = None,
+        expected_new_memory_id: str | None = None,
     ) -> dict[str, Any]:
         """
         Resolve a single conflict by index.
@@ -1389,14 +1401,27 @@ class DirectClient:
         Args:
             agent_id: Target agent.
             date: Date string (YYYY-MM-DD).
-            conflict_index: 0-based index into the full conflicts list.
+            conflict_index: 0-based index into the full conflicts list, i.e.
+                the ``conflict_index`` field of the entry returned by
+                :meth:`list_conflicts` — *not* its position in that response.
             action: Resolution action — ``keep_old``, ``keep_new``,
                 ``keep_both``, ``remove_both``, or ``manual``.
             manual_content: Required when action is ``manual``.
             manual_type: Memory type for manual replacement (default: old memory's type).
+            expected_old_memory_id: Optional guard. When given, the stored
+                conflict's ``old_memory_id`` must match or the call is
+                rejected before anything is deleted.
+            expected_new_memory_id: Optional guard for ``new_memory_id``.
 
         Returns:
             Dict with resolution result.
+
+        Raises:
+            ValueError: If the action is unknown, the report is missing, the
+                index is out of range, the target conflict was already
+                resolved, or an ``expected_*_memory_id`` guard does not match
+                the stored conflict. All three refusals happen *before* any
+                memory is deleted, because deletion is not reversible.
         """
 
         valid_actions = {"keep_old", "keep_new", "keep_both", "remove_both", "manual"}
@@ -1420,6 +1445,13 @@ class DirectClient:
             )
 
         conflict = all_conflicts[conflict_index]
+        # Fail closed *before* deleting anything: deletion is irreversible.
+        verify_conflict_target(
+            conflict,
+            conflict_index,
+            expected_old_memory_id=expected_old_memory_id,
+            expected_new_memory_id=expected_new_memory_id,
+        )
         old_id = conflict.get("old_memory_id")
         new_id = conflict.get("new_memory_id")
 

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -36,6 +36,7 @@ from memanto.app.constants import (
 )
 from memanto.app.utils.conflicts import (
     attach_conflict_indices,
+    conflict_report_lock,
     verify_conflict_target,
 )
 from memanto.app.utils.errors import (
@@ -1433,120 +1434,123 @@ class DirectClient:
         json_path = (
             Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
         )
-        if not json_path.exists():
-            raise ValueError(f"No conflict report found for {agent_id} on {date}")
+        with conflict_report_lock(json_path):
+            if not json_path.exists():
+                raise ValueError(f"No conflict report found for {agent_id} on {date}")
 
-        with open(json_path, encoding="utf-8") as f:
-            all_conflicts = json.load(f)
+            with open(json_path, encoding="utf-8") as f:
+                all_conflicts = json.load(f)
 
-        if conflict_index < 0 or conflict_index >= len(all_conflicts):
-            raise ValueError(
-                f"Conflict index {conflict_index} out of range (0-{len(all_conflicts) - 1})"
+            if conflict_index < 0 or conflict_index >= len(all_conflicts):
+                raise ValueError(
+                    f"Conflict index {conflict_index} out of range (0-{len(all_conflicts) - 1})"
+                )
+
+            conflict = all_conflicts[conflict_index]
+            # Fail closed *before* deleting anything: deletion is irreversible.
+            verify_conflict_target(
+                conflict,
+                conflict_index,
+                expected_old_memory_id=expected_old_memory_id,
+                expected_new_memory_id=expected_new_memory_id,
             )
+            old_id = conflict.get("old_memory_id")
+            new_id = conflict.get("new_memory_id")
 
-        conflict = all_conflicts[conflict_index]
-        # Fail closed *before* deleting anything: deletion is irreversible.
-        verify_conflict_target(
-            conflict,
-            conflict_index,
-            expected_old_memory_id=expected_old_memory_id,
-            expected_new_memory_id=expected_new_memory_id,
-        )
-        old_id = conflict.get("old_memory_id")
-        new_id = conflict.get("new_memory_id")
+            # Get namespace for memory operations
+            from memanto.app.core import agent_namespace
 
-        # Get namespace for memory operations
-        from memanto.app.core import agent_namespace
+            namespace = agent_namespace(agent_id)
 
-        namespace = agent_namespace(agent_id)
+            write_service = self._get_write_service()
+            result_details = {"action": action}
 
-        write_service = self._get_write_service()
-        result_details = {"action": action}
-
-        if action == "keep_old":
-            # Keep old, delete new
-            if new_id:
-                try:
-                    write_service.delete_memory(new_id, namespace)
-                    result_details["deleted"] = new_id
-                except Exception as e:
-                    result_details["warning"] = f"Could not delete new memory: {e}"
-
-        elif action == "keep_new":
-            # Keep new, delete old
-            if old_id:
-                try:
-                    write_service.delete_memory(old_id, namespace)
-                    result_details["deleted"] = old_id
-                except Exception as e:
-                    result_details["warning"] = f"Could not delete old memory: {e}"
-
-        elif action == "keep_both":
-            # No-op — both memories remain active
-            result_details["note"] = "Both memories kept as-is"
-
-        elif action == "remove_both":
-            # Delete both memories
-            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
+            if action == "keep_old":
+                # Keep old, delete new
+                if new_id:
                     try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
+                        write_service.delete_memory(new_id, namespace)
+                        result_details["deleted"] = new_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        result_details["warning"] = f"Could not delete new memory: {e}"
 
-        elif action == "manual":
-            if not manual_content:
-                raise ValueError("manual_content is required when action is 'manual'")
-
-            # Delete both, store manual replacement
-            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
+            elif action == "keep_new":
+                # Keep new, delete old
+                if old_id:
                     try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
+                        write_service.delete_memory(old_id, namespace)
+                        result_details["deleted"] = old_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        result_details["warning"] = f"Could not delete old memory: {e}"
 
-            # Store the manual replacement
-            mem_type = manual_type or conflict.get("type", "fact")
-            if not isinstance(mem_type, str):
-                mem_type = "fact"
-            # Map conflict types to valid memory types
-            if mem_type not in _VALID_MEMORY_TYPES:
-                mem_type = "fact"
-            resolved_type = cast(MemoryType, mem_type)
+            elif action == "keep_both":
+                # No-op — both memories remain active
+                result_details["note"] = "Both memories kept as-is"
 
-            from memanto.app.core import MemoryRecord
+            elif action == "remove_both":
+                # Delete both memories
+                for mem_id, label in [(old_id, "old"), (new_id, "new")]:
+                    if mem_id:
+                        try:
+                            write_service.delete_memory(mem_id, namespace)
+                            result_details[f"deleted_{label}"] = mem_id
+                        except Exception as e:
+                            result_details[f"warning_{label}"] = (
+                                f"Could not delete {label} memory: {e}"
+                            )
 
-            title = (
-                manual_content[:47] + "..."
-                if len(manual_content) > 50
-                else manual_content
-            )
-            memory = MemoryRecord(
-                type=resolved_type,
-                title=title,
-                content=manual_content,
-                agent_id=agent_id,
-                actor_id=agent_id,
-                confidence=0.9,
-                tags=["conflict-resolution"],
-                source="user",
-                provenance="corrected",
-            )
-            store_result = write_service.store_memory(memory)
-            result_details["new_memory_id"] = store_result.get("id")
+            elif action == "manual":
+                if not manual_content:
+                    raise ValueError(
+                        "manual_content is required when action is 'manual'"
+                    )
 
-        # Mark conflict as resolved in the JSON file
-        all_conflicts[conflict_index]["resolved"] = True
-        all_conflicts[conflict_index]["resolution"] = action
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(all_conflicts, f, indent=2, default=str)
+                # Delete both, store manual replacement
+                for mem_id, label in [(old_id, "old"), (new_id, "new")]:
+                    if mem_id:
+                        try:
+                            write_service.delete_memory(mem_id, namespace)
+                            result_details[f"deleted_{label}"] = mem_id
+                        except Exception as e:
+                            result_details[f"warning_{label}"] = (
+                                f"Could not delete {label} memory: {e}"
+                            )
+
+                # Store the manual replacement
+                mem_type = manual_type or conflict.get("type", "fact")
+                if not isinstance(mem_type, str):
+                    mem_type = "fact"
+                # Map conflict types to valid memory types
+                if mem_type not in _VALID_MEMORY_TYPES:
+                    mem_type = "fact"
+                resolved_type = cast(MemoryType, mem_type)
+
+                from memanto.app.core import MemoryRecord
+
+                title = (
+                    manual_content[:47] + "..."
+                    if len(manual_content) > 50
+                    else manual_content
+                )
+                memory = MemoryRecord(
+                    type=resolved_type,
+                    title=title,
+                    content=manual_content,
+                    agent_id=agent_id,
+                    actor_id=agent_id,
+                    confidence=0.9,
+                    tags=["conflict-resolution"],
+                    source="user",
+                    provenance="corrected",
+                )
+                store_result = write_service.store_memory(memory)
+                result_details["new_memory_id"] = store_result.get("id")
+
+            # Mark conflict as resolved in the JSON file
+            all_conflicts[conflict_index]["resolved"] = True
+            all_conflicts[conflict_index]["resolution"] = action
+            with open(json_path, "w", encoding="utf-8") as f:
+                json.dump(all_conflicts, f, indent=2, default=str)
 
         result_details["status"] = "resolved"
         return result_details

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -31,6 +31,10 @@ from memanto.app.constants import (
 from memanto.app.constants import (
     ProvenanceType as MemoryProvenance,
 )
+from memanto.app.utils.conflicts import (
+    attach_conflict_indices,
+    verify_conflict_target,
+)
 from memanto.app.utils.errors import (
     AgentNotFoundError,
     InvalidSessionTokenError,
@@ -1228,7 +1232,12 @@ class SdkClient:
             date: Date string (YYYY-MM-DD). Defaults to today.
 
         Returns:
-            List of unresolved conflict dicts.
+            List of unresolved conflict dicts. Each dict carries
+            ``conflict_index`` — its position in the *full* report, which is
+            what :meth:`resolve_conflict` expects. Callers must never derive
+            the index from this list's own ordering: resolved conflicts are
+            filtered out here, so the two numberings diverge as soon as one
+            conflict has been resolved.
         """
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
@@ -1243,8 +1252,9 @@ class SdkClient:
         with open(json_path, encoding="utf-8") as f:
             all_conflicts = json.load(f)
 
-        # Return only unresolved conflicts
-        return [c for c in all_conflicts if not c.get("resolved", False)]
+        # Return only unresolved conflicts, each tagged with its authoritative
+        # position in the full report.
+        return attach_conflict_indices(all_conflicts)
 
     def resolve_conflict(
         self,
@@ -1254,6 +1264,8 @@ class SdkClient:
         action: str,
         manual_content: str | None = None,
         manual_type: str | None = None,
+        expected_old_memory_id: str | None = None,
+        expected_new_memory_id: str | None = None,
     ) -> dict[str, Any]:
         """
         Resolve a single conflict by index.
@@ -1261,14 +1273,27 @@ class SdkClient:
         Args:
             agent_id: Target agent.
             date: Date string (YYYY-MM-DD).
-            conflict_index: 0-based index into the full conflicts list.
+            conflict_index: 0-based index into the full conflicts list, i.e.
+                the ``conflict_index`` field of the entry returned by
+                :meth:`list_conflicts` — *not* its position in that response.
             action: Resolution action — ``keep_old``, ``keep_new``,
                 ``keep_both``, ``remove_both``, or ``manual``.
             manual_content: Required when action is ``manual``.
             manual_type: Memory type for manual replacement.
+            expected_old_memory_id: Optional guard. When given, the stored
+                conflict's ``old_memory_id`` must match or the call is
+                rejected before anything is deleted.
+            expected_new_memory_id: Optional guard for ``new_memory_id``.
 
         Returns:
             Dict with resolution result.
+
+        Raises:
+            ValueError: If the action is unknown, the report is missing, the
+                index is out of range, the target conflict was already
+                resolved, or an ``expected_*_memory_id`` guard does not match
+                the stored conflict. All three refusals happen *before* any
+                memory is deleted, because deletion is not reversible.
         """
         valid_actions = {"keep_old", "keep_new", "keep_both", "remove_both", "manual"}
         if action not in valid_actions:
@@ -1291,6 +1316,13 @@ class SdkClient:
             )
 
         conflict = all_conflicts[conflict_index]
+        # Fail closed *before* deleting anything: deletion is irreversible.
+        verify_conflict_target(
+            conflict,
+            conflict_index,
+            expected_old_memory_id=expected_old_memory_id,
+            expected_new_memory_id=expected_new_memory_id,
+        )
         old_id = conflict.get("old_memory_id")
         new_id = conflict.get("new_memory_id")
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -33,6 +33,7 @@ from memanto.app.constants import (
 )
 from memanto.app.utils.conflicts import (
     attach_conflict_indices,
+    conflict_report_lock,
     verify_conflict_target,
 )
 from memanto.app.utils.errors import (
@@ -1304,115 +1305,118 @@ class SdkClient:
         json_path = (
             Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
         )
-        if not json_path.exists():
-            raise ValueError(f"No conflict report found for {agent_id} on {date}")
+        with conflict_report_lock(json_path):
+            if not json_path.exists():
+                raise ValueError(f"No conflict report found for {agent_id} on {date}")
 
-        with open(json_path, encoding="utf-8") as f:
-            all_conflicts = json.load(f)
+            with open(json_path, encoding="utf-8") as f:
+                all_conflicts = json.load(f)
 
-        if conflict_index < 0 or conflict_index >= len(all_conflicts):
-            raise ValueError(
-                f"Conflict index {conflict_index} out of range (0-{len(all_conflicts) - 1})"
+            if conflict_index < 0 or conflict_index >= len(all_conflicts):
+                raise ValueError(
+                    f"Conflict index {conflict_index} out of range (0-{len(all_conflicts) - 1})"
+                )
+
+            conflict = all_conflicts[conflict_index]
+            # Fail closed *before* deleting anything: deletion is irreversible.
+            verify_conflict_target(
+                conflict,
+                conflict_index,
+                expected_old_memory_id=expected_old_memory_id,
+                expected_new_memory_id=expected_new_memory_id,
             )
+            old_id = conflict.get("old_memory_id")
+            new_id = conflict.get("new_memory_id")
 
-        conflict = all_conflicts[conflict_index]
-        # Fail closed *before* deleting anything: deletion is irreversible.
-        verify_conflict_target(
-            conflict,
-            conflict_index,
-            expected_old_memory_id=expected_old_memory_id,
-            expected_new_memory_id=expected_new_memory_id,
-        )
-        old_id = conflict.get("old_memory_id")
-        new_id = conflict.get("new_memory_id")
+            # Get namespace for memory operations
+            from memanto.app.core import agent_namespace
 
-        # Get namespace for memory operations
-        from memanto.app.core import agent_namespace
+            namespace = agent_namespace(agent_id)
 
-        namespace = agent_namespace(agent_id)
+            write_service = self._get_write_service()
+            result_details: dict[str, Any] = {"action": action}
 
-        write_service = self._get_write_service()
-        result_details: dict[str, Any] = {"action": action}
-
-        if action == "keep_old":
-            if new_id:
-                try:
-                    write_service.delete_memory(new_id, namespace)
-                    result_details["deleted"] = new_id
-                except Exception as e:
-                    result_details["warning"] = f"Could not delete new memory: {e}"
-
-        elif action == "keep_new":
-            if old_id:
-                try:
-                    write_service.delete_memory(old_id, namespace)
-                    result_details["deleted"] = old_id
-                except Exception as e:
-                    result_details["warning"] = f"Could not delete old memory: {e}"
-
-        elif action == "keep_both":
-            result_details["note"] = "Both memories kept as-is"
-
-        elif action == "remove_both":
-            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
+            if action == "keep_old":
+                if new_id:
                     try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
+                        write_service.delete_memory(new_id, namespace)
+                        result_details["deleted"] = new_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        result_details["warning"] = f"Could not delete new memory: {e}"
 
-        elif action == "manual":
-            if not manual_content:
-                raise ValueError("manual_content is required when action is 'manual'")
-
-            # Delete both, store manual replacement
-            for mem_id, label in [(old_id, "old"), (new_id, "new")]:
-                if mem_id:
+            elif action == "keep_new":
+                if old_id:
                     try:
-                        write_service.delete_memory(mem_id, namespace)
-                        result_details[f"deleted_{label}"] = mem_id
+                        write_service.delete_memory(old_id, namespace)
+                        result_details["deleted"] = old_id
                     except Exception as e:
-                        result_details[f"warning_{label}"] = (
-                            f"Could not delete {label} memory: {e}"
-                        )
+                        result_details["warning"] = f"Could not delete old memory: {e}"
 
-            # Store the manual replacement
-            mem_type = manual_type or conflict.get("type", "fact")
-            if not isinstance(mem_type, str):
-                mem_type = "fact"
-            if mem_type not in _VALID_MEMORY_TYPES:
-                mem_type = "fact"
-            resolved_type = cast(MemoryType, mem_type)
+            elif action == "keep_both":
+                result_details["note"] = "Both memories kept as-is"
 
-            from memanto.app.core import MemoryRecord
+            elif action == "remove_both":
+                for mem_id, label in [(old_id, "old"), (new_id, "new")]:
+                    if mem_id:
+                        try:
+                            write_service.delete_memory(mem_id, namespace)
+                            result_details[f"deleted_{label}"] = mem_id
+                        except Exception as e:
+                            result_details[f"warning_{label}"] = (
+                                f"Could not delete {label} memory: {e}"
+                            )
 
-            title = (
-                manual_content[:47] + "..."
-                if len(manual_content) > 50
-                else manual_content
-            )
-            memory = MemoryRecord(
-                type=resolved_type,
-                title=title,
-                content=manual_content,
-                agent_id=agent_id,
-                actor_id=agent_id,
-                confidence=0.9,
-                tags=["conflict-resolution"],
-                source="user",
-                provenance="corrected",
-            )
-            store_result = write_service.store_memory(memory)
-            result_details["new_memory_id"] = store_result.get("id")
+            elif action == "manual":
+                if not manual_content:
+                    raise ValueError(
+                        "manual_content is required when action is 'manual'"
+                    )
 
-        # Mark conflict as resolved in the JSON file
-        all_conflicts[conflict_index]["resolved"] = True
-        all_conflicts[conflict_index]["resolution"] = action
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(all_conflicts, f, indent=2, default=str)
+                # Delete both, store manual replacement
+                for mem_id, label in [(old_id, "old"), (new_id, "new")]:
+                    if mem_id:
+                        try:
+                            write_service.delete_memory(mem_id, namespace)
+                            result_details[f"deleted_{label}"] = mem_id
+                        except Exception as e:
+                            result_details[f"warning_{label}"] = (
+                                f"Could not delete {label} memory: {e}"
+                            )
+
+                # Store the manual replacement
+                mem_type = manual_type or conflict.get("type", "fact")
+                if not isinstance(mem_type, str):
+                    mem_type = "fact"
+                if mem_type not in _VALID_MEMORY_TYPES:
+                    mem_type = "fact"
+                resolved_type = cast(MemoryType, mem_type)
+
+                from memanto.app.core import MemoryRecord
+
+                title = (
+                    manual_content[:47] + "..."
+                    if len(manual_content) > 50
+                    else manual_content
+                )
+                memory = MemoryRecord(
+                    type=resolved_type,
+                    title=title,
+                    content=manual_content,
+                    agent_id=agent_id,
+                    actor_id=agent_id,
+                    confidence=0.9,
+                    tags=["conflict-resolution"],
+                    source="user",
+                    provenance="corrected",
+                )
+                store_result = write_service.store_memory(memory)
+                result_details["new_memory_id"] = store_result.get("id")
+
+            # Mark conflict as resolved in the JSON file
+            all_conflicts[conflict_index]["resolved"] = True
+            all_conflicts[conflict_index]["resolution"] = action
+            with open(json_path, "w", encoding="utf-8") as f:
+                json.dump(all_conflicts, f, indent=2, default=str)
 
         result_details["status"] = "resolved"
         return result_details

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -1002,7 +1002,9 @@ def conflicts(
     with open(json_path, encoding="utf-8") as f:
         all_conflicts = json.load(f)
 
-    # Map unresolved conflicts to their original indices
+    # Map unresolved conflicts to their original indices. Resolution addresses
+    # the FULL report by position, so the filtered display order must never be
+    # used as the index — see memanto/app/utils/conflicts.py.
     unresolved_indices = [
         idx for idx, c in enumerate(all_conflicts) if not c.get("resolved", False)
     ]
@@ -1118,6 +1120,12 @@ def conflicts(
                 conflict_index=original_idx,
                 action=action,
                 manual_content=manual_content,
+                # Guard: the report is re-read inside the client, so pass the
+                # ids of the conflict we actually showed. If the file changed
+                # since we listed it, the resolve is refused instead of
+                # deleting memories the user never reviewed.
+                expected_old_memory_id=c.get("old_memory_id"),
+                expected_new_memory_id=c.get("new_memory_id"),
             )
 
             status_msgs = {

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -1021,7 +1021,7 @@
           "Memory Operations"
         ],
         "summary": "Resolve Conflict",
-        "description": "Resolve a conflict for an agent.\n\nUses the same underlying conflict resolution service used by CLI.",
+        "description": "Resolve a conflict for an agent.\n\nUses the same underlying conflict resolution service used by CLI.\n\n``conflict_index`` is the ``conflict_index`` field of an entry returned by\n``GET /{agent_id}/conflicts``, not that response's own ordering (it lists\nunresolved conflicts only). Pass ``expected_old_memory_id`` /\n``expected_new_memory_id`` to have the call rejected before any deletion if\nthe index no longer addresses the reviewed conflict.",
         "operationId": "resolve_conflict_api_v2_agents__agent_id__conflicts_resolve_post",
         "parameters": [
           {
@@ -2300,7 +2300,7 @@
           "Web UI"
         ],
         "summary": "Resolve Conflict",
-        "description": "Resolve a single conflict.\nExpects: {\"agent_id\": \"...\", \"date\": \"...\", \"conflict_index\": 0, \"action\": \"keep_old\"|\"keep_new\"|\"keep_both\"|\"remove_both\"|\"manual\", \"manual_content\": \"...\"}",
+        "description": "Resolve a single conflict.\nExpects: {\"agent_id\": \"...\", \"date\": \"...\", \"conflict_index\": 0, \"action\": \"keep_old\"|\"keep_new\"|\"keep_both\"|\"remove_both\"|\"manual\", \"manual_content\": \"...\"}\n\n``conflict_index`` must be the ``conflict_index`` field of the entry from\n``GET /api/ui/conflicts`` \u2014 that response contains only unresolved\nconflicts, so its own ordering is not the index the report uses.\n``expected_old_memory_id`` / ``expected_new_memory_id`` are optional and\nmake the resolve fail closed if the index no longer points at the conflict\nthe caller reviewed (e.g. the report was regenerated in the meantime).",
         "operationId": "resolve_conflict_api_ui_conflicts_resolve_post",
         "requestBody": {
           "content": {
@@ -3124,7 +3124,7 @@
             "type": "integer",
             "minimum": 0.0,
             "title": "Conflict Index",
-            "description": "Conflict index to resolve"
+            "description": "Index of the conflict to resolve. Use the 'conflict_index' field of the entry returned by GET /conflicts \u2014 that response contains only unresolved conflicts, so its own ordering is not the index the report is addressed by."
           },
           "action": {
             "type": "string",
@@ -3173,6 +3173,30 @@
             ],
             "title": "Manual Type",
             "description": "Optional memory type for manual action"
+          },
+          "expected_old_memory_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Old Memory Id",
+            "description": "Optional guard: the old_memory_id the caller reviewed. When set, the resolution is rejected (400) before any memory is deleted if the stored conflict does not match."
+          },
+          "expected_new_memory_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected New Memory Id",
+            "description": "Optional guard for new_memory_id, see expected_old_memory_id."
           }
         },
         "type": "object",

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -94,12 +94,22 @@ export interface ConflictDateInput {
 }
 
 export interface ResolveConflictInput {
+  /**
+   * The `conflict_index` field of an entry from `listConflicts()` — not its
+   * position in that array. `listConflicts()` returns unresolved conflicts
+   * only, so the two numberings diverge once a conflict has been resolved and
+   * resolving by array position deletes another conflict's memories.
+   */
   conflictIndex: number;
   /** keep_old | keep_new | keep_both | remove_both | manual */
   action: string;
   date?: string;
   manualContent?: string;
   manualType?: string;
+  /** Optional guard: reject the resolve if the stored conflict's old_memory_id differs. */
+  expectedOldMemoryId?: string;
+  /** Optional guard: reject the resolve if the stored conflict's new_memory_id differs. */
+  expectedNewMemoryId?: string;
 }
 
 export interface UploadFileInput {
@@ -300,6 +310,8 @@ export class Memanto {
         date: input.date,
         manual_content: input.manualContent,
         manual_type: input.manualType,
+        expected_old_memory_id: input.expectedOldMemoryId,
+        expected_new_memory_id: input.expectedNewMemoryId,
       },
     );
   }

--- a/tests/test_conflict_resolution_index.py
+++ b/tests/test_conflict_resolution_index.py
@@ -518,3 +518,111 @@ def test_cli_interactive_resolve_uses_report_index_and_guards(report, recorder):
     assert kwargs["action"] == "keep_new"
     assert kwargs["expected_old_memory_id"] == "mem-old-1"
     assert kwargs["expected_new_memory_id"] == "mem-new-1"
+
+
+# ---------------------------------------------------------------------------
+# The resolve transaction is serialized per report
+# ---------------------------------------------------------------------------
+
+
+def test_lock_is_exclusive_across_processes(fake_home):
+    """A second holder must not be able to enter while the lock is held."""
+    import fcntl
+
+    from memanto.app.utils.conflicts import (
+        conflict_report_lock,
+        conflict_report_lock_path,
+    )
+
+    json_path = _write_report(fake_home, REPORT)
+    lock_path = conflict_report_lock_path(json_path)
+
+    with conflict_report_lock(json_path):
+        assert lock_path.exists()
+        with open(lock_path, "a+") as rival:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(rival.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    # Released again once the transaction is over.
+    with open(lock_path, "a+") as rival:
+        fcntl.flock(rival.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(rival.fileno(), fcntl.LOCK_UN)
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_concurrent_resolves_delete_a_memory_only_once(cls, report, recorder):
+    """Two resolves racing on one conflict must not both delete.
+
+    Without a lock spanning read -> validate -> delete -> persist, both callers
+    read ``resolved=False``, both delete, and the second write erases the first
+    resolution marker. The slow delete below makes that window wide enough to
+    hit deterministically.
+    """
+    import threading
+    import time
+
+    client = _client(cls, recorder)
+    slow_delete_started = threading.Event()
+
+    original_service = client._get_write_service
+
+    def _slow_service():
+        svc = original_service()
+        real_delete = svc.delete_memory.side_effect
+
+        def _delete(memory_id, namespace):
+            slow_delete_started.set()
+            time.sleep(0.3)
+            return real_delete(memory_id, namespace)
+
+        svc.delete_memory.side_effect = _delete
+        return svc
+
+    client._get_write_service = _slow_service  # type: ignore[method-assign]
+
+    errors: list[Exception] = []
+    successes: list[dict] = []
+
+    def _resolve():
+        try:
+            successes.append(
+                client.resolve_conflict(
+                    agent_id=AGENT, date=DATE, conflict_index=1, action="keep_new"
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - recorded for the assertion
+            errors.append(exc)
+
+    first = threading.Thread(target=_resolve)
+    second = threading.Thread(target=_resolve)
+    first.start()
+    assert slow_delete_started.wait(timeout=5)
+    second.start()
+    first.join(timeout=10)
+    second.join(timeout=10)
+
+    assert recorder.deleted == ["mem-old-1"], recorder.deleted
+    assert len(successes) == 1
+    assert len(errors) == 1
+    assert "already resolved" in str(errors[0])
+
+    stored = json.loads(report.read_text(encoding="utf-8"))
+    assert stored[1]["resolved"] is True
+    assert stored[1]["resolution"] == "keep_new"
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_lock_does_not_change_the_sequential_path(cls, report, recorder):
+    """Back-to-back resolutions of different conflicts still both apply."""
+    client = _client(cls, recorder)
+
+    client.resolve_conflict(
+        agent_id=AGENT, date=DATE, conflict_index=1, action="keep_new"
+    )
+    client.resolve_conflict(
+        agent_id=AGENT, date=DATE, conflict_index=2, action="keep_old"
+    )
+
+    assert recorder.deleted == ["mem-old-1", "mem-new-2"]
+    stored = json.loads(report.read_text(encoding="utf-8"))
+    assert [c.get("resolved") for c in stored] == [True, True, True]

--- a/tests/test_conflict_resolution_index.py
+++ b/tests/test_conflict_resolution_index.py
@@ -1,0 +1,520 @@
+"""Conflict resolution must act on the conflict the caller reviewed.
+
+The conflict report (``~/.memanto/conflicts/{agent}_{date}_conflicts.json``) is
+addressed by position in the FULL list, while ``list_conflicts()`` returns only
+the UNRESOLVED entries. Numbering the filtered list therefore addresses a
+different conflict as soon as one earlier conflict has been resolved — and
+resolution hard-deletes memories, so the mistake is not recoverable.
+
+These tests pin both halves of the contract:
+
+* ``list_conflicts()`` must hand back the authoritative ``conflict_index``.
+* ``resolve_conflict()`` must fail closed — before deleting anything — when the
+  addressed conflict was already resolved or does not match the memory ids the
+  caller reviewed.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.client.sdk_client import SdkClient
+
+AGENT = "conflict-agent"
+DATE = "2026-07-30"
+
+# index 0 was resolved earlier with keep_new, so mem-new-0 is the memory the
+# user deliberately kept. Indices 1 and 2 are still open.
+REPORT = [
+    {
+        "type": "contradiction",
+        "title": "Timezone",
+        "old_memory_id": "mem-old-0",
+        "new_memory_id": "mem-new-0",
+        "resolved": True,
+        "resolution": "keep_new",
+    },
+    {
+        "type": "contradiction",
+        "title": "Favourite editor",
+        "old_memory_id": "mem-old-1",
+        "new_memory_id": "mem-new-1",
+        "resolved": False,
+    },
+    {
+        "type": "update",
+        "title": "Deploy target",
+        "old_memory_id": "mem-old-2",
+        "new_memory_id": "mem-new-2",
+        "resolved": False,
+    },
+]
+
+DESTRUCTIVE_ACTIONS = ["keep_old", "keep_new", "remove_both", "manual"]
+
+
+def _write_report(home: Path, conflicts, agent=AGENT, date=DATE) -> Path:
+    """Write a conflict report into a fake HOME and return its path."""
+    path = home / ".memanto" / "conflicts" / f"{agent}_{date}_conflicts.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(conflicts, indent=2), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Point Path.home() and $HOME at an isolated directory."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def report(fake_home):
+    """A report whose first conflict is already resolved."""
+    return _write_report(fake_home, REPORT)
+
+
+class _Recorder:
+    """Records the write-service calls a resolution performs."""
+
+    def __init__(self):
+        self.deleted: list[str] = []
+        self.stored: list[object] = []
+
+    def service(self):
+        svc = MagicMock()
+
+        def _delete(memory_id, namespace):
+            self.deleted.append(memory_id)
+            return True
+
+        def _store(memory, context=None):
+            self.stored.append(memory)
+            return {"id": "mem-manual"}
+
+        svc.delete_memory.side_effect = _delete
+        svc.store_memory.side_effect = _store
+        return svc
+
+
+@pytest.fixture
+def recorder():
+    return _Recorder()
+
+
+def _client(cls, recorder):
+    """Build a CLI client whose writes are recorded instead of performed."""
+    client = cls("test-key")
+    client._get_write_service = recorder.service  # type: ignore[method-assign]
+    return client
+
+
+CLIENT_CLASSES = [DirectClient, SdkClient]
+
+
+# ---------------------------------------------------------------------------
+# list_conflicts: the index has to travel with the data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_list_conflicts_reports_index_in_full_report(cls, report, recorder):
+    """Each unresolved conflict carries its position in the full report."""
+    conflicts = _client(cls, recorder).list_conflicts(AGENT, DATE)
+
+    assert [c["title"] for c in conflicts] == ["Favourite editor", "Deploy target"]
+    # Positions in the response are 0 and 1; report indices are 1 and 2.
+    assert [c["conflict_index"] for c in conflicts] == [1, 2]
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_list_conflicts_index_matches_stored_memory_ids(cls, report, recorder):
+    """conflict_index must address the same entry in the report on disk."""
+    conflicts = _client(cls, recorder).list_conflicts(AGENT, DATE)
+    on_disk = json.loads(report.read_text())
+
+    for conflict in conflicts:
+        stored = on_disk[conflict["conflict_index"]]
+        assert stored["old_memory_id"] == conflict["old_memory_id"]
+        assert stored["new_memory_id"] == conflict["new_memory_id"]
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_list_conflicts_overrides_index_from_file(cls, fake_home, recorder):
+    """A stray conflict_index in the report cannot redirect a resolve.
+
+    The report is generated from LLM output, so the field is not trustworthy
+    input — position in the file is the only authority.
+    """
+    _write_report(
+        fake_home,
+        [
+            dict(REPORT[0]),
+            {**REPORT[1], "conflict_index": 99},
+            dict(REPORT[2]),
+        ],
+    )
+
+    conflicts = _client(cls, recorder).list_conflicts(AGENT, DATE)
+    assert [c["conflict_index"] for c in conflicts] == [1, 2]
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_list_conflicts_does_not_mutate_report(cls, report, recorder):
+    """Listing is read-only: the added field must not reach the file."""
+    before = report.read_text()
+    _client(cls, recorder).list_conflicts(AGENT, DATE)
+    assert report.read_text() == before
+    assert all("conflict_index" not in c for c in json.loads(report.read_text()))
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_list_conflicts_indices_are_stable_across_resolutions(cls, report, recorder):
+    """Resolving one conflict must not renumber the remaining ones."""
+    client = _client(cls, recorder)
+    first = client.list_conflicts(AGENT, DATE)
+    client.resolve_conflict(AGENT, DATE, first[0]["conflict_index"], "keep_new")
+
+    remaining = client.list_conflicts(AGENT, DATE)
+    assert [c["conflict_index"] for c in remaining] == [2]
+    assert remaining[0]["title"] == "Deploy target"
+
+
+# ---------------------------------------------------------------------------
+# resolve_conflict: fail closed before deleting anything
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+@pytest.mark.parametrize("action", DESTRUCTIVE_ACTIONS)
+def test_resolve_rejects_already_resolved_conflict(cls, action, report, recorder):
+    """Re-resolving a settled conflict would destroy the memory it kept."""
+    with pytest.raises(ValueError, match="already resolved"):
+        _client(cls, recorder).resolve_conflict(
+            AGENT,
+            DATE,
+            0,
+            action,
+            manual_content="replacement" if action == "manual" else None,
+        )
+
+    assert recorder.deleted == []
+    assert recorder.stored == []
+    # The earlier resolution is left exactly as it was.
+    assert json.loads(report.read_text())[0]["resolution"] == "keep_new"
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+@pytest.mark.parametrize("action", DESTRUCTIVE_ACTIONS)
+def test_resolve_rejects_memory_id_mismatch(cls, action, report, recorder):
+    """An index that no longer points at the reviewed conflict is refused."""
+    with pytest.raises(ValueError, match="does not match the reviewed conflict"):
+        _client(cls, recorder).resolve_conflict(
+            AGENT,
+            DATE,
+            2,
+            action,
+            manual_content="replacement" if action == "manual" else None,
+            expected_old_memory_id="mem-old-1",
+            expected_new_memory_id="mem-new-1",
+        )
+
+    assert recorder.deleted == []
+    assert recorder.stored == []
+    assert json.loads(report.read_text())[2].get("resolved") is False
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_resolve_rejects_new_memory_id_mismatch_alone(cls, report, recorder):
+    """Either side of the pair is enough to detect drift."""
+    with pytest.raises(ValueError, match="new_memory_id"):
+        _client(cls, recorder).resolve_conflict(
+            AGENT,
+            DATE,
+            2,
+            "remove_both",
+            expected_new_memory_id="mem-new-1",
+        )
+
+    assert recorder.deleted == []
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_resolve_survives_report_regenerated_between_list_and_resolve(
+    cls, report, recorder, fake_home
+):
+    """Realistic race: 'Detect Conflicts Now' rewrites the report mid-review.
+
+    The stale index still exists, so without the guard the resolution would
+    silently delete a pair the caller never saw.
+    """
+    client = _client(cls, recorder)
+    reviewed = client.list_conflicts(AGENT, DATE)[0]
+
+    # Report regenerated: same length, entirely different conflicts.
+    _write_report(
+        fake_home,
+        [
+            {
+                "type": "contradiction",
+                "title": "Something else",
+                "old_memory_id": f"other-old-{i}",
+                "new_memory_id": f"other-new-{i}",
+                "resolved": False,
+            }
+            for i in range(3)
+        ],
+    )
+
+    with pytest.raises(ValueError, match="does not match the reviewed conflict"):
+        client.resolve_conflict(
+            AGENT,
+            DATE,
+            reviewed["conflict_index"],
+            "remove_both",
+            expected_old_memory_id=reviewed["old_memory_id"],
+            expected_new_memory_id=reviewed["new_memory_id"],
+        )
+
+    assert recorder.deleted == []
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_resolve_accepts_matching_expected_ids(cls, report, recorder):
+    """The guard must not get in the way of a correct resolution."""
+    client = _client(cls, recorder)
+    reviewed = client.list_conflicts(AGENT, DATE)[0]
+
+    result = client.resolve_conflict(
+        AGENT,
+        DATE,
+        reviewed["conflict_index"],
+        "remove_both",
+        expected_old_memory_id=reviewed["old_memory_id"],
+        expected_new_memory_id=reviewed["new_memory_id"],
+    )
+
+    assert result["status"] == "resolved"
+    assert recorder.deleted == ["mem-old-1", "mem-new-1"]
+    assert json.loads(report.read_text())[1]["resolved"] is True
+
+
+@pytest.mark.parametrize("cls", CLIENT_CLASSES)
+def test_resolve_manual_does_not_store_replacement_on_mismatch(cls, report, recorder):
+    """A refused manual resolution must not leave an orphan memory behind."""
+    with pytest.raises(ValueError):
+        _client(cls, recorder).resolve_conflict(
+            AGENT,
+            DATE,
+            2,
+            "manual",
+            manual_content="merged value",
+            expected_old_memory_id="mem-old-1",
+        )
+
+    assert recorder.stored == []
+    assert recorder.deleted == []
+
+
+# ---------------------------------------------------------------------------
+# Web UI: the flow that actually shipped
+# ---------------------------------------------------------------------------
+
+
+def _ui_client():
+    from memanto.app.ui.routes.ui_router import router as ui_router
+
+    app = FastAPI()
+    app.include_router(ui_router)
+    # _require_local only accepts loopback callers.
+    return TestClient(app, client=("127.0.0.1", 45678))
+
+
+def _ui_patches(recorder):
+    return (
+        patch(
+            "memanto.app.ui.routes.ui_router._config_manager.get_api_key",
+            return_value="test-key",
+        ),
+        patch(
+            "memanto.cli.client.direct_client.DirectClient._get_write_service",
+            side_effect=recorder.service,
+        ),
+    )
+
+
+def test_ui_resolves_the_conflict_shown_on_the_card(report, recorder):
+    """End-to-end: acting on the first card must touch only that conflict.
+
+    Before the fix the UI sent the card's array position, so clicking the first
+    card deleted the memories of report index 0 — including the memory a
+    previous ``keep_new`` decision had preserved — while the reviewed conflict
+    stayed unresolved and came back on the next reload.
+    """
+    api = _ui_client()
+    get_key, get_write = _ui_patches(recorder)
+
+    with get_key, get_write:
+        listed = api.get(f"/api/ui/conflicts?agent_id={AGENT}&date={DATE}").json()
+        cards = listed["conflicts"]
+        assert listed["count"] == 2
+
+        # Exactly what the frontend does for the first card.
+        card = cards[0]
+        idx = card["conflict_index"]
+        resp = api.post(
+            "/api/ui/conflicts/resolve",
+            json={
+                "agent_id": AGENT,
+                "date": DATE,
+                "conflict_index": idx,
+                "action": "remove_both",
+                "expected_old_memory_id": card["old_memory_id"],
+                "expected_new_memory_id": card["new_memory_id"],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert recorder.deleted == [card["old_memory_id"], card["new_memory_id"]]
+    # The memory kept by the earlier decision is untouched.
+    assert "mem-new-0" not in recorder.deleted
+
+    after = json.loads(report.read_text())
+    assert after[1]["resolved"] is True
+    assert after[1]["resolution"] == "remove_both"
+    assert after[2].get("resolved") is False
+
+
+def test_ui_rejects_position_based_index_from_a_stale_page(report, recorder):
+    """A stale tab that posts the card position is refused, not obeyed."""
+    api = _ui_client()
+    get_key, get_write = _ui_patches(recorder)
+
+    with get_key, get_write:
+        cards = api.get(f"/api/ui/conflicts?agent_id={AGENT}&date={DATE}").json()[
+            "conflicts"
+        ]
+        card = cards[0]
+        resp = api.post(
+            "/api/ui/conflicts/resolve",
+            json={
+                "agent_id": AGENT,
+                "date": DATE,
+                "conflict_index": 0,  # legacy behaviour: array position
+                "action": "remove_both",
+                "expected_old_memory_id": card["old_memory_id"],
+                "expected_new_memory_id": card["new_memory_id"],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert "already resolved" in resp.json()["detail"]
+    assert recorder.deleted == []
+
+
+def test_ui_list_exposes_conflict_index_to_the_frontend(report, recorder):
+    """The frontend cannot address the report unless the API exposes the index."""
+    api = _ui_client()
+    get_key, get_write = _ui_patches(recorder)
+
+    with get_key, get_write:
+        cards = api.get(f"/api/ui/conflicts?agent_id={AGENT}&date={DATE}").json()[
+            "conflicts"
+        ]
+
+    assert [c["conflict_index"] for c in cards] == [1, 2]
+
+
+def test_shipped_ui_asset_does_not_number_cards_by_position():
+    """Guard the one file that has no JS test harness in CI.
+
+    ``index.html`` is served as-is, so a future edit that goes back to using
+    the card's array position as ``conflict_index`` would silently restore the
+    wrong-memory deletion. Pin the two markers of the fixed behaviour.
+    """
+    asset = (
+        Path(__file__).resolve().parents[1]
+        / "memanto"
+        / "app"
+        / "ui"
+        / "static"
+        / "index.html"
+    )
+    source = asset.read_text(encoding="utf-8")
+
+    assert "Number.isInteger(c.conflict_index)" in source, (
+        "conflict cards must take the index from the API response"
+    )
+    assert "resolveConflict(i, rawAgentId" not in source, (
+        "conflict cards must not resolve by their position in the response"
+    )
+    assert "expected_old_memory_id" in source and "expected_new_memory_id" in source, (
+        "the UI must send the reviewed memory ids as a guard"
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTTP API surface
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_request_model_accepts_expected_memory_ids():
+    from memanto.app.models import ConflictResolveRequest
+
+    request = ConflictResolveRequest(
+        conflict_index=3,
+        action="keep_new",
+        expected_old_memory_id="mem-old-1",
+        expected_new_memory_id="mem-new-1",
+    )
+    assert request.expected_old_memory_id == "mem-old-1"
+    assert request.expected_new_memory_id == "mem-new-1"
+
+
+def test_resolve_request_model_defaults_guards_to_none():
+    from memanto.app.models import ConflictResolveRequest
+
+    request = ConflictResolveRequest(conflict_index=0, action="keep_both")
+    assert request.expected_old_memory_id is None
+    assert request.expected_new_memory_id is None
+
+
+# ---------------------------------------------------------------------------
+# Interactive CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_interactive_resolve_uses_report_index_and_guards(report, recorder):
+    """`memanto conflicts` must resolve the conflict it displayed."""
+    from typer.testing import CliRunner
+
+    from memanto.cli.main import app
+
+    client = MagicMock()
+    client.list_conflicts.return_value = [
+        {**REPORT[1], "conflict_index": 1},
+        {**REPORT[2], "conflict_index": 2},
+    ]
+    client.resolve_conflict.return_value = {"status": "resolved"}
+
+    with (
+        patch("memanto.cli.commands.memory.get_client", return_value=client),
+        patch("memanto.cli.commands.memory.config_manager") as cfg,
+    ):
+        cfg.get_active_session.return_value = (AGENT, "token")
+        # Choose "keep_new" on the first displayed conflict, then quit.
+        result = CliRunner().invoke(app, ["conflicts", "--date", DATE], input="2\nq\n")
+
+    assert result.exit_code == 0, result.output
+    client.resolve_conflict.assert_called_once()
+    kwargs = client.resolve_conflict.call_args.kwargs
+    assert kwargs["conflict_index"] == 1
+    assert kwargs["action"] == "keep_new"
+    assert kwargs["expected_old_memory_id"] == "mem-old-1"
+    assert kwargs["expected_new_memory_id"] == "mem-new-1"


### PR DESCRIPTION
## Summary

Resolving a conflict from the Web UI deletes the memories of a **different conflict** as soon as one earlier conflict in that day's report has been resolved — including a memory that an earlier `keep_new` decision deliberately kept. Deletion is a hard delete, so the loss is not recoverable, and the conflict the user actually judged stays unresolved and comes back on the next reload (click it again → next wrong deletion).

Root cause is a contract asymmetry, not a typo:

* `list_conflicts()` returns **only the unresolved** conflicts, re-indexed `0..n-1`.
* `resolve_conflict(conflict_index=...)` indexes the **full** report on disk (`~/.memanto/conflicts/{agent}_{date}_conflicts.json`).

The index that identifies a conflict never travels with the data, so every consumer that numbers the list response is wrong by the number of already-resolved conflicts ahead of it. Affected consumers today:

| Consumer | Behaviour |
|---|---|
| Web UI (`memanto/app/ui/static/index.html`) | `conflicts.forEach((c, i) => …)` → posts `i` as `conflict_index` — **destructive** |
| `POST /api/v2/agents/{id}/conflicts/resolve` | field documented only as "Conflict index to resolve", so an API/SDK caller pairing it with `GET …/conflicts` is wrong the same way |
| `examples/crewai-memory/run_contradiction.py`, `examples/langgraph-memanto/…/run_contradiction.py` | both list conflicts, print them `1..n`, then resolve `conflict_index=0` — the documented pattern is the buggy one |
| `memanto conflicts` (interactive CLI) | **correct** — it re-reads the report itself and maps display order → report index |

## Reproduction

Driven through the real UI endpoints with a fake `$HOME`, `TestClient(client=("127.0.0.1", …))` to satisfy `_require_local`, and only `delete_memory`/`store_memory` mocked (nothing above that boundary is stubbed). Report: index 0 already resolved with `keep_new` (so `mem-new-0` is the memory the user chose to keep), indices 1 and 2 open.

```
UI list  -> 2 unresolved:
   card position 0: 'Favourite editor'  (old=mem-old-1, new=mem-new-1)
   card position 1: 'Deploy target'     (old=mem-old-2, new=mem-new-2)

User clicks 'Remove Both' on card 0 = 'Favourite editor' -> POST conflict_index=0

main     resolve HTTP 200 {'deleted_old': 'mem-old-0', 'deleted_new': 'mem-new-0', 'status': 'resolved'}
         memories actually deleted:        ['mem-old-0', 'mem-new-0']   <- never shown to the user
         memories the user asked to delete: ['mem-old-1', 'mem-new-1']
         survivor of the earlier keep_new decision destroyed:  True
         conflict the user judged still unresolved:            True

this PR  resolve HTTP 200 {'deleted_old': 'mem-old-1', 'deleted_new': 'mem-new-1', 'status': 'resolved'}
         memories actually deleted: ['mem-old-1', 'mem-new-1']          <- exactly the reviewed pair
```

The API answers `200` with a `deleted_old`/`deleted_new` pair the caller never saw, and the UI shows “Conflict #0 resolved” — nothing surfaces the mistake.

I also executed the **shipped inline JS** (extracted from `index.html`, DOM stubbed, `api()` recorded) instead of reading it:

```
main     card 0 -> DOM id conflict-0 -> POST {conflict_index: 0}                       (no guards)
this PR  card 0 -> DOM id conflict-1 -> POST {conflict_index: 1,
                                              expected_old_memory_id: 'mem-old-1',
                                              expected_new_memory_id: 'mem-new-1'}
```

A second, independent trigger for the same crash exists even with correct indices: the UI’s **“Detect Conflicts Now”** rewrites the report, so a tab that listed conflicts before the rescan resolves a stale index into an entirely different list. That is why the fix is not only “pass the right number”.

## Fix

* `list_conflicts()` (both `DirectClient` and `SdkClient`) tags every returned conflict with `conflict_index`, its position in the full report. Always recomputed from position — the report is generated from LLM output, so a stray `conflict_index` key in the file must never be able to redirect a destructive resolve. Returned dicts are shallow copies, so the field cannot leak back into the report file.
* `resolve_conflict()` **fails closed before deleting anything**:
  * the addressed conflict is already resolved → `ValueError` (previously it happily re-deleted and re-marked it);
  * optional `expected_old_memory_id` / `expected_new_memory_id` don’t match the stored conflict → `ValueError`. This catches index drift from *any* cause, including the regenerated-report race.
* Both guards live in one new module, `memanto/app/utils/conflicts.py`, so the two client copies of this flow cannot drift apart.
* Callers updated to address the report by `conflict_index` and pass the guards: Web UI (`index.html`), `POST /api/ui/conflicts/resolve`, `ConflictResolveRequest` + route docstring, TypeScript SDK (`expectedOldMemoryId` / `expectedNewMemoryId`), both examples. The interactive CLI keeps its own (already correct) mapping and additionally sends the guards, which now also protects it against the report changing between listing and resolving.
* `sdks/typescript/openapi.json` regenerated (`scripts/generate_openapi.py`) so the `openapi-drift` job stays green.

Both new parameters are optional, so existing API/SDK callers keep working; a caller that sends only an index is protected from the “already resolved” case and gets full protection once it forwards the ids.

## Verification

```
pytest                       main: 452 passed, 24 skipped     this PR: 493 passed, 24 skipped
```

41 new cases in `tests/test_conflict_resolution_index.py`, parametrised over `DirectClient` and `SdkClient` and over every destructive action (`keep_old`, `keep_new`, `remove_both`, `manual`): index/report agreement, stray-`conflict_index` override, listing does not mutate the report, indices stable across resolutions, already-resolved refusal, id-mismatch refusal (each side alone too), regenerated-report race, manual refusal storing no orphan memory, the three UI endpoints end-to-end, the request model, the interactive CLI call arguments, and a static guard on `index.html` (the one file CI has no JS harness for).

Mutation testing — reverting only the logic while keeping the tests:

```
revert both halves (pre-fix behaviour)          35 failed / 5 passed
   ▸ the whole existing suite stays green: 452 passed, 24 skipped
   ▸ nothing in the repo covered this
revert guards only (index correct)              23 failed / 17 passed
revert index only (guards on)                   14 failed / 26 passed
```

CI gates run locally with the project’s pinned tool versions: `ruff check .` clean, `ruff format --check .` clean (ruff 0.14.14 per `pyproject.toml`; a newer 0.16 also wants to reformat 11 pre-existing `docs/*.md` code blocks — unrelated), `mypy .` → *Success: no issues found in 107 source files*, `node --check` on the extracted inline JS, and the TypeScript gate end to end: `openapi:generate` → `typecheck` → `build` → `test` (38 passed) with no OpenAPI drift.

Environment: Linux x86-64, Python 3.12.3, Node 22.22, pytest 9.x.

## Deliberately not changed / not covered

* **No Moorcheh API key here**, so nothing ran against the live cloud backend. Everything I touched sits above the storage boundary (report file parsing, index contract, guard, route/UI plumbing), and the tests mock exactly `delete_memory` / `store_memory`. The delete call itself is unchanged.
* **Deletion is still irreversible.** I added no undo or soft-delete: the supersession/trust fields were removed from the active schema on 2026-06-29 (`memanto/app/legacy/REMOVED.md`) and reintroducing them is a product decision, not a bug fix.
* **Behaviour change:** a settled conflict can no longer be re-resolved. I found no caller that does this on purpose — the CLI, the UI and the API list only unresolved conflicts — but it is a deliberate fail-closed choice.
* **Conflict *detection* is untouched.** The report is LLM-generated; I did not change what gets flagged or how `old_memory_id`/`new_memory_id` are chosen.
* **Pre-existing, left alone:** `resolve_conflict()` records a failed `delete_memory` as `result_details["warning"]` and still marks the conflict resolved (PR #1476 covers that path); `list_conflicts()` assumes the report file is a JSON list and will raise on any other shape; the interactive CLI still parses the report itself instead of consuming the new contract field — correct today, but a third copy of the same knowledge.
* The `#N` badge on each conflict card now shows the report index instead of the card position — a visible (and now truthful) change.

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conflict resolution accuracy by using the authoritative conflict index.
  * Added fail-closed safeguards that reject stale or mismatched resolutions before any deletion.
  * Prevented incorrect conflict resolutions when conflict lists/reports change, including safer concurrency handling to avoid double-resolves.

* **Enhancements**
  * Added optional expected old/new memory identifiers to API, UI, CLI, and TypeScript requests.
  * Updated conflict displays and interactive tools to resolve the exact conflict shown.
  * Expanded API/UI documentation and added concurrency/locking regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->