### PR TITLE
fix(integrations): restore valid memory writes

### DIFF
--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -205,7 +205,7 @@ class MemantoRememberTool(BaseTool):
             content=content,
             confidence=confidence,
             tags=tag_list,
-            source="crewai-agent",
+            source="tool",
             provenance="explicit_statement",
         )
 

--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -196,6 +196,7 @@ class MemantoRememberTool(BaseTool):
         confidence: float,
         tags: str = "",
     ) -> str:
+        """Store a CrewAI tool memory in Memanto."""
         tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
 
         result = self._client.remember(

--- a/integrations/crewai/tests/test_tools.py
+++ b/integrations/crewai/tests/test_tools.py
@@ -48,6 +48,7 @@ def test_memanto_setup_teardown():
 
 
 def test_memanto_remember_tool():
+    """Verify CrewAI remember writes use the valid tool source."""
     client = MagicMock()
     client.remember.return_value = {"memory_id": "mem-123"}
 

--- a/integrations/crewai/tests/test_tools.py
+++ b/integrations/crewai/tests/test_tools.py
@@ -73,7 +73,7 @@ def test_memanto_remember_tool():
         content="The content",
         confidence=0.9,
         tags=["tag1", "tag2"],
-        source="crewai-agent",
+        source="tool",
         provenance="explicit_statement",
     )
 

--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -34,7 +34,7 @@ import re
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 try:  # resolved against the host Hermes at runtime
     from agent.memory_provider import MemoryProvider
@@ -66,6 +66,7 @@ _MIN_CAPTURE_LENGTH = 10
 _MAX_TITLE_LENGTH = 100
 _MAX_AGENT_ID_LENGTH = 64
 _ACTIVATION_RETRY_COOLDOWN = 60.0
+_MemorySource = Literal["user", "agent", "tool", "system"]
 
 
 def _sanitize_agent_id(raw: str) -> str:
@@ -351,7 +352,7 @@ class _MemantoClient:
         content: str,
         confidence: float,
         tags: list[str] | None = None,
-        source: str = "hermes",
+        source: _MemorySource = "agent",
         provenance: str = "explicit_statement",
     ) -> dict:
         self.ensure_session()
@@ -650,8 +651,8 @@ class MemantoMemoryProvider(MemoryProvider):
                     title=title,
                     content=content,
                     confidence=_CAPTURE_CONFIDENCE,
-                    tags=["conversation"],
-                    source="hermes",
+                    tags=["conversation", "hermes"],
+                    source="agent",
                     provenance="observed",
                 )
             except Exception:
@@ -688,6 +689,7 @@ class MemantoMemoryProvider(MemoryProvider):
             else clean
         )
         mem_type = "preference" if target == "user" else _detect_memory_type(clean)
+        source: _MemorySource = "user" if target == "user" else "agent"
 
         def _run():
             try:
@@ -697,7 +699,7 @@ class MemantoMemoryProvider(MemoryProvider):
                     content=clean,
                     confidence=0.9,
                     tags=["hermes-memory", target],
-                    source="hermes-memory",
+                    source=source,
                     provenance="explicit_statement",
                 )
             except Exception:
@@ -749,7 +751,7 @@ class MemantoMemoryProvider(MemoryProvider):
                 content=content,
                 confidence=confidence,
                 tags=[str(t) for t in tags],
-                source="hermes-tool",
+                source="tool",
                 provenance="explicit_statement",
             )
             return json.dumps(

--- a/integrations/hermes-agents/hermes_memanto/provider.py
+++ b/integrations/hermes-agents/hermes_memanto/provider.py
@@ -355,6 +355,7 @@ class _MemantoClient:
         source: _MemorySource = "agent",
         provenance: str = "explicit_statement",
     ) -> dict:
+        """Store one memory after ensuring the agent session is active."""
         self.ensure_session()
         return self._client.remember(
             agent_id=self._agent_id,
@@ -619,6 +620,7 @@ class MemantoMemoryProvider(MemoryProvider):
     def sync_turn(
         self, user_content: str, assistant_content: str, *, session_id: str = ""
     ) -> None:
+        """Capture a completed user and assistant turn asynchronously."""
         if (
             not self._active
             or not self._auto_capture
@@ -645,6 +647,7 @@ class MemantoMemoryProvider(MemoryProvider):
         content = f"User: {clean_user}\n\nAssistant: {clean_assistant}"
 
         def _run():
+            """Persist the captured conversation turn."""
             try:
                 client.remember(
                     memory_type="event",
@@ -672,6 +675,7 @@ class MemantoMemoryProvider(MemoryProvider):
         content: str,
         metadata: dict[str, Any] | None = None,
     ) -> None:
+        """Mirror an eligible Hermes memory write asynchronously."""
         if (
             not self._active
             or not self._write_enabled
@@ -692,6 +696,7 @@ class MemantoMemoryProvider(MemoryProvider):
         source: _MemorySource = "user" if target == "user" else "agent"
 
         def _run():
+            """Persist the mirrored Hermes memory."""
             try:
                 client.remember(
                     memory_type=mem_type,
@@ -725,6 +730,7 @@ class MemantoMemoryProvider(MemoryProvider):
         return [REMEMBER_SCHEMA, RECALL_SCHEMA, ANSWER_SCHEMA]
 
     def _tool_remember(self, args: dict) -> str:
+        """Handle an explicit ``memanto_remember`` tool call."""
         content = str(args.get("content") or "").strip()
         if not content:
             return tool_error("content is required")

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -64,6 +64,7 @@ class FakeClient:
         source="agent",
         provenance="explicit_statement",
     ):
+        """Record a fake memory write for provider assertions."""
         self.remember_calls.append(
             {
                 "memory_type": memory_type,
@@ -363,6 +364,7 @@ def test_sync_turn_skips_trivial(provider):
 
 
 def test_sync_turn_persists_event(provider):
+    """Verify automatic turn capture writes an agent-sourced event."""
     provider.sync_turn(
         "Please remember I work in Pacific time",
         "Got it — noting your timezone as Pacific.",
@@ -433,6 +435,7 @@ def test_sync_turn_skipped_in_cron_context(monkeypatch, tmp_path):
 
 
 def test_on_memory_write_mirrors_to_memanto(provider):
+    """Verify mirrored agent memory uses the valid agent source."""
     provider.on_memory_write("add", "memory", "The deploy pipeline lives in gh actions")
     provider._write_thread.join(timeout=1)
     assert len(provider._client.remember_calls) == 1
@@ -449,6 +452,7 @@ def test_on_memory_write_uses_daemon_thread(provider):
 
 
 def test_on_memory_write_user_target_is_preference(provider):
+    """Verify user-targeted memory uses the valid user source."""
     provider.on_memory_write("add", "user", "Name is Jordan")
     provider._write_thread.join(timeout=1)
     assert provider._client.remember_calls[0]["memory_type"] == "preference"
@@ -469,6 +473,7 @@ def test_get_tool_schemas_names(provider):
 
 
 def test_remember_tool(provider):
+    """Verify the explicit remember tool uses the valid tool source."""
     result = json.loads(
         provider.handle_tool_call(
             "memanto_remember", {"content": "Prefers TypeScript", "type": "preference"}

--- a/integrations/hermes-agents/tests/test_provider.py
+++ b/integrations/hermes-agents/tests/test_provider.py
@@ -8,6 +8,8 @@ monkeypatched with an in-memory fake.
 import json
 
 import pytest
+from memanto.app.constants import SourceType
+from pydantic import TypeAdapter
 
 from hermes_memanto.provider import (
     MemantoMemoryProvider,
@@ -59,7 +61,7 @@ class FakeClient:
         content,
         confidence,
         tags=None,
-        source="hermes",
+        source="agent",
         provenance="explicit_statement",
     ):
         self.remember_calls.append(
@@ -371,6 +373,9 @@ def test_sync_turn_persists_event(provider):
     call = provider._client.remember_calls[0]
     assert call["memory_type"] == "event"
     assert "User:" in call["content"] and "Assistant:" in call["content"]
+    assert call["source"] == "agent"
+    assert call["tags"] == ["conversation", "hermes"]
+    assert TypeAdapter(SourceType).validate_python(call["source"]) == "agent"
 
 
 def test_sync_turn_binds_client_at_schedule_time(provider, monkeypatch):
@@ -431,7 +436,9 @@ def test_on_memory_write_mirrors_to_memanto(provider):
     provider.on_memory_write("add", "memory", "The deploy pipeline lives in gh actions")
     provider._write_thread.join(timeout=1)
     assert len(provider._client.remember_calls) == 1
-    assert provider._client.remember_calls[0]["source"] == "hermes-memory"
+    call = provider._client.remember_calls[0]
+    assert call["source"] == "agent"
+    assert TypeAdapter(SourceType).validate_python(call["source"]) == "agent"
 
 
 def test_on_memory_write_uses_daemon_thread(provider):
@@ -445,6 +452,7 @@ def test_on_memory_write_user_target_is_preference(provider):
     provider.on_memory_write("add", "user", "Name is Jordan")
     provider._write_thread.join(timeout=1)
     assert provider._client.remember_calls[0]["memory_type"] == "preference"
+    assert provider._client.remember_calls[0]["source"] == "user"
 
 
 def test_on_memory_write_ignores_non_add(provider):
@@ -469,7 +477,9 @@ def test_remember_tool(provider):
     assert result["saved"] is True
     assert result["memory_id"] == "mem_123"
     assert result["type"] == "preference"
-    assert provider._client.remember_calls[0]["source"] == "hermes-tool"
+    call = provider._client.remember_calls[0]
+    assert call["source"] == "tool"
+    assert TypeAdapter(SourceType).validate_python(call["source"]) == "tool"
 
 
 def test_remember_tool_infers_type_when_invalid(provider):

--- a/integrations/langgraph/langgraph_memanto/nodes.py
+++ b/integrations/langgraph/langgraph_memanto/nodes.py
@@ -257,7 +257,7 @@ def create_remember_node(
                 memory_type=None,
                 title=title,
                 content=content,
-                source="langgraph-node",
+                source="agent",
                 provenance="explicit_statement",
             )
         except SessionError:
@@ -270,7 +270,7 @@ def create_remember_node(
                     memory_type=None,
                     title=title,
                     content=content,
-                    source="langgraph-node",
+                    source="agent",
                     provenance="explicit_statement",
                 )
             except Exception as inner_e:

--- a/integrations/langgraph/langgraph_memanto/nodes.py
+++ b/integrations/langgraph/langgraph_memanto/nodes.py
@@ -213,6 +213,7 @@ def create_remember_node(
     def remember_node(
         state: dict, config: RunnableConfig | None = None
     ) -> dict[str, Any]:
+        """Persist the latest human messages for the resolved agent."""
         resolved_agent_id = agent_id
         if resolved_agent_id is None and config:
             configurable = config.get("configurable", {})

--- a/integrations/langgraph/langgraph_memanto/store.py
+++ b/integrations/langgraph/langgraph_memanto/store.py
@@ -275,7 +275,7 @@ class MemantoStore(BaseStore):
                     "content": str(raw_content),
                     "confidence": confidence,
                     "tags": all_tags,
-                    "source": "langgraph-store",
+                    "source": "tool",
                 }
                 if memory_type is not None:
                     updates["type"] = memory_type
@@ -292,7 +292,7 @@ class MemantoStore(BaseStore):
                     content=str(raw_content),
                     confidence=confidence,
                     tags=all_tags,
-                    source="langgraph-store",
+                    source="tool",
                     provenance="explicit_statement",
                 )
 

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -111,7 +111,7 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
                 content=content,
                 confidence=confidence,
                 tags=tag_list,
-                source="langgraph-agent",
+                source="tool",
             )
         except Exception:
             _do_setup()
@@ -122,7 +122,7 @@ def create_memanto_tools(client: SdkClient, agent_id: str):
                 content=content,
                 confidence=confidence,
                 tags=tag_list,
-                source="langgraph-agent",
+                source="tool",
             )
 
         return f"Memory stored: {result['memory_id']}"

--- a/integrations/langgraph/langgraph_memanto/tools.py
+++ b/integrations/langgraph/langgraph_memanto/tools.py
@@ -26,6 +26,7 @@ VALID_MEMORY_TYPES = (
 
 
 def create_memanto_tools(client: SdkClient, agent_id: str):
+    """Create LangGraph memory tools bound to a Memanto agent."""
     import copy
     import threading
 

--- a/integrations/langgraph/tests/test_nodes.py
+++ b/integrations/langgraph/tests/test_nodes.py
@@ -60,7 +60,7 @@ def test_remember_node():
         memory_type=None,
         title="My name is Bob.",
         content="My name is Bob.",
-        source="langgraph-node",
+        source="agent",
         provenance="explicit_statement",
     )
 
@@ -87,7 +87,7 @@ def test_dynamic_agent_id_from_config():
         memory_type=None,
         title="Hello",
         content="Hello",
-        source="langgraph-node",
+        source="agent",
         provenance="explicit_statement",
     )
 

--- a/integrations/langgraph/tests/test_nodes.py
+++ b/integrations/langgraph/tests/test_nodes.py
@@ -43,6 +43,7 @@ def test_recall_node():
 
 
 def test_remember_node():
+    """Verify node capture writes with the valid agent source."""
     client = MagicMock()
     client.activate_agent.return_value = {"session_token": "mock-token"}
 
@@ -66,6 +67,7 @@ def test_remember_node():
 
 
 def test_dynamic_agent_id_from_config():
+    """Verify dynamic node capture retains a valid agent source."""
     client = MagicMock()
     client.activate_agent.return_value = {"session_token": "mock-token"}
     client.recall.return_value = {"memories": []}

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -170,6 +170,7 @@ def test_do_get_not_found(mock_sdk_client):
 
 
 def test_do_put_success(mock_sdk_client):
+    """Verify new store entries use the valid tool source."""
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()
     mock_sdk_client.return_value = client_instance
@@ -244,6 +245,7 @@ def test_do_put_upsert_behavior(mock_sdk_client):
 
 
 def test_do_put_stringifies_non_string_content(mock_sdk_client):
+    """Verify stringified store entries retain the valid tool source."""
     store = MemantoStore(api_key="test_key")
     client_instance = MagicMock()
     mock_sdk_client.return_value = client_instance

--- a/integrations/langgraph/tests/test_store.py
+++ b/integrations/langgraph/tests/test_store.py
@@ -190,7 +190,7 @@ def test_do_put_success(mock_sdk_client):
         content="my new fact",
         confidence=0.8,
         tags=["lg:key:my_key"],
-        source="langgraph-store",
+        source="tool",
         provenance="explicit_statement",
     )
 
@@ -258,7 +258,7 @@ def test_do_put_stringifies_non_string_content(mock_sdk_client):
         content="42",
         confidence=0.8,
         tags=["lg:key:answer"],
-        source="langgraph-store",
+        source="tool",
         provenance="explicit_statement",
     )
 

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -17,6 +17,7 @@ def test_create_memanto_tools_returns_all_tools():
 
 
 def test_memanto_remember_tool_success():
+    """Verify LangGraph remember writes use the valid tool source."""
     client = MagicMock()
     client.remember.return_value = {"memory_id": "mem-123"}
 

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -41,7 +41,7 @@ def test_memanto_remember_tool_success():
         content="This is a test fact.",
         confidence=0.9,
         tags=["test", "tag2"],
-        source="langgraph-agent",
+        source="tool",
     )
 
 

--- a/tests/test_integration_source_contracts.py
+++ b/tests/test_integration_source_contracts.py
@@ -1,0 +1,50 @@
+"""Contract checks for source literals used by optional integrations."""
+
+import ast
+from pathlib import Path
+
+from pydantic import TypeAdapter, ValidationError
+
+from memanto.app.constants import SourceType
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATIONS_ROOT = PROJECT_ROOT / "integrations"
+SOURCE_ADAPTER = TypeAdapter(SourceType)
+
+
+def _iter_source_literals(path: Path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for keyword in node.keywords:
+                if keyword.arg == "source" and isinstance(keyword.value, ast.Constant):
+                    if isinstance(keyword.value.value, str):
+                        yield keyword.value.lineno, keyword.value.value
+
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values, strict=True):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value == "source"
+                    and isinstance(value, ast.Constant)
+                    and isinstance(value.value, str)
+                ):
+                    yield value.lineno, value.value
+
+
+def test_shipped_integration_source_literals_match_core_contract():
+    invalid_sources: list[str] = []
+
+    for path in sorted(INTEGRATIONS_ROOT.rglob("*.py")):
+        if "tests" in path.parts:
+            continue
+
+        for line, source in _iter_source_literals(path):
+            try:
+                SOURCE_ADAPTER.validate_python(source)
+            except ValidationError:
+                relative_path = path.relative_to(PROJECT_ROOT)
+                invalid_sources.append(f"{relative_path}:{line}: {source!r}")
+
+    assert invalid_sources == []

--- a/tests/test_integration_source_contracts.py
+++ b/tests/test_integration_source_contracts.py
@@ -13,6 +13,7 @@ SOURCE_ADAPTER = TypeAdapter(SourceType)
 
 
 def _iter_source_literals(path: Path):
+    """Yield line numbers and literal values assigned to integration sources."""
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
 
     for node in ast.walk(tree):
@@ -34,6 +35,7 @@ def _iter_source_literals(path: Path):
 
 
 def test_shipped_integration_source_literals_match_core_contract():
+    """Require shipped integration source literals to satisfy ``SourceType``."""
     invalid_sources: list[str] = []
 
     for path in sorted(INTEGRATIONS_ROOT.rglob("*.py")):


### PR DESCRIPTION
## Summary

- map Hermes automatic, mirrored, user-targeted, and explicit writes to valid core source values
- map CrewAI remember-tool writes to `tool`
- map LangGraph tool/store writes to `tool` and automatic node capture to `agent`
- add a dependency-free contract test that checks every literal `source` emitted by shipped integrations
- update integration assertions to lock in the valid mappings

## Root cause

`MemoryRecord.source` accepts only `user`, `agent`, `tool`, or `system`, but three shipped integrations emitted provider-specific strings:

| Integration path | Invalid value | Valid mapping |
| --- | --- | --- |
| Hermes conversation capture | `hermes` | `agent` |
| Hermes mirrored memory | `hermes-memory` | `user` / `agent` |
| Hermes explicit tool | `hermes-tool` | `tool` |
| CrewAI remember tool | `crewai-agent` | `tool` |
| LangGraph remember tool | `langgraph-agent` | `tool` |
| LangGraph remember node | `langgraph-node` | `agent` |
| LangGraph store | `langgraph-store` | `tool` |

Pydantic rejects those provider-specific values when `SdkClient.remember()` constructs a `MemoryRecord`, before storage begins. Hermes background paths catch the exception and log it only at debug level, so the data loss can otherwise look like a successful write.

## Minimal reproduction

```python
from memanto.app.constants import SourceType
from pydantic import TypeAdapter

TypeAdapter(SourceType).validate_python("langgraph-node")
# pydantic.ValidationError: Input should be 'user', 'agent', 'tool' or 'system'
```

The new AST-based contract test reproduces this validation for every literal integration source without requiring optional frameworks to be installed.

## Validation

- `pytest tests/test_integration_source_contracts.py -q` — 1 passed
- `pytest integrations/hermes-agents/tests/test_provider.py -q` — 39 passed
- `pytest tests -q` — 457 passed, 24 live E2E tests skipped because no real Moorcheh API key is available
- `ruff check` on all changed files — passed
- `ruff format --check tests/test_integration_source_contracts.py` — passed
- `python -m py_compile` on the changed CrewAI/LangGraph modules — passed
- `git diff --check` — passed

CrewAI and LangGraph are optional and are not installed in the isolated local environment; their existing unit assertions were updated, while the new core contract test validates their shipped source literals without adding dependencies.

Fixes #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized memory provenance labels across integrations, distinguishing agent-, user-, and tool-created memories.
  * Improved consistency for conversation capture, explicit memory saves, mirrored writes, and tool-based memory actions.
  * Memory records now provide clearer origin information for more reliable tracking and interpretation.

* **Tests**
  * Added integration checks to validate supported memory source values.
  * Updated integration coverage to reflect the standardized provenance labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->