### PR TITLE
[Bug Fix] Batch memory constants dedup, is_valid_memory_id hardening, and input validation

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -528,6 +528,7 @@ async def edit_memory(
     The session must be for the specified agent_id.
     """
     enforce_session_scope(session, agent_id)
+    validate_safe_id(memory_id, "memory_id")
 
     updates = request.to_updates()
     if not updates:
@@ -825,6 +826,7 @@ async def delete_memory(
     The session must be for the specified agent_id.
     """
     enforce_session_scope(session, agent_id)
+    validate_safe_id(memory_id, "memory_id")
 
     try:
         write_service = MemoryWriteService(client)

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -49,6 +49,7 @@ from memanto.app.utils.errors import (
 from memanto.app.utils.validation import (
     CostGuard,
     is_successful_write_result,
+    validate_memory_id,
     validate_safe_id,
 )
 from memanto.cli.client.direct_client import DirectClient
@@ -528,7 +529,10 @@ async def edit_memory(
     The session must be for the specified agent_id.
     """
     enforce_session_scope(session, agent_id)
-    validate_safe_id(memory_id, "memory_id")
+    try:
+        validate_memory_id(memory_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid memory identifier")
 
     updates = request.to_updates()
     if not updates:
@@ -826,7 +830,10 @@ async def delete_memory(
     The session must be for the specified agent_id.
     """
     enforce_session_scope(session, agent_id)
-    validate_safe_id(memory_id, "memory_id")
+    try:
+        validate_memory_id(memory_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid memory identifier")
 
     try:
         write_service = MemoryWriteService(client)

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -30,8 +30,6 @@ _REMOVED_TRUST_FIELDS = frozenset(
     }
 )
 
-_SUCCESSFUL_UPLOAD_STATUSES = {"queued", "success", "ok"}
-
 
 class MemoryWriteService:
     """Persist memory records to Moorcheh-backed namespaces."""
@@ -239,7 +237,7 @@ class MemoryWriteService:
                 moorcheh_status = str(upload_result.get("status", "unknown")).lower()
                 for result in results:
                     if result["status"] == "pending":
-                        if moorcheh_status in _SUCCESSFUL_UPLOAD_STATUSES:
+                        if moorcheh_status in SUCCESSFUL_UPLOAD_STATUSES:
                             result["status"] = moorcheh_status
                         else:
                             result["status"] = "failed"

--- a/memanto/app/utils/ids.py
+++ b/memanto/app/utils/ids.py
@@ -32,11 +32,13 @@ def generate_session_id() -> str:
 
 def is_valid_memory_id(memory_id: str) -> bool:
     """Validate memory ID format using strict pattern.
-    
+
     Only allows alphanumeric characters, hyphens, and underscores.
     Requires minimum length of 5 characters.
     Must contain at least one underscore (to separate prefix from random part).
     """
     if not memory_id or len(memory_id) < 5:
+        return False
+    if "_" not in memory_id:
         return False
     return bool(re.fullmatch(r"[A-Za-z0-9_-]+", memory_id))

--- a/memanto/app/utils/ids.py
+++ b/memanto/app/utils/ids.py
@@ -37,7 +37,9 @@ def is_valid_memory_id(memory_id: str) -> bool:
     Requires minimum length of 5 characters.
     Must contain at least one underscore (to separate prefix from random part).
     """
-    if not memory_id or len(memory_id) < 5:
+    if not isinstance(memory_id, str) or not memory_id:
+        return False
+    if len(memory_id) < 5:
         return False
     if "_" not in memory_id:
         return False

--- a/memanto/app/utils/ids.py
+++ b/memanto/app/utils/ids.py
@@ -2,6 +2,7 @@
 ID Generation Utilities
 """
 
+import re
 import time
 import uuid
 
@@ -30,5 +31,12 @@ def generate_session_id() -> str:
 
 
 def is_valid_memory_id(memory_id: str) -> bool:
-    """Validate memory ID format"""
-    return bool(memory_id and len(memory_id) > 4 and "_" in memory_id)
+    """Validate memory ID format using strict pattern.
+    
+    Only allows alphanumeric characters, hyphens, and underscores.
+    Requires minimum length of 5 characters.
+    Must contain at least one underscore (to separate prefix from random part).
+    """
+    if not memory_id or len(memory_id) < 5:
+        return False
+    return bool(re.fullmatch(r"[A-Za-z0-9_-]+", memory_id))

--- a/memanto/app/utils/validation.py
+++ b/memanto/app/utils/validation.py
@@ -9,6 +9,8 @@ from typing import Any
 from fastapi import HTTPException
 from pydantic import BaseModel, Field, validator
 
+from memanto.app.utils.ids import is_valid_memory_id
+
 
 class InputLimits:
     """Input size and cost limits"""
@@ -182,6 +184,20 @@ def validate_safe_id(value: str, field_name: str = "id") -> str:
         raise ValueError(
             f"{field_name} '{value}' contains invalid characters. "
             "Only letters, digits, hyphens, and underscores are allowed."
+        )
+    return value
+
+
+def validate_memory_id(value: str) -> str:
+    """Validate a memory ID using the same contract as is_valid_memory_id.
+
+    Requires at least 5 characters and an underscore; only alphanumeric
+    characters, hyphens, and underscores are allowed.
+    """
+    if not is_valid_memory_id(value):
+        raise ValueError(
+            "memory_id must be at least 5 characters, contain an underscore, "
+            "and use only letters, digits, hyphens, and underscores."
         )
     return value
 

--- a/tests/test_fix_batch.py
+++ b/tests/test_fix_batch.py
@@ -1,0 +1,61 @@
+﻿""" Unit tests for bug fix batch: memory validation & constants. """
+import re
+import sys
+sys.path.insert(0, "I:/Project/money/memanto")
+
+from memanto.app.utils.ids import is_valid_memory_id, generate_id, generate_memory_id
+
+
+def test_is_valid_memory_id_accepts_valid_ids():
+    assert is_valid_memory_id("mem_abc123") is True
+    assert is_valid_memory_id("mem_1") is True  # 6 chars, has underscore
+    assert is_valid_memory_id("user-pref_fact") is True
+    assert is_valid_memory_id("a_b_c_d") is True  # 7 chars with underscores
+
+
+def test_is_valid_memory_id_rejects_too_short():
+    assert is_valid_memory_id("a_b") is False    # only 3 chars
+    assert is_valid_memory_id("ab_c") is False    # 4 chars
+
+
+def test_is_valid_memory_id_rejects_no_underscore():
+    assert is_valid_memory_id("abcde") is False   # 5 chars, no underscore
+
+
+def test_is_valid_memory_id_rejects_path_traversal():
+    """The old validation accepted this pattern - new one must reject."""
+    assert is_valid_memory_id("../../../etc/passwd") is False
+    assert is_valid_memory_id("..%2F..%2Fetc") is False
+
+
+def test_is_valid_memory_id_rejects_empty_and_none():
+    assert is_valid_memory_id("") is False
+    assert is_valid_memory_id(None) is False  # type: ignore
+
+
+def test_is_valid_memory_id_rejects_special_chars():
+    assert is_valid_memory_id("mem@123") is False
+    assert is_valid_memory_id("mem 123") is False
+    assert is_valid_memory_id("mem.123") is False
+    assert is_valid_memory_id("mem/123") is False
+    assert is_valid_memory_id("mem\\123") is False
+
+
+def test_is_valid_memory_id_rejects_unicode():
+    assert is_valid_memory_id("mem_测试") is False
+
+
+def test_generate_id_length():
+    """Just ensure gen functions still work."""
+    i = generate_id()
+    assert len(i) == 12
+    assert isinstance(i, str)
+
+
+def test_generate_memory_id_has_underscore():
+    mid = generate_memory_id()
+    assert "_" in mid
+    assert is_valid_memory_id(mid) is True
+
+
+print("All 10 tests PASSED")

--- a/tests/test_fix_batch.py
+++ b/tests/test_fix_batch.py
@@ -1,9 +1,6 @@
 ﻿""" Unit tests for bug fix batch: memory validation & constants. """
-import re
-import sys
-sys.path.insert(0, "I:/Project/money/memanto")
 
-from memanto.app.utils.ids import is_valid_memory_id, generate_id, generate_memory_id
+from memanto.app.utils.ids import generate_id, generate_memory_id, is_valid_memory_id
 
 
 def test_is_valid_memory_id_accepts_valid_ids():
@@ -57,5 +54,3 @@ def test_generate_memory_id_has_underscore():
     assert "_" in mid
     assert is_valid_memory_id(mid) is True
 
-
-print("All 10 tests PASSED")

--- a/tests/test_fix_batch.py
+++ b/tests/test_fix_batch.py
@@ -1,5 +1,11 @@
-﻿""" Unit tests for bug fix batch: memory validation & constants. """
+""" Unit tests for bug fix batch: memory validation & constants. """
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from memanto.app.routes.memory import delete_memory, edit_memory
 from memanto.app.utils.ids import generate_id, generate_memory_id, is_valid_memory_id
 
 
@@ -28,6 +34,7 @@ def test_is_valid_memory_id_rejects_path_traversal():
 def test_is_valid_memory_id_rejects_empty_and_none():
     assert is_valid_memory_id("") is False
     assert is_valid_memory_id(None) is False  # type: ignore
+    assert is_valid_memory_id(12345) is False  # type: ignore[arg-type]
 
 
 def test_is_valid_memory_id_rejects_special_chars():
@@ -54,3 +61,37 @@ def test_generate_memory_id_has_underscore():
     assert "_" in mid
     assert is_valid_memory_id(mid) is True
 
+
+@pytest.mark.asyncio
+async def test_edit_memory_rejects_invalid_memory_id():
+    """Invalid memory_id returns HTTP 400 before any service call."""
+    with patch("memanto.app.routes.memory.MemoryWriteService") as mock_service:
+        with pytest.raises(HTTPException) as exc_info:
+            session = MagicMock()
+            session.agent_id = "test-agent"
+            await edit_memory(
+                agent_id="test-agent",
+                memory_id="abcde",
+                request=MagicMock(),
+                session=session,
+                client=MagicMock(),
+            )
+        assert exc_info.value.status_code == 400
+        mock_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_memory_rejects_invalid_memory_id():
+    """Invalid memory_id returns HTTP 400 before any service call."""
+    with patch("memanto.app.routes.memory.MemoryWriteService") as mock_service:
+        with pytest.raises(HTTPException) as exc_info:
+            session = MagicMock()
+            session.agent_id = "test-agent"
+            await delete_memory(
+                agent_id="test-agent",
+                memory_id="abcde",
+                session=session,
+                client=MagicMock(),
+            )
+        assert exc_info.value.status_code == 400
+        mock_service.assert_not_called()


### PR DESCRIPTION
# feat(migrations): add Claude Code memory adapter to OKF (#1609)

Path B migration showcase for **The Great Memory Migration** bounty (#1609): a permanent adapter that turns Claude Code `JSONL` session archives into a portable OKF bundle consumable by `memanto migrate okf`.

Claude Code stores every interactive session locally under `~/.claude/projects/**/*.jsonl` in a proprietary, undocumented format. This adapter liberates that memory: preferences, decisions, instructions, commitments, goals, relationships, events, observations, facts and context become plain, versionable markdown that users own — then import into Memanto for semantic recall.

## Demo video

Watch the demo on YouTube: [https://www.youtube.com/watch?v=kqiLORSvrHw](https://www.youtube.com/watch?v=kqiLORSvrHw)

The 2-minute walkthrough shows the full pipeline: source session → JSONL parsing → memory extraction → OKF bundle → `memanto migrate okf` import → same questions answered in Memanto recall (zero amnesia).

## What's included

- `parser.py` — normalises real Claude Code JSONL (user/assistant turns, text blocks, `tool_use`/`tool_result` blocks, snapshots, `isMeta` wrappers, last-prompt sentinels)
- `extractor.py` — deterministic heuristics classify durable memories into Memanto's memory types
- `okf_writer.py` — emits the exact OKF layout (`memories/<type>/<slug>.md`) with the `x_memanto` block Memanto's loader expects; clears stale artifacts on re-runs
- `cli.py` — `--archive` / `--projects` / `--user-only` entry point with per-archive source tracing and clean error handling
- `scripts/generate_demo_session.py` — reproducible, byte-stable realistic source archive
- `scripts/golden_questions.json` + `scripts/evaluate_recall.py` — offline golden-set content-retention evaluation (deterministic, no API key needed)
- `fixtures/real_session_excerpt.jsonl` — sanitized real-shape Claude Code 2.x archive following the tool-result message contract
- `demo_source/` — generated demo session (9 turns)
- `okf_bundle/` — sample output, verified loadable by Memanto's own OKF loader (6/6 memories)
- `tests/` — 14 tests: parsing, extraction, OKF round-trip, stale-bundle cleanup, memanto loader round-trip (hard requirement), fixture contract, two-archive source tracing, golden-set parity, CLI errors
- `README.md` — setup, mapping table, migration summary, validation + demo video guide

## Migration summary (demo run)

| Metric                             | Value                                                        |
| ---------------------------------- | ------------------------------------------------------------ |
| Source turns parsed                | 9                                                            |
| Durable memories extracted         | 6                                                            |
| Memory types emitted               | instruction, decision, commitment, preference x2, relationship |
| OKF loader round-trip              | 6/6 memories loaded                                          |
| Golden-set content retention       | 7/7 before, 7/7 after, parity 1.0                            |
| Tests                              | 14 passed                                                    |
| Docstring coverage (changed files) | 100%                                                         |

Per-type breakdown:

| Type         | Count | Example                                                      |
| ------------ | ----- | ------------------------------------------------------------ |
| instruction  | 1     | "Remember to always use pydantic v2, never log API keys..."  |
| decision     | 1     | "We will use pydantic v2... Stripe client behind an interface" |
| commitment   | 1     | "I will generate OpenAPI docs for Sarah..."                  |
| preference   | 2     | "I prefer SQLAlchemy over raw SQL"; "PCI compliant..."       |
| relationship | 1     | "My colleague Sarah works on the mobile app..."              |

## Round-trip validation

The suite hard-requires that the generated bundle loads through Memanto's own `memanto.cli.migrate.okf_loader` (no skips). The golden-set evaluator answers the same 7 questions before (raw JSONL) and after (OKF → loader → `mappers.map_okf`) with **parity 1.0** — deterministic and offline, reproducible in CI. Live Memanto recall after `memanto migrate okf` is demonstrated in the demo video (requires a Moorcheh API key).

## Reproducibility

```bash
cd examples/migrations/claude-code-memory
pip install -r requirements.txt
python scripts/generate_demo_session.py --output demo_source/demo_session.jsonl
python -m claude_code_adapter.cli --archive demo_source/demo_session.jsonl --output okf_bundle

# from the memanto repo root
python -m pytest examples/migrations/claude-code-memory/tests/
python scripts/evaluate_recall.py --archive demo_source/demo_session.jsonl --bundle /tmp/recall-bundle
```

Closes #1609