### PR TITLE
fix(validation): reject overly long session IDs to prevent OSError [Bug #770]

### DIFF
--- a/memanto/app/utils/validation.py
+++ b/memanto/app/utils/validation.py
@@ -10,9 +10,10 @@ from fastapi import HTTPException
 from pydantic import BaseModel, Field, validator
 
 # Maximum length for agent_id / session_id values.
-# Most filesystems limit filenames to 255 bytes. With the ``.json`` suffix (5
-# bytes) and parent path components, an ID longer than 128 chars can exceed
-# that limit and cause OSError on file creation/read.
+# A conservative application limit that leaves headroom for platform-specific
+# path-length constraints (some systems enforce a 255-byte limit on the full
+# path, not just the filename component). Real agent IDs are UUIDs (36 chars)
+# or short slugs, so 128 chars is generous while preventing pathological inputs.
 MAX_ID_LENGTH = 128
 
 
@@ -180,9 +181,8 @@ def validate_safe_id(value: str, field_name: str = "id") -> str:
 
     Only alphanumeric characters, hyphens, and underscores are allowed.
     Additionally, the value must not exceed MAX_ID_LENGTH characters to
-    prevent filesystem errors (most filesystems limit filenames to 255
-    bytes; with the ``.json`` suffix and parent path components, an ID
-    longer than 128 chars can exceed that limit and cause OSError).
+    prevent filesystem errors on systems with path-length limits and to
+    reject pathological inputs early (real IDs are UUIDs or short slugs).
     """
     if not value:
         raise ValueError(f"{field_name} must not be empty")

--- a/memanto/app/utils/validation.py
+++ b/memanto/app/utils/validation.py
@@ -9,6 +9,12 @@ from typing import Any
 from fastapi import HTTPException
 from pydantic import BaseModel, Field, validator
 
+# Maximum length for agent_id / session_id values.
+# Most filesystems limit filenames to 255 bytes. With the ``.json`` suffix (5
+# bytes) and parent path components, an ID longer than 128 chars can exceed
+# that limit and cause OSError on file creation/read.
+MAX_ID_LENGTH = 128
+
 
 class InputLimits:
     """Input size and cost limits"""
@@ -173,6 +179,10 @@ def validate_safe_id(value: str, field_name: str = "id") -> str:
     agent_id contains '..' or OS-level path separators.
 
     Only alphanumeric characters, hyphens, and underscores are allowed.
+    Additionally, the value must not exceed MAX_ID_LENGTH characters to
+    prevent filesystem errors (most filesystems limit filenames to 255
+    bytes; with the ``.json`` suffix and parent path components, an ID
+    longer than 128 chars can exceed that limit and cause OSError).
     """
     if not value:
         raise ValueError(f"{field_name} must not be empty")
@@ -182,6 +192,11 @@ def validate_safe_id(value: str, field_name: str = "id") -> str:
         raise ValueError(
             f"{field_name} '{value}' contains invalid characters. "
             "Only letters, digits, hyphens, and underscores are allowed."
+        )
+    if len(value) > MAX_ID_LENGTH:
+        raise ValueError(
+            f"{field_name} exceeds maximum length of {MAX_ID_LENGTH} characters "
+            f"(got {len(value)}). Overly long IDs can cause filesystem errors."
         )
     return value
 


### PR DESCRIPTION
## Bug Report for #770 — Memanto Bug & Exploit Challenge

### Summary

`validate_safe_id` checked the character whitelist but **not the length**. An `agent_id` of 300+ characters (all valid alphanumeric) passed validation, then caused `OSError: [Errno 36] File name too long` when the code tried to create `sessions/{agent_id}.json` (304-char filename, exceeds the 255-byte filesystem limit).

### Reproduction

On current `main`, run:
```bash
pytest tests/test_review_followups.py::TestCorruptActiveMarker -v
```

**Result (before fix):**
```
FAILED tests/test_review_followups.py::TestCorruptActiveMarker::test_corrupt_marker_reports_no_active_session[a*300]
E   OSError: [Errno 36] File name too long: '.../sessions/aaa...aaa.json'
```

The test was parametrized with `"a" * 300` and was **FAILING on main**.

### Impact

A corrupt active-session marker containing a long string would crash `get_active_session()` with an **unhandled OSError** instead of degrading to `None` (the documented behavior for corrupt markers). This violates the class-level invariant:

> An unreadable active marker means "no active session", never a crash.

### Root Cause

The original `validate_safe_id` was designed to prevent path traversal (`../`, `/`) but **not path-length-based failures**. A defense-in-depth approach requires both character AND length validation.

### Fix

Added `MAX_ID_LENGTH = 128` constant and length check to `validate_safe_id`:

```python
MAX_ID_LENGTH = 128

def validate_safe_id(value: str, field_name: str = "id") -> str:
    if not value:
        raise ValueError(f"{field_name} must not be empty")
    if not re.fullmatch(r"[A-Za-z0-9_-]+", value):
        raise ValueError(...)
    if len(value) > MAX_ID_LENGTH:
        raise ValueError(
            f"{field_name} exceeds maximum length of {MAX_ID_LENGTH} characters "
            f"(got {len(value)}). Overly long IDs can cause filesystem errors."
        )
    return value
```

IDs longer than 128 chars now raise `ValueError`, which `get_active_session` already catches (line 442: `except ValueError: return None`).

### Why 128?

- Real agent IDs are UUIDs (36 chars) or short slugs (<50 chars)
- 128 chars is generous for any real use case
- Stays well under the 255-byte filesystem limit even with `.json` suffix + path components
- Matches common ID length limits in web frameworks

### Verification

```bash
# Previously failing test now passes:
pytest tests/test_review_followups.py::TestCorruptActiveMarker -v
# 7/7 pass (was 6/7 with 1 FAILED)

# Full test suite — no regressions:
pytest tests/ -k 'not moorcheh and not live and not e2e'
# All pass, 0 failures
```

### AI Assistance Disclosure

This finding, implementation, and verification were prepared with an AI coding agent under the GitHub account owner's direction. The changes were validated locally with the commands and results above. No social-amplification points are claimed.

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a maximum length of 128 characters for identifiers.
  * Identifiers that are empty, contain invalid characters, or exceed the limit now produce a clear validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->