### PR TITLE
perf(okf): prevent quadratic link parsing in malformed notes

### DIFF
--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -25,7 +25,6 @@ from memanto.app.services.okf_export_service import ENTRY_DELIMITER
 # non-greedy so the first ``\n---`` closes the block even when the body below
 # contains its own ``---`` rules.
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
-_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
 _SKIP_FILENAMES = {"index.md", "log.md"}
 # OKF baseline fields + Memanto's namespaced extension block. Anything else in
@@ -39,6 +38,44 @@ _KNOWN_FIELDS = {
     "timestamp",
     "x_memanto",
 }
+
+
+def _extract_links(body: str) -> list[tuple[str, str]]:
+    """Extract inline Markdown links in a single left-to-right pass.
+
+    Repeatedly applying a regular expression from every ``[`` candidate makes
+    malformed Markdown increasingly expensive to scan. ``str.find`` keeps the
+    loader linear while preserving the intentionally small link syntax handled
+    here (non-empty ``[text](target)`` pairs).
+    """
+    links: list[tuple[str, str]] = []
+    cursor = 0
+
+    while True:
+        opening = body.find("[", cursor)
+        if opening == -1:
+            break
+
+        closing = body.find("]", opening + 1)
+        if closing == -1:
+            break
+
+        if closing == opening + 1 or not body.startswith("(", closing + 1):
+            cursor = closing + 1
+            continue
+
+        target_end = body.find(")", closing + 2)
+        if target_end == -1:
+            break
+
+        if target_end == closing + 2:
+            cursor = target_end + 1
+            continue
+
+        links.append((body[opening + 1 : closing], body[closing + 2 : target_end]))
+        cursor = target_end + 1
+
+    return links
 
 
 def load_okf_bundle(path: str | Path) -> dict[str, Any]:
@@ -109,7 +146,7 @@ def _parse_entry(chunk: str, file_path: Path, rel_base: Path) -> dict[str, Any] 
         x_memanto = {}
 
     extra = {k: v for k, v in frontmatter.items() if k not in _KNOWN_FIELDS}
-    links = [f"{text} -> {target}" for text, target in _LINK_RE.findall(body)]
+    links = [f"{text} -> {target}" for text, target in _extract_links(body)]
 
     try:
         source_path = str(file_path.relative_to(rel_base))

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -8,6 +8,8 @@ foreign OKF bundle whose free-form ``type`` and unknown keys must land in the
 ``[Supporting data]`` footer without loss.
 """
 
+from time import perf_counter
+
 from memanto.app.services.okf_export_service import OkfExportService
 from memanto.cli.migrate.mappers import map_okf
 from memanto.cli.migrate.okf_loader import load_okf_bundle
@@ -186,3 +188,37 @@ def test_loader_splits_stacked_file(tmp_path):
     assert {m["title"] for m in export["memories"]} == {
         f"Standup {i}" for i in range(5)
     }
+
+
+def test_loader_extracts_multiple_links_around_malformed_markup(tmp_path):
+    """Malformed candidates do not hide valid links that follow them."""
+    okf_file = tmp_path / "links.md"
+    okf_file.write_text(
+        "---\ntype: fact\ntitle: Links\n---\n"
+        "Broken [label] text, then [first](/one) and [](ignored), "
+        "then [second](https://example.com/two).\n",
+        encoding="utf-8",
+    )
+
+    memory = load_okf_bundle(okf_file)["memories"][0]
+
+    assert memory["links"] == [
+        "first -> /one",
+        "second -> https://example.com/two",
+    ]
+
+
+def test_loader_handles_many_unclosed_link_markers_quickly(tmp_path):
+    """A malformed large note must not make link extraction scale quadratically."""
+    okf_file = tmp_path / "malformed-links.md"
+    okf_file.write_text(
+        "---\ntype: fact\ntitle: Malformed links\n---\n" + "[" * 25_000,
+        encoding="utf-8",
+    )
+
+    started = perf_counter()
+    memory = load_okf_bundle(okf_file)["memories"][0]
+    elapsed = perf_counter() - started
+
+    assert memory["links"] == []
+    assert elapsed < 1.0


### PR DESCRIPTION
## Summary

The OKF loader used a backtracking regular expression to extract Markdown links. On a note containing many unmatched `[` characters, the engine retried the pattern at every candidate and rescanned the remaining suffix. Import time therefore grew quadratically with note size and could stall an OKF migration before any memories were mapped.

This PR replaces that regex with a single left-to-right parser. It preserves the loader's deliberately small `[text](target)` syntax, ignores empty text/targets as before, and continues past malformed candidates so later valid links are still captured.

Refs #770

## Reproduction

On current `main` (`ebf9c690`), running `_LINK_RE.findall("[" * n)` produced:

| Input size | Time |
| ---: | ---: |
| 4,000 | 0.0880 s |
| 8,000 | 0.4407 s |
| 12,000 | 1.0788 s |
| 16,000 | 1.7480 s |

The new regression creates a real OKF document with 25,000 unmatched markers and loads it through `load_okf_bundle`. It completes below one second and returns no spurious links.

With this patch, including file I/O, frontmatter parsing, and YAML parsing:

| Input size | Time |
| ---: | ---: |
| 4,000 | 0.0186 s |
| 8,000 | 0.0213 s |
| 16,000 | 0.0302 s |
| 25,000 | 0.0336 s |
| 100,000 | 0.0379 s |

## Validation

- `uv run pytest -o "addopts=-ra"`: **468 passed, 24 skipped** (credential-only live E2E tests), 1 dependency deprecation warning
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: 258 files already formatted
- `uv run mypy .`: no issues in 106 source files
- Randomized compatibility comparison against the old regex: **35,700 cases passed**
- GitHub PR searches for `_LINK_RE`, `OKF regex`, `malformed links`, and related terms found no matching prior submission

## Scope

No public API or stored OKF format changes. No Moorcheh API key is required because the affected code is the local OKF bundle loader.

## AI assistance disclosure

This finding, implementation, benchmarks, tests, and PR text were prepared with an AI coding agent under the GitHub account owner's direction. The changes were validated locally with the commands and results above. No social-amplification points are claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown link parsing to correctly handle multiple links, malformed markup, and empty links.
  * Prevented slow processing when parsing large amounts of malformed link content.

* **Tests**
  * Added coverage for valid, empty, and malformed links, including performance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->