### PR TITLE
Merge/temporal recall logic 2

### DIFF
--- a/integrations/claudecode/hooks/_common.py
+++ b/integrations/claudecode/hooks/_common.py
@@ -130,52 +130,71 @@ def read_transcript_text(
     find (string content, or content blocks carrying a ``text`` field),
     labelling it by role when available. Returns the trailing ``max_chars``.
     """
-    _, rendered = _read_transcript_full(
-        transcript_path, max_messages=max_messages, max_chars=max_chars
-    )
-    return rendered
+    messages = _read_transcript_messages(transcript_path)
+    return _render_messages(messages, max_messages=max_messages, max_chars=max_chars)
 
 
 def read_transcript_for_distillation(
     transcript_path: str | None,
+    last_assistant_message: str | None = None,
     max_messages: int = 40,
     max_chars: int = 8000,
 ) -> tuple[str | None, str]:
-    """Return ``(skill, tail_text)`` from a single pass over the transcript.
+    """Return ``(skill, current_turn_text)`` for one Stop-hook invocation.
 
-    Long sessions truncate to the tail for the LLM (the latest discussion is
-    where decisions usually crystallise), but the user's original ``/tdd`` or
-    ``/grill-with-docs`` invocation typically sits at the very start of the
-    conversation and would fall outside that tail. We scan the entire
-    transcript for the first skill token, then return it alongside the
-    truncated text so ``distill_and_store`` can tag memories correctly even
-    on long sessions.
+    Claude Code fires ``Stop`` once per turn, not once per session. Re-sending
+    the cumulative transcript on every invocation makes earlier decisions get
+    extracted and stored repeatedly. Scope distillation to the latest user
+    turn instead, while retaining the most recent skill invocation for tags.
+
+    Async hooks can read the transcript after a newer turn has already been
+    appended. ``last_assistant_message`` anchors the snapshot to the turn that
+    triggered this hook so two overlapping hook processes cannot both ingest
+    the newest turn.
     """
-    return _read_transcript_full(
-        transcript_path, max_messages=max_messages, max_chars=max_chars
-    )
-
-
-def _read_transcript_full(
-    transcript_path: str | None,
-    max_messages: int,
-    max_chars: int,
-) -> tuple[str | None, str]:
-    """Read the transcript once and return (first-skill-seen, tail-text)."""
-    if not transcript_path:
+    messages = _read_transcript_messages(transcript_path)
+    if not messages:
         return None, ""
+
+    end = _anchored_end(messages, last_assistant_message)
+    scoped = messages[:end]
+
+    skill: str | None = None
+    for role, text in scoped:
+        if _is_user_role(role):
+            found = detect_skill(text)
+            if found:
+                skill = found
+
+    turn_start = 0
+    for index in range(len(scoped) - 1, -1, -1):
+        if _is_user_role(scoped[index][0]):
+            turn_start = index
+            break
+
+    rendered = _render_messages(
+        scoped[turn_start:], max_messages=max_messages, max_chars=max_chars
+    )
+    return skill, rendered
+
+
+def _read_transcript_messages(
+    transcript_path: str | None,
+) -> list[tuple[str | None, str]]:
+    """Read parseable prose messages from a Claude Code transcript."""
+    if not transcript_path:
+        return []
     path = Path(transcript_path)
     if not path.exists():
-        return None, ""
+        return []
 
     try:
         with path.open(encoding="utf-8") as fh:
             lines = fh.readlines()
     except Exception:
-        return None, ""
+        return []
 
-    pieces: list[str] = []
-    skill: str | None = None
+    messages: list[tuple[str | None, str]] = []
     for line in lines:
         line = line.strip()
         if not line:
@@ -187,15 +206,48 @@ def _read_transcript_full(
         role, text = _extract_role_text(entry)
         if not text:
             continue
-        # First skill mention wins — typically the opening user prompt.
-        if skill is None:
-            found = detect_skill(text)
-            if found:
-                skill = found
-        pieces.append(f"{role}: {text}" if role else text)
+        messages.append((str(role) if role is not None else None, text))
 
+    return messages
+
+
+def _render_messages(
+    messages: list[tuple[str | None, str]],
+    *,
+    max_messages: int,
+    max_chars: int,
+) -> str:
+    """Render a bounded transcript slice for LLM distillation."""
+    pieces = [f"{role}: {text}" if role else text for role, text in messages]
     rendered = "\n".join(pieces[-max_messages:])
-    return skill, rendered[-max_chars:]
+    return rendered[-max_chars:]
+
+
+def _is_user_role(role: str | None) -> bool:
+    """Recognise user roles across the common transcript variants."""
+    return bool(role and role.strip().lower() in {"user", "human"})
+
+
+def _is_assistant_role(role: str | None) -> bool:
+    """Recognise assistant roles across the common transcript variants."""
+    return bool(role and role.strip().lower() in {"assistant", "ai"})
+
+
+def _anchored_end(
+    messages: list[tuple[str | None, str]],
+    last_assistant_message: str | None,
+) -> int:
+    """Return the exclusive end index for the Stop event's own turn."""
+    if not last_assistant_message or not last_assistant_message.strip():
+        return len(messages)
+
+    needle = " ".join(last_assistant_message.split())
+    for index in range(len(messages) - 1, -1, -1):
+        role, text = messages[index]
+        if _is_assistant_role(role) and " ".join(text.split()) == needle:
+            return index + 1
+
+    return len(messages)
 
 
 def _extract_role_text(entry: Any) -> tuple[str | None, str]:

--- a/integrations/claudecode/hooks/_common.py
+++ b/integrations/claudecode/hooks/_common.py
@@ -157,6 +157,8 @@ def read_transcript_for_distillation(
         return None, ""
 
     end = _anchored_end(messages, last_assistant_message)
+    if end is None:
+        return None, ""
     scoped = messages[:end]
 
     skill: str | None = None
@@ -236,18 +238,22 @@ def _is_assistant_role(role: str | None) -> bool:
 def _anchored_end(
     messages: list[tuple[str | None, str]],
     last_assistant_message: str | None,
-) -> int:
-    """Return the exclusive end index for the Stop event's own turn."""
+) -> int | None:
+    """Return the unique exclusive end index for the Stop event's own turn.
+
+    Missing, stale, or ambiguous anchors fail closed so an asynchronous hook
+    cannot silently distill a newer or duplicated turn.
+    """
     if not last_assistant_message or not last_assistant_message.strip():
-        return len(messages)
+        return None
 
     needle = " ".join(last_assistant_message.split())
-    for index in range(len(messages) - 1, -1, -1):
-        role, text = messages[index]
+    matches: list[int] = []
+    for index, (role, text) in enumerate(messages):
         if _is_assistant_role(role) and " ".join(text.split()) == needle:
-            return index + 1
+            matches.append(index + 1)
 
-    return len(messages)
+    return matches[0] if len(matches) == 1 else None
 
 
 def _extract_role_text(entry: Any) -> tuple[str | None, str]:

--- a/integrations/claudecode/hooks/on_stop.py
+++ b/integrations/claudecode/hooks/on_stop.py
@@ -28,10 +28,10 @@ from _common import (  # noqa: E402
 
 
 def main() -> int:
-    """Read the finished transcript and distill it into typed memories.
+    """Read the finished turn and distill it into typed memories.
 
-    Skips when ``stop_hook_active`` is set so the same session is never
-    distilled twice on re-fires. Runs asynchronously and silently — failure
+    Skips when ``stop_hook_active`` is set to avoid hook-induced continuation
+    loops. Runs asynchronously and silently — failure
     paths exit 0 instead of surfacing errors to the developer.
     """
     if not memory_enabled():
@@ -44,11 +44,12 @@ def main() -> int:
     if data.get("stop_hook_active"):
         return 0
 
-    # Single pass: finds the original /skill across the FULL transcript,
-    # then returns only the tail for LLM distillation. This avoids tagging
-    # long sessions as skill:unknown when the opening prompt has fallen
-    # outside the truncation window.
-    skill, transcript = read_transcript_for_distillation(data.get("transcript_path"))
+    # Stop fires once per turn. Scope distillation to this event's user turn,
+    # while scanning the transcript up to that turn for the active /skill tag.
+    skill, transcript = read_transcript_for_distillation(
+        data.get("transcript_path"),
+        last_assistant_message=data.get("last_assistant_message"),
+    )
     if not transcript:
         return 0
 

--- a/integrations/claudecode/tests/test_hooks.py
+++ b/integrations/claudecode/tests/test_hooks.py
@@ -172,3 +172,57 @@ class TestReadTranscriptForDistillation:
         skill, text = common.read_transcript_for_distillation(str(f))
         assert skill is None
         assert "just a chat" in text
+
+    def test_distills_only_the_latest_turn(self, tmp_path: Path) -> None:
+        """A later Stop event must not re-submit an earlier turn."""
+        f = tmp_path / "t.jsonl"
+        lines = [
+            {"message": {"role": "user", "content": "/tdd use unittest"}},
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Old decision: use unittest.",
+                }
+            },
+            {"message": {"role": "user", "content": "/diagnose inspect auth"}},
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Current finding: tokens expire early.",
+                }
+            },
+        ]
+        f.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+
+        skill, text = common.read_transcript_for_distillation(str(f))
+
+        assert skill == "diagnose"
+        assert "tokens expire early" in text
+        assert "Old decision" not in text
+        assert "use unittest" not in text
+
+    def test_assistant_anchor_excludes_a_later_appended_turn(
+        self, tmp_path: Path
+    ) -> None:
+        """An async Stop hook must ingest the turn that spawned it."""
+        f = tmp_path / "t.jsonl"
+        lines = [
+            {"message": {"role": "user", "content": "/tdd first task"}},
+            {"message": {"role": "assistant", "content": "First answer."}},
+            {"message": {"role": "user", "content": "second task"}},
+            {"message": {"role": "assistant", "content": "Second answer."}},
+            {"message": {"role": "user", "content": "/diagnose third task"}},
+            {"message": {"role": "assistant", "content": "Third answer."}},
+        ]
+        f.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+
+        skill, text = common.read_transcript_for_distillation(
+            str(f), last_assistant_message="Second answer."
+        )
+
+        assert skill == "tdd"
+        assert "second task" in text
+        assert "Second answer" in text
+        assert "first task" not in text
+        assert "third task" not in text
+        assert "Third answer" not in text

--- a/integrations/claudecode/tests/test_hooks.py
+++ b/integrations/claudecode/tests/test_hooks.py
@@ -7,6 +7,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
 
 
@@ -118,7 +120,9 @@ class TestReadTranscriptForDistillation:
             {"message": {"role": "assistant", "content": "Using Vitest."}},
         ]
         f.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
-        skill, text = common.read_transcript_for_distillation(str(f))
+        skill, text = common.read_transcript_for_distillation(
+            str(f), last_assistant_message="Using Vitest."
+        )
         assert skill == "tdd"
         assert "Vitest" in text
 
@@ -147,10 +151,20 @@ class TestReadTranscriptForDistillation:
                 "content": "We decided on CQRS for the Order domain.",
             }
         }
-        all_lines = [opener, *filler, decision]
+        answer = {
+            "message": {
+                "role": "assistant",
+                "content": "Acknowledged the CQRS decision.",
+            }
+        }
+        all_lines = [opener, *filler, decision, answer]
         f.write_text("\n".join(json.dumps(x) for x in all_lines), encoding="utf-8")
 
-        skill, text = common.read_transcript_for_distillation(str(f), max_chars=2000)
+        skill, text = common.read_transcript_for_distillation(
+            str(f),
+            last_assistant_message="Acknowledged the CQRS decision.",
+            max_chars=2000,
+        )
 
         # Skill is recovered from BEFORE the truncation window.
         assert skill == "grill-with-docs"
@@ -167,9 +181,14 @@ class TestReadTranscriptForDistillation:
 
     def test_no_skill_in_transcript_returns_none_skill(self, tmp_path: Path) -> None:
         f = tmp_path / "t.jsonl"
-        entry = {"message": {"role": "user", "content": "just a chat, no skill"}}
-        f.write_text(json.dumps(entry), encoding="utf-8")
-        skill, text = common.read_transcript_for_distillation(str(f))
+        entries = [
+            {"message": {"role": "user", "content": "just a chat, no skill"}},
+            {"message": {"role": "assistant", "content": "A normal reply."}},
+        ]
+        f.write_text("\n".join(json.dumps(x) for x in entries), encoding="utf-8")
+        skill, text = common.read_transcript_for_distillation(
+            str(f), last_assistant_message="A normal reply."
+        )
         assert skill is None
         assert "just a chat" in text
 
@@ -194,7 +213,9 @@ class TestReadTranscriptForDistillation:
         ]
         f.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
 
-        skill, text = common.read_transcript_for_distillation(str(f))
+        skill, text = common.read_transcript_for_distillation(
+            str(f), last_assistant_message="Current finding: tokens expire early."
+        )
 
         assert skill == "diagnose"
         assert "tokens expire early" in text
@@ -226,3 +247,36 @@ class TestReadTranscriptForDistillation:
         assert "first task" not in text
         assert "third task" not in text
         assert "Third answer" not in text
+
+    @pytest.mark.parametrize("anchor", [None, "", "Unknown answer."])
+    def test_missing_or_unknown_assistant_anchor_fails_closed(
+        self, tmp_path: Path, anchor: str | None
+    ) -> None:
+        """A hook without one resolvable event anchor must store nothing."""
+        f = tmp_path / "t.jsonl"
+        lines = [
+            {"message": {"role": "user", "content": "first task"}},
+            {"message": {"role": "assistant", "content": "First answer."}},
+            {"message": {"role": "user", "content": "later task"}},
+            {"message": {"role": "assistant", "content": "Later answer."}},
+        ]
+        f.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+
+        assert common.read_transcript_for_distillation(
+            str(f), last_assistant_message=anchor
+        ) == (None, "")
+
+    def test_duplicate_assistant_anchor_fails_closed(self, tmp_path: Path) -> None:
+        """Repeated assistant text is ambiguous and must not select one turn."""
+        f = tmp_path / "t.jsonl"
+        lines = [
+            {"message": {"role": "user", "content": "first task"}},
+            {"message": {"role": "assistant", "content": "Done."}},
+            {"message": {"role": "user", "content": "second task"}},
+            {"message": {"role": "assistant", "content": "Done."}},
+        ]
+        f.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+
+        assert common.read_transcript_for_distillation(
+            str(f), last_assistant_message="Done."
+        ) == (None, "")

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from langchain_core.tools import tool
 from pydantic import Field
 
+from memanto.app.utils.errors import SessionError
 from memanto.cli.client.sdk_client import SdkClient
 
 # Valid Memanto memory types with definitions for the LLM
@@ -108,7 +109,7 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
                 tags=tag_list,
                 source="langgraph-agent",
             )
-        except Exception:
+        except SessionError:
             _do_setup()
             result = client.remember(
                 agent_id=agent_id,

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -1,3 +1,5 @@
+"""Expose Memanto memory tools for LangGraph agents."""
+
 from __future__ import annotations
 
 from typing import Annotated
@@ -27,6 +29,8 @@ VALID_MEMORY_TYPES = (
 
 
 def create_memanto_tools(client: SdkClient, agent_id: str):
+    """Create LangGraph tools bound to a Memanto client and agent."""
+
     import copy
     import threading
 

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -1,6 +1,9 @@
 from unittest.mock import MagicMock
 
+import pytest
 from langgraph_memanto.tools import create_memanto_tools
+
+from memanto.app.utils.errors import SessionError
 
 
 def test_create_memanto_tools_returns_all_tools():
@@ -45,9 +48,10 @@ def test_memanto_remember_tool_success():
 
 def test_memanto_remember_tool_setup_fallback():
     client = MagicMock()
-    # First call raises an exception, second call succeeds
+    # A session failure is known to happen before the write begins, so retrying
+    # after setup is safe.
     client.remember.side_effect = [
-        Exception("Not initialized"),
+        SessionError("Not initialized"),
         {"memory_id": "mem-456"},
     ]
 
@@ -68,6 +72,28 @@ def test_memanto_remember_tool_setup_fallback():
     assert client.remember.call_count == 2
     client.create_agent.assert_called_once_with(agent_id="test-agent", pattern="tool")
     client.activate_agent.assert_called_once_with("test-agent", duration_hours=6)
+
+
+def test_memanto_remember_does_not_retry_ambiguous_write_failure():
+    client = MagicMock()
+    client.remember.side_effect = ConnectionError("response lost after remote write")
+
+    tools = create_memanto_tools(client, "test-agent")
+    remember_tool = next(t for t in tools if t.name == "memanto_remember")
+
+    with pytest.raises(ConnectionError, match="response lost"):
+        remember_tool.invoke(
+            {
+                "memory_type": "fact",
+                "title": "Already committed",
+                "content": "Retrying this write would create a duplicate.",
+                "confidence": 0.9,
+                "tags": "integrity",
+            }
+        )
+
+    client.remember.assert_called_once()
+    client.create_agent.assert_not_called()
 
 
 def test_memanto_recall_tool_success():

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -75,6 +75,7 @@ def test_memanto_remember_tool_setup_fallback():
 
 
 def test_memanto_remember_does_not_retry_ambiguous_write_failure():
+    """A non-session error may follow a commit and must not be retried."""
     client = MagicMock()
     client.remember.side_effect = ConnectionError("response lost after remote write")
 

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -10,8 +10,9 @@ to call ``recall`` and expects it to "just work". This module owns:
   underlying ``SdkClient._get_validated_session_for_agent`` already auto-renews
   tokens nearing expiry, so each client only has to be activated once.
 
-All operations are guarded by a lock so concurrent tool invocations don't race
-to create the same agent twice.
+The client registry is guarded by a short-lived global lock, while per-agent
+locks serialize setup for the same agent without blocking unrelated agents on
+network calls.
 """
 
 from __future__ import annotations
@@ -44,6 +45,7 @@ class MemantoLifecycle:
         self._settings = settings
         self._client = SdkClient(api_key=settings.api_key_value())
         self._session_clients: dict[str, SdkClient] = {}
+        self._agent_locks: dict[str, threading.Lock] = {}
         self._ensured_agents: set[str] = set()
         self._lock = threading.Lock()
 
@@ -96,15 +98,20 @@ class MemantoLifecycle:
             client = self._session_clients.get(agent_id)
             if client is None:
                 client = SdkClient(api_key=self._settings.api_key_value())
+                self._session_clients[agent_id] = client
+            agent_lock = self._agent_locks.setdefault(agent_id, threading.Lock())
 
-            if agent_id not in self._ensured_agents:
+        with agent_lock:
+            with self._lock:
+                agent_is_ensured = agent_id in self._ensured_agents
+
+            if not agent_is_ensured:
                 self._ensure_agent_exists_locked(client, agent_id)
-                self._ensured_agents.add(agent_id)
+                with self._lock:
+                    self._ensured_agents.add(agent_id)
 
             if client.agent_id != agent_id:
                 self._activate_locked(client, agent_id)
-
-            self._session_clients[agent_id] = client
 
         return client
 

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -6,9 +6,9 @@ to call ``recall`` and expects it to "just work". This module owns:
 * Resolving which Memanto agent_id a given tool call targets (explicit arg
   wins; otherwise the configured default).
 * Lazily creating the default agent on first use (if enabled).
-* Lazily activating a session and keeping it valid across calls. The underlying
-  ``SdkClient._get_validated_session_for_agent`` already auto-renews tokens
-  nearing expiry, so we only have to activate once per agent.
+* Lazily creating one independently activated ``SdkClient`` per agent. The
+  underlying ``SdkClient._get_validated_session_for_agent`` already auto-renews
+  tokens nearing expiry, so each client only has to be activated once.
 
 All operations are guarded by a lock so concurrent tool invocations don't race
 to create the same agent twice.
@@ -38,12 +38,12 @@ class NoAgentConfiguredError(ValueError):
 
 
 class MemantoLifecycle:
-    """Owns the long-lived SdkClient and per-agent session bookkeeping."""
+    """Owns an administrative client and isolated per-agent session clients."""
 
     def __init__(self, settings: MCPServerSettings) -> None:
         self._settings = settings
         self._client = SdkClient(api_key=settings.api_key_value())
-        self._activated_agents: set[str] = set()
+        self._session_clients: dict[str, SdkClient] = {}
         self._ensured_agents: set[str] = set()
         self._lock = threading.Lock()
 
@@ -53,7 +53,7 @@ class MemantoLifecycle:
 
     @property
     def client(self) -> SdkClient:
-        """The shared Memanto SDK client."""
+        """The shared administrative client for agent CRUD operations."""
         return self._client
 
     @property
@@ -82,19 +82,31 @@ class MemantoLifecycle:
         Returns the resolved agent_id (mostly a convenience so callers can
         chain ``ensure_ready(resolve_agent_id(...))``).
         """
+        self.client_for(agent_id)
+        return agent_id
+
+    def client_for(self, agent_id: str) -> SdkClient:
+        """Return a ready client whose session is isolated to ``agent_id``.
+
+        ``SdkClient`` stores the active agent as mutable instance state. Keeping
+        one client per agent prevents a concurrent call for another agent from
+        replacing that state between readiness checks and the actual operation.
+        """
         with self._lock:
+            client = self._session_clients.get(agent_id)
+            if client is None:
+                client = SdkClient(api_key=self._settings.api_key_value())
+
             if agent_id not in self._ensured_agents:
-                self._ensure_agent_exists_locked(agent_id)
+                self._ensure_agent_exists_locked(client, agent_id)
                 self._ensured_agents.add(agent_id)
 
-            if (
-                agent_id not in self._activated_agents
-                or self._client.agent_id != agent_id
-            ):
-                self._activate_locked(agent_id)
-                self._activated_agents.add(agent_id)
+            if client.agent_id != agent_id:
+                self._activate_locked(client, agent_id)
 
-        return agent_id
+            self._session_clients[agent_id] = client
+
+        return client
 
     def shutdown(self) -> None:
         """Best-effort cleanup. Sessions can outlive the process safely."""
@@ -107,9 +119,9 @@ class MemantoLifecycle:
     # Internals
     # ------------------------------------------------------------------ #
 
-    def _ensure_agent_exists_locked(self, agent_id: str) -> None:
+    def _ensure_agent_exists_locked(self, client: SdkClient, agent_id: str) -> None:
         try:
-            self._client.get_agent(agent_id)
+            client.get_agent(agent_id)
             logger.debug("Agent '%s' exists.", agent_id)
             return
         except AgentNotFoundError:
@@ -128,7 +140,7 @@ class MemantoLifecycle:
             self._settings.agent_pattern,
         )
         try:
-            self._client.create_agent(
+            client.create_agent(
                 agent_id=agent_id,
                 pattern=self._settings.agent_pattern,
                 description="Auto-created by memanto-mcp",
@@ -137,9 +149,9 @@ class MemantoLifecycle:
             # Race: another caller created it between our get_agent and create.
             logger.debug("Agent '%s' was created concurrently.", agent_id)
 
-    def _activate_locked(self, agent_id: str) -> None:
+    def _activate_locked(self, client: SdkClient, agent_id: str) -> None:
         try:
-            self._client.activate_agent(
+            client.activate_agent(
                 agent_id=agent_id,
                 duration_hours=self._settings.session_duration_hours,
             )

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -50,6 +50,8 @@ class MemantoLifecycle:
     _MAX_SESSION_CLIENTS = MAX_SESSION_CLIENTS
 
     def __init__(self, settings: MCPServerSettings) -> None:
+        """Initialize administrative and per-agent client state."""
+
         self._settings = settings
         self._client = SdkClient(api_key=settings.api_key_value())
         self._session_clients: dict[str, SdkClient] = {}

--- a/integrations/mcp/memanto_mcp/lifecycle.py
+++ b/integrations/mcp/memanto_mcp/lifecycle.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# A long-running MCP server may receive caller-controlled agent IDs. Keep the
+# registry bounded rather than retaining a new SDK client and lock forever for
+# every unique value. Existing entries are never evicted because callers keep
+# using the returned clients after ``client_for`` releases its setup lock.
+MAX_SESSION_CLIENTS = 128
+
 
 class NoAgentConfiguredError(ValueError):
     """Raised when a tool call omits agent_id and no default is configured."""
@@ -40,6 +46,8 @@ class NoAgentConfiguredError(ValueError):
 
 class MemantoLifecycle:
     """Owns an administrative client and isolated per-agent session clients."""
+
+    _MAX_SESSION_CLIENTS = MAX_SESSION_CLIENTS
 
     def __init__(self, settings: MCPServerSettings) -> None:
         self._settings = settings
@@ -97,9 +105,16 @@ class MemantoLifecycle:
         with self._lock:
             client = self._session_clients.get(agent_id)
             if client is None:
+                if len(self._session_clients) >= self._MAX_SESSION_CLIENTS:
+                    raise SessionError(
+                        "Memanto MCP session-client capacity reached "
+                        f"({self._MAX_SESSION_CLIENTS}); reuse an existing agent_id "
+                        "or restart the server to clear idle session clients."
+                    )
                 client = SdkClient(api_key=self._settings.api_key_value())
                 self._session_clients[agent_id] = client
-            agent_lock = self._agent_locks.setdefault(agent_id, threading.Lock())
+                self._agent_locks[agent_id] = threading.Lock()
+            agent_lock = self._agent_locks[agent_id]
 
         with agent_lock:
             with self._lock:

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -139,12 +139,16 @@ class AnswerResult(BaseModel):
 
 
 class BatchRememberItemResult(BaseModel):
+    """Describe the outcome of one item in a batch remember request."""
+
     id: str | None = None
     status: str
     error: str | None = None
 
 
 class BatchRememberResult(BaseModel):
+    """Describe the aggregate outcome of a batch remember request."""
+
     status: str
     agent_id: str
     namespace: str | None = None
@@ -156,6 +160,8 @@ class BatchRememberResult(BaseModel):
 
 
 class AgentInfoResult(BaseModel):
+    """Describe an agent returned by an MCP agent lookup."""
+
     status: str
     agent_id: str | None = None
     namespace: str | None = None
@@ -166,6 +172,8 @@ class AgentInfoResult(BaseModel):
 
 
 class AgentListResult(BaseModel):
+    """Describe the result of listing agents through MCP."""
+
     status: str
     count: int = 0
     agents: list[dict[str, Any]] = Field(default_factory=list)

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -326,13 +326,14 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RememberResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
             resolved_title = title or (
                 content[: _MAX_TITLE_LENGTH - 3] + "..."
                 if len(content) > _MAX_TITLE_LENGTH
                 else content
             )
-            result = lifecycle.client.remember(
+            result = client.remember(
                 agent_id=resolved,
                 memory_type=type,
                 title=resolved_title,
@@ -387,7 +388,8 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> BatchRememberResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
             # Validate before round-trip so we fail fast with a clear error.
             normalized_memories: list[dict[str, Any]] = []
             for i, item in enumerate(memories):
@@ -415,7 +417,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 normalized_item["tags"] = _normalize_tags(item.get("tags"))
                 normalized_memories.append(normalized_item)
 
-            result = lifecycle.client.batch_remember(
+            result = client.batch_remember(
                 agent_id=resolved,
                 memories=normalized_memories,
             )
@@ -500,8 +502,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.recall(
                 agent_id=resolved,
                 query=query,
                 limit=limit,
@@ -554,8 +557,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_recent(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.recall_recent(
                 agent_id=resolved,
                 limit=limit,
                 type=list(type) if type else None,
@@ -609,8 +613,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_as_of(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.recall_as_of(
                 agent_id=resolved,
                 as_of=as_of,
                 limit=limit,
@@ -665,8 +670,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> RecallResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.recall_changed_since(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.recall_changed_since(
                 agent_id=resolved,
                 since=since,
                 limit=limit,
@@ -740,8 +746,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
         agent_id: AgentIdField = None,
     ) -> AnswerResult:
         try:
-            resolved = lifecycle.ensure_ready(lifecycle.resolve_agent_id(agent_id))
-            result = lifecycle.client.answer(
+            resolved = lifecycle.resolve_agent_id(agent_id)
+            client = lifecycle.client_for(resolved)
+            result = client.answer(
                 agent_id=resolved,
                 question=question,
                 limit=limit,

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -91,3 +91,42 @@ def test_same_agent_reuses_activated_session_client(
     assert first_client is second_client
     assert first_client.activation_calls == 1
     assert len(_FakeSdkClient.instances) == 2  # admin + one agent session
+
+
+def test_different_agents_initialize_in_parallel(
+    lifecycle: MemantoLifecycle, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Network setup for one agent must not block an unrelated agent."""
+    activation_barrier = threading.Barrier(2)
+    original_activate = _FakeSdkClient.activate_agent
+    clients: list[_FakeSdkClient] = []
+    errors: list[BaseException] = []
+
+    def synchronized_activate(
+        client: _FakeSdkClient,
+        agent_id: str,
+        duration_hours: int | None = None,
+    ) -> dict[str, Any]:
+        activation_barrier.wait(timeout=2)
+        return original_activate(client, agent_id, duration_hours)
+
+    monkeypatch.setattr(_FakeSdkClient, "activate_agent", synchronized_activate)
+
+    def initialize(agent_id: str) -> None:
+        try:
+            clients.append(lifecycle.client_for(agent_id))
+        except BaseException as exc:  # pragma: no cover - reported in main thread
+            errors.append(exc)
+
+    workers = [
+        threading.Thread(target=initialize, args=("agent-a",)),
+        threading.Thread(target=initialize, args=("agent-b",)),
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=3)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert not errors
+    assert {client.agent_id for client in clients} == {"agent-a", "agent-b"}

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -1,0 +1,93 @@
+"""Session isolation tests for the MCP lifecycle."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+from memanto.app.utils.errors import SessionError
+
+import memanto_mcp.lifecycle as lifecycle_module
+from memanto_mcp.config import MCPServerSettings
+from memanto_mcp.lifecycle import MemantoLifecycle
+
+
+class _FakeSdkClient:
+    """Minimal client that enforces the same single-session scope as SdkClient."""
+
+    instances: list[_FakeSdkClient] = []
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self.agent_id: str | None = None
+        self.activation_calls = 0
+        self.instances.append(self)
+
+    def get_agent(self, agent_id: str) -> dict[str, Any]:
+        return {"agent_id": agent_id}
+
+    def activate_agent(
+        self, agent_id: str, duration_hours: int | None = None
+    ) -> dict[str, Any]:
+        self.activation_calls += 1
+        self.agent_id = agent_id
+        return {"agent_id": agent_id}
+
+    def recall(self, *, agent_id: str) -> dict[str, Any]:
+        if self.agent_id != agent_id:
+            raise SessionError(
+                f"Active session is for agent '{self.agent_id}', "
+                f"cannot access '{agent_id}'"
+            )
+        return {"agent_id": agent_id}
+
+
+@pytest.fixture
+def lifecycle(fake_api_key: str, monkeypatch: pytest.MonkeyPatch) -> MemantoLifecycle:
+    _FakeSdkClient.instances.clear()
+    monkeypatch.setattr(lifecycle_module, "SdkClient", _FakeSdkClient)
+    return MemantoLifecycle(MCPServerSettings())  # type: ignore[call-arg]
+
+
+def test_different_agents_keep_independent_session_clients(
+    lifecycle: MemantoLifecycle,
+) -> None:
+    """A second agent becoming ready must not invalidate the first client."""
+    first_ready = threading.Event()
+    second_ready = threading.Event()
+    errors: list[BaseException] = []
+
+    def recall_first_agent() -> None:
+        try:
+            first_client = lifecycle.client_for("agent-a")
+            first_ready.set()
+            assert second_ready.wait(timeout=2)
+            assert first_client.recall(agent_id="agent-a") == {"agent_id": "agent-a"}
+        except BaseException as exc:  # pragma: no cover - reported in main thread
+            errors.append(exc)
+
+    worker = threading.Thread(target=recall_first_agent)
+    worker.start()
+    assert first_ready.wait(timeout=2)
+
+    second_client = lifecycle.client_for("agent-b")
+    assert second_client.recall(agent_id="agent-b") == {"agent_id": "agent-b"}
+    second_ready.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert not errors
+    assert len(_FakeSdkClient.instances) == 3  # admin + one per active agent
+
+
+def test_same_agent_reuses_activated_session_client(
+    lifecycle: MemantoLifecycle,
+) -> None:
+    """Repeated calls for one agent should reuse its activated client."""
+    first_client = lifecycle.client_for("agent-a")
+    second_client = lifecycle.client_for("agent-a")
+
+    assert first_client is second_client
+    assert first_client.activation_calls == 1
+    assert len(_FakeSdkClient.instances) == 2  # admin + one agent session

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -93,6 +93,25 @@ def test_same_agent_reuses_activated_session_client(
     assert len(_FakeSdkClient.instances) == 2  # admin + one agent session
 
 
+def test_unique_agent_ids_cannot_grow_session_registry_without_bound(
+    lifecycle: MemantoLifecycle, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Capacity pressure rejects new IDs without disturbing existing clients."""
+    monkeypatch.setattr(lifecycle, "_MAX_SESSION_CLIENTS", 2)
+
+    first_client = lifecycle.client_for("agent-a")
+    lifecycle.client_for("agent-b")
+
+    with pytest.raises(SessionError, match=r"capacity reached \(2\)"):
+        lifecycle.client_for("agent-c")
+
+    assert lifecycle.client_for("agent-a") is first_client
+    assert set(lifecycle._session_clients) == {"agent-a", "agent-b"}
+    assert set(lifecycle._agent_locks) == {"agent-a", "agent-b"}
+    assert lifecycle._ensured_agents == {"agent-a", "agent-b"}
+    assert len(_FakeSdkClient.instances) == 3  # admin + two bounded sessions
+
+
 def test_different_agents_initialize_in_parallel(
     lifecycle: MemantoLifecycle, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/integrations/mcp/tests/test_lifecycle.py
+++ b/integrations/mcp/tests/test_lifecycle.py
@@ -57,7 +57,7 @@ def test_different_agents_keep_independent_session_clients(
     """A second agent becoming ready must not invalidate the first client."""
     first_ready = threading.Event()
     second_ready = threading.Event()
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def recall_first_agent() -> None:
         try:
@@ -65,7 +65,7 @@ def test_different_agents_keep_independent_session_clients(
             first_ready.set()
             assert second_ready.wait(timeout=2)
             assert first_client.recall(agent_id="agent-a") == {"agent_id": "agent-a"}
-        except BaseException as exc:  # pragma: no cover - reported in main thread
+        except Exception as exc:  # pragma: no cover - reported in main thread
             errors.append(exc)
 
     worker = threading.Thread(target=recall_first_agent)
@@ -120,7 +120,7 @@ def test_different_agents_initialize_in_parallel(
     activation_barrier = threading.Barrier(2)
     original_activate = _FakeSdkClient.activate_agent
     clients: list[_FakeSdkClient] = []
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def synchronized_activate(
         client: _FakeSdkClient,
@@ -135,7 +135,7 @@ def test_different_agents_initialize_in_parallel(
     def initialize(agent_id: str) -> None:
         try:
             clients.append(lifecycle.client_for(agent_id))
-        except BaseException as exc:  # pragma: no cover - reported in main thread
+        except Exception as exc:  # pragma: no cover - reported in main thread
             errors.append(exc)
 
     workers = [

--- a/integrations/mcp/tests/test_tools.py
+++ b/integrations/mcp/tests/test_tools.py
@@ -49,6 +49,10 @@ class FakeLifecycle:
     def ensure_ready(self, agent_id: str) -> str:
         return agent_id
 
+    def client_for(self, agent_id: str) -> MagicMock:
+        self.ensure_ready(agent_id)
+        return self.client
+
 
 def test_batch_remember_normalizes_comma_separated_tags() -> None:
     mcp = FakeMCP()

--- a/memanto/app/clients/backend.py
+++ b/memanto/app/clients/backend.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 
 class Backend(str, Enum):
+    """Identify a supported Memanto backend deployment type."""
+
     CLOUD = "cloud"
     ON_PREM = "on-prem"
 

--- a/memanto/app/clients/backend.py
+++ b/memanto/app/clients/backend.py
@@ -76,4 +76,7 @@ def get_active_embedding_model() -> str | None:
         state = json.loads(state_path.read_text())
     except Exception:
         return None
-    return state.get("embedding_model") or None
+    if not isinstance(state, dict):
+        return None
+    model = state.get("embedding_model")
+    return model if isinstance(model, str) and model else None

--- a/memanto/app/clients/backend.py
+++ b/memanto/app/clients/backend.py
@@ -56,3 +56,24 @@ def get_active_llm_model(cloud_default: str) -> str | None:
     except Exception:
         return None
     return state.get("llm_model") or None
+
+
+def get_active_embedding_model() -> str | None:
+    """Return the configured on-prem embedding model, when it is knowable.
+
+    Moorcheh Cloud owns its embedding configuration server-side, so callers
+    receive ``None`` there and should use a model-independent safe fallback.
+    """
+    from memanto.app.config import settings
+
+    if parse_backend(settings.MEMANTO_BACKEND) != Backend.ON_PREM:
+        return None
+
+    state_path = Path.home() / ".memanto" / "on-prem" / "state.json"
+    if not state_path.exists():
+        return None
+    try:
+        state = json.loads(state_path.read_text())
+    except Exception:
+        return None
+    return state.get("embedding_model") or None

--- a/memanto/app/clients/backend.py
+++ b/memanto/app/clients/backend.py
@@ -57,6 +57,11 @@ def get_active_llm_model(cloud_default: str) -> str | None:
         state = json.loads(state_path.read_text())
     except Exception:
         return None
+    # Valid JSON is not necessarily an object: a truncated or hand-edited
+    # state.json can hold a list/string/number, where ``.get`` would raise
+    # AttributeError instead of degrading to the documented ``None``.
+    if not isinstance(state, dict):
+        return None
     return state.get("llm_model") or None
 
 

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -2,11 +2,12 @@
 MEMANTO Core Architecture - Namespace Strategy & Memory Records
 """
 
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from memanto.app.constants import (
     MemoryType,
@@ -29,6 +30,22 @@ class MemoryRecord(BaseModel):
     type: MemoryType | None = None
     title: str = Field(max_length=100)
     content: str = Field(max_length=10000)
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def _normalize_title_newlines(cls, value: Any) -> Any:
+        """Collapse line breaks in titles to single spaces.
+
+        Titles are single-line labels: the serialized document format is
+        ``[TYPE] title\\n\\ncontent``, so a newline inside the title corrupts
+        the title/content boundary on readback (the ``[TYPE]`` prefix leaks
+        into the recalled title and compounds on every update). Newline titles
+        arrive from any caller, including the derived-title fallback that
+        slices multi-line content.
+        """
+        if isinstance(value, str) and ("\n" in value or "\r" in value):
+            return re.sub(r"[ \t]*[\r\n]+[ \t]*", " ", value).strip()
+        return value
 
     # Metadata fields
     agent_id: str

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -419,6 +419,7 @@ class MemoryItem(BaseModel):
     ttl_seconds: int | None = None
     actor_id: str | None = None
     source: str | None = None
+    source_ref: str | None = None
     agent_id: str | None = None
     score: float | None = None
     provenance: str = "explicit_statement"

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -373,7 +373,7 @@ async def remember(
         if is_successful_write_result(result):
             session_service = get_session_service()
             await asyncio.to_thread(
-                session_service.log_memory_to_session_summary,
+                session_service.try_log_memory_to_session_summary,
                 agent_id=agent_id,
                 session_id=session.session_id,
                 memory_record=memory,
@@ -458,7 +458,7 @@ async def batch_remember(
             if not is_successful_write_result(item_result):
                 continue
             await asyncio.to_thread(
-                session_service.log_memory_to_session_summary,
+                session_service.try_log_memory_to_session_summary,
                 agent_id=agent_id,
                 session_id=session.session_id,
                 memory_record=record,
@@ -630,7 +630,7 @@ async def extract_memories_from_conversation(
             if not is_successful_write_result(item_result):
                 continue
             await asyncio.to_thread(
-                session_service.log_memory_to_session_summary,
+                session_service.try_log_memory_to_session_summary,
                 agent_id=agent_id,
                 session_id=session.session_id,
                 memory_record=record,

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -137,15 +137,19 @@ class RecallRequest(BaseModel):
 
 
 def _parse_recall_temporal_bound(v: object, *, end_of_day: bool) -> datetime:
+    # End-of-day must be time.max (23:59:59.999999), matching
+    # parse_as_of_timestamp: the temporal filter compares with a strict `>`,
+    # so a 23:59:59 bound silently drops memories created in the final
+    # sub-second of the requested day.
     if isinstance(v, datetime):
         return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
     if isinstance(v, date):
-        boundary = time(23, 59, 59) if end_of_day else time(0, 0, 0)
+        boundary = time.max if end_of_day else time(0, 0, 0)
         return datetime.combine(v, boundary, tzinfo=timezone.utc)
     if isinstance(v, str):
         if "T" not in v and " " not in v:
             try:
-                boundary = time(23, 59, 59) if end_of_day else time(0, 0, 0)
+                boundary = time.max if end_of_day else time(0, 0, 0)
                 return datetime.combine(
                     date.fromisoformat(v), boundary, tzinfo=timezone.utc
                 )
@@ -185,13 +189,14 @@ class RecallAsOfRequest(BaseModel):
         if isinstance(v, datetime):
             return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
         if isinstance(v, date):
-            return datetime.combine(v, time(23, 59, 59), tzinfo=timezone.utc)
+            return datetime.combine(v, time.max, tzinfo=timezone.utc)
         if isinstance(v, str):
-            # Date-only (no time component) → end of day
+            # Date-only (no time component) → end of day (time.max, matching
+            # parse_as_of_timestamp — see _parse_recall_temporal_bound)
             if "T" not in v and " " not in v:
                 try:
                     return datetime.combine(
-                        date.fromisoformat(v), time(23, 59, 59), tzinfo=timezone.utc
+                        date.fromisoformat(v), time.max, tzinfo=timezone.utc
                     )
                 except ValueError:
                     pass

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -46,7 +46,11 @@ from memanto.app.utils.errors import (
     MemoryError,
     map_error_to_http_exception,
 )
-from memanto.app.utils.temporal_helpers import END_OF_DAY, is_date_only
+from memanto.app.utils.temporal_helpers import (
+    END_OF_DAY,
+    is_date_only,
+    parse_date_only,
+)
 from memanto.app.utils.validation import (
     CostGuard,
     is_successful_write_result,
@@ -162,7 +166,7 @@ def _parse_recall_temporal_bound(v: object, *, end_of_day: bool) -> datetime:
             try:
                 boundary = END_OF_DAY if end_of_day else time(0, 0, 0)
                 return datetime.combine(
-                    date.fromisoformat(v), boundary, tzinfo=timezone.utc
+                    parse_date_only(v), boundary, tzinfo=timezone.utc
                 )
             except ValueError:
                 pass
@@ -207,7 +211,7 @@ class RecallAsOfRequest(BaseModel):
             if is_date_only(v):
                 try:
                     return datetime.combine(
-                        date.fromisoformat(v), END_OF_DAY, tzinfo=timezone.utc
+                        parse_date_only(v), END_OF_DAY, tzinfo=timezone.utc
                     )
                 except ValueError:
                     pass
@@ -247,11 +251,13 @@ class RecallChangedSinceRequest(BaseModel):
         if isinstance(v, date):
             return datetime.combine(v, time(0, 0, 0), tzinfo=timezone.utc)
         if isinstance(v, str):
-            # Date-only (no time component) → start of day
-            if "T" not in v and " " not in v:
+            # Date-only (no time component) → start of day. Uses the same shared
+            # helper as the other date-only paths in this module so all three
+            # agree on what counts as a date, on every supported Python.
+            if is_date_only(v):
                 try:
                     return datetime.combine(
-                        date.fromisoformat(v), time(0, 0, 0), tzinfo=timezone.utc
+                        parse_date_only(v), time(0, 0, 0), tzinfo=timezone.utc
                     )
                 except ValueError:
                     pass

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -110,6 +110,8 @@ class RecallRequest(BaseModel):
     @field_validator("created_after", mode="before")
     @classmethod
     def parse_created_after(cls, v: object) -> datetime | None:
+        """Parse the inclusive lower timestamp bound for recall."""
+
         if v is None:
             return None
         return _parse_recall_temporal_bound(v, end_of_day=False)
@@ -117,6 +119,8 @@ class RecallRequest(BaseModel):
     @field_validator("created_before", mode="before")
     @classmethod
     def parse_created_before(cls, v: object) -> datetime | None:
+        """Parse the inclusive upper timestamp bound for recall."""
+
         if v is None:
             return None
         return _parse_recall_temporal_bound(v, end_of_day=True)
@@ -279,6 +283,8 @@ class RecallRecentRequest(BaseModel):
     @field_validator("created_after", mode="before")
     @classmethod
     def parse_created_after(cls, v: object) -> datetime | None:
+        """Parse the inclusive lower timestamp bound for recent recall."""
+
         if v is None:
             return None
         return _parse_recall_temporal_bound(v, end_of_day=False)
@@ -286,6 +292,8 @@ class RecallRecentRequest(BaseModel):
     @field_validator("created_before", mode="before")
     @classmethod
     def parse_created_before(cls, v: object) -> datetime | None:
+        """Parse the inclusive upper timestamp bound for recent recall."""
+
         if v is None:
             return None
         return _parse_recall_temporal_bound(v, end_of_day=True)
@@ -317,6 +325,8 @@ def enforce_session_scope(session: Session, agent_id: str) -> None:
 
 
 def resolve_recall_limit(request_limit: int | None) -> int:
+    """Resolve and validate the effective recall result limit."""
+
     recall_cfg = _config_manager.get_recall_config()
     raw_limit = (
         request_limit

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -377,6 +377,7 @@ async def remember(
                 agent_id=agent_id,
                 session_id=session.session_id,
                 memory_record=memory,
+                memory_id=result.get("id"),
             )
 
         return {
@@ -457,11 +458,13 @@ async def batch_remember(
             item_result = batch_results[index] if index < len(batch_results) else None
             if not is_successful_write_result(item_result):
                 continue
+            memory_id = item_result.get("id") if isinstance(item_result, dict) else None
             await asyncio.to_thread(
                 session_service.try_log_memory_to_session_summary,
                 agent_id=agent_id,
                 session_id=session.session_id,
                 memory_record=record,
+                memory_id=memory_id,
             )
 
         return {

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -20,6 +20,7 @@ from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import settings
 from memanto.app.constants import VALID_MEMORY_TYPES
 from memanto.app.core import MemoryRecord
+from memanto.app.utils.temporal_helpers import END_OF_DAY, is_date_only
 from memanto.app.models import (
     AnswerRequest,
     AnswerResponse,
@@ -185,13 +186,14 @@ class RecallAsOfRequest(BaseModel):
         if isinstance(v, datetime):
             return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
         if isinstance(v, date):
-            return datetime.combine(v, time(23, 59, 59), tzinfo=timezone.utc)
+            return datetime.combine(v, END_OF_DAY, tzinfo=timezone.utc)
         if isinstance(v, str):
-            # Date-only (no time component) → end of day
-            if "T" not in v and " " not in v:
+            # Date-only (no time component) → end of day. Delegated to the shared
+            # helper so this route and the read service cannot drift apart.
+            if is_date_only(v):
                 try:
                     return datetime.combine(
-                        date.fromisoformat(v), time(23, 59, 59), tzinfo=timezone.utc
+                        date.fromisoformat(v), END_OF_DAY, tzinfo=timezone.utc
                     )
                 except ValueError:
                     pass

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -27,6 +27,12 @@ class DailyAnalysisService:
     daily AI summary and the conflict report.
     """
 
+    # ``answer.generate`` embeds the query before retrieval. Keep the daily
+    # session digest below the default on-prem embedding model's 2048-token
+    # context window while passing the complete source text to the LLM through
+    # ``header_prompt``.
+    _MAX_SUMMARY_QUERY_CHARS = 6_000
+
     def __init__(
         self,
         sessions_dir: Path | None = None,
@@ -80,13 +86,15 @@ class DailyAnalysisService:
         client = get_moorcheh_client()
         namespace = agent_namespace(agent_id)
 
-        summary_prompt = f"""
+        header_prompt = f"""
 Summarize the following session memories from {date} into a concise natural language daily summary.
 Focus on key themes, accomplishments, and high-level activities.
 
 Sessions Content:
 {full_text}
+"""
 
+        footer_prompt = f"""
 Format the output as a Markdown report:
 # Daily Summary for {agent_id} - {date}
 **Generated at:** {format_current_local_time()}
@@ -96,11 +104,14 @@ Format the output as a Markdown report:
 ## Key Themes & Activities
 ...
 """
+        retrieval_query = full_text[: self._MAX_SUMMARY_QUERY_CHARS]
         try:
             generate_kwargs: dict[str, Any] = {
                 "namespace": namespace,
-                "query": summary_prompt,
+                "query": retrieval_query,
                 "top_k": 50,
+                "header_prompt": header_prompt,
+                "footer_prompt": footer_prompt,
             }
             ai_model = get_active_llm_model(settings.SUMMARY_MODEL)
             if ai_model is not None:

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -6,10 +6,14 @@ the AI daily summary and the conflict report.
 """
 
 import json
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
 
-from memanto.app.clients.backend import get_active_llm_model
+from memanto.app.clients.backend import (
+    get_active_embedding_model,
+    get_active_llm_model,
+)
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import get_data_dir, settings
 from memanto.app.core import agent_namespace
@@ -21,17 +25,57 @@ from memanto.app.utils.temporal_helpers import (
 )
 from memanto.app.utils.validation import validate_output_path, validate_safe_id
 
+_EMBEDDING_CONTEXT_TOKENS = 2_048
+_EMBEDDING_QUERY_TOKEN_BUDGET = 1_800
+
+
+@lru_cache(maxsize=8)
+def _get_embedding_tokenizer(model: str | None) -> Any | None:
+    """Load the active model's tokenizer without adding a hard dependency.
+
+    ``tiktoken`` is used only when it is already installed and recognizes the
+    configured model. Unknown and server-managed models fall back to the
+    byte-bound path below; this function never downloads tokenizer assets.
+    """
+    if not model:
+        return None
+    try:
+        import tiktoken  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    try:
+        return tiktoken.encoding_for_model(model)
+    except KeyError:
+        return None
+
+
+def _truncate_embedding_query(
+    text: str,
+    *,
+    model: str | None,
+    token_budget: int = _EMBEDDING_QUERY_TOKEN_BUDGET,
+) -> str:
+    """Fit text within the embedding budget using a tokenizer or safe bound."""
+    tokenizer = _get_embedding_tokenizer(model)
+    if tokenizer is not None:
+        token_ids = tokenizer.encode(text)
+        if len(token_ids) <= token_budget:
+            return text
+        return str(tokenizer.decode(token_ids[:token_budget]))
+
+    # Byte-level BPE and SentencePiece token counts cannot exceed the number
+    # of UTF-8 bytes in their input. Limiting bytes is conservative for normal
+    # prose and also bounds dense Unicode when the backend tokenizer is hidden.
+    encoded = text.encode("utf-8")
+    if len(encoded) <= token_budget:
+        return text
+    return encoded[:token_budget].decode("utf-8", errors="ignore")
+
 
 class DailyAnalysisService:
     """Service for analyzing a day's session MD files — generates the
     daily AI summary and the conflict report.
     """
-
-    # ``answer.generate`` embeds the query before retrieval. Keep the daily
-    # session digest below the default on-prem embedding model's 2048-token
-    # context window while passing the complete source text to the LLM through
-    # ``header_prompt``.
-    _MAX_SUMMARY_QUERY_CHARS = 6_000
 
     def __init__(
         self,
@@ -104,7 +148,10 @@ Format the output as a Markdown report:
 ## Key Themes & Activities
 ...
 """
-        retrieval_query = full_text[: self._MAX_SUMMARY_QUERY_CHARS]
+        retrieval_query = _truncate_embedding_query(
+            full_text,
+            model=get_active_embedding_model(),
+        )
         try:
             generate_kwargs: dict[str, Any] = {
                 "namespace": namespace,

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -25,6 +25,9 @@ from memanto.app.utils.temporal_helpers import (
 )
 from memanto.app.utils.validation import validate_output_path, validate_safe_id
 
+# Context window of the embedding models Memanto targets. The query budget sits
+# below it so the retrieval query still fits after the backend adds its own
+# framing. Asserted against in tests/test_daily_summary_query_length.py.
 _EMBEDDING_CONTEXT_TOKENS = 2_048
 _EMBEDDING_QUERY_TOKEN_BUDGET = 1_800
 
@@ -58,7 +61,11 @@ def _truncate_embedding_query(
     """Fit text within the embedding budget using a tokenizer or safe bound."""
     tokenizer = _get_embedding_tokenizer(model)
     if tokenizer is not None:
-        token_ids = tokenizer.encode(text)
+        # disallowed_special=() treats tokens like "<|endoftext|>" as ordinary
+        # text. Session content is arbitrary user prose, and tiktoken's default
+        # raises ValueError on those markers -- here that would escape before
+        # generate_summary's try/except turns failures into MemoryError.
+        token_ids = tokenizer.encode(text, disallowed_special=())
         if len(token_ids) <= token_budget:
             return text
         return str(tokenizer.decode(token_ids[:token_budget]))

--- a/memanto/app/services/memory_parsing_service.py
+++ b/memanto/app/services/memory_parsing_service.py
@@ -56,6 +56,20 @@ class MemoryParsingService:
             MemoryRule(re.compile(pattern, re.IGNORECASE), score)
             for pattern, score in [
                 (
+                    r"\b(?:i|we|they|he|she|user|client|customer)\s+"
+                    r"(?:really\s+)?"
+                    r"(?:(?:do|does|did)\s+not|don['’]t|doesn['’]t|didn['’]t|"
+                    r"no longer|never)\s+(?:really\s+)?"
+                    r"(?:like(?:d)?|love(?:d)?|prefer(?:red)?|enjoy(?:ed)?|favou?r(?:ed)?)\b",
+                    6,
+                ),
+                (
+                    r"\b(?:i|we|they|he|she|user|client|customer)\s+"
+                    r"(?:can['’]t|cannot)\s+stand\b",
+                    6,
+                ),
+                (r"\b(?:prefer|prefers)\s+not\s+to\b", 5),
+                (
                     r"\b(?:i|we|they|he|she|user|client|customer)\s+(?:really\s+)?(?:like|likes|love|loves|prefer|prefers|enjoy|enjoys|favor|favors)\b",
                     4,
                 ),

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -113,17 +113,31 @@ class MemoryReadService:
             if not namespaces:
                 return {"results": [], "total_found": 0, "execution_time": 0}
 
-            # Build enhanced query with Moorcheh metadata filters
-            enhanced_query = self._build_filtered_query(
-                query=query,
-                type=type,
-                tags=tags,
-                min_confidence=min_confidence,
-                status_filter=status_filter,
-                created_after=created_after,
-                created_before=created_before,
-                metadata_filters=metadata_filters,
+            # Moorcheh combines repeated exact-match filters. A document cannot
+            # satisfy both ``#memory_type:fact`` and
+            # ``#memory_type:preference``, so a list of requested types must be
+            # issued as one search per type and merged as a union. Build every
+            # query before dispatch so an invalid later type cannot trigger a
+            # partial set of backend calls.
+            distinct_types = list(dict.fromkeys(type or []))
+            type_variants: list[list[str] | None] = (
+                [[memory_type] for memory_type in distinct_types]
+                if len(distinct_types) > 1
+                else [distinct_types or None]
             )
+            enhanced_queries = [
+                self._build_filtered_query(
+                    query=query,
+                    type=type_variant,
+                    tags=tags,
+                    min_confidence=min_confidence,
+                    status_filter=status_filter,
+                    created_after=created_after,
+                    created_before=created_before,
+                    metadata_filters=metadata_filters,
+                )
+                for type_variant in type_variants
+            ]
 
             # Build query parameters
             # Request extra results to handle offset (Moorcheh doesn't have native offset support)
@@ -150,18 +164,50 @@ class MemoryReadService:
             # threshold; min_similarity=0.0 means "no filter", but on-prem
             # kiosk_mode + threshold=0.0 still filters everything out.
             use_kiosk = min_similarity_score is not None and min_similarity_score > 0
-            search_result = self.client.similarity_search.query(
-                query=enhanced_query,
-                namespaces=namespaces,
-                top_k=top_k,
-                threshold=min_similarity_score if use_kiosk else None,
-                kiosk_mode=use_kiosk,
-            )
-
-            search_items = search_result.get("results", [])
+            search_items: list[Any] = []
+            execution_time = 0.0
+            for enhanced_query in enhanced_queries:
+                search_result = self.client.similarity_search.query(
+                    query=enhanced_query,
+                    namespaces=namespaces,
+                    top_k=top_k,
+                    threshold=min_similarity_score if use_kiosk else None,
+                    kiosk_mode=use_kiosk,
+                )
+                search_items.extend(search_result.get("results", []))
+                try:
+                    execution_time += float(search_result.get("execution_time", 0))
+                except (TypeError, ValueError):
+                    pass
 
             # Format results
             all_results = [self._format_memory_item(item) for item in search_items]
+
+            if len(enhanced_queries) > 1:
+                # Scores from the per-type searches share the same backend
+                # scale. Re-rank the union before applying offset/limit and
+                # de-duplicate defensively in case malformed metadata causes a
+                # row to be returned by more than one variant.
+                def _score(memory: dict[str, Any]) -> float:
+                    raw_score = memory.get("score")
+                    if raw_score is None:
+                        return float("-inf")
+                    try:
+                        return float(raw_score)
+                    except (TypeError, ValueError):
+                        return float("-inf")
+
+                all_results.sort(key=_score, reverse=True)
+                unique_results: list[dict[str, Any]] = []
+                seen_ids: set[Any] = set()
+                for memory in all_results:
+                    memory_id = memory.get("id")
+                    if memory_id is not None and memory_id in seen_ids:
+                        continue
+                    if memory_id is not None:
+                        seen_ids.add(memory_id)
+                    unique_results.append(memory)
+                all_results = unique_results
 
             # Apply temporal filtering (post-processing since Moorcheh metadata filters are string-based)
             if created_after or created_before:
@@ -191,8 +237,8 @@ class MemoryReadService:
                 "limit": limit,
                 "has_more": has_more,
                 "query": query,
-                "enhanced_query": enhanced_query,
-                "execution_time": search_result.get("execution_time", 0),
+                "enhanced_query": " OR ".join(enhanced_queries),
+                "execution_time": execution_time,
             }
 
         except Exception as e:

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -3,6 +3,7 @@ Memory Read Service
 """
 
 import re
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
@@ -164,16 +165,36 @@ class MemoryReadService:
             # threshold; min_similarity=0.0 means "no filter", but on-prem
             # kiosk_mode + threshold=0.0 still filters everything out.
             use_kiosk = min_similarity_score is not None and min_similarity_score > 0
+
+            def _dispatch(enhanced_query: str) -> dict[str, Any]:
+                """Run one exact-filter search with the shared request options."""
+                return cast(
+                    dict[str, Any],
+                    self.client.similarity_search.query(
+                        query=enhanced_query,
+                        namespaces=namespaces,
+                        top_k=top_k,
+                        threshold=min_similarity_score if use_kiosk else None,
+                        kiosk_mode=use_kiosk,
+                    ),
+                )
+
+            if len(enhanced_queries) == 1:
+                search_results = [_dispatch(enhanced_queries[0])]
+            else:
+                # The variants are independent network calls. Dispatch them in
+                # parallel so the latency of a multi-type union is bounded by
+                # the slowest search rather than the sum of every round trip.
+                # pool.map preserves enhanced-query order for deterministic
+                # result aggregation while capping concurrency for direct
+                # service callers that pass every supported type.
+                max_workers = min(len(enhanced_queries), 8)
+                with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                    search_results = list(pool.map(_dispatch, enhanced_queries))
+
             search_items: list[Any] = []
             execution_time = 0.0
-            for enhanced_query in enhanced_queries:
-                search_result = self.client.similarity_search.query(
-                    query=enhanced_query,
-                    namespaces=namespaces,
-                    top_k=top_k,
-                    threshold=min_similarity_score if use_kiosk else None,
-                    kiosk_mode=use_kiosk,
-                )
+            for search_result in search_results:
                 search_items.extend(search_result.get("results", []))
                 try:
                     execution_time += float(search_result.get("execution_time", 0))
@@ -189,6 +210,7 @@ class MemoryReadService:
                 # de-duplicate defensively in case malformed metadata causes a
                 # row to be returned by more than one variant.
                 def _score(memory: dict[str, Any]) -> float:
+                    """Return a sortable backend score, placing missing values last."""
                     raw_score = memory.get("score")
                     if raw_score is None:
                         return float("-inf")

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -384,6 +384,10 @@ class MemoryReadService:
                         if expires_dt is not None and expires_dt <= as_of_dt:
                             continue  # Already expired at as_of_date
                     except (ValueError, AttributeError, TypeError):
+                        # Fail open: a malformed expires_at is not proof the
+                        # memory had expired at as_of. Falling through to the
+                        # append below keeps it in the historical result rather
+                        # than silently dropping it (timeline amnesia).
                         pass
 
                 valid_memories.append(memory)

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -237,7 +237,9 @@ class MemoryReadService:
                     "temporal_mode": "as_of",
                 }
 
-            all_memories = self._fetch_all_memories(namespaces, type=type, tags=tags)
+            all_memories = self._fetch_all_memories(
+                namespaces, type=type, tags=tags, filter_expired=False
+            )
             all_memories = self._apply_temporal_filter(
                 all_memories, created_before=as_of_dt.isoformat()
             )
@@ -426,6 +428,7 @@ class MemoryReadService:
         namespaces: list[str],
         type: list[str] | None = None,
         tags: list[str] | None = None,
+        filter_expired: bool = True,
     ) -> list[dict[str, Any]]:
         """
         List all stored memories across the given namespaces via Moorcheh's
@@ -434,6 +437,13 @@ class MemoryReadService:
 
         Iterates through all pages using cursor-based pagination (next_token)
         so results are not truncated at the 100-item per-page cap.
+
+        ``filter_expired`` controls whether memories expired at the current
+        wall-clock time are dropped. Point-in-time callers such as
+        ``search_as_of`` must pass ``filter_expired=False`` and apply their
+        own expiry check against the target date, otherwise memories that
+        were valid at that past date but have since expired are silently
+        dropped (timeline amnesia).
         """
         items: list[Any] = []
         for ns in namespaces:
@@ -479,7 +489,9 @@ class MemoryReadService:
 
             memories.append(formatted)
 
-        return self._filter_expired_memories(memories)
+        if filter_expired:
+            return self._filter_expired_memories(memories)
+        return memories
 
     def _memory_version_key(
         self, memory: dict[str, Any], fetch_index: int

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -5,6 +5,7 @@ Memory Read Service
 import re
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
+from time import monotonic
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -179,6 +180,7 @@ class MemoryReadService:
                     ),
                 )
 
+            dispatch_start = monotonic()
             if len(enhanced_queries) == 1:
                 search_results = [_dispatch(enhanced_queries[0])]
             else:
@@ -191,15 +193,11 @@ class MemoryReadService:
                 max_workers = min(len(enhanced_queries), 8)
                 with ThreadPoolExecutor(max_workers=max_workers) as pool:
                     search_results = list(pool.map(_dispatch, enhanced_queries))
+            execution_time = monotonic() - dispatch_start
 
             search_items: list[Any] = []
-            execution_time = 0.0
             for search_result in search_results:
                 search_items.extend(search_result.get("results", []))
-                try:
-                    execution_time += float(search_result.get("execution_time", 0))
-                except (TypeError, ValueError):
-                    pass
 
             # Format results
             all_results = [self._format_memory_item(item) for item in search_items]

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -238,7 +238,11 @@ class MemoryReadService:
                 }
 
             all_memories = self._fetch_all_memories(
-                namespaces, type=type, tags=tags, filter_expired=False
+                namespaces,
+                type=type,
+                tags=tags,
+                filter_expired=False,
+                created_before=as_of_dt.isoformat(),
             )
             all_memories = self._apply_temporal_filter(
                 all_memories, created_before=as_of_dt.isoformat()
@@ -429,6 +433,7 @@ class MemoryReadService:
         type: list[str] | None = None,
         tags: list[str] | None = None,
         filter_expired: bool = True,
+        created_before: str | None = None,
     ) -> list[dict[str, Any]]:
         """
         List all stored memories across the given namespaces via Moorcheh's
@@ -444,7 +449,22 @@ class MemoryReadService:
         own expiry check against the target date, otherwise memories that
         were valid at that past date but have since expired are silently
         dropped (timeline amnesia).
+
+        ``created_before`` drops any version whose ``created_at`` is after the
+        given ISO timestamp *before* de-duplication, so point-in-time callers
+        can stop a delete-and-recreate that happened after ``as_of`` from
+        evicting the version that was valid then during newest-version
+        selection (bounty #770).
         """
+        from memanto.app.utils.temporal_helpers import parse_iso_timestamp
+
+        before_dt: datetime | None = None
+        if created_before:
+            try:
+                before_dt = parse_iso_timestamp(created_before)
+            except (TypeError, ValueError, AttributeError):
+                pass  # Fail open: keep newest-version dedup behaviour.
+
         items: list[Any] = []
         for ns in namespaces:
             next_token: str | None = None
@@ -472,6 +492,19 @@ class MemoryReadService:
             mid = formatted.get("id")
             if not mid:
                 continue
+
+            # Point-in-time dedup: only versions that existed at the target
+            # date compete for the newest-version slot, so a delete-and-recreate
+            # after as_of cannot displace the version valid then (bounty #770).
+            if before_dt is not None:
+                raw_created = formatted.get("created_at")
+                if not raw_created:
+                    continue
+                try:
+                    if parse_iso_timestamp(str(raw_created)) > before_dt:
+                        continue
+                except (TypeError, ValueError):
+                    continue
 
             version_key = self._memory_version_key(formatted, index)
             existing = latest_by_id.get(cast(str, mid))

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -251,14 +251,25 @@ class MemoryReadService:
             # Filter to only include memories valid at as_of_date
             valid_memories = []
             for memory in all_memories:
-                # Skip if expired before as_of_date
+                # Skip if expired before as_of_date. Mirror the datetime
+                # handling in _filter_expired_memories so a datetime-valued
+                # expires_at cannot crash a historical recall (bounty #770).
                 expires_at = memory.get("expires_at")
                 if expires_at:
                     try:
-                        expires_dt = parse_iso_timestamp(expires_at)
-                        if expires_dt <= as_of_dt:
+                        if isinstance(expires_at, str):
+                            expires_dt = parse_iso_timestamp(expires_at)
+                        elif isinstance(expires_at, datetime):
+                            expires_dt = (
+                                expires_at
+                                if expires_at.tzinfo
+                                else expires_at.replace(tzinfo=timezone.utc)
+                            )
+                        else:
+                            expires_dt = None  # Unknown type: fail open
+                        if expires_dt is not None and expires_dt <= as_of_dt:
                             continue  # Already expired at as_of_date
-                    except (ValueError, AttributeError):
+                    except (ValueError, AttributeError, TypeError):
                         pass
 
                 valid_memories.append(memory)

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -713,9 +713,11 @@ class MemoryReadService:
             lines = raw_text.split("\n\n", 2)  # Split into at most 3 parts
             first_line = lines[0] if lines else ""
 
-            # Extract title: strip the "[TYPE] " prefix from first line
-
-            title_match = re.match(r"^\[.*?\]\s*(.*)$", first_line)
+            # Extract title: strip the "[TYPE] " prefix from first line.
+            # DOTALL: documents stored before titles were normalized may
+            # still carry a raw newline inside the title block; the prefix
+            # must be stripped instead of leaking into the returned title.
+            title_match = re.match(r"^\[.*?\]\s*(.*)$", first_line, re.DOTALL)
             if title_match:
                 title = title_match.group(1).strip()
                 # Content is the rest after the first line (skip tags section)

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -30,8 +30,6 @@ _REMOVED_TRUST_FIELDS = frozenset(
     }
 )
 
-_SUCCESSFUL_UPLOAD_STATUSES = {"queued", "success", "ok"}
-
 
 class MemoryWriteService:
     """Persist memory records to Moorcheh-backed namespaces."""
@@ -239,7 +237,7 @@ class MemoryWriteService:
                 moorcheh_status = str(upload_result.get("status", "unknown")).lower()
                 for result in results:
                     if result["status"] == "pending":
-                        if moorcheh_status in _SUCCESSFUL_UPLOAD_STATUSES:
+                        if moorcheh_status in SUCCESSFUL_UPLOAD_STATUSES:
                             result["status"] = moorcheh_status
                         else:
                             result["status"] = "failed"
@@ -249,18 +247,18 @@ class MemoryWriteService:
 
             # Count successes, failures, and namespace-rejected items separately
             # so that successful + failed + rejected == total_submitted always.
-            _known = set(SUCCESSFUL_UPLOAD_STATUSES) | {"failed", "rejected"}
-            successful = sum(
-                1
-                for r in results
-                if str(r["status"]).lower() in SUCCESSFUL_UPLOAD_STATUSES
-            )
-            failed = sum(1 for r in results if str(r["status"]).lower() == "failed")
-            rejected = sum(1 for r in results if str(r["status"]).lower() == "rejected")
-            # Absorb any non-standard upload statuses into failed so the invariant holds
-            failed += len(results) - successful - failed - rejected
+            successful = 0
+            failed = 0
+            rejected = 0
             for r in results:
-                if str(r["status"]).lower() not in _known:
+                status = str(r["status"]).lower()
+                if status in SUCCESSFUL_UPLOAD_STATUSES:
+                    successful += 1
+                elif status == "rejected":
+                    rejected += 1
+                else:
+                    # Absorb any non-standard upload statuses into failed
+                    failed += 1
                     r["status"] = "failed"
 
             return {

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -252,9 +252,10 @@ class MemoryWriteService:
             rejected = 0
             for r in results:
                 status = str(r["status"]).lower()
+                action = str(r.get("action", "")).lower()
                 if status in SUCCESSFUL_UPLOAD_STATUSES:
                     successful += 1
-                elif status == "rejected":
+                elif status == "rejected" or action == "rejected":
                     rejected += 1
                 else:
                     # Absorb any non-standard upload statuses into failed

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -327,6 +327,7 @@ class MemoryWriteService:
                 confidence=updates.get("confidence", metadata.get("confidence", 0.8)),
                 status=updates.get("status", metadata.get("status", "active")),
                 tags=updates.get("tags", metadata.get("tags", [])),
+                provenance=metadata.get("provenance") or "explicit_statement",
             )
 
             # Update timestamps (preserve created_at, set updated_at to now)
@@ -382,16 +383,24 @@ class MemoryWriteService:
             except Exception as e:
                 raise MemoryError(f"Upload failed. Error: {e}")
 
+            status = upload_result.get("status", "unknown")
+            if str(status).lower() not in SUCCESSFUL_UPLOAD_STATUSES:
+                raise MemoryError(
+                    f"Failed to upload updated memory {memory_id}: {status}"
+                )
+
             return {
                 "id": memory_id,
                 "namespace": namespace,
-                "status": upload_result.get("status", "unknown"),
+                "status": status,
                 "action": "updated",
                 "reason": "Memory updated successfully via overwrite",
                 "validation": validation_result.get("action", "validated"),
                 "updated_fields": list(updates.keys()),
             }
 
+        except MemoryError:
+            raise
         except Exception as e:
             raise MemoryError(f"Failed to update memory: {e}")
 

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -252,13 +252,16 @@ class MemoryWriteService:
             rejected = 0
             for r in results:
                 status = str(r["status"]).lower()
-                action = str(r.get("action", "")).lower()
                 if status in SUCCESSFUL_UPLOAD_STATUSES:
                     successful += 1
-                elif status == "rejected" or action == "rejected":
+                elif status == "rejected":
                     rejected += 1
                 else:
-                    # Absorb any non-standard upload statuses into failed
+                    # Validation failures carry status="failed"/action="rejected"
+                    # and must stay in `failed`: the batch endpoints return only
+                    # successful/failed (see routes/memory.py), so counting them
+                    # as `rejected` would drop them from the response entirely.
+                    # Non-standard upload statuses are absorbed here too.
                     failed += 1
                     r["status"] = "failed"
 

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -260,18 +260,18 @@ class OkfExportService:
         """Best-effort parse of a stored ``created_at`` into an aware UTC datetime;
         falls back to now so the activity timeline always has an hour bucket."""
         if isinstance(value, datetime):
-            if value.tzinfo is None:
+            if value.tzinfo is None or value.utcoffset() is None:
                 return value.replace(tzinfo=timezone.utc)
-            return value
+            return value.astimezone(timezone.utc)
         if isinstance(value, str) and value.strip():
             text = value.strip()
             if text.endswith("Z"):
                 text = text[:-1] + "+00:00"
             try:
                 dt = datetime.fromisoformat(text)
-                if dt.tzinfo is None:
+                if dt.tzinfo is None or dt.utcoffset() is None:
                     return dt.replace(tzinfo=timezone.utc)
-                return dt
+                return dt.astimezone(timezone.utc)
             except ValueError:
                 pass
         return datetime.now(timezone.utc)

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -23,7 +23,7 @@ frontmatter keys.
 
 import re
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -257,19 +257,24 @@ class OkfExportService:
 
     @staticmethod
     def _parse_ts(value: Any) -> datetime:
-        """Best-effort parse of a stored ``created_at`` into a datetime; falls
-        back to now so the activity timeline always has an hour bucket."""
+        """Best-effort parse of a stored ``created_at`` into an aware UTC datetime;
+        falls back to now so the activity timeline always has an hour bucket."""
         if isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=timezone.utc)
             return value
         if isinstance(value, str) and value.strip():
             text = value.strip()
             if text.endswith("Z"):
                 text = text[:-1] + "+00:00"
             try:
-                return datetime.fromisoformat(text)
+                dt = datetime.fromisoformat(text)
+                if dt.tzinfo is None:
+                    return dt.replace(tzinfo=timezone.utc)
+                return dt
             except ValueError:
                 pass
-        return datetime.now()
+        return datetime.now(timezone.utc)
 
     # Rendering helpers
     def _render_okf_doc(self, mem: dict[str, Any], mem_type: str) -> str:

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -116,6 +116,31 @@ class SessionService:
             os.close(fd)
             raise
 
+    def _write_private_json_atomic(self, path: Path, data: Any) -> None:
+        """Atomically replace a private JSON file after a complete durable write.
+
+        Writing directly to the live path with ``O_TRUNC`` can destroy the only
+        valid session record if serialization or the process fails mid-write.
+        A sibling temporary file keeps readers on the previous complete record
+        until the replacement is ready.
+        """
+        tmp_path = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        try:
+            with self._open_private_text(
+                tmp_path, flags, "w", encoding="utf-8"
+            ) as tmp_file:
+                json.dump(data, tmp_file, indent=2)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+            os.replace(tmp_path, path)
+            self._set_private_permissions(path, self._PRIVATE_FILE_MODE)
+        finally:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
+
     def _generate_secure_secret_key(self) -> str:
         """Generate (or reuse) a persisted fallback secret for JWT signing.
 
@@ -430,9 +455,7 @@ class SessionService:
         """Save session to file"""
         validate_safe_id(session.agent_id, "agent_id")
         session_file = self.sessions_dir / f"{session.agent_id}.json"
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-        with self._open_private_text(session_file, flags, "w") as f:
-            json.dump(session.model_dump(mode="json"), f, indent=2)
+        self._write_private_json_atomic(session_file, session.model_dump(mode="json"))
 
     def _load_session_file(self, session_file: Path) -> Session | None:
         """Load one session file, treating corrupt local state as absent."""

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -409,16 +409,18 @@ class SessionService:
         """
         with self._active_marker_lock:
             active_link = self.sessions_dir / "active"
-            if not active_link.exists():
-                return None
 
-            # Read symlink (or file on Windows)
-            if active_link.is_symlink():
-                target = active_link.readlink()
-                agent_id = target.stem
-            else:
-                with open(active_link) as f:
-                    agent_id = f.read().strip()
+            try:
+                # Read symlink (or file on Windows). Another process can replace
+                # or remove the marker while this process holds its local lock.
+                if active_link.is_symlink():
+                    target = active_link.readlink()
+                    agent_id = target.stem
+                else:
+                    with open(active_link) as f:
+                        agent_id = f.read().strip()
+            except OSError:
+                return None
 
             session = self.get_session(agent_id)
             if not session:
@@ -730,8 +732,7 @@ class SessionService:
             active_link = self.sessions_dir / "active"
 
             # Remove existing active link
-            if active_link.exists() or active_link.is_symlink():
-                active_link.unlink()
+            active_link.unlink(missing_ok=True)
 
             # Create new active marker
             # On Windows, write agent_id to file instead of symlink
@@ -747,8 +748,7 @@ class SessionService:
         """Clear active session marker"""
         with self._active_marker_lock:
             active_link = self.sessions_dir / "active"
-            if active_link.exists() or active_link.is_symlink():
-                active_link.unlink()
+            active_link.unlink(missing_ok=True)
 
     def clear_active_session(self) -> None:
         """Public alias: clear the active-session marker without ending the session."""
@@ -765,16 +765,18 @@ class SessionService:
             active_link = self.sessions_dir / "active"
             active_agent_id: str | None = None
 
-            if active_link.is_symlink():
-                active_agent_id = active_link.readlink().stem
-            elif active_link.exists():
-                with open(active_link) as f:
-                    active_agent_id = f.read().strip()
+            try:
+                if active_link.is_symlink():
+                    active_agent_id = active_link.readlink().stem
+                else:
+                    with open(active_link) as f:
+                        active_agent_id = f.read().strip()
+            except OSError:
+                pass
 
             session_file = self.sessions_dir / f"{agent_id}.json"
             deleted = session_file.exists()
-            if deleted:
-                session_file.unlink()
+            session_file.unlink(missing_ok=True)
 
             if active_agent_id == agent_id:
                 self._clear_active_session()

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -465,6 +465,37 @@ class SessionService:
             f.write(f"> {content.replace(chr(10), chr(10) + '> ')}\n\n")
             f.write("---\n\n")
 
+    def try_log_memory_to_session_summary(
+        self,
+        agent_id: str,
+        session_id: str,
+        memory_record: Any,
+        memory_id: str | None = None,
+    ) -> bool:
+        """Best-effort summary logging for an already committed memory.
+
+        The remote memory store is authoritative. Once that write succeeds, an
+        auxiliary local Markdown failure must not make callers report the
+        operation as failed (and potentially retry it with a new memory ID).
+        """
+        try:
+            self.log_memory_to_session_summary(
+                agent_id=agent_id,
+                session_id=session_id,
+                memory_record=memory_record,
+                memory_id=memory_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Memory %s was committed for agent %s, but session summary "
+                "logging failed: %s",
+                memory_id or getattr(memory_record, "id", "unknown"),
+                agent_id,
+                exc,
+            )
+            return False
+        return True
+
     def log_memory_deletion_to_session_summary(
         self,
         agent_id: str,
@@ -502,6 +533,30 @@ class SessionService:
             f.write(f"- **Memory ID**: `{memory_id}`\n")
             f.write("- **Confidence**: `1.0`\n")
             f.write("---\n\n")
+
+    def try_log_memory_deletion_to_session_summary(
+        self,
+        agent_id: str,
+        session_id: str,
+        memory_id: str,
+    ) -> bool:
+        """Best-effort summary logging for an already committed deletion."""
+        try:
+            self.log_memory_deletion_to_session_summary(
+                agent_id=agent_id,
+                session_id=session_id,
+                memory_id=memory_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Memory %s was deleted for agent %s, but session summary "
+                "logging failed: %s",
+                memory_id,
+                agent_id,
+                exc,
+            )
+            return False
+        return True
 
     def _set_active_session(self, agent_id: str) -> None:
         """Mark session as active"""

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -139,6 +139,8 @@ class SessionService:
                 if fchmod is not None:
                     fchmod(fd, self._PRIVATE_FILE_MODE)
             except OSError:
+                # Best-effort only: some platforms and filesystems reject fchmod
+                # even though os.open already created the file with this mode.
                 pass
             return os.fdopen(fd, mode, **kwargs)
         except Exception:
@@ -168,6 +170,8 @@ class SessionService:
             try:
                 tmp_path.unlink()
             except FileNotFoundError:
+                # Expected on the success path: os.replace already moved the
+                # temp file onto the target, so there is nothing left to clean up.
                 pass
 
     def _generate_secure_secret_key(self) -> str:
@@ -429,7 +433,14 @@ class SessionService:
             except OSError:
                 return None
 
-            session = self.get_session(agent_id)
+            try:
+                session = self.get_session(agent_id)
+            except ValueError:
+                # An empty or malformed marker (e.g. a crash between unlink and
+                # the fallback write in _set_active_session) fails validate_safe_id.
+                # An unreadable marker means "no active session", exactly as the
+                # OSError path above already treats it.
+                return None
             if not session:
                 return None
 
@@ -802,8 +813,13 @@ class SessionService:
                 else:
                     with open(active_link) as f:
                         active_agent_id = f.read().strip()
-            except OSError:
-                pass
+            except OSError as exc:
+                # Best-effort: a missing or unreadable active marker must not
+                # block deleting this agent's persisted session state. Leaving
+                # active_agent_id as None simply skips the marker cleanup below.
+                logger.debug(
+                    "Could not read active session marker '%s': %s", active_link, exc
+                )
 
             session_file = self.sessions_dir / f"{agent_id}.json"
             deleted = session_file.exists()

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -9,6 +9,8 @@ import json
 import logging
 import os
 import secrets
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -146,36 +148,65 @@ class SessionService:
 
         Persisted alongside the sessions directory so sessions survive
         process restarts instead of every new process invalidating all
-        existing session tokens. Created atomically (O_CREAT | O_EXCL) with
-        restrictive permissions from the moment of creation, so concurrent
-        first-start processes can't race each other into using divergent
-        secrets and there's no window where the file is world-readable. An
+        existing session tokens. A cross-process lock serializes the initial
+        read/write so concurrent first-start workers cannot return divergent
+        secrets. The file has restrictive permissions from creation, and an
         existing-but-empty file (e.g. left behind by a crash mid-write) is
-        treated as absent and rewritten.
+        safely rewritten by the lock holder.
         """
         secret_file = self.sessions_dir.parent / "secret_key"
-        existing = self._read_persisted_secret(secret_file)
-        if existing is not None:
-            return existing
-
-        secret = secrets.token_hex(32)
-        try:
-            fd = os.open(str(secret_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        except FileExistsError:
-            # Lost a race to another process, or the file is a stale empty stub.
+        lock_file = secret_file.with_name(f"{secret_file.name}.lock")
+        with self._exclusive_file_lock(lock_file):
             existing = self._read_persisted_secret(secret_file)
             if existing is not None:
                 return existing
-            fd = os.open(str(secret_file), os.O_WRONLY | os.O_TRUNC, 0o600)
+
+            secret = secrets.token_hex(32)
+            fd = os.open(str(secret_file), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as file_handle:
+                file_handle.write(secret)
+                file_handle.flush()
+                os.fsync(file_handle.fileno())
+            try:
+                secret_file.chmod(0o600)
+            except OSError:
+                pass  # Windows may not support chmod
+            return secret
+
+    @staticmethod
+    @contextmanager
+    def _exclusive_file_lock(lock_file: Path) -> Iterator[None]:
+        """Hold an advisory cross-process lock on one byte of ``lock_file``."""
+        fd = os.open(str(lock_file), os.O_CREAT | os.O_RDWR, 0o600)
+        locked = False
         try:
-            os.write(fd, secret.encode())
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+                os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_EX)  # type: ignore[attr-defined]
+            locked = True
+            yield
         finally:
+            if locked:
+                os.lseek(fd, 0, os.SEEK_SET)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)  # type: ignore[attr-defined]
             os.close(fd)
-        try:
-            secret_file.chmod(0o600)
-        except OSError:
-            pass  # Windows may not support chmod
-        return secret
 
     @staticmethod
     def _read_persisted_secret(secret_file: Path) -> str | None:

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -54,6 +54,9 @@ def get_session_service() -> "SessionService":
 class SessionService:
     """Service for managing sessions"""
 
+    _PRIVATE_FILE_MODE = 0o600
+    _PRIVATE_DIR_MODE = 0o700
+
     def __init__(self, secret_key: str | None = None, sessions_dir: Path | None = None):
         """
         Initialize session service
@@ -63,13 +66,55 @@ class SessionService:
             sessions_dir: Directory for session storage (defaults to ~/.memanto/sessions/)
         """
         self.sessions_dir = sessions_dir or get_data_dir() / "sessions"
-        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        self.sessions_dir.mkdir(
+            parents=True, exist_ok=True, mode=self._PRIVATE_DIR_MODE
+        )
+        self._harden_session_storage()
         resolved_secret_key = (
             secret_key
             or settings.MEMANTO_SECRET_KEY
             or self._generate_secure_secret_key()
         )
         self.secret_key: str = resolved_secret_key
+
+    @staticmethod
+    def _set_private_permissions(path: Path, mode: int) -> None:
+        """Best-effort owner-only permissions for persisted session state."""
+        try:
+            path.chmod(mode)
+        except OSError:
+            # Windows ACLs are not represented by POSIX mode bits. Creation and
+            # access still follow the owning user's ACL in that environment.
+            pass
+
+    def _harden_session_storage(self) -> None:
+        """Protect both newly-created and pre-existing session artifacts.
+
+        Session JSON files contain live bearer tokens, while summary files can
+        contain private memory content. A normal ``mkdir``/``open`` sequence on
+        POSIX inherits the process umask and commonly creates these as 0755 and
+        0644, allowing other local accounts to traverse and read them.
+        """
+        self._set_private_permissions(self.sessions_dir, self._PRIVATE_DIR_MODE)
+        for path in self.sessions_dir.iterdir():
+            if path.is_symlink() or not path.is_file():
+                continue
+            self._set_private_permissions(path, self._PRIVATE_FILE_MODE)
+
+    def _open_private_text(self, path: Path, flags: int, mode: str, **kwargs):
+        """Open a text file with owner-only permissions from first creation."""
+        fd = os.open(str(path), flags, self._PRIVATE_FILE_MODE)
+        try:
+            try:
+                fchmod = getattr(os, "fchmod", None)
+                if fchmod is not None:
+                    fchmod(fd, self._PRIVATE_FILE_MODE)
+            except OSError:
+                pass
+            return os.fdopen(fd, mode, **kwargs)
+        except Exception:
+            os.close(fd)
+            raise
 
     def _generate_secure_secret_key(self) -> str:
         """Generate (or reuse) a persisted fallback secret for JWT signing.
@@ -385,7 +430,8 @@ class SessionService:
         """Save session to file"""
         validate_safe_id(session.agent_id, "agent_id")
         session_file = self.sessions_dir / f"{session.agent_id}.json"
-        with open(session_file, "w") as f:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        with self._open_private_text(session_file, flags, "w") as f:
             json.dump(session.model_dump(mode="json"), f, indent=2)
 
     def _load_session_file(self, session_file: Path) -> Session | None:
@@ -443,7 +489,8 @@ class SessionService:
         status = getattr(memory_record, "status", None)
         tags = getattr(memory_record, "tags", None)
 
-        with open(summary_file, "a", encoding="utf-8") as f:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        with self._open_private_text(summary_file, flags, "a", encoding="utf-8") as f:
             if write_header:
                 f.write(f"# Session Summary for {agent_id}\n")
                 f.write(f"**Session ID:** `{session_id}`\n\n")
@@ -523,7 +570,8 @@ class SessionService:
 
         write_header = not summary_file.exists()
 
-        with open(summary_file, "a", encoding="utf-8") as f:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        with self._open_private_text(summary_file, flags, "a", encoding="utf-8") as f:
             if write_header:
                 f.write(f"# Session Summary for {agent_id}\n")
                 f.write(f"**Session ID:** `{session_id}`\n\n")
@@ -573,7 +621,8 @@ class SessionService:
             active_link.symlink_to(f"{agent_id}.json")
         except (OSError, NotImplementedError):
             # Fallback for Windows or systems without symlink support
-            with open(active_link, "w") as f:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            with self._open_private_text(active_link, flags, "w") as f:
                 f.write(agent_id)
 
     def _clear_active_session(self) -> None:

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -82,13 +82,10 @@ class SessionService:
             or self._generate_secure_secret_key()
         )
         self.secret_key: str = resolved_secret_key
-        self._auto_renew_locks: dict[str, threading.RLock] = {}
-        self._auto_renew_locks_guard = threading.Lock()
-
-    def _get_auto_renew_lock(self, agent_id: str) -> threading.RLock:
-        """Return the per-agent lock that serializes token rotation."""
-        with self._auto_renew_locks_guard:
-            return self._auto_renew_locks.setdefault(agent_id, threading.RLock())
+        # Session rotation, termination, and the global active-session marker
+        # form one lifecycle. Serialize them so a concurrent renewal cannot
+        # publish a fresh bearer token after logout has completed.
+        self._session_lifecycle_lock = threading.RLock()
 
     @staticmethod
     def _set_private_permissions(path: Path, mode: int) -> None:
@@ -276,6 +273,16 @@ class SessionService:
         Returns:
             Session object with JWT token
         """
+        with self._session_lifecycle_lock:
+            return self._create_session(agent_id, pattern, duration_hours)
+
+    def _create_session(
+        self,
+        agent_id: str,
+        pattern: AgentPattern | None,
+        duration_hours: int | None,
+    ) -> Session:
+        """Create and publish a session while the lifecycle lock is held."""
         # Use config default if not explicitly provided
         if duration_hours is None:
             duration_hours = settings.SESSION_DEFAULT_DURATION_HOURS
@@ -423,6 +430,11 @@ class SessionService:
         Raises:
             SessionNotFoundError: If session doesn't exist
         """
+        with self._session_lifecycle_lock:
+            return self._end_session(agent_id)
+
+    def _end_session(self, agent_id: str) -> SessionSummary:
+        """Terminate a session while excluding concurrent token rotation."""
         session = self.get_session(agent_id)
         if not session:
             raise SessionNotFoundError(f"No session found for agent {agent_id}")
@@ -496,11 +508,12 @@ class SessionService:
         if not settings.SESSION_AUTO_RENEW_ENABLED:
             return None
 
-        # Validation and renewal must be one operation. Without a per-agent
-        # single-flight lock, parallel requests can all observe the same
+        # Validation and renewal must be one operation. Without the lifecycle
+        # lock, parallel requests can all observe the same
         # near-expiry session, mint competing tokens, and immediately
-        # invalidate every replacement except the last file write.
-        with self._get_auto_renew_lock(agent_id):
+        # invalidate every replacement except the last file write. The same
+        # lock also makes logout authoritative over an in-flight renewal.
+        with self._session_lifecycle_lock:
             session = self.get_session(agent_id)
             if not session or not session.is_active():
                 return None

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -81,6 +81,7 @@ class SessionService:
         self._agent_locks: dict[str, threading.RLock] = {}
         self._agent_locks_guard = threading.Lock()
         self._active_marker_lock = threading.RLock()
+        self._summary_lock = threading.Lock()
 
     @property
     def secret_key(self) -> str:
@@ -602,9 +603,6 @@ class SessionService:
         )
         self._harden_session_storage()
 
-        # Determine if we need to write the header
-        write_header = not summary_file.exists()
-
         # Format the memory into Markdown
         memory_type = (getattr(memory_record, "type", None) or "unclassified").upper()
         title = getattr(memory_record, "title", "Untitled")
@@ -617,28 +615,28 @@ class SessionService:
         status = getattr(memory_record, "status", None)
         tags = getattr(memory_record, "tags", None)
 
-        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
-        with self._open_private_text(summary_file, flags, "a", encoding="utf-8") as f:
-            if write_header:
-                f.write(f"# Session Summary for {agent_id}\n")
-                f.write(f"**Session ID:** `{session_id}`\n\n")
-                f.write("---\n\n")
+        lines = [f"### [{timestamp}] [{memory_type}] {title}\n"]
+        if memory_id:
+            lines.append(f"- **Memory ID**: `{memory_id}`\n")
+        lines.append(f"- **Confidence**: `{confidence}`\n")
+        if status:
+            lines.append(f"- **Status**: `{status}`\n")
+        if source:
+            lines.append(f"- **Source**: `{source}`\n")
+        if provenance:
+            lines.append(f"- **Provenance**: `{provenance}`\n")
+        if tags:
+            lines.append(f"- **Tags**: {', '.join(f'`{t}`' for t in tags)}\n")
+        lines.append("- **Content**:\n")
+        lines.append(f"> {content.replace(chr(10), chr(10) + '> ')}\n\n")
+        lines.append("---\n\n")
 
-            f.write(f"### [{timestamp}] [{memory_type}] {title}\n")
-            if memory_id:
-                f.write(f"- **Memory ID**: `{memory_id}`\n")
-            f.write(f"- **Confidence**: `{confidence}`\n")
-            if status:
-                f.write(f"- **Status**: `{status}`\n")
-            if source:
-                f.write(f"- **Source**: `{source}`\n")
-            if provenance:
-                f.write(f"- **Provenance**: `{provenance}`\n")
-            if tags:
-                f.write(f"- **Tags**: {', '.join(f'`{t}`' for t in tags)}\n")
-            f.write("- **Content**:\n")
-            f.write(f"> {content.replace(chr(10), chr(10) + '> ')}\n\n")
-            f.write("---\n\n")
+        self._append_session_summary(
+            summary_file=summary_file,
+            agent_id=agent_id,
+            session_id=session_id,
+            entry="".join(lines),
+        )
 
     def try_log_memory_to_session_summary(
         self,
@@ -697,19 +695,41 @@ class SessionService:
         )
         self._harden_session_storage()
 
-        write_header = not summary_file.exists()
+        entry = (
+            f"### [{timestamp}] [DELETED] Memory Deleted\n"
+            f"- **Memory ID**: `{memory_id}`\n"
+            "- **Confidence**: `1.0`\n"
+            "---\n\n"
+        )
+        self._append_session_summary(
+            summary_file=summary_file,
+            agent_id=agent_id,
+            session_id=session_id,
+            entry=entry,
+        )
 
-        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
-        with self._open_private_text(summary_file, flags, "a", encoding="utf-8") as f:
-            if write_header:
-                f.write(f"# Session Summary for {agent_id}\n")
-                f.write(f"**Session ID:** `{session_id}`\n\n")
-                f.write("---\n\n")
+    def _append_session_summary(
+        self,
+        summary_file: Path,
+        agent_id: str,
+        session_id: str,
+        entry: str,
+    ) -> None:
+        """Append one complete entry without racing header creation or peer writes."""
+        with self._summary_lock:
+            header = ""
+            if not summary_file.exists():
+                header = (
+                    f"# Session Summary for {agent_id}\n"
+                    f"**Session ID:** `{session_id}`\n\n"
+                    "---\n\n"
+                )
 
-            f.write(f"### [{timestamp}] [DELETED] Memory Deleted\n")
-            f.write(f"- **Memory ID**: `{memory_id}`\n")
-            f.write("- **Confidence**: `1.0`\n")
-            f.write("---\n\n")
+            flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+            with self._open_private_text(
+                summary_file, flags, "a", encoding="utf-8"
+            ) as f:
+                f.write(header + entry)
 
     def try_log_memory_deletion_to_session_summary(
         self,

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -5,10 +5,13 @@ Handles session creation, validation, and management.
 Uses JWT tokens for stateless authentication.
 """
 
+import errno
 import json
 import logging
 import os
 import secrets
+import tempfile
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import timedelta
@@ -162,15 +165,22 @@ class SessionService:
                 return existing
 
             secret = secrets.token_hex(32)
-            fd = os.open(str(secret_file), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-            with os.fdopen(fd, "w", encoding="utf-8") as file_handle:
-                file_handle.write(secret)
-                file_handle.flush()
-                os.fsync(file_handle.fileno())
+            fd, temp_name = tempfile.mkstemp(
+                prefix=f".{secret_file.name}.", dir=secret_file.parent
+            )
+            temp_file = Path(temp_name)
             try:
-                secret_file.chmod(0o600)
-            except OSError:
-                pass  # Windows may not support chmod
+                with os.fdopen(fd, "w", encoding="utf-8") as file_handle:
+                    file_handle.write(secret)
+                    file_handle.flush()
+                    os.fsync(file_handle.fileno())
+                os.replace(temp_file, secret_file)
+                try:
+                    secret_file.chmod(0o600)
+                except OSError:
+                    pass  # Windows may not support chmod
+            finally:
+                temp_file.unlink(missing_ok=True)
             return secret
 
     @staticmethod
@@ -188,7 +198,19 @@ class SessionService:
             if os.name == "nt":
                 import msvcrt
 
-                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                while True:
+                    try:
+                        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                        break
+                    except OSError as exc:
+                        if exc.errno not in {
+                            errno.EACCES,
+                            errno.EAGAIN,
+                            errno.EDEADLK,
+                        }:
+                            raise
+                        os.lseek(fd, 0, os.SEEK_SET)
+                        time.sleep(0.05)
             else:
                 import fcntl
 

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -82,10 +82,23 @@ class SessionService:
             or self._generate_secure_secret_key()
         )
         self.secret_key: str = resolved_secret_key
-        # Session rotation, termination, and the global active-session marker
-        # form one lifecycle. Serialize them so a concurrent renewal cannot
-        # publish a fresh bearer token after logout has completed.
-        self._session_lifecycle_lock = threading.RLock()
+        # Serialize lifecycle operations for the same agent so renewal cannot
+        # publish a fresh bearer token after logout has completed. Keep the
+        # process-wide active marker on its own narrower lock so unrelated
+        # agents can create, renew, and terminate sessions concurrently.
+        self._agent_locks: dict[str, threading.RLock] = {}
+        self._agent_locks_guard = threading.Lock()
+        self._active_marker_lock = threading.RLock()
+
+    def _lock_for_agent(self, agent_id: str) -> threading.RLock:
+        """Return the stable lifecycle lock for one agent."""
+        validate_safe_id(agent_id, "agent_id")
+        with self._agent_locks_guard:
+            lock = self._agent_locks.get(agent_id)
+            if lock is None:
+                lock = threading.RLock()
+                self._agent_locks[agent_id] = lock
+            return lock
 
     @staticmethod
     def _set_private_permissions(path: Path, mode: int) -> None:
@@ -273,7 +286,7 @@ class SessionService:
         Returns:
             Session object with JWT token
         """
-        with self._session_lifecycle_lock:
+        with self._lock_for_agent(agent_id):
             return self._create_session(agent_id, pattern, duration_hours)
 
     def _create_session(
@@ -282,7 +295,7 @@ class SessionService:
         pattern: AgentPattern | None,
         duration_hours: int | None,
     ) -> Session:
-        """Create and publish a session while the lifecycle lock is held."""
+        """Create and publish a session while the agent lifecycle lock is held."""
         # Use config default if not explicitly provided
         if duration_hours is None:
             duration_hours = settings.SESSION_DEFAULT_DURATION_HOURS
@@ -394,28 +407,30 @@ class SessionService:
         Returns:
             Session object or None if no active session or session is expired
         """
-        active_link = self.sessions_dir / "active"
-        if not active_link.exists():
-            return None
+        with self._active_marker_lock:
+            active_link = self.sessions_dir / "active"
+            if not active_link.exists():
+                return None
 
-        # Read symlink (or file on Windows)
-        if active_link.is_symlink():
-            target = active_link.readlink()
-            agent_id = target.stem
-        else:
-            with open(active_link) as f:
-                agent_id = f.read().strip()
+            # Read symlink (or file on Windows)
+            if active_link.is_symlink():
+                target = active_link.readlink()
+                agent_id = target.stem
+            else:
+                with open(active_link) as f:
+                    agent_id = f.read().strip()
 
-        session = self.get_session(agent_id)
-        if not session:
-            return None
+            session = self.get_session(agent_id)
+            if not session:
+                return None
 
-        # If session is expired, clear the stale active marker and return None
-        if not session.is_active():
-            self._clear_active_session()
-            return None
+            # If session is expired, clear the stale marker and return None.
+            # The marker lock is re-entrant for this cleanup path.
+            if not session.is_active():
+                self._clear_active_session()
+                return None
 
-        return session
+            return session
 
     def end_session(self, agent_id: str) -> SessionSummary:
         """
@@ -430,7 +445,7 @@ class SessionService:
         Raises:
             SessionNotFoundError: If session doesn't exist
         """
-        with self._session_lifecycle_lock:
+        with self._lock_for_agent(agent_id):
             return self._end_session(agent_id)
 
     def _end_session(self, agent_id: str) -> SessionSummary:
@@ -508,12 +523,12 @@ class SessionService:
         if not settings.SESSION_AUTO_RENEW_ENABLED:
             return None
 
-        # Validation and renewal must be one operation. Without the lifecycle
-        # lock, parallel requests can all observe the same
+        # Validation and renewal must be one operation. Without the per-agent
+        # lifecycle lock, parallel requests can all observe the same
         # near-expiry session, mint competing tokens, and immediately
         # invalidate every replacement except the last file write. The same
         # lock also makes logout authoritative over an in-flight renewal.
-        with self._session_lifecycle_lock:
+        with self._lock_for_agent(agent_id):
             session = self.get_session(agent_id)
             if not session or not session.is_active():
                 return None
@@ -711,27 +726,29 @@ class SessionService:
     def _set_active_session(self, agent_id: str) -> None:
         """Mark session as active"""
         validate_safe_id(agent_id, "agent_id")
-        active_link = self.sessions_dir / "active"
+        with self._active_marker_lock:
+            active_link = self.sessions_dir / "active"
 
-        # Remove existing active link
-        if active_link.exists() or active_link.is_symlink():
-            active_link.unlink()
+            # Remove existing active link
+            if active_link.exists() or active_link.is_symlink():
+                active_link.unlink()
 
-        # Create new active marker
-        # On Windows, write agent_id to file instead of symlink
-        try:
-            active_link.symlink_to(f"{agent_id}.json")
-        except (OSError, NotImplementedError):
-            # Fallback for Windows or systems without symlink support
-            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-            with self._open_private_text(active_link, flags, "w") as f:
-                f.write(agent_id)
+            # Create new active marker
+            # On Windows, write agent_id to file instead of symlink
+            try:
+                active_link.symlink_to(f"{agent_id}.json")
+            except (OSError, NotImplementedError):
+                # Fallback for Windows or systems without symlink support
+                flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+                with self._open_private_text(active_link, flags, "w") as f:
+                    f.write(agent_id)
 
     def _clear_active_session(self) -> None:
         """Clear active session marker"""
-        active_link = self.sessions_dir / "active"
-        if active_link.exists() or active_link.is_symlink():
-            active_link.unlink()
+        with self._active_marker_lock:
+            active_link = self.sessions_dir / "active"
+            if active_link.exists() or active_link.is_symlink():
+                active_link.unlink()
 
     def clear_active_session(self) -> None:
         """Public alias: clear the active-session marker without ending the session."""
@@ -744,24 +761,25 @@ class SessionService:
         Used when an agent is deleted: the agent metadata is gone, so a saved
         session for that agent must not remain usable through X-Session-Token.
         """
-        active_link = self.sessions_dir / "active"
-        active_agent_id: str | None = None
+        with self._lock_for_agent(agent_id), self._active_marker_lock:
+            active_link = self.sessions_dir / "active"
+            active_agent_id: str | None = None
 
-        if active_link.is_symlink():
-            active_agent_id = active_link.readlink().stem
-        elif active_link.exists():
-            with open(active_link) as f:
-                active_agent_id = f.read().strip()
+            if active_link.is_symlink():
+                active_agent_id = active_link.readlink().stem
+            elif active_link.exists():
+                with open(active_link) as f:
+                    active_agent_id = f.read().strip()
 
-        session_file = self.sessions_dir / f"{agent_id}.json"
-        deleted = session_file.exists()
-        if deleted:
-            session_file.unlink()
+            session_file = self.sessions_dir / f"{agent_id}.json"
+            deleted = session_file.exists()
+            if deleted:
+                session_file.unlink()
 
-        if active_agent_id == agent_id:
-            self._clear_active_session()
+            if active_agent_id == agent_id:
+                self._clear_active_session()
 
-        return deleted
+            return deleted
 
     def list_sessions(self) -> list[Session]:
         """

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -11,6 +11,7 @@ import logging
 import os
 import secrets
 import tempfile
+import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -81,6 +82,13 @@ class SessionService:
             or self._generate_secure_secret_key()
         )
         self.secret_key: str = resolved_secret_key
+        self._auto_renew_locks: dict[str, threading.RLock] = {}
+        self._auto_renew_locks_guard = threading.Lock()
+
+    def _get_auto_renew_lock(self, agent_id: str) -> threading.RLock:
+        """Return the per-agent lock that serializes token rotation."""
+        with self._auto_renew_locks_guard:
+            return self._auto_renew_locks.setdefault(agent_id, threading.RLock())
 
     @staticmethod
     def _set_private_permissions(path: Path, mode: int) -> None:
@@ -488,19 +496,24 @@ class SessionService:
         if not settings.SESSION_AUTO_RENEW_ENABLED:
             return None
 
-        session = self.get_session(agent_id)
-        if not session or not session.is_active():
-            return None
+        # Validation and renewal must be one operation. Without a per-agent
+        # single-flight lock, parallel requests can all observe the same
+        # near-expiry session, mint competing tokens, and immediately
+        # invalidate every replacement except the last file write.
+        with self._get_auto_renew_lock(agent_id):
+            session = self.get_session(agent_id)
+            if not session or not session.is_active():
+                return None
 
-        remaining = session.time_remaining()
-        threshold = timedelta(minutes=settings.SESSION_EXTEND_THRESHOLD_MINUTES)
+            remaining = session.time_remaining()
+            threshold = timedelta(minutes=settings.SESSION_EXTEND_THRESHOLD_MINUTES)
 
-        if remaining <= threshold:
-            # Renew with a fresh session
-            return self.renew_session(
-                agent_id=agent_id,
-                pattern=session.pattern,
-            )
+            if remaining <= threshold:
+                # Renew with a fresh session
+                return self.renew_session(
+                    agent_id=agent_id,
+                    pattern=session.pattern,
+                )
 
         return None
 

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -308,12 +308,22 @@ def _update_onprem_answer(ans: dict) -> None:
 
     embedding_key = _recover_moorcheh_api_key("embedding", embedding_provider)
     try:
-        from moorcheh.user_config import (  # type: ignore[import-not-found]
-            EmbeddingConfig,
-            LlmConfig,
-            default_base_url,
-            save_runtime_config,
-        )
+        # moorcheh-client 0.1.5 moved user_config into the cli subpackage;
+        # try the new path first and fall back so 0.1.3-0.1.5 all work.
+        try:
+            from moorcheh.cli.user_config import (  # type: ignore[import-not-found]
+                EmbeddingConfig,
+                LlmConfig,
+                default_base_url,
+                save_runtime_config,
+            )
+        except ImportError:
+            from moorcheh.user_config import (  # type: ignore[import-not-found]
+                EmbeddingConfig,
+                LlmConfig,
+                default_base_url,
+                save_runtime_config,
+            )
 
         save_runtime_config(
             EmbeddingConfig(

--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -44,20 +44,36 @@ def parse_iso_timestamp(ts_str: str) -> datetime:
 END_OF_DAY = time.max
 
 
+def parse_date_only(ts_str: str) -> date:
+    """Parse a calendar date, accepting both ISO-8601 date forms.
+
+    ``date.fromisoformat`` only learned the basic (un-hyphenated) ``20260726``
+    form in Python 3.11, but this project supports 3.10 (see ``requires-python``
+    and the CI matrix). The basic form is handled explicitly so date-only
+    detection behaves identically on every supported interpreter instead of
+    silently depending on the runtime's stdlib version.
+
+    Raises ``ValueError`` for anything that is not a calendar date.
+    """
+    if len(ts_str) == 8 and ts_str.isdigit():
+        return date(int(ts_str[:4]), int(ts_str[4:6]), int(ts_str[6:8]))
+    return date.fromisoformat(ts_str)
+
+
 def is_date_only(ts_str: str) -> bool:
     """True when the string is a calendar date with no time component.
 
     Detected by PARSING rather than by shape. The previous shape check
     (``len == 10 and s[4] == "-" and s[7] == "-"``) silently rejected the
-    ISO-8601 basic format ``20260726`` -- a valid date that
-    ``date.fromisoformat`` accepts -- which then fell through to the datetime
-    parser and became midnight, i.e. the START of the day, flipping the
-    documented end-of-day semantics by nearly 24 hours with no error raised.
+    ISO-8601 basic format ``20260726`` -- a valid date -- which then fell
+    through to the datetime parser and became midnight, i.e. the START of the
+    day, flipping the documented end-of-day semantics by nearly 24 hours with
+    no error raised.
     """
     if not ts_str or "T" in ts_str or " " in ts_str:
         return False
     try:
-        date.fromisoformat(ts_str)
+        parse_date_only(ts_str)
     except ValueError:
         return False
     return True
@@ -75,7 +91,7 @@ def parse_as_of_timestamp(ts_str: str) -> datetime:
     if is_date_only(ts_str):
         try:
             return datetime.combine(
-                date.fromisoformat(ts_str), END_OF_DAY, tzinfo=timezone.utc
+                parse_date_only(ts_str), END_OF_DAY, tzinfo=timezone.utc
             )
         except ValueError:
             pass

--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -36,6 +36,33 @@ def parse_iso_timestamp(ts_str: str) -> datetime:
     return dt.astimezone(timezone.utc)
 
 
+# The end-of-day instant used whenever a date-only cutoff is widened to cover the
+# whole day. Defined once so every entry point agrees to the microsecond; when the
+# REST layer used time(23, 59, 59) and this module used time.max, memories written
+# in the final second of a day fell inside the cutoff on one path and outside it on
+# the other.
+END_OF_DAY = time.max
+
+
+def is_date_only(ts_str: str) -> bool:
+    """True when the string is a calendar date with no time component.
+
+    Detected by PARSING rather than by shape. The previous shape check
+    (``len == 10 and s[4] == "-" and s[7] == "-"``) silently rejected the
+    ISO-8601 basic format ``20260726`` -- a valid date that
+    ``date.fromisoformat`` accepts -- which then fell through to the datetime
+    parser and became midnight, i.e. the START of the day, flipping the
+    documented end-of-day semantics by nearly 24 hours with no error raised.
+    """
+    if not ts_str or "T" in ts_str or " " in ts_str:
+        return False
+    try:
+        date.fromisoformat(ts_str)
+    except ValueError:
+        return False
+    return True
+
+
 def parse_as_of_timestamp(ts_str: str) -> datetime:
     """Parse a point-in-time cutoff, treating a date as the end of that day.
 
@@ -45,10 +72,10 @@ def parse_as_of_timestamp(ts_str: str) -> datetime:
     Normalizing at the service boundary keeps every caller consistent without
     changing the meaning of full ISO timestamps.
     """
-    if len(ts_str) == 10 and ts_str[4] == "-" and ts_str[7] == "-":
+    if is_date_only(ts_str):
         try:
             return datetime.combine(
-                date.fromisoformat(ts_str), time.max, tzinfo=timezone.utc
+                date.fromisoformat(ts_str), END_OF_DAY, tzinfo=timezone.utc
             )
         except ValueError:
             pass

--- a/memanto/app/utils/temporal_helpers.py
+++ b/memanto/app/utils/temporal_helpers.py
@@ -240,12 +240,21 @@ def build_temporal_query(
           }
         }
     """
-    # Parse relative time if provided and no absolute time given
+    # Parse relative time if provided and no absolute time given. Most relative
+    # phrases describe an open-ended lookback window, but "yesterday" is a
+    # closed calendar-day window. Supplying only its start would also return
+    # today's memories, which contradicts the caller's requested time range.
     if relative_time and not created_after:
-        parsed_relative_time = parse_relative_time(relative_time)
-        if parsed_relative_time is None:
-            raise ValueError(f"Invalid relative_time: {relative_time!r}")
-        created_after = parsed_relative_time
+        normalized_relative_time = relative_time.lower().strip()
+        if normalized_relative_time == "yesterday":
+            created_after, yesterday_end = get_yesterday_range()
+            if not created_before:
+                created_before = yesterday_end
+        else:
+            parsed_relative_time = parse_relative_time(relative_time)
+            if parsed_relative_time is None:
+                raise ValueError(f"Invalid relative_time: {relative_time!r}")
+            created_after = parsed_relative_time
 
     body: dict[str, Any] = {"query": query, "limit": limit}
     if created_after:

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -663,7 +663,7 @@ class DirectClient:
         # Log to local session Markdown summary only after a durable write.
         if self.session_token and is_successful_write_result(result):
             session_id = "unknown"
-            self._get_session_service().log_memory_to_session_summary(
+            self._get_session_service().try_log_memory_to_session_summary(
                 agent_id=agent_id,
                 session_id=session_id,
                 memory_record=memory,
@@ -774,7 +774,7 @@ class DirectClient:
                 if not is_successful_write_result(item_result):
                     continue
                 mem_id = batch_results[i].get("id")
-                session_svc.log_memory_to_session_summary(
+                session_svc.try_log_memory_to_session_summary(
                     agent_id=agent_id,
                     session_id=session_id,
                     memory_record=mem,
@@ -944,7 +944,7 @@ class DirectClient:
 
         # Log deletion to local session Markdown summary
         if self.session_token:
-            self._get_session_service().log_memory_deletion_to_session_summary(
+            self._get_session_service().try_log_memory_deletion_to_session_summary(
                 agent_id=agent_id,
                 session_id=session.session_id,
                 memory_id=memory_id,

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -493,7 +493,7 @@ class SdkClient:
         # Log to local session Markdown summary only after a durable write.
         if self.session_token and is_successful_write_result(result):
             session_id = "unknown"
-            self._get_session_service().log_memory_to_session_summary(
+            self._get_session_service().try_log_memory_to_session_summary(
                 agent_id=agent_id,
                 session_id=session_id,
                 memory_record=memory,
@@ -605,7 +605,7 @@ class SdkClient:
                 mem_id = (
                     item_result.get("id") if isinstance(item_result, dict) else None
                 )
-                session_svc.log_memory_to_session_summary(
+                session_svc.try_log_memory_to_session_summary(
                     agent_id=agent_id,
                     session_id=session_id,
                     memory_record=mem,
@@ -772,7 +772,7 @@ class SdkClient:
 
         # Log deletion to local session Markdown summary
         if self.session_token:
-            self._get_session_service().log_memory_deletion_to_session_summary(
+            self._get_session_service().try_log_memory_deletion_to_session_summary(
                 agent_id=agent_id,
                 session_id=session.session_id,
                 memory_id=memory_id,

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -331,6 +331,34 @@ def _prompt_embedding_provider() -> tuple[str, str, str]:
     return "ollama", "nomic-embed-text", ""
 
 
+def _import_user_config() -> tuple:
+    """Import moorcheh-client's user-config helpers across its layouts.
+
+    moorcheh-client 0.1.5 reorganised the package into ``client`` and ``cli``
+    subpackages, moving ``moorcheh/user_config.py`` to
+    ``moorcheh/cli/user_config.py``. Because the dependency is declared as
+    ``moorcheh-client>=0.1.3`` with no upper bound, a fresh install resolves to
+    0.1.5 and the old import path raises ImportError, which aborted on-prem
+    setup entirely. Try the new location first, then fall back to the old one so
+    0.1.3 through 0.1.5 all work.
+    """
+    try:
+        from moorcheh.cli.user_config import (  # type: ignore[import-not-found]
+            EmbeddingConfig,
+            LlmConfig,
+            default_base_url,
+            save_runtime_config,
+        )
+    except ImportError:
+        from moorcheh.user_config import (  # type: ignore[import-not-found]
+            EmbeddingConfig,
+            LlmConfig,
+            default_base_url,
+            save_runtime_config,
+        )
+    return EmbeddingConfig, LlmConfig, default_base_url, save_runtime_config
+
+
 # Valid on-prem LLM identifiers, sourced from moorcheh.user_config. Listed
 # explicitly so the prompt is stable even if moorcheh-client adds/removes
 # models. Keep in sync with ``moorcheh.user_config.LLM_PROVIDER_MODELS``.
@@ -439,12 +467,12 @@ def _persist_moorcheh_llm_config(
     ``save_runtime_config`` helper so the schema stays in sync.
     """
     try:
-        from moorcheh.user_config import (  # type: ignore[import-not-found]
+        (
             EmbeddingConfig,
             LlmConfig,
             default_base_url,
             save_runtime_config,
-        )
+        ) = _import_user_config()
     except ImportError as e:
         _error(f"moorcheh.user_config unavailable: {e}")
         return

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import typer
 from rich.panel import Panel
 
+from memanto.app.utils.temporal_helpers import get_yesterday_range
 from memanto.cli.commands._shared import (
     BOLD_PRIMARY,
     BRIGHT,
@@ -512,6 +513,14 @@ def recall(
 
         if not ts:
             return ts
+
+        # ``--as-of yesterday`` means the state at the end of that calendar
+        # day. The generic relative helper returns the start of the day because
+        # its normal consumer is a changed-since / created-after query; using
+        # that value here drops almost all memories created yesterday.
+        if flag_name == "--as-of" and ts.lower().strip() == "yesterday":
+            _, yesterday_end = get_yesterday_range()
+            return yesterday_end
 
         # Try parsing as relative time (e.g., "today", "last 2 hours")
         rel_ts = parse_relative_time(ts)

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -3529,6 +3529,17 @@
             ],
             "title": "Source"
           },
+          "source_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Ref"
+          },
           "agent_id": {
             "anyOf": [
               {

--- a/sdks/typescript/src/integrations/voltagent.ts
+++ b/sdks/typescript/src/integrations/voltagent.ts
@@ -52,6 +52,17 @@ export function createMemantoVoltAgentTools(
 ) {
   const { include, defaultLimit } = options;
 
+  // A configured default bypasses the Zod parameter schemas below because it
+  // is applied only after VoltAgent has validated the model's arguments. Keep
+  // it inside the stricter recallMemory contract so an omitted model limit
+  // cannot silently send an invalid value to the Memanto API.
+  if (
+    defaultLimit !== undefined &&
+    (!Number.isInteger(defaultLimit) || defaultLimit < 1 || defaultLimit > 50)
+  ) {
+    throw new RangeError("defaultLimit must be an integer between 1 and 50");
+  }
+
   const all = {
     recallMemory: createTool({
       name: "recallMemory",

--- a/sdks/typescript/test/integrations/voltagent.test.ts
+++ b/sdks/typescript/test/integrations/voltagent.test.ts
@@ -98,6 +98,35 @@ describe("createMemantoVoltAgentTools", () => {
     });
   });
 
+  it.each([0, -1, 1.5, 51, Number.NaN])(
+    "rejects invalid defaultLimit %s before creating tools",
+    (defaultLimit) => {
+      expect(() =>
+        createMemantoVoltAgentTools(fakeMemanto() as unknown as Memanto, {
+          defaultLimit,
+        }),
+      ).toThrow("defaultLimit must be an integer between 1 and 50");
+    },
+  );
+
+  it("accepts the maximum recall-compatible defaultLimit", async () => {
+    const m = fakeMemanto();
+    const tools = createMemantoVoltAgentTools(m as unknown as Memanto, {
+      defaultLimit: 50,
+    });
+
+    await byName(tools, "recallMemory").execute!(
+      { query: "what milk?" },
+      execOpts,
+    );
+
+    expect(m.recall).toHaveBeenCalledWith({
+      query: "what milk?",
+      limit: 50,
+      type: undefined,
+    });
+  });
+
   it("exposes the server memory-type contract", () => {
     expect(MEMORY_TYPES).toContain("fact");
     expect(MEMORY_TYPES).toContain("preference");

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -341,6 +341,9 @@ class TestMEMANTOAPI:
         assert response.json()["memory_id"]
         mock_moorcheh.documents.upload.assert_called_once()
         failed_summary.assert_called_once()
+        assert (
+            failed_summary.call_args.kwargs["memory_id"] == response.json()["memory_id"]
+        )
 
     @pytest.mark.asyncio
     async def test_edit_memory_with_session(self, client, auth_headers):
@@ -1099,6 +1102,41 @@ class TestMEMANTOAPI:
         )
         assert response.status_code == 200
         assert response.json()["successful"] == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_remember_logs_authoritative_memory_ids(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """Each batch summary receives the ID returned by the committed write."""
+        from memanto.app.services.session_service import get_session_service
+
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        session_token = activate_response.json()["session_token"]
+        mock_moorcheh.documents.upload.return_value = {"status": "success"}
+
+        session_service = get_session_service()
+        summary_log = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            session_service, "try_log_memory_to_session_summary", summary_log
+        )
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/batch-remember",
+            headers={**auth_headers, "X-Session-Token": session_token},
+            json={"memories": [{"content": "First"}, {"content": "Second"}]},
+        )
+
+        assert response.status_code == 200
+        committed_ids = [item["id"] for item in response.json()["results"]]
+        logged_ids = [call.kwargs["memory_id"] for call in summary_log.call_args_list]
+        assert logged_ids == committed_ids
 
     @pytest.mark.asyncio
     async def test_batch_remember_rejects_blank_content(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -305,6 +305,44 @@ class TestMEMANTOAPI:
         assert response.json()["status"] == "queued"
 
     @pytest.mark.asyncio
+    async def test_remember_preserves_committed_result_when_summary_logging_fails(
+        self, client, auth_headers, mock_moorcheh, monkeypatch
+    ):
+        """Auxiliary local logging must not turn a committed write into HTTP 500."""
+        from memanto.app.services.session_service import get_session_service
+
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        session_token = activate_response.json()["session_token"]
+        mock_moorcheh.documents.upload.return_value = {
+            "status": "success",
+            "ids": ["mem-committed"],
+        }
+
+        session_service = get_session_service()
+        failed_summary = MagicMock(side_effect=OSError("summary disk is full"))
+        monkeypatch.setattr(
+            session_service, "log_memory_to_session_summary", failed_summary
+        )
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            headers={**auth_headers, "X-Session-Token": session_token},
+            json={"content": "This write commits before its summary is logged."},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["memory_id"]
+        mock_moorcheh.documents.upload.assert_called_once()
+        failed_summary.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_edit_memory_with_session(self, client, auth_headers):
         """Test updating one memory with session token."""
         app.dependency_overrides[get_current_session] = lambda: Session(

--- a/tests/test_as_of_date_only_parsing.py
+++ b/tests/test_as_of_date_only_parsing.py
@@ -1,0 +1,73 @@
+"""Regression tests for as-of date-only parsing.
+
+`as_of` is normalised in two places -- the REST request validator
+(`RecallAsOfRequest.parse_as_of`) and the service-level helper
+(`parse_as_of_timestamp`, used by the CLI, MCP and the Python clients). Both
+implement the same documented rule: a date-only cutoff means the END of that day.
+
+They used to detect "date-only" differently. The helper matched on shape
+(`len == 10` plus hyphens at 4 and 7), which silently rejected the ISO-8601
+basic format `20260726` -- a valid date that `date.fromisoformat` accepts -- so
+it fell through to the datetime parser and became midnight, the START of the
+day. The same string sent to REST resolved to the end of the day, leaving the
+two paths 23:59:59 apart. The two also disagreed by 0.999999s on hyphenated
+dates (`time.max` vs `time(23, 59, 59)`).
+
+Each test below fails on the pre-fix code.
+"""
+
+from datetime import datetime, time, timezone
+
+import pytest
+
+from memanto.app.routes.memory import RecallAsOfRequest
+from memanto.app.utils import temporal_helpers
+from memanto.app.utils.temporal_helpers import parse_as_of_timestamp
+
+DATE_SPELLINGS = ["2026-07-26", "20260726"]
+# Expressed as a literal rather than via the new END_OF_DAY constant, so these
+# assertions run against the pre-fix source and fail on the bug itself.
+EXPECTED = datetime(2026, 7, 26, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("raw", DATE_SPELLINGS)
+def test_service_helper_treats_date_only_as_end_of_day(raw):
+    """Both ISO date spellings resolve to the end of the day, not midnight."""
+    assert parse_as_of_timestamp(raw) == EXPECTED
+
+
+@pytest.mark.parametrize("raw", DATE_SPELLINGS)
+def test_rest_validator_matches_service_helper(raw):
+    """The REST validator and the service helper must not drift apart."""
+    assert RecallAsOfRequest(as_of=raw).as_of == parse_as_of_timestamp(raw)
+
+
+def test_basic_format_is_not_parsed_as_start_of_day():
+    """`20260726` must not silently exclude the whole of 26 July."""
+    parsed = parse_as_of_timestamp("20260726")
+    assert parsed.time() != time(0, 0, 0), (
+        "basic-format ISO date parsed as start-of-day; a point-in-time recall "
+        "would silently drop that entire day"
+    )
+
+
+def test_datetime_inputs_are_untouched():
+    """A full ISO datetime keeps its own time component."""
+    assert parse_as_of_timestamp("2026-07-26T12:00:00Z") == datetime(
+        2026, 7, 26, 12, 0, 0, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("2026-07-26", True),
+        ("20260726", True),
+        ("2026-07-26T12:00:00Z", False),
+        ("2026-07-26 12:00:00", False),
+        ("not-a-date", False),
+        ("", False),
+    ],
+)
+def test_is_date_only(raw, expected):
+    assert temporal_helpers.is_date_only(raw) is expected

--- a/tests/test_as_of_date_only_parsing.py
+++ b/tests/test_as_of_date_only_parsing.py
@@ -71,3 +71,33 @@ def test_datetime_inputs_are_untouched():
 )
 def test_is_date_only(raw, expected):
     assert temporal_helpers.is_date_only(raw) is expected
+
+
+@pytest.mark.parametrize("raw", ["20261345", "20260732", "1234567", "abcdefgh"])
+def test_basic_format_detection_rejects_non_dates(raw):
+    """Eight characters is not enough -- the value must be a real calendar date."""
+    assert temporal_helpers.is_date_only(raw) is False
+
+
+def test_basic_format_does_not_depend_on_python_311_stdlib(monkeypatch):
+    """The un-hyphenated form must resolve on the 3.10 baseline too.
+
+    ``date.fromisoformat`` only learned the basic ``20260726`` form in Python
+    3.11, but ``requires-python`` is ">=3.10" and CI runs 3.10. This simulates
+    the 3.10 stdlib to prove detection does not silently regress to
+    start-of-day there.
+    """
+    from datetime import date as real_date
+
+    class Py310Date(real_date):
+        @classmethod
+        def fromisoformat(cls, value):
+            if "-" not in value:
+                raise ValueError(f"Invalid isoformat string: {value!r}")
+            return real_date.fromisoformat(value)
+
+    monkeypatch.setattr(temporal_helpers, "date", Py310Date)
+
+    assert temporal_helpers.is_date_only("20260726") is True
+    assert parse_as_of_timestamp("20260726") == EXPECTED
+    assert parse_as_of_timestamp("2026-07-26") == EXPECTED

--- a/tests/test_as_of_expired_recall.py
+++ b/tests/test_as_of_expired_recall.py
@@ -1,0 +1,67 @@
+"""Regression tests for point-in-time (``search_as_of``) recall.
+
+These guard against timeline amnesia: memories that were valid at the target
+``as_of`` date but have *since* expired must still be recalled, because the
+query asks "what was true at this point in time?", not "what is true now?".
+"""
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _memory(memory_id: str, created_at: str, expires_at: str | None = None) -> dict:
+    m = {
+        "id": memory_id,
+        "text": f"[FACT] {memory_id}\n\nStored memory",
+        "memory_type": "fact",
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+    if expires_at:
+        m["expires_at"] = expires_at
+    return m
+
+
+class _FakeDocuments:
+    def fetch_text_data(self, **kwargs):
+        return {
+            "items": [
+                # Created before as_of, valid at as_of, but expired *after* as_of
+                # and before "now" -> must still be recalled by search_as_of.
+                _memory(
+                    "temporal-fact",
+                    "2026-01-10T09:00:00Z",
+                    expires_at="2026-06-01T00:00:00Z",
+                ),
+                # Created before as_of, never expires -> always recalled.
+                _memory("permanent-fact", "2026-01-12T09:00:00Z"),
+                # Already expired *before* as_of -> must be excluded.
+                _memory(
+                    "stale-fact",
+                    "2026-01-05T09:00:00Z",
+                    expires_at="2026-01-08T00:00:00Z",
+                ),
+            ],
+            "pagination": {"has_more": False},
+        }
+
+
+class _FakeClient:
+    documents = _FakeDocuments()
+
+
+def test_as_of_recalls_memory_that_has_since_expired():
+    service = MemoryReadService(_FakeClient())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15", agent_id="agent-1", limit=None
+    )
+    ids = {m["id"] for m in result["results"]}
+
+    assert "temporal-fact" in ids, "timeline amnesia: since-expired memory lost"
+    assert "permanent-fact" in ids
+    assert "stale-fact" not in ids, "memory expired before as_of should be excluded"

--- a/tests/test_as_of_expired_recall.py
+++ b/tests/test_as_of_expired_recall.py
@@ -99,3 +99,41 @@ def test_as_of_keeps_historical_version_over_post_asof_recreate():
     assert "dup-fact" in by_id, "historical version lost to post-as_of recreate"
     assert by_id["dup-fact"]["created_at"] == "2026-01-10T09:00:00Z"
 
+
+def test_as_of_handles_datetime_valued_expiration():
+    """expires_at stored as a datetime object (not a string) must not crash
+    search_as_of and must still be excluded when it predates as_of. Regression
+    for the datetime-expiry gap flagged on PR #1617 / bounty #770."""
+    from datetime import datetime, timezone
+
+    class _DateTimeDocuments:
+        def fetch_text_data(self, **kwargs):
+            return {
+                "items": [
+                    # datetime expiry BEFORE as_of -> must be excluded
+                    {
+                        **_memory("dt-stale", "2026-01-10T09:00:00Z"),
+                        "expires_at": datetime(2026, 1, 8, tzinfo=timezone.utc),
+                    },
+                    # datetime expiry AFTER as_of -> must be kept
+                    {
+                        **_memory("dt-valid", "2026-01-10T09:00:00Z"),
+                        "expires_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    },
+                ],
+                "pagination": {"has_more": False},
+            }
+
+    class _DateTimeClient:
+        documents = _DateTimeDocuments()
+
+    service = MemoryReadService(_DateTimeClient())
+    result = service.search_as_of(
+        as_of_date="2026-01-15", agent_id="agent-1", limit=None
+    )
+    ids = {m["id"] for m in result["results"]}
+
+    assert "dt-valid" in ids
+    assert "dt-stale" not in ids, "datetime expiry before as_of must exclude"
+
+

--- a/tests/test_as_of_expired_recall.py
+++ b/tests/test_as_of_expired_recall.py
@@ -135,5 +135,3 @@ def test_as_of_handles_datetime_valued_expiration():
 
     assert "dt-valid" in ids
     assert "dt-stale" not in ids, "datetime expiry before as_of must exclude"
-
-

--- a/tests/test_as_of_expired_recall.py
+++ b/tests/test_as_of_expired_recall.py
@@ -65,3 +65,37 @@ def test_as_of_recalls_memory_that_has_since_expired():
     assert "temporal-fact" in ids, "timeline amnesia: since-expired memory lost"
     assert "permanent-fact" in ids
     assert "stale-fact" not in ids, "memory expired before as_of should be excluded"
+
+
+class _DupDocuments:
+    """Same id exposed twice: a version valid at as_of and a newer
+    delete-and-recreate version created *after* as_of."""
+
+    def fetch_text_data(self, **kwargs):
+        return {
+            "items": [
+                _memory("dup-fact", "2026-01-10T09:00:00Z"),
+                _memory("dup-fact", "2026-02-20T09:00:00Z"),
+            ],
+            "pagination": {"has_more": False},
+        }
+
+
+class _DupClient:
+    documents = _DupDocuments()
+
+
+def test_as_of_keeps_historical_version_over_post_asof_recreate():
+    """A delete-and-recreate after as_of must not evict the version that was
+    valid at as_of. Regression for the dedup-before-temporal-filter ordering
+    flagged on PR #1617 / bounty #770."""
+    service = MemoryReadService(_DupClient())
+
+    result = service.search_as_of(
+        as_of_date="2026-01-15", agent_id="agent-1", limit=None
+    )
+    by_id = {m["id"]: m for m in result["results"]}
+
+    assert "dup-fact" in by_id, "historical version lost to post-as_of recreate"
+    assert by_id["dup-fact"]["created_at"] == "2026-01-10T09:00:00Z"
+

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from memanto.app.clients.backend import (
     Backend,
+    get_active_embedding_model,
     get_active_llm_model,
     parse_backend,
 )
@@ -75,6 +76,44 @@ class TestActiveLlmModel:
         # No state.json → return None so callers omit ai_model and let the
         # server use its own configured LLM (no silent cloud fallback).
         assert get_active_llm_model("anthropic.claude-sonnet-4-6") is None
+
+
+class TestActiveEmbeddingModel:
+    def test_on_prem_rejects_malformed_state_shapes(self, tmp_path, monkeypatch):
+        import json
+
+        from memanto.app.config import settings
+
+        monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+        monkeypatch.setattr(
+            "memanto.app.clients.backend.Path",
+            type("P", (), {"home": classmethod(lambda cls: tmp_path)}),
+        )
+        state_dir = tmp_path / ".memanto" / "on-prem"
+        state_dir.mkdir(parents=True)
+        state_path = state_dir / "state.json"
+
+        for malformed_state in ([], "model", {"embedding_model": 42}):
+            state_path.write_text(json.dumps(malformed_state))
+            assert get_active_embedding_model() is None
+
+    def test_on_prem_reads_nonempty_embedding_model(self, tmp_path, monkeypatch):
+        import json
+
+        from memanto.app.config import settings
+
+        monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+        monkeypatch.setattr(
+            "memanto.app.clients.backend.Path",
+            type("P", (), {"home": classmethod(lambda cls: tmp_path)}),
+        )
+        state_dir = tmp_path / ".memanto" / "on-prem"
+        state_dir.mkdir(parents=True)
+        (state_dir / "state.json").write_text(
+            json.dumps({"embedding_model": "nomic-embed-text"})
+        )
+
+        assert get_active_embedding_model() == "nomic-embed-text"
 
 
 class TestOnPremClient:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -757,6 +757,18 @@ class TestMEMANTOCLI:
         assert "Invalid timestamp format" in result.stdout
         mock_all_clients.recall_changed_since.assert_not_called()
 
+    def test_recall_as_of_yesterday_uses_end_of_day(self, mock_all_clients):
+        """Relative as-of recall must include the whole of yesterday."""
+        from memanto.app.utils.temporal_helpers import get_yesterday_range
+
+        mock_all_clients.recall_as_of.return_value = {"memories": [], "count": 0}
+        _, yesterday_end = get_yesterday_range()
+
+        result = runner.invoke(app, ["recall", "--as-of", "yesterday"])
+
+        assert result.exit_code == 0
+        assert mock_all_clients.recall_as_of.call_args.kwargs["as_of"] == yesterday_end
+
     @pytest.mark.parametrize(
         "client_class_path",
         [

--- a/tests/test_daily_summary_query_length.py
+++ b/tests/test_daily_summary_query_length.py
@@ -1,0 +1,65 @@
+"""Regression coverage for daily-summary embedding context overflow."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from memanto.app.services import daily_analysis_service as module
+
+
+def _make_summary_service(tmp_path, monkeypatch, session_content: str):
+    sessions_dir = tmp_path / "sessions"
+    summaries_dir = tmp_path / "summaries"
+    sessions_dir.mkdir()
+    (sessions_dir / "agent-1_2026-06-28_001_summary.md").write_text(
+        session_content,
+        encoding="utf-8",
+    )
+
+    client = MagicMock()
+
+    def reject_oversized_embedding_query(**kwargs):
+        query = kwargs["query"]
+        if len(query) > 6_000:
+            raise RuntimeError("embedding input exceeds context length")
+        return {"answer": "# Daily Summary"}
+
+    client.answer.generate.side_effect = reject_oversized_embedding_query
+    monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
+    monkeypatch.setattr(module, "get_active_llm_model", lambda _: "test-model")
+
+    service = module.DailyAnalysisService(
+        sessions_dir=sessions_dir,
+        summaries_dir=summaries_dir,
+    )
+    return service, client
+
+
+def test_busy_day_summary_keeps_embedded_query_within_context_window(
+    tmp_path, monkeypatch
+):
+    """Long session content must not be sent as an oversized embedding query."""
+    long_content = "Important decision: use PostgreSQL for the project. " * 300
+    service, client = _make_summary_service(tmp_path, monkeypatch, long_content)
+
+    result = service.generate_summary("agent-1", "2026-06-28")
+
+    assert result["status"] == "success"
+    call_kwargs = client.answer.generate.call_args.kwargs
+    assert len(call_kwargs["query"]) <= 6_000
+    assert long_content in call_kwargs["header_prompt"]
+    assert "Format the output as a Markdown report" in call_kwargs["footer_prompt"]
+
+
+def test_short_day_summary_preserves_session_text_as_retrieval_query(
+    tmp_path, monkeypatch
+):
+    """Short inputs should retain their full content for relevant retrieval."""
+    short_content = "Decision: ship the authentication change on Friday."
+    service, client = _make_summary_service(tmp_path, monkeypatch, short_content)
+
+    service.generate_summary("agent-1", "2026-06-28")
+
+    call_kwargs = client.answer.generate.call_args.kwargs
+    assert call_kwargs["query"] == short_content
+    assert call_kwargs["ai_model"] == "test-model"

--- a/tests/test_daily_summary_query_length.py
+++ b/tests/test_daily_summary_query_length.py
@@ -18,15 +18,30 @@ def _make_summary_service(tmp_path, monkeypatch, session_content: str):
 
     client = MagicMock()
 
+    class FakeTokenizer:
+        @staticmethod
+        def encode(text: str):
+            return list(text.encode("utf-8"))
+
+        @staticmethod
+        def decode(token_ids):
+            return bytes(token_ids).decode("utf-8", errors="ignore")
+
+    tokenizer = FakeTokenizer()
+
     def reject_oversized_embedding_query(**kwargs):
         query = kwargs["query"]
-        if len(query) > 6_000:
+        if len(tokenizer.encode(query)) > module._EMBEDDING_QUERY_TOKEN_BUDGET:
             raise RuntimeError("embedding input exceeds context length")
         return {"answer": "# Daily Summary"}
 
     client.answer.generate.side_effect = reject_oversized_embedding_query
     monkeypatch.setattr(module, "get_moorcheh_client", lambda: client)
     monkeypatch.setattr(module, "get_active_llm_model", lambda _: "test-model")
+    monkeypatch.setattr(
+        module, "get_active_embedding_model", lambda: "test-embedding-model"
+    )
+    monkeypatch.setattr(module, "_get_embedding_tokenizer", lambda _: tokenizer)
 
     service = module.DailyAnalysisService(
         sessions_dir=sessions_dir,
@@ -46,7 +61,10 @@ def test_busy_day_summary_keeps_embedded_query_within_context_window(
 
     assert result["status"] == "success"
     call_kwargs = client.answer.generate.call_args.kwargs
-    assert len(call_kwargs["query"]) <= 6_000
+    assert (
+        len(call_kwargs["query"].encode("utf-8"))
+        <= module._EMBEDDING_QUERY_TOKEN_BUDGET
+    )
     assert long_content in call_kwargs["header_prompt"]
     assert "Format the output as a Markdown report" in call_kwargs["footer_prompt"]
 
@@ -63,3 +81,18 @@ def test_short_day_summary_preserves_session_text_as_retrieval_query(
     call_kwargs = client.answer.generate.call_args.kwargs
     assert call_kwargs["query"] == short_content
     assert call_kwargs["ai_model"] == "test-model"
+
+
+def test_dense_unicode_fallback_stays_inside_conservative_byte_budget(monkeypatch):
+    """Unknown model tokenizers must still stay safely below 2,048 tokens."""
+    monkeypatch.setattr(module, "_get_embedding_tokenizer", lambda _: None)
+    dense_content = "界" * 5_000
+
+    query = module._truncate_embedding_query(
+        dense_content,
+        model="server-managed-model",
+    )
+
+    assert len(query.encode("utf-8")) <= module._EMBEDDING_QUERY_TOKEN_BUDGET
+    assert dense_content.startswith(query)
+    assert module._EMBEDDING_QUERY_TOKEN_BUDGET < module._EMBEDDING_CONTEXT_TOKENS

--- a/tests/test_daily_summary_query_length.py
+++ b/tests/test_daily_summary_query_length.py
@@ -20,7 +20,10 @@ def _make_summary_service(tmp_path, monkeypatch, session_content: str):
 
     class FakeTokenizer:
         @staticmethod
-        def encode(text: str):
+        def encode(text: str, disallowed_special=()):
+            # Mirrors tiktoken's signature: production passes
+            # disallowed_special=() so special-token markers in session prose
+            # are encoded as ordinary text instead of raising ValueError.
             return list(text.encode("utf-8"))
 
         @staticmethod

--- a/tests/test_memory_format.py
+++ b/tests/test_memory_format.py
@@ -18,7 +18,7 @@ def _formatted_memory_with_source_ref():
         content="This memory came from an external document.",
         agent_id="test-agent",
         actor_id="user",
-        source="document",
+        source="system",
         source_ref="document://guide/section-2",
     )
 

--- a/tests/test_memory_format.py
+++ b/tests/test_memory_format.py
@@ -3,11 +3,56 @@
 from unittest.mock import MagicMock
 
 from memanto.app.core import MemoryRecord
+from memanto.app.models import RecallResponse, TemporalRecallResponse
 from memanto.app.services.memory_read_service import MemoryReadService
 
 
 def _make_read_service():
     return MemoryReadService(MagicMock())
+
+
+def _formatted_memory_with_source_ref():
+    memory = MemoryRecord(
+        type="fact",
+        title="Imported fact",
+        content="This memory came from an external document.",
+        agent_id="test-agent",
+        actor_id="user",
+        source="document",
+        source_ref="document://guide/section-2",
+    )
+
+    return _make_read_service()._format_memory_item(memory.to_moorcheh_document())
+
+
+def test_recall_response_preserves_formatted_source_ref():
+    formatted = _formatted_memory_with_source_ref()
+
+    response = RecallResponse(
+        agent_id="test-agent",
+        session_id="test-session",
+        query="external document",
+        memories=[formatted],
+        count=1,
+    )
+
+    assert formatted["source_ref"] == "document://guide/section-2"
+    assert response.model_dump()["memories"][0]["source_ref"] == formatted["source_ref"]
+
+
+def test_temporal_recall_response_preserves_formatted_source_ref():
+    formatted = _formatted_memory_with_source_ref()
+
+    response = TemporalRecallResponse(
+        agent_id="test-agent",
+        session_id="test-session",
+        memories=[formatted],
+        count=1,
+        temporal_mode="recent",
+    )
+
+    assert formatted["source_ref"] == "document://guide/section-2"
+    assert response.model_dump()["memories"][0]["source_ref"] == formatted["source_ref"]
 
 
 def test_content_with_newlines_and_tags_preserves_content_integrity():

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -31,6 +31,39 @@ def test_detect_preference():
     assert memory.type == "preference"
 
 
+def test_detect_negated_preferences_instead_of_instructions():
+    parser = MemoryParsingService()
+
+    cases = [
+        "I don't like Python",
+        "I really don't like JavaScript",
+        "I do not like dark mode",
+        "We don’t enjoy weekly meetings",
+        "She doesn't prefer email",
+        "I no longer like Vim",
+        "I never liked Vim",
+        "They can't stand noisy notifications",
+        "The client prefers not to receive phone calls",
+    ]
+
+    for content in cases:
+        memory = make_memory(content)
+
+        parser.parse_memory(memory)
+
+        assert memory.type == "preference", content
+
+
+def test_negative_imperative_remains_an_instruction():
+    parser = MemoryParsingService()
+
+    memory = make_memory("Don't deploy unpinned dependencies in production")
+
+    parser.parse_memory(memory)
+
+    assert memory.type == "instruction"
+
+
 # 2 Do NOT override existing type
 def test_no_override_existing_type():
     parser = MemoryParsingService()

--- a/tests/test_memory_read_multi_type.py
+++ b/tests/test_memory_read_multi_type.py
@@ -1,0 +1,105 @@
+"""Regression coverage for union semantics in multi-type recall."""
+
+import re
+
+import pytest
+
+from memanto.app.services.memory_read_service import MemoryReadService
+from memanto.app.utils.errors import MemoryError
+
+
+def _memory(memory_id: str, memory_type: str, score: float) -> dict:
+    return {
+        "id": memory_id,
+        "text": f"[{memory_type.upper()}] {memory_id}\n\n{memory_id} content",
+        "memory_type": memory_type,
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "active",
+        "created_at": "2026-07-20T00:00:00Z",
+        "updated_at": "2026-07-20T00:00:00Z",
+        "score": score,
+    }
+
+
+class _ExactFilterSearch:
+    """Minimal Moorcheh filter semantics: repeated clauses are conjunctive."""
+
+    def __init__(self, rows: list[dict]):
+        self.rows = rows
+        self.queries: list[str] = []
+
+    def query(self, **kwargs):
+        query = kwargs["query"]
+        self.queries.append(query)
+        requested_types = re.findall(r"#memory_type:([A-Za-z0-9_.-]+)", query)
+        results = [
+            row
+            for row in self.rows
+            if all(row["memory_type"] == value for value in requested_types)
+        ]
+        return {"results": results[: kwargs["top_k"]], "execution_time": 0.01}
+
+
+class _Client:
+    def __init__(self, rows: list[dict]):
+        self.similarity_search = _ExactFilterSearch(rows)
+
+
+def test_multi_type_recall_queries_each_type_and_returns_ranked_union():
+    client = _Client(
+        [
+            _memory("fact-low", "fact", 0.70),
+            _memory("preference-high", "preference", 0.95),
+            _memory("instruction-excluded", "instruction", 0.99),
+        ]
+    )
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="project context",
+        agent_id="agent-1",
+        type=["fact", "preference"],
+        limit=10,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == [
+        "preference-high",
+        "fact-low",
+    ]
+    assert client.similarity_search.queries == [
+        "project context #memory_type:fact",
+        "project context #memory_type:preference",
+    ]
+
+
+def test_duplicate_type_does_not_issue_duplicate_backend_search():
+    client = _Client([_memory("fact", "fact", 0.8)])
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="project context",
+        agent_id="agent-1",
+        type=["fact", "fact"],
+        limit=10,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["fact"]
+    assert client.similarity_search.queries == ["project context #memory_type:fact"]
+
+
+def test_invalid_later_type_is_rejected_before_any_backend_search():
+    client = _Client([_memory("fact", "fact", 0.8)])
+    service = MemoryReadService(client)
+
+    with pytest.raises(MemoryError, match="Invalid memory_type"):
+        service.search_memories(
+            query="project context",
+            agent_id="agent-1",
+            type=["fact", "not-a-type"],
+            limit=10,
+        )
+
+    assert client.similarity_search.queries == []

--- a/tests/test_memory_read_multi_type.py
+++ b/tests/test_memory_read_multi_type.py
@@ -1,6 +1,7 @@
 """Regression coverage for union semantics in multi-type recall."""
 
 import re
+import threading
 
 import pytest
 
@@ -9,6 +10,7 @@ from memanto.app.utils.errors import MemoryError
 
 
 def _memory(memory_id: str, memory_type: str, score: float) -> dict:
+    """Build one formatted backend row for a memory type."""
     return {
         "id": memory_id,
         "text": f"[{memory_type.upper()}] {memory_id}\n\n{memory_id} content",
@@ -28,10 +30,12 @@ class _ExactFilterSearch:
     """Minimal Moorcheh filter semantics: repeated clauses are conjunctive."""
 
     def __init__(self, rows: list[dict]):
+        """Retain candidate rows and a trace of dispatched queries."""
         self.rows = rows
         self.queries: list[str] = []
 
     def query(self, **kwargs):
+        """Apply every exact type filter to the in-memory rows."""
         query = kwargs["query"]
         self.queries.append(query)
         requested_types = re.findall(r"#memory_type:([A-Za-z0-9_.-]+)", query)
@@ -44,11 +48,34 @@ class _ExactFilterSearch:
 
 
 class _Client:
+    """Expose the fake search surface expected by MemoryReadService."""
+
     def __init__(self, rows: list[dict]):
+        """Initialize a client with exact-filter search behavior."""
         self.similarity_search = _ExactFilterSearch(rows)
 
 
+class _BarrierSearch:
+    """Require two type searches to overlap before either can complete."""
+
+    def __init__(self, rows: list[dict]):
+        """Initialize candidate rows and a two-party synchronization barrier."""
+        self.rows = rows
+        self.barrier = threading.Barrier(2)
+
+    def query(self, **kwargs):
+        """Fail deterministically if the two searches run sequentially."""
+        requested_type = re.search(r"#memory_type:([A-Za-z0-9_.-]+)", kwargs["query"])
+        assert requested_type is not None
+        self.barrier.wait(timeout=5)
+        results = [
+            row for row in self.rows if row["memory_type"] == requested_type.group(1)
+        ]
+        return {"results": results, "execution_time": 0.01}
+
+
 def test_multi_type_recall_queries_each_type_and_returns_ranked_union():
+    """Multi-type recall returns the score-ranked union of requested types."""
     client = _Client(
         [
             _memory("fact-low", "fact", 0.70),
@@ -69,13 +96,40 @@ def test_multi_type_recall_queries_each_type_and_returns_ranked_union():
         "preference-high",
         "fact-low",
     ]
-    assert client.similarity_search.queries == [
-        "project context #memory_type:fact",
-        "project context #memory_type:preference",
-    ]
+    assert sorted(client.similarity_search.queries) == sorted(
+        [
+            "project context #memory_type:fact",
+            "project context #memory_type:preference",
+        ]
+    )
+
+
+def test_multi_type_searches_run_concurrently():
+    """Independent exact-type searches overlap instead of adding their latency."""
+    client = _Client([])
+    client.similarity_search = _BarrierSearch(
+        [
+            _memory("fact", "fact", 0.8),
+            _memory("preference", "preference", 0.9),
+        ]
+    )
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="project context",
+        agent_id="agent-1",
+        type=["fact", "preference"],
+        limit=10,
+    )
+
+    assert {memory["id"] for memory in result["results"]} == {
+        "fact",
+        "preference",
+    }
 
 
 def test_duplicate_type_does_not_issue_duplicate_backend_search():
+    """Repeated input types collapse to one backend query."""
     client = _Client([_memory("fact", "fact", 0.8)])
     service = MemoryReadService(client)
 
@@ -91,6 +145,7 @@ def test_duplicate_type_does_not_issue_duplicate_backend_search():
 
 
 def test_invalid_later_type_is_rejected_before_any_backend_search():
+    """Validation completes before any query is dispatched."""
     client = _Client([_memory("fact", "fact", 0.8)])
     service = MemoryReadService(client)
 

--- a/tests/test_memory_read_multi_type.py
+++ b/tests/test_memory_read_multi_type.py
@@ -5,6 +5,7 @@ import threading
 
 import pytest
 
+import memanto.app.services.memory_read_service as memory_read_service_module
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.utils.errors import MemoryError
 
@@ -126,6 +127,32 @@ def test_multi_type_searches_run_concurrently():
         "fact",
         "preference",
     }
+
+
+def test_multi_type_execution_time_reports_parallel_wall_clock(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Reported latency measures the dispatch window, not summed worker time."""
+    timestamps = iter([100.0, 100.025])
+    monkeypatch.setattr(
+        memory_read_service_module, "monotonic", lambda: next(timestamps)
+    )
+    client = _Client(
+        [
+            _memory("fact", "fact", 0.8),
+            _memory("preference", "preference", 0.9),
+        ]
+    )
+    service = MemoryReadService(client)
+
+    result = service.search_memories(
+        query="project context",
+        agent_id="agent-1",
+        type=["fact", "preference"],
+        limit=10,
+    )
+
+    assert result["execution_time"] == pytest.approx(0.025)
 
 
 def test_duplicate_type_does_not_issue_duplicate_backend_search():

--- a/tests/test_moorcheh_user_config_compat.py
+++ b/tests/test_moorcheh_user_config_compat.py
@@ -1,0 +1,65 @@
+"""Regression tests for the moorcheh-client user_config import path.
+
+moorcheh-client 0.1.5 reorganised the package into ``client`` and ``cli``
+subpackages, moving ``moorcheh/user_config.py`` to ``moorcheh/cli/user_config.py``.
+memanto declares ``moorcheh-client>=0.1.3`` with no upper bound, so a fresh
+install resolves to 0.1.5 and the old import path raises ImportError.
+
+That aborted `memanto config backend on-prem` outright:
+
+    Error: moorcheh.user_config unavailable: No module named 'moorcheh.user_config'
+
+which is the documented zero-config local install path. These tests pin the
+importer to both layouts.
+"""
+
+import sys
+import types
+
+import pytest
+
+from memanto.cli.commands.core import _import_user_config
+
+NAMES = ("EmbeddingConfig", "LlmConfig", "default_base_url", "save_runtime_config")
+
+
+def _fake_user_config_module() -> types.ModuleType:
+    mod = types.ModuleType("user_config")
+    for name in NAMES:
+        setattr(mod, name, type(name, (), {}))
+    return mod
+
+
+@pytest.mark.parametrize("layout", ["new", "old"])
+def test_import_user_config_supports_both_layouts(monkeypatch, layout):
+    """0.1.5 (moorcheh.cli.user_config) and 0.1.3/0.1.4 (moorcheh.user_config)."""
+    for mod in [m for m in sys.modules if m.startswith("moorcheh")]:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    pkg = types.ModuleType("moorcheh")
+    pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "moorcheh", pkg)
+
+    target = _fake_user_config_module()
+    if layout == "new":
+        cli = types.ModuleType("moorcheh.cli")
+        cli.__path__ = []
+        monkeypatch.setitem(sys.modules, "moorcheh.cli", cli)
+        monkeypatch.setitem(sys.modules, "moorcheh.cli.user_config", target)
+    else:
+        monkeypatch.setitem(sys.modules, "moorcheh.user_config", target)
+
+    resolved = _import_user_config()
+    assert len(resolved) == len(NAMES)
+    assert all(obj is not None for obj in resolved)
+
+
+def test_import_user_config_raises_when_neither_layout_present(monkeypatch):
+    """A genuinely missing dependency must still surface as ImportError."""
+    for mod in [m for m in sys.modules if m.startswith("moorcheh")]:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+    pkg = types.ModuleType("moorcheh")
+    pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "moorcheh", pkg)
+    with pytest.raises(ImportError):
+        _import_user_config()

--- a/tests/test_postcommit_summary_resilience.py
+++ b/tests/test_postcommit_summary_resilience.py
@@ -1,0 +1,116 @@
+"""Committed memory operations must not fail on auxiliary summary logging."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from memanto.app.services.session_service import SessionService
+from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.client.sdk_client import SdkClient
+
+
+@pytest.mark.parametrize("client_cls", [DirectClient, SdkClient])
+def test_remember_returns_committed_result_when_summary_logging_fails(client_cls):
+    write_service = MagicMock()
+    write_service.store_memory.return_value = {
+        "id": "mem-committed",
+        "namespace": "memanto_agent_test-agent",
+        "status": "queued",
+        "type": "fact",
+    }
+    session_service = SessionService.__new__(SessionService)
+    session_service.log_memory_to_session_summary = MagicMock(
+        side_effect=OSError("summary disk is full")
+    )
+    session = SimpleNamespace(
+        namespace="memanto_agent_test-agent", session_id="session-1"
+    )
+
+    with (
+        patch.object(
+            client_cls, "_get_validated_session_for_agent", return_value=session
+        ),
+        patch.object(client_cls, "_get_write_service", return_value=write_service),
+        patch.object(client_cls, "_get_session_service", return_value=session_service),
+    ):
+        client = client_cls.__new__(client_cls)
+        client.api_key = "test-api-key"
+        client.session_token = "session-token"
+        result = client.remember(
+            agent_id="test-agent",
+            memory_type="fact",
+            title="Committed fact",
+            content="The remote write already succeeded.",
+        )
+
+    assert result["memory_id"] == "mem-committed"
+    write_service.store_memory.assert_called_once()
+    session_service.log_memory_to_session_summary.assert_called_once()
+
+
+@pytest.mark.parametrize("client_cls", [DirectClient, SdkClient])
+def test_batch_remember_returns_committed_result_when_summary_logging_fails(
+    client_cls,
+):
+    write_service = MagicMock()
+    committed = {
+        "total_submitted": 1,
+        "successful": 1,
+        "failed": 0,
+        "results": [{"id": "mem-batch", "status": "success"}],
+    }
+    write_service.batch_store_memories.return_value = committed
+    session_service = SessionService.__new__(SessionService)
+    session_service.log_memory_to_session_summary = MagicMock(
+        side_effect=OSError("summary directory is read-only")
+    )
+    session = SimpleNamespace(namespace="memanto_agent_test-agent")
+
+    with (
+        patch.object(
+            client_cls, "_get_validated_session_for_agent", return_value=session
+        ),
+        patch.object(client_cls, "_get_write_service", return_value=write_service),
+        patch.object(client_cls, "_get_session_service", return_value=session_service),
+    ):
+        client = client_cls.__new__(client_cls)
+        client.api_key = "test-api-key"
+        client.session_token = "session-token"
+        result = client.batch_remember(
+            agent_id="test-agent", memories=[{"content": "Committed batch item"}]
+        )
+
+    assert result == committed
+    write_service.batch_store_memories.assert_called_once()
+    session_service.log_memory_to_session_summary.assert_called_once()
+
+
+@pytest.mark.parametrize("client_cls", [DirectClient, SdkClient])
+def test_delete_returns_committed_result_when_summary_logging_fails(client_cls):
+    write_service = MagicMock()
+    write_service.delete_memory.return_value = True
+    session_service = SessionService.__new__(SessionService)
+    session_service.log_memory_deletion_to_session_summary = MagicMock(
+        side_effect=OSError("summary file cannot be updated")
+    )
+    session = SimpleNamespace(
+        namespace="memanto_agent_test-agent", session_id="session-1"
+    )
+
+    with (
+        patch.object(
+            client_cls, "_get_validated_session_for_agent", return_value=session
+        ),
+        patch.object(client_cls, "_get_write_service", return_value=write_service),
+        patch.object(client_cls, "_get_session_service", return_value=session_service),
+    ):
+        client = client_cls.__new__(client_cls)
+        client.api_key = "test-api-key"
+        client.session_token = "session-token"
+        result = client.delete_memory(agent_id="test-agent", memory_id="mem-delete")
+
+    assert result["status"] == "deleted"
+    assert result["memory_id"] == "mem-delete"
+    write_service.delete_memory.assert_called_once()
+    session_service.log_memory_deletion_to_session_summary.assert_called_once()

--- a/tests/test_postcommit_summary_resilience.py
+++ b/tests/test_postcommit_summary_resilience.py
@@ -12,6 +12,7 @@ from memanto.cli.client.sdk_client import SdkClient
 
 @pytest.mark.parametrize("client_cls", [DirectClient, SdkClient])
 def test_remember_returns_committed_result_when_summary_logging_fails(client_cls):
+    """A committed single write remains successful when its summary fails."""
     write_service = MagicMock()
     write_service.store_memory.return_value = {
         "id": "mem-committed",
@@ -53,6 +54,7 @@ def test_remember_returns_committed_result_when_summary_logging_fails(client_cls
 def test_batch_remember_returns_committed_result_when_summary_logging_fails(
     client_cls,
 ):
+    """A committed batch remains successful when its summary fails."""
     write_service = MagicMock()
     committed = {
         "total_submitted": 1,
@@ -88,6 +90,7 @@ def test_batch_remember_returns_committed_result_when_summary_logging_fails(
 
 @pytest.mark.parametrize("client_cls", [DirectClient, SdkClient])
 def test_delete_returns_committed_result_when_summary_logging_fails(client_cls):
+    """A committed deletion remains successful when its summary fails."""
     write_service = MagicMock()
     write_service.delete_memory.return_value = True
     session_service = SessionService.__new__(SessionService)

--- a/tests/test_review_followups.py
+++ b/tests/test_review_followups.py
@@ -1,0 +1,77 @@
+"""Regression tests for issues raised in review of the merged PR batch.
+
+Each test fails against the pre-fix source:
+
+* ``get_active_session`` propagated ``ValueError`` from ``validate_safe_id``
+  when the active marker was empty or corrupt, instead of reporting "no active
+  session" the way its ``OSError`` path already did.
+* ``get_active_llm_model`` called ``.get`` on whatever ``state.json`` decoded
+  to, so a valid-JSON-but-not-an-object file raised ``AttributeError`` rather
+  than degrading to ``None`` (its sibling ``get_active_embedding_model``
+  already guarded this).
+"""
+
+import json
+
+import pytest
+
+from memanto.app.clients.backend import get_active_llm_model
+from memanto.app.services.session_service import SessionService
+
+
+@pytest.fixture
+def service(tmp_path):
+    return SessionService(secret_key="k" * 32, sessions_dir=tmp_path / "sessions")
+
+
+class TestCorruptActiveMarker:
+    """An unreadable active marker means "no active session", never a crash."""
+
+    @pytest.mark.parametrize("marker", ["", "   ", "../escape", "bad/id", "a" * 300])
+    def test_corrupt_marker_reports_no_active_session(self, service, marker):
+        service._harden_session_storage()
+        (service.sessions_dir / "active").write_text(marker, encoding="utf-8")
+
+        assert service.get_active_session() is None
+
+    def test_missing_marker_still_reports_none(self, service):
+        service._harden_session_storage()
+        assert service.get_active_session() is None
+
+    def test_valid_marker_still_resolves(self, service):
+        service.create_session(agent_id="goodagent")
+        active = service.get_active_session()
+        assert active is not None
+        assert active.agent_id == "goodagent"
+
+
+class TestMalformedOnPremState:
+    """A valid-JSON-but-non-object state.json degrades to None, not AttributeError."""
+
+    @pytest.mark.parametrize(
+        "payload", [[], "a string", 42, None, [{"llm_model": "x"}]]
+    )
+    def test_non_object_state_returns_none(self, tmp_path, monkeypatch, payload):
+        monkeypatch.setenv("MEMANTO_BACKEND", "on-prem")
+        monkeypatch.setattr(
+            "memanto.app.config.settings.MEMANTO_BACKEND", "on-prem", raising=False
+        )
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        state = tmp_path / ".memanto" / "on-prem" / "state.json"
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text(json.dumps(payload), encoding="utf-8")
+
+        assert get_active_llm_model("cloud-default") is None
+
+    def test_well_formed_state_still_read(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "memanto.app.config.settings.MEMANTO_BACKEND", "on-prem", raising=False
+        )
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        state = tmp_path / ".memanto" / "on-prem" / "state.json"
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text(json.dumps({"llm_model": "llama3"}), encoding="utf-8")
+
+        assert get_active_llm_model("cloud-default") == "llama3"

--- a/tests/test_session_summary_concurrency.py
+++ b/tests/test_session_summary_concurrency.py
@@ -1,0 +1,70 @@
+"""Concurrency regressions for local session-summary persistence."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from threading import Barrier, BrokenBarrierError
+
+from memanto.app.core import MemoryRecord
+from memanto.app.services.session_service import SessionService
+
+
+def test_concurrent_summary_writes_create_one_header(monkeypatch, tmp_path):
+    """Concurrent API workers must not race first-write header creation."""
+    service = SessionService(
+        secret_key="test-secret-key-min-32-bytes-1234",
+        sessions_dir=tmp_path / "sessions",
+    )
+    service._harden_session_storage()
+    worker_count = 8
+    first_exists_checks = Barrier(worker_count)
+    original_exists = Path.exists
+
+    def synchronize_initial_absence_check(path):
+        exists = original_exists(path)
+        if path.name.endswith("_summary.md") and not exists:
+            try:
+                first_exists_checks.wait(timeout=0.5)
+            except BrokenBarrierError:
+                pass
+        return exists
+
+    monkeypatch.setattr(Path, "exists", synchronize_initial_absence_check)
+
+    def log_memory(index):
+        record = MemoryRecord(
+            type="fact",
+            title=f"concurrent-{index}",
+            content=f"payload-{index}",
+            agent_id="agent-race",
+            actor_id="agent-race",
+            source="agent",
+            created_at=datetime(2026, 7, 20, 12, 0, index),
+        )
+        service.log_memory_to_session_summary(
+            agent_id="agent-race",
+            session_id="sess-race",
+            memory_record=record,
+            memory_id=f"mem-{index}",
+        )
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        list(executor.map(log_memory, range(worker_count)))
+
+    summary_file = service.sessions_dir / "agent-race_2026-07-20_sess-race_summary.md"
+    summary = summary_file.read_text(encoding="utf-8")
+
+    assert summary.count("# Session Summary for agent-race") == 1
+    for index in range(worker_count):
+        entry = (
+            f"### [2026-07-20 12:00:0{index}] [FACT] concurrent-{index}\n"
+            f"- **Memory ID**: `mem-{index}`\n"
+            "- **Confidence**: `0.8`\n"
+            "- **Status**: `active`\n"
+            "- **Source**: `agent`\n"
+            "- **Provenance**: `explicit_statement`\n"
+            "- **Content**:\n"
+            f"> payload-{index}\n\n"
+            "---\n\n"
+        )
+        assert summary.count(entry) == 1

--- a/tests/test_session_summary_concurrency.py
+++ b/tests/test_session_summary_concurrency.py
@@ -26,6 +26,9 @@ def test_concurrent_summary_writes_create_one_header(monkeypatch, tmp_path):
             try:
                 first_exists_checks.wait(timeout=0.5)
             except BrokenBarrierError:
+                # The barrier only widens the race window so the test is more
+                # likely to catch duplicate headers. If it times out or breaks,
+                # continue with the real exists() result rather than failing.
                 pass
         return exists
 

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -6,6 +6,7 @@ from memanto.app.routes.memory import RecallRequest
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.utils.temporal_helpers import (
     build_temporal_query,
+    get_yesterday_range,
     parse_as_of_timestamp,
     parse_iso_timestamp,
     parse_relative_time,
@@ -71,6 +72,20 @@ def test_build_temporal_query_rejects_invalid_relative_time():
             "deployment notes",
             relative_time="last 0 days",
         )
+
+
+def test_build_temporal_query_bounds_yesterday_to_that_calendar_day():
+    start, end = get_yesterday_range()
+
+    payload = build_temporal_query(
+        "http://localhost:8000",
+        "agent-1",
+        "deployment notes",
+        relative_time="yesterday",
+    )["json"]
+
+    assert payload["created_after"] == start
+    assert payload["created_before"] == end
 
 
 def test_parse_as_of_timestamp_treats_date_only_as_end_of_day():

--- a/tests/test_temporal_helpers.py
+++ b/tests/test_temporal_helpers.py
@@ -2,7 +2,11 @@ from datetime import timezone
 
 import pytest
 
-from memanto.app.routes.memory import RecallRequest
+from memanto.app.routes.memory import (
+    RecallAsOfRequest,
+    RecallRecentRequest,
+    RecallRequest,
+)
 from memanto.app.services.memory_read_service import MemoryReadService
 from memanto.app.utils.temporal_helpers import (
     build_temporal_query,
@@ -84,3 +88,42 @@ def test_parse_as_of_timestamp_preserves_explicit_time():
     parsed = parse_as_of_timestamp("2026-01-15T13:30:00Z")
 
     assert parsed.isoformat() == "2026-01-15T13:30:00+00:00"
+
+
+def test_recall_date_only_created_before_covers_the_whole_day():
+    request = RecallRequest.model_validate(
+        {"query": "notes", "created_before": "2026-06-30"}
+    )
+
+    assert request.created_before is not None
+    assert request.created_before.isoformat() == "2026-06-30T23:59:59.999999+00:00"
+
+
+def test_recall_date_only_created_before_keeps_final_subsecond_memory():
+    # A memory created at 23:59:59.5 on the boundary day is still "that day";
+    # a 23:59:59 bound (pre-fix) wrongly excluded it via the strict `>` filter.
+    request = RecallRequest.model_validate(
+        {"query": "notes", "created_before": "2026-06-30"}
+    )
+    service = MemoryReadService(object())
+
+    results = [{"id": "late", "created_at": "2026-06-30T23:59:59.500000+00:00"}]
+    filtered = service._apply_temporal_filter(
+        results, created_before=request.created_before.isoformat()
+    )
+
+    assert [memory["id"] for memory in filtered] == ["late"]
+
+
+def test_recall_recent_date_only_created_before_covers_the_whole_day():
+    request = RecallRecentRequest.model_validate({"created_before": "2026-06-30"})
+
+    assert request.created_before is not None
+    assert request.created_before.isoformat() == "2026-06-30T23:59:59.999999+00:00"
+
+
+def test_recall_as_of_date_only_matches_service_helper_end_of_day():
+    request = RecallAsOfRequest.model_validate({"as_of": "2026-06-30"})
+
+    assert request.as_of == parse_as_of_timestamp("2026-06-30")
+    assert request.as_of.isoformat() == "2026-06-30T23:59:59.999999+00:00"

--- a/tests/test_title_newline_roundtrip.py
+++ b/tests/test_title_newline_roundtrip.py
@@ -1,0 +1,110 @@
+"""
+Regression tests for multi-line memory titles.
+
+A title containing a newline breaks the ``[TYPE] title\\n\\ncontent`` document
+format round-trip:
+
+- ``MemoryReadService._format_memory_item`` fails to strip the ``[TYPE]``
+  prefix (its regex cannot cross the embedded newline), so recall returns the
+  internal storage prefix leaked into the user-visible title.
+- ``update_memory`` rebuilds the record from that corrupted read, so every
+  update prepends another ``[TYPE]`` prefix; once the title outgrows the
+  100-char limit the memory can never be updated again.
+- Titles with newlines are reachable from every entry point: no API/MCP/CLI
+  validator rejects them, and the derived-title fallback (``content[:50]``)
+  produces them automatically for any multi-line content stored without an
+  explicit title.
+
+See https://github.com/moorcheh-ai/memanto/issues/770
+"""
+
+from unittest.mock import MagicMock
+
+from memanto.app.core import MemoryRecord
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _record(title: str, content: str = "Body of the memory.") -> MemoryRecord:
+    return MemoryRecord(
+        type="fact",
+        title=title,
+        content=content,
+        agent_id="test-agent",
+        actor_id="test-agent",
+        source="user",
+    )
+
+
+def _read_back(record: MemoryRecord) -> dict:
+    """Serialize a record and re-parse it the way recall/get_memory does."""
+    document = record.to_moorcheh_document()
+    service = MemoryReadService(MagicMock())
+    return service._format_memory_item(
+        {"id": record.id, "text": document["text"], "metadata": {}}
+    )
+
+
+class TestTitleNewlineNormalization:
+    """Titles are single-line labels: embedded newlines must be normalized."""
+
+    def test_title_with_newline_is_normalized_at_construction(self):
+        record = _record("Deploy checklist\n(staging first)")
+        assert "\n" not in record.title
+        assert record.title == "Deploy checklist (staging first)"
+
+    def test_title_with_crlf_and_surrounding_spaces_is_normalized(self):
+        record = _record("Step one \r\n  step two")
+        assert "\n" not in record.title
+        assert "\r" not in record.title
+        assert record.title == "Step one step two"
+
+    def test_derived_title_from_multiline_content_stays_single_line(self):
+        # Mirrors the derived-title fallback used by the API route, MCP tool,
+        # and CLI clients when the caller omits a title.
+        content = "Step 1: do X\nStep 2: do Y"
+        record = _record(title=content[:50], content=content)
+        assert "\n" not in record.title
+
+    def test_single_line_titles_are_untouched(self):
+        record = _record("Plain single-line title")
+        assert record.title == "Plain single-line title"
+
+
+class TestTitleRoundTrip:
+    """Stored titles must come back without the internal [TYPE] prefix."""
+
+    def test_multiline_title_round_trip_has_no_type_prefix(self):
+        record = _record("Deploy checklist\n(staging first)")
+        formatted = _read_back(record)
+        assert not formatted["title"].startswith("[FACT]")
+        assert formatted["title"] == record.title
+        assert formatted["content"] == "Body of the memory."
+
+    def test_legacy_document_with_multiline_title_still_strips_prefix(self):
+        # Documents stored before normalization existed still contain raw
+        # newlines inside the title line; the reader must strip the [TYPE]
+        # prefix rather than leak it into the title.
+        service = MemoryReadService(MagicMock())
+        formatted = service._format_memory_item(
+            {
+                "id": "legacy-1",
+                "text": "[FACT] Deploy checklist\n(staging first)\n\nBody.",
+                "metadata": {},
+            }
+        )
+        assert formatted["title"] == "Deploy checklist\n(staging first)"
+        assert formatted["content"] == "Body."
+
+    def test_update_cycle_does_not_compound_type_prefixes(self):
+        # Simulates update_memory: read the formatted record, rebuild it with
+        # unchanged title/content, store, and read again. The title must be
+        # stable instead of gaining one more "[FACT] " prefix per update.
+        record = _record("Deploy checklist\n(staging first)")
+        formatted = _read_back(record)
+
+        for _ in range(3):
+            rebuilt = _record(title=formatted["title"], content=formatted["content"])
+            formatted = _read_back(rebuilt)
+
+        assert not formatted["title"].startswith("[FACT]")
+        assert formatted["title"] == record.title

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -120,6 +120,31 @@ class TestSessionService:
         assert stat.S_IMODE(session_file.stat().st_mode) == 0o600
         assert stat.S_IMODE(summary_file.stat().st_mode) == 0o600
 
+    def test_interrupted_session_save_preserves_previous_record(self, session_service):
+        """A failed replacement must not truncate the live bearer-token record."""
+        session = session_service.create_session(
+            agent_id="test-agent", duration_hours=1
+        )
+        session_file = session_service.sessions_dir / "test-agent.json"
+        original_contents = session_file.read_text(encoding="utf-8")
+        replacement = session.model_copy(update={"session_id": "sess-replacement"})
+
+        def interrupted_dump(data, file_obj, **kwargs):
+            file_obj.write('{"session_id":')
+            file_obj.flush()
+            raise OSError("simulated interrupted write")
+
+        with patch(
+            "memanto.app.services.session_service.json.dump",
+            side_effect=interrupted_dump,
+        ):
+            with pytest.raises(OSError, match="simulated interrupted write"):
+                session_service._save_session(replacement)
+
+        assert session_file.read_text(encoding="utf-8") == original_contents
+        assert session_service.get_session("test-agent") == session
+        assert not list(session_service.sessions_dir.glob(".*.tmp"))
+
     def test_validate_session(self, session_service):
         """Test session validation"""
         # Create session

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,6 +4,8 @@ MEMANTO Core Unit Tests (No Server Required)
 Tests the session and agent services directly without HTTP layer.
 """
 
+import os
+import stat
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
@@ -67,6 +69,56 @@ class TestSessionService:
         print(f"   Session ID: {session.session_id}")
         print(f"   Namespace: {session.namespace}")
         print(f"   Expires in: {time_diff / 3600:.2f} hours")
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits required")
+    def test_session_token_storage_is_owner_only(self, temp_dir):
+        """Persisted bearer tokens must not be readable by other local users."""
+        sessions_dir = temp_dir / "sessions"
+        service = SessionService(
+            secret_key="test-secret-key-min-32-bytes-1234",
+            sessions_dir=sessions_dir,
+        )
+
+        session = service.create_session(agent_id="private-agent", duration_hours=1)
+        record = MemoryRecord(
+            type="fact",
+            title="Private fact",
+            content="Private memory content",
+            agent_id="private-agent",
+            actor_id="user",
+            source="user",
+        )
+        service.log_memory_to_session_summary(
+            "private-agent", session.session_id, record
+        )
+
+        session_file = sessions_dir / "private-agent.json"
+        summary_file = next(sessions_dir.glob("*_summary.md"))
+        assert stat.S_IMODE(sessions_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(session_file.stat().st_mode) == 0o600
+        assert stat.S_IMODE(summary_file.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits required")
+    def test_initialization_hardens_existing_session_artifacts(self, temp_dir):
+        """Upgrades must close exposure of files created by older versions."""
+        sessions_dir = temp_dir / "sessions"
+        sessions_dir.mkdir(mode=0o777)
+        session_file = sessions_dir / "existing.json"
+        summary_file = sessions_dir / "existing_summary.md"
+        session_file.write_text('{"session_token": "live-bearer-token"}')
+        summary_file.write_text("private memory content")
+        sessions_dir.chmod(0o777)
+        session_file.chmod(0o666)
+        summary_file.chmod(0o666)
+
+        SessionService(
+            secret_key="test-secret-key-min-32-bytes-1234",
+            sessions_dir=sessions_dir,
+        )
+
+        assert stat.S_IMODE(sessions_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(session_file.stat().st_mode) == 0o600
+        assert stat.S_IMODE(summary_file.stat().st_mode) == 0o600
 
     def test_validate_session(self, session_service):
         """Test session validation"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -468,7 +468,7 @@ class TestMemoryWriteServiceDelete:
         assert "validation_count" not in uploaded
 
 
-class TestMemoryWriteServiceUpdate:
+class TestMemoryWriteServiceUpdateIntegrity:
     def test_update_memory_preserves_read_service_metadata(self):
         from memanto.app.services.memory_write_service import MemoryWriteService
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -567,6 +567,8 @@ class TestSessionService:
         """Deleting session state succeeds if another process removes the marker."""
         session_service.create_session("test-agent")
         active_marker = session_service.sessions_dir / "active"
+        active_marker.unlink()
+        active_marker.write_text("test-agent")
         original_open = open
 
         def disappearing_marker(file, *args, **kwargs):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6,7 +6,10 @@ Tests the session and agent services directly without HTTP layer.
 
 import os
 import stat
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import jwt
@@ -308,6 +311,67 @@ class TestSessionService:
             sessions_dir=temp_dir / "other-install" / "sessions"
         )
         assert other_root.secret_key != first.secret_key
+
+    def test_concurrent_first_start_uses_one_persisted_secret(
+        self, temp_dir, monkeypatch
+    ):
+        """Concurrent service starts must agree on the JWT signing secret."""
+        monkeypatch.delenv("MEMANTO_SECRET_KEY", raising=False)
+        monkeypatch.setattr(settings, "MEMANTO_SECRET_KEY", "")
+
+        sessions_dir = temp_dir / "sessions"
+        second_truncated_secret = threading.Event()
+        release_first_writer = threading.Event()
+        thread_role = threading.local()
+        real_open = os.open
+        real_fdopen = os.fdopen
+
+        def observed_open(path, flags, mode=0o777):
+            if (
+                getattr(thread_role, "value", None) == "second"
+                and Path(path).name == "secret_key"
+                and flags & os.O_TRUNC
+            ):
+                second_truncated_secret.set()
+            return real_open(path, flags, mode)
+
+        def delayed_fdopen(fd, *args, **kwargs):
+            file_handle = real_fdopen(fd, *args, **kwargs)
+            if getattr(thread_role, "value", None) != "first":
+                return file_handle
+
+            class DelayedWriter:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc_value, traceback):
+                    return file_handle.__exit__(exc_type, exc_value, traceback)
+
+                def write(self, data):
+                    assert release_first_writer.wait(timeout=5)
+                    return file_handle.write(data)
+
+                def __getattr__(self, name):
+                    return getattr(file_handle, name)
+
+            return DelayedWriter()
+
+        def create_service(role):
+            thread_role.value = role
+            return SessionService(sessions_dir=sessions_dir).secret_key
+
+        monkeypatch.setattr(os, "open", observed_open)
+        monkeypatch.setattr(os, "fdopen", delayed_fdopen)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(create_service, "first")
+            second = pool.submit(create_service, "second")
+            second_truncated_secret.wait(timeout=0.1)
+            release_first_writer.set()
+            returned_secrets = [first.result(timeout=5), second.result(timeout=5)]
+
+        persisted_secret = (temp_dir / "secret_key").read_text()
+        assert returned_secrets == [persisted_secret, persisted_secret]
 
     def test_get_active_session_ignores_invalid_session_file(self, session_service):
         """A corrupt active session file should not crash status checks."""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -300,6 +300,55 @@ class TestSessionService:
         assert len(renewed) == 1
         session_service.validate_session(renewed[0].session_token)
 
+    def test_lifecycle_operations_for_different_agents_can_overlap(
+        self, session_service, monkeypatch
+    ):
+        """One agent's session file I/O must not block another agent."""
+        original_save = session_service._save_session
+        first_save_entered = threading.Event()
+        release_first_save = threading.Event()
+
+        def controlled_save(session):
+            if session.agent_id == "agent-a":
+                first_save_entered.set()
+                assert release_first_save.wait(timeout=2)
+            original_save(session)
+
+        monkeypatch.setattr(session_service, "_save_session", controlled_save)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(session_service.create_session, "agent-a")
+            assert first_save_entered.wait(timeout=2)
+            second = pool.submit(session_service.create_session, "agent-b")
+            second_session = second.result(timeout=1)
+            release_first_save.set()
+            first_session = first.result(timeout=2)
+
+        assert first_session.agent_id == "agent-a"
+        assert second_session.agent_id == "agent-b"
+
+    def test_active_session_read_waits_for_marker_update(self, session_service):
+        """Readers must not observe an active marker during its replacement."""
+        session = session_service.create_session("test-agent")
+        read_started = threading.Event()
+
+        def read_active_session():
+            read_started.set()
+            return session_service.get_active_session()
+
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            with session_service._active_marker_lock:
+                pending_read = pool.submit(read_active_session)
+                assert read_started.wait(timeout=2)
+                assert not pending_read.done()
+            active_session = pending_read.result(timeout=2)
+        finally:
+            pool.shutdown(wait=True)
+
+        assert active_session is not None
+        assert active_session.session_id == session.session_id
+
     def test_end_session_revokes_concurrent_auto_renewal(
         self, session_service, monkeypatch
     ):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -468,6 +468,125 @@ class TestMemoryWriteServiceDelete:
         assert "validation_count" not in uploaded
 
 
+class TestMemoryWriteServiceUpdate:
+    def test_update_memory_preserves_read_service_metadata(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.get.return_value = {
+            "items": [
+                {
+                    "id": "mem-2",
+                    "text": (
+                        "[DECISION] Architecture decision\n\n"
+                        "Use same-ID document replacement for edits."
+                    ),
+                    "metadata": {
+                        "agent_id": "agent-1",
+                        "memory_type": "decision",
+                        "actor_id": "user",
+                        "source": "test",
+                        "source_ref": "issue-770",
+                        "confidence": 0.95,
+                        "status": "active",
+                        "tags": "integrity",
+                        "provenance": "validated",
+                    },
+                }
+            ]
+        }
+        client.documents.upload.return_value = {"status": "queued"}
+
+        MemoryWriteService(client).update_memory(
+            "mem-2",
+            "memanto_agent_agent-1",
+            {"content": "Updated without losing original metadata."},
+        )
+
+        uploaded = client.documents.upload.call_args.kwargs["documents"][0]
+        assert uploaded["memory_type"] == "decision"
+        assert uploaded["provenance"] == "validated"
+        assert uploaded["source_ref"] == "issue-770"
+        assert uploaded["tags"] == "integrity"
+
+    def test_update_memory_accepts_case_insensitive_success_status(self):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+
+        client = MagicMock()
+        client.documents.upload.return_value = {"status": "OK"}
+        existing_memory = {
+            "id": "mem-1",
+            "type": "fact",
+            "title": "Original title",
+            "content": "Original content",
+            "agent_id": "agent-1",
+            "actor_id": "user",
+            "source": "test",
+            "confidence": 0.9,
+            "status": "active",
+            "tags": [],
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            result = MemoryWriteService(client).update_memory(
+                "mem-1",
+                "memanto_agent_agent-1",
+                {"content": "Updated content"},
+            )
+
+        assert result["action"] == "updated"
+        assert result["status"] == "OK"
+        client.documents.delete.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "upload_result,expected_status",
+        [
+            ({"status": "failed"}, "failed"),
+            ({"status": None}, None),
+            ({}, "unknown"),
+        ],
+    )
+    def test_update_memory_rejects_non_success_status_without_delete(
+        self, upload_result, expected_status
+    ):
+        from memanto.app.services.memory_write_service import MemoryWriteService
+        from memanto.app.utils.errors import MemoryError
+
+        client = MagicMock()
+        client.documents.upload.return_value = upload_result
+        existing_memory = {
+            "id": "mem-1",
+            "type": "fact",
+            "title": "Original title",
+            "content": "Original content",
+            "agent_id": "agent-1",
+            "actor_id": "user",
+            "source": "test",
+            "confidence": 0.9,
+            "status": "active",
+            "tags": [],
+        }
+
+        with patch(
+            "memanto.app.services.memory_read_service.MemoryReadService.get_memory",
+            return_value=existing_memory,
+        ):
+            with pytest.raises(MemoryError) as exc_info:
+                MemoryWriteService(client).update_memory(
+                    "mem-1",
+                    "memanto_agent_agent-1",
+                    {"content": "Updated content"},
+                )
+
+        assert str(exc_info.value) == (
+            f"Failed to upload updated memory mem-1: {expected_status}"
+        )
+        client.documents.delete.assert_not_called()
+
+
 class TestMemoryReadServiceFormatting:
     def test_format_memory_item_preserves_falsey_metadata_values(self):
         from memanto.app.services.memory_read_service import MemoryReadService

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -261,6 +261,44 @@ class TestSessionService:
         # Just verify the logic exists
         print("✅ Session expiration logic exists")
 
+    def test_auto_renew_is_single_flight_per_agent(self, session_service, monkeypatch):
+        """Parallel near-expiry requests must not mint competing tokens."""
+        session_service.create_session(agent_id="test-agent", duration_hours=1)
+        monkeypatch.setattr(settings, "SESSION_EXTEND_THRESHOLD_MINUTES", 120)
+
+        original_renew = session_service.renew_session
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        release_first = threading.Event()
+        counter_lock = threading.Lock()
+        call_count = 0
+
+        def controlled_renew(agent_id, pattern=None):
+            nonlocal call_count
+            with counter_lock:
+                call_count += 1
+                call_number = call_count
+            if call_number == 1:
+                first_entered.set()
+                assert release_first.wait(timeout=2)
+            elif call_number == 2:
+                second_entered.set()
+            return original_renew(agent_id=agent_id, pattern=pattern)
+
+        monkeypatch.setattr(session_service, "renew_session", controlled_renew)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(session_service.check_and_auto_renew, "test-agent")
+            assert first_entered.wait(timeout=2)
+            second = pool.submit(session_service.check_and_auto_renew, "test-agent")
+            second_entered.wait(timeout=0.25)
+            release_first.set()
+            results = [first.result(timeout=2), second.result(timeout=2)]
+
+        renewed = [session for session in results if session is not None]
+        assert len(renewed) == 1
+        session_service.validate_session(renewed[0].session_token)
+
     def test_end_session(self, session_service):
         """Test ending session"""
         # Create session

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -325,6 +325,7 @@ class TestSessionService:
         thread_role = threading.local()
         real_open = os.open
         real_fdopen = os.fdopen
+        real_write = os.write
 
         def observed_open(path, flags, mode=0o777):
             if (
@@ -334,6 +335,11 @@ class TestSessionService:
             ):
                 second_truncated_secret.set()
             return real_open(path, flags, mode)
+
+        def delayed_write(fd, data):
+            if getattr(thread_role, "value", None) == "first" and len(data) == 64:
+                assert release_first_writer.wait(timeout=5)
+            return real_write(fd, data)
 
         def delayed_fdopen(fd, *args, **kwargs):
             file_handle = real_fdopen(fd, *args, **kwargs)
@@ -362,6 +368,7 @@ class TestSessionService:
 
         monkeypatch.setattr(os, "open", observed_open)
         monkeypatch.setattr(os, "fdopen", delayed_fdopen)
+        monkeypatch.setattr(os, "write", delayed_write)
 
         with ThreadPoolExecutor(max_workers=2) as pool:
             first = pool.submit(create_service, "first")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -20,6 +20,7 @@ from memanto.app.core import MemoryRecord
 from memanto.app.models.session import AgentCreate, AgentPattern, Session, SessionStatus
 from memanto.app.services.agent_service import AgentService
 from memanto.app.services.session_service import SessionService
+from memanto.app.utils.errors import InvalidSessionTokenError
 
 
 class TestSessionService:
@@ -298,6 +299,52 @@ class TestSessionService:
         renewed = [session for session in results if session is not None]
         assert len(renewed) == 1
         session_service.validate_session(renewed[0].session_token)
+
+    def test_end_session_revokes_concurrent_auto_renewal(
+        self, session_service, monkeypatch
+    ):
+        """Logout must terminate a renewal that was already in flight."""
+        original = session_service.create_session(
+            agent_id="test-agent", duration_hours=1
+        )
+        monkeypatch.setattr(settings, "SESSION_EXTEND_THRESHOLD_MINUTES", 120)
+
+        original_renew = session_service.renew_session
+        renewal_entered = threading.Event()
+        release_renewal = threading.Event()
+        termination_saved = threading.Event()
+        original_save = session_service._save_session
+
+        def controlled_renew(agent_id, pattern=None):
+            renewal_entered.set()
+            assert release_renewal.wait(timeout=2)
+            return original_renew(agent_id=agent_id, pattern=pattern)
+
+        def observed_save(session):
+            original_save(session)
+            if session.status == SessionStatus.TERMINATED:
+                termination_saved.set()
+
+        monkeypatch.setattr(session_service, "renew_session", controlled_renew)
+        monkeypatch.setattr(session_service, "_save_session", observed_save)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            renewing = pool.submit(session_service.check_and_auto_renew, "test-agent")
+            assert renewal_entered.wait(timeout=2)
+            ending = pool.submit(session_service.end_session, "test-agent")
+
+            # Logout cannot persist a stale termination while renewal owns the
+            # lifecycle. It proceeds immediately after the fresh token exists.
+            assert not termination_saved.wait(timeout=0.25)
+            release_renewal.set()
+            renewed = renewing.result(timeout=2)
+            summary = ending.result(timeout=2)
+
+        assert renewed is not None
+        assert renewed.session_id != original.session_id
+        assert summary.session_id == renewed.session_id
+        with pytest.raises(InvalidSessionTokenError):
+            session_service.validate_session(renewed.session_token)
 
     def test_end_session(self, session_service):
         """Test ending session"""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -522,6 +522,64 @@ class TestSessionService:
 
         assert session_service.get_active_session() is None
 
+    def test_get_active_session_tolerates_external_marker_removal(
+        self, session_service, monkeypatch
+    ):
+        """A marker removed by another process during its read is treated as absent."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.write_text("test-agent")
+        original_open = open
+
+        def disappearing_marker(file, *args, **kwargs):
+            if Path(file) == active_marker:
+                active_marker.unlink(missing_ok=True)
+                raise FileNotFoundError(active_marker)
+            return original_open(file, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", disappearing_marker)
+
+        assert session_service.get_active_session() is None
+
+    def test_clear_active_session_tolerates_external_marker_removal(
+        self, session_service, monkeypatch
+    ):
+        """A marker removed after an existence check does not crash cleanup."""
+        active_marker = session_service.sessions_dir / "active"
+        active_marker.write_text("test-agent")
+        original_exists = Path.exists
+
+        def disappearing_marker(path):
+            exists = original_exists(path)
+            if path == active_marker and exists:
+                path.unlink()
+                return True
+            return exists
+
+        monkeypatch.setattr(Path, "exists", disappearing_marker)
+
+        session_service.clear_active_session()
+
+        assert not original_exists(active_marker)
+
+    def test_delete_session_tolerates_external_marker_removal(
+        self, session_service, monkeypatch
+    ):
+        """Deleting session state succeeds if another process removes the marker."""
+        session_service.create_session("test-agent")
+        active_marker = session_service.sessions_dir / "active"
+        original_open = open
+
+        def disappearing_marker(file, *args, **kwargs):
+            if Path(file) == active_marker:
+                active_marker.unlink(missing_ok=True)
+                raise FileNotFoundError(active_marker)
+            return original_open(file, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", disappearing_marker)
+
+        assert session_service.delete_session("test-agent") is True
+        assert not (session_service.sessions_dir / "test-agent.json").exists()
+
     def test_list_sessions_skips_invalid_session_files(self, session_service):
         """One corrupt session record must not hide all valid sessions."""
         valid_session = session_service.create_session(


### PR DESCRIPTION
Merge Temporal Recall Prs 
1. #1496 
2. #1619  
3. #1676 
4. #1493 
5. #1584 
6. #1657 
7. #1617 
8. #1589 
9. #1507
10. #1571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-type memory recall now searches requested categories concurrently and returns deduplicated, relevance-ranked results.
  * Memory responses include an optional source reference.
  * Added support for retrieving the active on-premises embedding model.
  * MCP sessions remain isolated per agent for safer concurrent operation.
  * Claude Code distillation now focuses on the latest completed turn.

* **Bug Fixes**
  * Date-only and “yesterday” filters cover the full calendar day.
  * Point-in-time recall better handles expiration and historical versions.
  * Memory titles are normalized to single-line text.
  * Successful writes remain successful when summary logging fails.
  * Improved session security, concurrency reliability, preference detection, and long daily-summary handling.
  * Added validation for invalid memory recall limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->