### PR TITLE
Fix: feat(migrations): add privacy-first Codex session to OKF adapter

### DIFF
--- a/migrate_codex_to_okf.py
+++ b/migrate_codex_to_okf.py
@@ -1,0 +1,24 @@
+import json
+import os
+import hashlib
+from okf import OKF
+
+def migrate_codex_to_okf(codex_jsonl_file, okf_file):
+    okf = OKF()
+    with open(codex_jsonl_file, 'r') as f:
+        for line in f:
+            data = json.loads(line)
+            if data['type'] == 'user' or data['type'] == 'assistant':
+                # Remove sensitive information
+                del data['developer_instructions']
+                del data['reasoning']
+                del data['tool_calls']
+                del data['function_payloads']
+                del data['transport_state']
+                # Truncate SHA-256 fingerprint
+                data['source'] = hashlib.sha256(data['source'].encode()).hexdigest()[:16]
+                okf.add_memory(data)
+    okf.save(okf_file)
+
+if __name__ == '__main__':
+    migrate_codex_to_okf('codex_session.jsonl', 'okf_bundle.okf')

--- a/test_migrate_codex_to_okf.py
+++ b/test_migrate_codex_to_okf.py
@@ -1,0 +1,27 @@
+import unittest
+import json
+import os
+from migrate_codex_to_okf import migrate_codex_to_okf
+
+class TestMigrateCodexToOKF(unittest.TestCase):
+    def test_migration(self):
+        # Create a test Codex JSONL file
+        with open('test_codex.jsonl', 'w') as f:
+            f.write(json.dumps({'type': 'user', 'text': 'Hello', 'source': 'path/to/source'}) + '\n')
+            f.write(json.dumps({'type': 'assistant', 'text': 'Hi', 'source': 'path/to/source'}) + '\n')
+        # Run the migration
+        migrate_codex_to_okf('test_codex.jsonl', 'test_okf.okf')
+        # Check the resulting OKF file
+        with open('test_okf.okf', 'r') as f:
+            okf_data = json.load(f)
+            self.assertEqual(len(okf_data), 2)
+            self.assertEqual(okf_data[0]['type'], 'user')
+            self.assertEqual(okf_data[0]['text'], 'Hello')
+            self.assertEqual(okf_data[1]['type'], 'assistant')
+            self.assertEqual(okf_data[1]['text'], 'Hi')
+        # Clean up
+        os.remove('test_codex.jsonl')
+        os.remove('test_okf.okf')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Automated fix for #1732

See https://github.com/moorcheh-ai/memanto/pull/1732

/claim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a migration utility to convert Codex session records into OKF bundles.
  * Removes sensitive and internal metadata during conversion.
  * Anonymizes source identifiers while preserving migrated record content.

* **Tests**
  * Added coverage verifying successful conversion and preservation of key record fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->