### PR TITLE
fix: prevent FastAPI Header metadata from becoming an API key

### DIFF
--- a/memanto/app/clients/moorcheh.py
+++ b/memanto/app/clients/moorcheh.py
@@ -10,7 +10,7 @@ Service code keeps calling ``get_moorcheh_client()`` and uses the same
 backends expose it.
 """
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import Header
 from moorcheh_sdk import AsyncMoorchehClient, MoorchehClient
@@ -120,14 +120,20 @@ moorcheh_client = MoorchehClientSingleton()
 
 
 def get_moorcheh_client(
-    api_key: str | None = Header(None, alias="X-Api-Key"),
+    api_key: Annotated[str | None, Header(alias="X-Api-Key")] = None,
 ) -> Any:
-    """Dependency injection function (cloud or on-prem)."""
+    """Return the active client as a FastAPI dependency or plain Python call.
+
+    Keeping ``None`` as the actual default matters for internal callers such
+    as the answer and upload routes, which invoke this function directly.
+    With ``Header(...)`` as the default value, those calls passed FastAPI's
+    ``Header`` metadata object to the cloud SDK as the API key.
+    """
     return moorcheh_client.get_client(api_key=api_key)
 
 
 def get_async_moorcheh_client(
-    api_key: str | None = Header(None, alias="X-Api-Key"),
+    api_key: Annotated[str | None, Header(alias="X-Api-Key")] = None,
 ) -> Any:
-    """Dependency injection function for async client (cloud or on-prem)."""
+    """Async equivalent of :func:`get_moorcheh_client`."""
     return moorcheh_client.get_async_client(api_key=api_key)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -160,97 +160,30 @@ class TestOnPremClient:
 
 
 class TestSingletonDispatch:
-    def test_dependency_wrapper_plain_call_uses_configured_sync_key(self):
-        """Direct Python calls must not forward FastAPI ``Header`` metadata."""
+    def test_dependency_wrappers_plain_calls_use_none_api_key(self):
+        """Plain calls must forward ``None`` (not FastAPI ``Header`` metadata)."""
         from memanto.app.clients import moorcheh as mclients
 
-        expected_client = object()
-        with patch.object(
-            mclients.moorcheh_client,
-            "get_client",
-            return_value=expected_client,
-        ) as dispatcher:
-            assert mclients.get_moorcheh_client() is expected_client
-
-        dispatcher.assert_called_once_with(api_key=None)
-
-    def test_dependency_wrapper_plain_call_uses_configured_async_key(self):
-        """The async dependency wrapper needs the same plain-call semantics."""
-        from memanto.app.clients import moorcheh as mclients
-
-        expected_client = object()
-        with patch.object(
-            mclients.moorcheh_client,
-            "get_async_client",
-            return_value=expected_client,
-        ) as dispatcher:
-            assert mclients.get_async_moorcheh_client() is expected_client
-
-        dispatcher.assert_called_once_with(api_key=None)
-
-    def test_dependency_wrappers_preserve_explicit_api_keys(self):
-        """FastAPI-resolved and embedded callers may still pass a key."""
-        from memanto.app.clients import moorcheh as mclients
+        sync_client = object()
+        async_client = object()
 
         with (
             patch.object(
                 mclients.moorcheh_client,
                 "get_client",
-                return_value=object(),
+                return_value=sync_client,
             ) as sync_dispatcher,
             patch.object(
                 mclients.moorcheh_client,
                 "get_async_client",
-                return_value=object(),
+                return_value=async_client,
             ) as async_dispatcher,
         ):
-            mclients.get_moorcheh_client("explicit-key")
-            mclients.get_async_moorcheh_client("explicit-key")
+            assert mclients.get_moorcheh_client() is sync_client
+            assert mclients.get_async_moorcheh_client() is async_client
 
-        sync_dispatcher.assert_called_once_with(api_key="explicit-key")
-        async_dispatcher.assert_called_once_with(api_key="explicit-key")
-
-    def test_dependency_wrappers_resolve_api_key_headers_through_fastapi(self):
-        """``Annotated`` metadata must preserve real FastAPI header injection."""
-        from fastapi import Depends, FastAPI
-        from fastapi.testclient import TestClient
-
-        from memanto.app.clients import moorcheh as mclients
-
-        app = FastAPI()
-
-        @app.get("/sync")
-        def sync_route(client=Depends(mclients.get_moorcheh_client)):
-            return {"resolved": client}
-
-        @app.get("/async")
-        def async_route(client=Depends(mclients.get_async_moorcheh_client)):
-            return {"resolved": client}
-
-        with (
-            patch.object(
-                mclients.moorcheh_client,
-                "get_client",
-                side_effect=lambda api_key: api_key,
-            ) as sync_dispatcher,
-            patch.object(
-                mclients.moorcheh_client,
-                "get_async_client",
-                side_effect=lambda api_key: api_key,
-            ) as async_dispatcher,
-        ):
-            test_client = TestClient(app)
-            sync_response = test_client.get(
-                "/sync", headers={"X-Api-Key": "header-key"}
-            )
-            async_response = test_client.get(
-                "/async", headers={"X-Api-Key": "header-key"}
-            )
-
-        assert sync_response.json() == {"resolved": "header-key"}
-        assert async_response.json() == {"resolved": "header-key"}
-        sync_dispatcher.assert_called_once_with(api_key="header-key")
-        async_dispatcher.assert_called_once_with(api_key="header-key")
+        sync_dispatcher.assert_called_once_with(api_key=None)
+        async_dispatcher.assert_called_once_with(api_key=None)
 
     def test_backend_switch_rebuilds_cached_client_without_manual_reset(self):
         from memanto.app.clients import moorcheh as mclients

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -160,6 +160,56 @@ class TestOnPremClient:
 
 
 class TestSingletonDispatch:
+    def test_dependency_wrapper_plain_call_uses_configured_sync_key(self):
+        """Direct Python calls must not forward FastAPI ``Header`` metadata."""
+        from memanto.app.clients import moorcheh as mclients
+
+        expected_client = object()
+        with patch.object(
+            mclients.moorcheh_client,
+            "get_client",
+            return_value=expected_client,
+        ) as dispatcher:
+            assert mclients.get_moorcheh_client() is expected_client
+
+        dispatcher.assert_called_once_with(api_key=None)
+
+    def test_dependency_wrapper_plain_call_uses_configured_async_key(self):
+        """The async dependency wrapper needs the same plain-call semantics."""
+        from memanto.app.clients import moorcheh as mclients
+
+        expected_client = object()
+        with patch.object(
+            mclients.moorcheh_client,
+            "get_async_client",
+            return_value=expected_client,
+        ) as dispatcher:
+            assert mclients.get_async_moorcheh_client() is expected_client
+
+        dispatcher.assert_called_once_with(api_key=None)
+
+    def test_dependency_wrappers_preserve_explicit_api_keys(self):
+        """FastAPI-resolved and embedded callers may still pass a key."""
+        from memanto.app.clients import moorcheh as mclients
+
+        with (
+            patch.object(
+                mclients.moorcheh_client,
+                "get_client",
+                return_value=object(),
+            ) as sync_dispatcher,
+            patch.object(
+                mclients.moorcheh_client,
+                "get_async_client",
+                return_value=object(),
+            ) as async_dispatcher,
+        ):
+            mclients.get_moorcheh_client("explicit-key")
+            mclients.get_async_moorcheh_client("explicit-key")
+
+        sync_dispatcher.assert_called_once_with(api_key="explicit-key")
+        async_dispatcher.assert_called_once_with(api_key="explicit-key")
+
     def test_backend_switch_rebuilds_cached_client_without_manual_reset(self):
         from memanto.app.clients import moorcheh as mclients
         from memanto.app.clients import onprem

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -210,6 +210,48 @@ class TestSingletonDispatch:
         sync_dispatcher.assert_called_once_with(api_key="explicit-key")
         async_dispatcher.assert_called_once_with(api_key="explicit-key")
 
+    def test_dependency_wrappers_resolve_api_key_headers_through_fastapi(self):
+        """``Annotated`` metadata must preserve real FastAPI header injection."""
+        from fastapi import Depends, FastAPI
+        from fastapi.testclient import TestClient
+
+        from memanto.app.clients import moorcheh as mclients
+
+        app = FastAPI()
+
+        @app.get("/sync")
+        def sync_route(client=Depends(mclients.get_moorcheh_client)):
+            return {"resolved": client}
+
+        @app.get("/async")
+        def async_route(client=Depends(mclients.get_async_moorcheh_client)):
+            return {"resolved": client}
+
+        with (
+            patch.object(
+                mclients.moorcheh_client,
+                "get_client",
+                side_effect=lambda api_key: api_key,
+            ) as sync_dispatcher,
+            patch.object(
+                mclients.moorcheh_client,
+                "get_async_client",
+                side_effect=lambda api_key: api_key,
+            ) as async_dispatcher,
+        ):
+            test_client = TestClient(app)
+            sync_response = test_client.get(
+                "/sync", headers={"X-Api-Key": "header-key"}
+            )
+            async_response = test_client.get(
+                "/async", headers={"X-Api-Key": "header-key"}
+            )
+
+        assert sync_response.json() == {"resolved": "header-key"}
+        assert async_response.json() == {"resolved": "header-key"}
+        sync_dispatcher.assert_called_once_with(api_key="header-key")
+        async_dispatcher.assert_called_once_with(api_key="header-key")
+
     def test_backend_switch_rebuilds_cached_client_without_manual_reset(self):
         from memanto.app.clients import moorcheh as mclients
         from memanto.app.clients import onprem


### PR DESCRIPTION
## Summary

Fix the backend dependency wrappers so ordinary Python calls use the configured Moorcheh API key instead of forwarding FastAPI's `Header` metadata object as a credential.

## Flaw and impact

`get_moorcheh_client()` and `get_async_moorcheh_client()` used `Header(None, alias="X-Api-Key")` as their real Python default. That works when FastAPI resolves the dependency, but internal code also invokes the functions directly. In a plain call, the default is a truthy `fastapi.params.Header` instance rather than `None`.

The cloud dispatcher therefore selects that object as `key_to_use` and constructs a Moorcheh client with invalid credentials. Direct call sites include the session-scoped answer and upload-file routes, so correctly configured deployments can fail authentication for core operations even though `settings.MOORCHEH_API_KEY` is valid.

Minimal pre-fix reproduction:

```python
from memanto.app.clients.moorcheh import get_moorcheh_client

default = get_moorcheh_client.__defaults__[0]
assert type(default).__name__ == "Header"  # invalid credential forwarded
```

## Fix

Use FastAPI's `Annotated[..., Header(...)]` form while retaining `None` as the actual Python default. FastAPI still reads `X-Api-Key`, explicit embedded callers still pass their key, and direct calls now correctly fall back to the configured key.

Regression coverage verifies:

- sync direct calls dispatch `api_key=None`
- async direct calls dispatch `api_key=None`
- explicit sync and async keys remain unchanged

## Validation

- `python -m pytest tests/test_backend.py -q` - 19 passed
- `python -m pytest -q` - full non-live suite passed; 24 live E2E tests skipped because they require a real Moorcheh key
- `python -m ruff check memanto/app/clients/moorcheh.py tests/test_backend.py` - passed
- `python -m mypy memanto --no-error-summary` - passed

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API-key handling for direct synchronous and asynchronous client access.
  * Prevented internal request-header metadata from being treated as an API key during direct calls.
  * Ensured explicitly provided API keys and request-header API keys are forwarded correctly.

* **Tests**
  * Added coverage for missing, explicitly supplied, and request-header API-key scenarios across both client access modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->