### PR TITLE
feat: make memory source an open label for per-writer attribution

### DIFF
--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -20,7 +20,8 @@ custom agents, …) can plug into long-term memory in a single config line.
 pip install memanto-mcp
 ```
 
-Requires Python 3.10+ and a [Moorcheh API key](https://console.moorcheh.ai/api-keys)
+Requires Python 3.10+, `memanto>=0.2.11`, and a
+[Moorcheh API key](https://console.moorcheh.ai/api-keys)
 (free tier: 100K ops/month).
 
 ## Quick start (Claude Desktop)
@@ -112,6 +113,9 @@ Memory types accepted by `remember` / `batch_remember`:
 
 Provenance values: `explicit_statement`, `inferred`, `corrected`,
 `validated`, `observed`, `imported`.
+
+Source values: `user`, `agent` (default), `tool`, `system`. Memanto core
+validates these at write time — a free-form label is rejected.
 
 ## Configuration
 

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -14,7 +14,7 @@ at tool-registration time, and we use closure-scoped type aliases (e.g.
 """
 
 import logging
-from typing import Annotated, Any, Literal, TypeVar
+from typing import Annotated, Any, Literal, TypeVar, get_args
 
 from memanto.app.constants import (
     VALID_MEMORY_TYPES,
@@ -63,6 +63,12 @@ ProvenanceLiteral = Literal[
     "observed",
     "imported",
 ]
+
+# Memanto core validates ``MemoryRecord.source`` against this closed set; a
+# free-form label (e.g. an agent name) is rejected at write time.
+SourceLiteral = Literal["user", "agent", "tool", "system"]
+
+VALID_SOURCE_TYPES = frozenset(get_args(SourceLiteral))
 
 # Hard caps mirroring the Memanto core service (see SdkClient).
 _MAX_CONTENT_LENGTH = InputLimits.MAX_TEXT_LENGTH
@@ -324,14 +330,16 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             ),
         ] = "explicit_statement",
         source: Annotated[
-            str,
+            SourceLiteral,
             Field(
                 description=(
-                    "Free-form label for the source of this memory "
-                    "(e.g. 'user', 'web', 'tool-call', or your agent name)."
+                    "Who produced this memory. 'user' means the user supplied "
+                    "it, 'agent' means you did (default), 'tool' means it came "
+                    "out of a tool call, 'system' means it was injected by the "
+                    "platform."
                 ),
             ),
-        ] = "mcp-agent",
+        ] = "agent",
         agent_id: AgentIdField = None,
     ) -> RememberResult:
         """Store a single memory for the resolved agent."""
@@ -389,7 +397,8 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 description=(
                     "List of memory dicts. Each item supports the same fields "
                     "as `remember` (content [required], type, title, "
-                    "confidence, tags, source, provenance). Max 100 items."
+                    "confidence, tags, source, provenance) with the same "
+                    "allowed values. Max 100 items."
                 ),
                 min_length=1,
                 max_length=_MAX_BATCH_SIZE,
@@ -423,8 +432,17 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                         f"memories[{i}].provenance={prov!r} is not valid. "
                         f"Choose one of: {sorted(VALID_PROVENANCE_TYPES)}"
                     )
+                src = item.get("source") or "agent"
+                if src not in VALID_SOURCE_TYPES:
+                    raise ValueError(
+                        f"memories[{i}].source={src!r} is not valid. "
+                        f"Choose one of: {sorted(VALID_SOURCE_TYPES)}"
+                    )
                 normalized_item = dict(item)
                 normalized_item["tags"] = _normalize_tags(item.get("tags"))
+                # The SDK defaults a missing source to "user"; keep batch
+                # writes consistent with `remember`, whose default is "agent".
+                normalized_item["source"] = src
                 normalized_memories.append(normalized_item)
 
             client = lifecycle.ensure_ready(resolved)
@@ -500,7 +518,11 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 default=None,
                 ge=0.0,
                 le=1.0,
-                description="Minimum similarity score 0-1.",
+                description=(
+                    "Minimum similarity score 0-1. Applied by the search "
+                    "backend, so the top-N is filled with results that pass "
+                    "the threshold. Defaults to the server config value."
+                ),
             ),
         ] = None,
         agent_id: AgentIdField = None,
@@ -514,10 +536,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 query=query,
                 limit=limit,
                 type=list(type) if type else None,
+                min_similarity=min_similarity,
             )
             hits = [_to_memory_hit(m) for m in result.get("memories", [])]
-            if min_similarity is not None:
-                hits = [h for h in hits if (h.score or 0.0) >= min_similarity]
             return RecallResult(
                 status="ok",
                 agent_id=resolved,
@@ -742,15 +763,16 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
             ),
         ] = None,
         kiosk_mode: Annotated[
-            bool,
+            bool | None,
             Field(
+                default=None,
                 description=(
                     "If true, refuses to answer when no memory clears the "
                     "similarity threshold (useful for strictly grounded "
-                    "applications)."
+                    "applications). Defaults to the server config value."
                 ),
             ),
-        ] = False,
+        ] = None,
         agent_id: AgentIdField = None,
     ) -> AnswerResult:
         """Answer a question using memories from the resolved agent."""
@@ -855,8 +877,26 @@ def _register_admin_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
     def list_agents() -> AgentListResult:
         """List available Memanto agents through the admin client."""
         try:
-            agents = lifecycle.client.list_agents()
-            return AgentListResult(status="ok", count=len(agents), agents=agents)
+            # SdkClient returned a bare list of agents up to memanto 0.2.12 and
+            # a {"agents", "count", "warnings"} envelope after it. Both are in
+            # our supported range, so accept either. The warnings flag agents
+            # whose local metadata could not be read: surface them instead of
+            # silently reporting a short list.
+            response = lifecycle.client.list_agents()
+            if isinstance(response, dict):
+                agents = response.get("agents", [])
+                count = response.get("count", len(agents))
+                warnings = response.get("warnings", [])
+            else:
+                agents = list(response)
+                count = len(agents)
+                warnings = []
+            return AgentListResult(
+                status="ok",
+                count=count,
+                agents=agents,
+                message="; ".join(warnings) if warnings else None,
+            )
         except Exception as exc:
             logger.exception("list_agents failed")
             return _error_payload(AgentListResult, _format_exception(exc))

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memanto-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Model Context Protocol (MCP) server for Memanto - persistent semantic memory for any MCP-compatible agent"
 readme = "README.md"
 license = { text = "MIT" }
@@ -38,7 +38,9 @@ classifiers = [
 ]
 dependencies = [
     "mcp[cli]>=1.2.0",
-    "memanto>=0.1.0",
+    # 0.2.11 narrowed MemoryRecord.source to a closed Literal; the tool schema
+    # here mirrors that set, so older cores are not interchangeable.
+    "memanto>=0.2.11",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",

--- a/integrations/mcp/tests/test_server.py
+++ b/integrations/mcp/tests/test_server.py
@@ -7,9 +7,14 @@ no network requests are made.
 from __future__ import annotations
 
 import pytest
+from memanto.app.constants import (
+    VALID_MEMORY_TYPES,
+    VALID_PROVENANCE_TYPES,
+)
 
 from memanto_mcp.config import MCPServerSettings
 from memanto_mcp.server import build_server
+from memanto_mcp.tools import VALID_SOURCE_TYPES
 
 MAIN_TOOL_NAMES = {
     "remember",
@@ -47,6 +52,24 @@ async def test_admin_tools_registered_when_enabled(
     assert ADMIN_TOOL_NAMES.issubset(tools), (
         f"Missing admin tools: {ADMIN_TOOL_NAMES - tools}"
     )
+
+
+@pytest.mark.asyncio
+async def test_advertised_enums_match_memanto_core(fake_api_key: str) -> None:
+    """The tool schema is a contract with the calling model.
+
+    Memanto core validates these fields at write time, so an enum that drifts
+    from core hands the model a value that is guaranteed to fail on write.
+    Every advertised source is separately round-tripped through a real
+    MemoryRecord in test_tools.py, which is what pins the source list.
+    """
+    mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
+    tools = {t.name: t for t in await mcp.list_tools()}
+    props = tools["remember"].inputSchema["properties"]
+
+    assert set(props["type"]["enum"]) == VALID_MEMORY_TYPES
+    assert set(props["provenance"]["enum"]) == VALID_PROVENANCE_TYPES
+    assert set(props["source"]["enum"]) == VALID_SOURCE_TYPES
 
 
 @pytest.mark.asyncio

--- a/integrations/mcp/tests/test_tools.py
+++ b/integrations/mcp/tests/test_tools.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from inspect import signature
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from memanto.app.core import MemoryRecord
+from memanto.cli.client.sdk_client import SdkClient
 
-from memanto_mcp.tools import _normalize_tags, register_tools
+from memanto_mcp.tools import VALID_SOURCE_TYPES, _normalize_tags, register_tools
 
 
 class FakeMCP:
@@ -24,10 +27,10 @@ class FakeMCP:
 
 
 class FakeLifecycle:
-    def __init__(self) -> None:
+    def __init__(self, expose_admin_tools: bool = False) -> None:
         self.settings = SimpleNamespace(
             default_agent_id="agent-1",
-            expose_admin_tools=False,
+            expose_admin_tools=expose_admin_tools,
         )
         self.client = MagicMock()
         self.client.batch_remember.return_value = {
@@ -41,6 +44,36 @@ class FakeLifecycle:
             "memory_id": "mem-1",
             "namespace": "memanto_agent_agent-1",
             "confidence": 0.85,
+        }
+        self.client.answer.return_value = {
+            "answer": "yes",
+            "sources": [],
+            "namespace": "memanto_agent_agent-1",
+        }
+        for recall_method in (
+            "recall",
+            "recall_recent",
+            "recall_as_of",
+            "recall_changed_since",
+        ):
+            getattr(self.client, recall_method).return_value = {"memories": []}
+        agent_payload = {
+            "agent_id": "agent-1",
+            "namespace": "memanto_agent_agent-1",
+            "pattern": "tool",
+            "description": None,
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        self.client.create_agent.return_value = agent_payload
+        self.client.get_agent.return_value = agent_payload
+        self.client.delete_agent.return_value = {
+            "status": "deleted",
+            "agent_id": "agent-1",
+        }
+        self.client.list_agents.return_value = {
+            "agents": [agent_payload],
+            "count": 1,
+            "warnings": [],
         }
 
     def resolve_agent_id(self, agent_id: str | None) -> str:
@@ -110,3 +143,182 @@ def test_remember_uses_same_tag_normalization_without_mutating_input() -> None:
         "remember",
     ]
     assert tags == ["mcp", " ", "remember"]
+
+
+def _as_memory_record(call_kwargs: dict[str, Any]) -> MemoryRecord:
+    """Rebuild the record the SDK would construct from a `remember` call.
+
+    Mirrors ``SdkClient.remember``. Building the *real* core model is the point:
+    the tool schema advertises enums (memory type, provenance, source) that
+    Memanto core validates at write time, and mock-only tests cannot see it
+    when core narrows one of them.
+    """
+    return MemoryRecord(
+        type=call_kwargs["memory_type"],
+        title=call_kwargs["title"],
+        content=call_kwargs["content"],
+        agent_id=call_kwargs["agent_id"],
+        actor_id=call_kwargs["agent_id"],
+        confidence=call_kwargs["confidence"],
+        tags=call_kwargs["tags"],
+        source=call_kwargs["source"],
+        provenance=call_kwargs["provenance"],
+    )
+
+
+def test_remember_defaults_are_accepted_by_memanto_core() -> None:
+    """Every default the tool ships must survive core's model validation."""
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["remember"](content="Prefers concise answers.")
+
+    assert result.status == "ok"
+    record = _as_memory_record(lifecycle.client.remember.call_args.kwargs)
+    assert record.source == "agent"
+    assert record.provenance == "explicit_statement"
+
+
+@pytest.mark.parametrize("source", sorted(VALID_SOURCE_TYPES))
+def test_remember_accepts_every_advertised_source(source: str) -> None:
+    """Each value the schema offers must be storable by the installed core."""
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["remember"](content="A stable fact.", source=source)
+
+    assert result.status == "ok"
+    assert (
+        _as_memory_record(lifecycle.client.remember.call_args.kwargs).source == source
+    )
+
+
+def test_batch_remember_rejects_source_core_would_refuse() -> None:
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["batch_remember"](
+        memories=[{"content": "A fact.", "source": "mcp-agent"}]
+    )
+
+    assert result.status == "error"
+    assert "source='mcp-agent'" in (result.message or "")
+    lifecycle.client.batch_remember.assert_not_called()
+
+
+def test_batch_remember_defaults_missing_source_to_agent() -> None:
+    """The SDK defaults an absent source to 'user'; `remember` uses 'agent'."""
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["batch_remember"](memories=[{"content": "A fact."}])
+
+    assert result.status == "ok"
+    sent = lifecycle.client.batch_remember.call_args.kwargs["memories"]
+    assert sent[0]["source"] == "agent"
+
+
+def test_recall_delegates_min_similarity_to_the_backend() -> None:
+    """Filtering server-side keeps the top-N full; post-filtering shrank it."""
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["recall"](query="what do I prefer?", min_similarity=0.4)
+
+    assert result.status == "ok"
+    assert lifecycle.client.recall.call_args.kwargs["min_similarity"] == 0.4
+
+
+def test_answer_leaves_kiosk_mode_to_server_config_by_default() -> None:
+    """An explicit False would silently override a configured kiosk_mode."""
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["answer"](question="what do I prefer?")
+
+    assert result.status == "ok"
+    assert lifecycle.client.answer.call_args.kwargs["kiosk_mode"] is None
+
+
+def test_list_agents_unwraps_the_sdk_envelope() -> None:
+    """After memanto 0.2.12, list_agents returns a dict, not a bare list."""
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle(expose_admin_tools=True)
+    lifecycle.client.list_agents.return_value = {
+        "agents": [{"agent_id": "agent-1"}, {"agent_id": "agent-2"}],
+        "count": 2,
+        "warnings": ["Skipped unreadable metadata for 'agent-3'"],
+    }
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["list_agents"]()
+
+    assert result.status == "ok"
+    assert result.count == 2
+    assert [a["agent_id"] for a in result.agents] == ["agent-1", "agent-2"]
+    assert "agent-3" in (result.message or "")
+
+
+def test_list_agents_still_accepts_the_pre_0_2_13_list() -> None:
+    """memanto <= 0.2.12 is inside our supported floor and returns a list."""
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle(expose_admin_tools=True)
+    lifecycle.client.list_agents.return_value = [
+        {"agent_id": "agent-1"},
+        {"agent_id": "agent-2"},
+    ]
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["list_agents"]()
+
+    assert result.status == "ok"
+    assert result.count == 2
+    assert [a["agent_id"] for a in result.agents] == ["agent-1", "agent-2"]
+
+
+# One minimal invocation per registered tool, admin tools included.
+TOOL_INVOCATIONS: list[tuple[str, dict[str, Any]]] = [
+    ("remember", {"content": "A fact."}),
+    ("batch_remember", {"memories": [{"content": "A fact."}]}),
+    ("recall", {"query": "what do I prefer?"}),
+    ("recall_recent", {}),
+    ("recall_as_of", {"as_of": "2026-01-01"}),
+    ("recall_changed_since", {"since": "2026-01-01"}),
+    ("answer", {"question": "what do I prefer?"}),
+    ("create_agent", {"agent_id": "agent-2"}),
+    ("list_agents", {}),
+    ("get_agent", {"agent_id": "agent-1"}),
+    ("delete_agent", {"agent_id": "agent-1"}),
+]
+
+
+def test_every_tool_succeeds_and_matches_the_sdk_signature() -> None:
+    """End-to-end shape check for the whole tool surface.
+
+    The mock accepts any call, so a tool that passes a parameter the SDK
+    dropped (or renamed) still "works" here. Binding each recorded call to the
+    real ``SdkClient`` signature is what makes this catch upstream drift.
+    """
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle(expose_admin_tools=True)
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    assert set(mcp.tools) == {name for name, _ in TOOL_INVOCATIONS}
+
+    for tool_name, kwargs in TOOL_INVOCATIONS:
+        result = mcp.tools[tool_name](**kwargs)
+        assert result.status == "ok", f"{tool_name}: {result.message}"
+
+    for call in lifecycle.client.mock_calls:
+        method_name = call[0]
+        if "." in method_name:  # a call on a returned value, not on the client
+            continue
+        sdk_method = getattr(SdkClient, method_name)
+        # ``None`` stands in for ``self``; every tool calls by keyword.
+        signature(sdk_method).bind(None, *call[1], **call[2])

--- a/memanto/app/constants.py
+++ b/memanto/app/constants.py
@@ -18,9 +18,12 @@ MemoryType = Literal[
 ]
 
 # Source Types
-SourceType = Literal[
-    "user", "agent", "tool", "system"
-]  # Valid sources for memory creation
+# Open by design: a source names *who wrote the memory* — "user", "agent",
+# "cursor", "codex", "claude_code", "mem0", any integration or MCP client — so
+# recall can be attributed and filtered per writer. This lenient alias is for
+# reading back stored records; writes go through ``core.MemorySource``, which
+# bounds the label so it stays a valid `#source:<value>` filter token.
+SourceType = str
 
 # Status Types
 StatusType = Literal["active", "superseded", "deleted", "provisional"]

--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel, Field, StringConstraints, field_validator
 from memanto.app.constants import (
     MemoryType,
     ProvenanceType,
-    SourceType,
     StatusType,
 )
 
@@ -24,6 +23,34 @@ BoundedTags = Annotated[list[MemoryTag], Field(max_length=20)]
 BoundedSourceRef = Annotated[
     str, StringConstraints(strip_whitespace=True, min_length=1, max_length=512)
 ]
+
+# Who wrote the memory: "user", "agent", "cursor", "codex", "claude_code",
+# "mem0", ... Deliberately open so every writer is identifiable in recall and
+# in the UI, but bounded to the Moorcheh filter-token charset so that
+# `#source:<value>` stays a usable observability filter — a space or a '#' in
+# the label would corrupt the query syntax it is embedded in.
+SOURCE_MAX_LENGTH = 64
+SOURCE_PATTERN = r"^[A-Za-z0-9._-]+$"
+
+MemorySource = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=SOURCE_MAX_LENGTH,
+        pattern=SOURCE_PATTERN,
+    ),
+]
+
+_SOURCE_RE = re.compile(SOURCE_PATTERN)
+
+
+def is_valid_source(value: Any) -> bool:
+    """Return True when *value* is a source label ``MemorySource`` accepts."""
+    if not isinstance(value, str):
+        return False
+    token = value.strip()
+    return bool(_SOURCE_RE.fullmatch(token)) and len(token) <= SOURCE_MAX_LENGTH
 
 
 def agent_namespace(agent_id: str) -> str:
@@ -59,7 +86,7 @@ class MemoryRecord(BaseModel):
     # Metadata fields
     agent_id: str
     actor_id: str
-    source: SourceType
+    source: MemorySource
     source_ref: BoundedSourceRef | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
     status: StatusType = "active"

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -21,6 +21,7 @@ from memanto.app.constants import (
 from memanto.app.core import (
     BoundedSourceRef,
     BoundedTags,
+    MemorySource,
 )
 
 
@@ -40,7 +41,7 @@ class MemoryStoreRequest(BaseModel):
     content: str = Field(max_length=10000)
     agent_id: str
     actor_id: str
-    source: SourceType
+    source: MemorySource
     source_ref: BoundedSourceRef | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
     tags: BoundedTags = Field(default_factory=list)
@@ -60,7 +61,7 @@ class MemoryBatchItem(BaseModel):
     type: MemoryType
     title: str = Field(max_length=100)
     content: str = Field(max_length=10000)
-    source: SourceType
+    source: MemorySource
     source_ref: BoundedSourceRef | None = None
     confidence: float = Field(ge=0.0, le=1.0, default=0.8)
     tags: BoundedTags = Field(default_factory=list)
@@ -98,7 +99,13 @@ class BatchRememberItem(BaseModel):
     )
     confidence: float = Field(0.8, ge=0.0, le=1.0, description="Confidence score (0-1)")
     tags: BoundedTags | None = Field(None, description="Tags for this memory")
-    source: SourceType = Field("agent", description="Source of memory")
+    source: MemorySource = Field(
+        "agent",
+        description=(
+            "Who wrote this memory — 'user', 'agent', or a specific writer "
+            "such as 'cursor', 'codex', or 'claude_code'."
+        ),
+    )
     provenance: str = Field(
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -18,8 +18,8 @@ from pydantic import BaseModel, Field, field_validator
 from memanto.app.clients.backend import get_active_llm_model
 from memanto.app.clients.moorcheh import get_moorcheh_client
 from memanto.app.config import settings
-from memanto.app.constants import VALID_MEMORY_TYPES, MemoryType, SourceType
-from memanto.app.core import MemoryRecord
+from memanto.app.constants import VALID_MEMORY_TYPES, MemoryType
+from memanto.app.core import MemoryRecord, MemorySource
 from memanto.app.models import (
     AnswerRequest,
     AnswerResponse,
@@ -325,7 +325,7 @@ class MemoryEditRequest(BaseModel):
     type: MemoryType | None = None
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
     tags: BoundedTags | None = None
-    source: SourceType | None = None
+    source: MemorySource | None = None
 
     def to_updates(self) -> dict[str, object]:
         """Return only fields the caller explicitly wants to update."""

--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from moorcheh_sdk import MoorchehClient
 
-from memanto.app.core import MemoryRecord
+from memanto.app.core import MemoryRecord, is_valid_source
 from memanto.app.services.memory_parsing_service import MemoryParsingService
 from memanto.app.utils.errors import MemoryError
 from memanto.app.utils.ids import generate_memory_id
@@ -332,9 +332,12 @@ class MemoryWriteService:
                     f"in namespace {namespace}"
                 )
 
-            # Normalize legacy source values
+            # Sources are open labels (the writer's name), so keep whatever the
+            # record carries. Only a value MemoryRecord would reject — blank, or
+            # one holding characters that break `#source:` filters — falls back,
+            # so an edit cannot fail on data written before the label was bounded.
             source_val = updates.get("source", metadata.get("source", "system"))
-            if source_val not in {"user", "agent", "tool", "system"}:
+            if not is_valid_source(source_val):
                 source_val = "system"
 
             # Build updated memory record

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -14,6 +14,7 @@ import typer
 from rich.panel import Panel
 
 from memanto.app.constants import SourceType
+from memanto.app.core import is_valid_source
 from memanto.app.utils.temporal_helpers import get_yesterday_range
 from memanto.cli.commands._shared import (
     BOLD_PRIMARY,
@@ -62,7 +63,10 @@ def remember(
     ),
     tags: str | None = typer.Option(None, "--tags", help="Comma-separated tags"),
     source: str = typer.Option(
-        "user", "--source", "-s", help="Source of the memory (e.g., user, agent_name)"
+        "user",
+        "--source",
+        "-s",
+        help="Who wrote the memory (e.g., user, agent, cursor, codex, claude_code)",
     ),
     provenance: str = typer.Option(
         "explicit_statement",
@@ -264,9 +268,11 @@ def remember(
     # Parse tags
     tag_list = [t.strip() for t in tags.split(",")] if tags else None
 
-    if source not in {"user", "agent", "tool", "system"}:
+    if not is_valid_source(source):
         _error(
-            f"Invalid source: '{source}'. Must be one of user, agent, tool, or system."
+            f"Invalid source: '{source}'.",
+            hint="A source names who wrote the memory (e.g. user, agent, cursor, "
+            "codex, claude_code). Use up to 64 letters, digits, '.', '_', or '-'.",
         )
 
     try:

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -63,7 +63,8 @@ Always categorize the source of the memory. Valid options:
 
 Always specify the tool or agent creating the memory.
 - For AI agents: Use the agent name (e.g., `--source claude_code` or `--source cursor`)
-- Valid base sources (if not using specific agent name): `user`, `agent`, `tool`, `system`
+- Generic fallbacks when no specific writer applies: `user`, `agent`, `tool`, `system`
+- Any label works, up to 64 letters, digits, `.`, `_`, or `-` (no spaces)
 
 ## Tagging Best Practices
 

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -3083,14 +3083,11 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "user",
-              "agent",
-              "tool",
-              "system"
-            ],
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._-]+$",
             "title": "Source",
-            "description": "Source of memory",
+            "description": "Who wrote this memory \u2014 'user', 'agent', or a specific writer such as 'cursor', 'codex', or 'claude_code'.",
             "default": "agent"
           },
           "provenance": {
@@ -3561,12 +3558,9 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "user",
-                  "agent",
-                  "tool",
-                  "system"
-                ]
+                "maxLength": 64,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9._-]+$"
               },
               {
                 "type": "null"
@@ -4188,14 +4182,11 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "user",
-              "agent",
-              "tool",
-              "system"
-            ],
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._-]+$",
             "title": "Source",
-            "description": "Source of memory",
+            "description": "Who wrote this memory \u2014 'user', 'agent', or a specific writer such as 'cursor', 'codex', or 'claude_code'.",
             "default": "agent"
           },
           "provenance": {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
+from pydantic import ValidationError
 
 from memanto.app.config import settings
 from memanto.app.core import MemoryRecord
@@ -602,6 +603,46 @@ class TestSessionService:
 class TestMemoryRecord:
     """Unit tests for core memory record invariants."""
 
+    @staticmethod
+    def _record(**overrides):
+        """Build a minimal valid MemoryRecord with *overrides* applied."""
+        fields = {
+            "type": "fact",
+            "title": "Source label",
+            "content": "Recording which writer produced this memory.",
+            "agent_id": "agent-1",
+            "actor_id": "agent-1",
+            "source": "agent",
+        }
+        fields.update(overrides)
+        return MemoryRecord(**fields)
+
+    @pytest.mark.parametrize(
+        "source",
+        ["user", "agent", "tool", "system", "cursor", "codex", "claude_code", "mem0"],
+    )
+    def test_source_accepts_any_writer_label(self, source):
+        """Sources are open so each writer is attributable in recall."""
+        assert self._record(source=source).source == source
+
+    def test_source_is_trimmed(self):
+        assert self._record(source="  cursor  ").source == "cursor"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "",
+            "   ",
+            "claude code",  # a space splits the `#source:` filter token
+            "cursor#hack",  # '#' opens a new Moorcheh filter clause
+            "x" * 65,
+        ],
+    )
+    def test_source_rejects_labels_that_break_filter_syntax(self, source):
+        """Open does not mean unbounded: `#source:<value>` must stay parseable."""
+        with pytest.raises(ValidationError):
+            self._record(source=source)
+
     def test_set_ttl_rejects_non_positive_values(self):
         """Zero/negative TTLs should not create immediately expired memories."""
         memory = MemoryRecord(
@@ -883,7 +924,8 @@ class TestMemoryWriteServiceDelete:
         assert uploaded.get("original_id") == "orig-123"
         assert "validation_count" not in uploaded
 
-    def test_update_memory_normalizes_legacy_source_values(self):
+    def _update_memory_with_source(self, source):
+        """Run an update over a stored memory carrying *source* and return it."""
         from memanto.app.services.memory_write_service import MemoryWriteService
 
         client = MagicMock()
@@ -894,7 +936,7 @@ class TestMemoryWriteServiceDelete:
             "title": "Title",
             "content": "Content",
             "actor_id": "tester",
-            "source": "manual",  # legacy value
+            "source": source,
             "confidence": 0.8,
             "status": "active",
         }
@@ -909,9 +951,18 @@ class TestMemoryWriteServiceDelete:
                 {"title": "New title"},
             )
 
-        uploaded = client.documents.upload.call_args.kwargs["documents"][0]
-        # Should normalize 'manual' (invalid SourceType) to 'system'
-        assert uploaded.get("source") == "system"
+        return client.documents.upload.call_args.kwargs["documents"][0].get("source")
+
+    @pytest.mark.parametrize("source", ["manual", "cursor", "codex", "claude_code"])
+    def test_update_memory_preserves_open_source_labels(self, source):
+        # Sources name the writer, so an update must not rewrite them.
+        assert self._update_memory_with_source(source) == source
+
+    @pytest.mark.parametrize("source", ["", "   ", "manual entry", "cursor#hack"])
+    def test_update_memory_falls_back_for_unusable_source_values(self, source):
+        # Blank or filter-breaking labels would make MemoryRecord reject the
+        # rewrite, so the update degrades instead of failing.
+        assert self._update_memory_with_source(source) == "system"
 
 
 class TestMemoryWriteServiceUpdateIntegrity:


### PR DESCRIPTION
- Update source to be open label for agent write
- Update MCP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Memory sources support custom writer labels, including `cursor`, `codex`, and `claude_code`.
  - Source labels are validated for safe formatting and length.
  - MCP tools support standardized sources and default to `agent`.
  - Answer kiosk mode can inherit server configuration automatically.
  - Agent listings support legacy and current response formats.

- **Bug Fixes**
  - Backend now handles similarity filtering consistently.
  - Invalid or blank sources fall back to `system`.

- **Documentation**
  - Updated installation requirements, source guidance, and command-line help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->