### PR TITLE
feat(migrations): add Zep session export migration adapter [Bounty #1609]

### DIFF
--- a/examples/migrations/zep-export/sample_zep_export.json
+++ b/examples/migrations/zep-export/sample_zep_export.json
@@ -1,0 +1,64 @@
+{
+  "sessions": [
+    {
+      "id": "session-001",
+      "user_id": "user-123",
+      "created_at": "2024-01-15T10:00:00Z",
+      "updated_at": "2024-01-15T10:30:00Z",
+      "summary": {
+        "content": "User discussed Python project setup preferences. Prefers uv over pip for dependency management. Wants pre-commit hooks for code quality.",
+        "created_at": "2024-01-15T10:30:00Z"
+      },
+      "messages": [
+        {
+          "id": "msg-001",
+          "role": "user",
+          "content": "What is the best way to manage Python dependencies in 2024?",
+          "created_at": "2024-01-15T10:00:00Z"
+        },
+        {
+          "id": "msg-002",
+          "role": "assistant",
+          "content": "I recommend using uv for fast dependency resolution and virtual environment management. It's a drop-in replacement for pip with 10x speed.",
+          "created_at": "2024-01-15T10:01:00Z"
+        },
+        {
+          "id": "msg-003",
+          "role": "user",
+          "content": "Great, I will try uv. How do I set up pre-commit hooks?",
+          "created_at": "2024-01-15T10:05:00Z"
+        },
+        {
+          "id": "msg-004",
+          "role": "assistant",
+          "content": "Install pre-commit via pip, create a .pre-commit-config.yaml file, and run pre-commit install to set up the git hooks.",
+          "created_at": "2024-01-15T10:06:00Z"
+        }
+      ]
+    },
+    {
+      "id": "session-002",
+      "user_id": "user-123",
+      "created_at": "2024-01-16T14:00:00Z",
+      "updated_at": "2024-01-16T14:15:00Z",
+      "summary": {
+        "content": "User asked about testing strategies for async Python code. Recommended pytest-asyncio for async test support.",
+        "created_at": "2024-01-16T14:15:00Z"
+      },
+      "messages": [
+        {
+          "id": "msg-005",
+          "role": "user",
+          "content": "How do I test async Python functions?",
+          "created_at": "2024-01-16T14:00:00Z"
+        },
+        {
+          "id": "msg-006",
+          "role": "assistant",
+          "content": "Use pytest-asyncio. Mark your test with @pytest.mark.asyncio and write async def test_... functions.",
+          "created_at": "2024-01-16T14:01:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -487,11 +487,116 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+
+
+# --------------------------------------------------------------------------
+# Zep
+# --------------------------------------------------------------------------
+
+def map_zep(export: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map a Zep session export to rich Memanto memory payloads.
+
+    Zep stores conversation history as sessions containing messages and
+    auto-generated summaries. This mapper transforms each summary into a
+    ``context`` memory and each message into an ``event`` memory, preserving
+    the session ID, user ID, and role as supporting data.
+    """
+    rows: list[dict[str, Any]] = []
+    migrated_at = _now_utc()
+
+    for session in export.get("sessions", []) or []:
+        session_id = session.get("id")
+        user_id = session.get("user_id")
+        session_created = _pick_first_dt(session, ("created_at", "createdAt"))
+        session_updated = _pick_first_dt(session, ("updated_at", "updatedAt"))
+
+        # --- Map session summary as a context memory ---
+        summary = session.get("summary")
+        if isinstance(summary, dict):
+            summary_content = (summary.get("content") or "").strip()
+            if summary_content:
+                summary_created = _pick_first_dt(summary, ("created_at", "createdAt")) or session_updated
+
+                footer = _format_supporting_data(
+                    [
+                        ("Source", f"zep:summary:{session_id}" if session_id else None),
+                        ("Zep session id", session_id),
+                        ("Zep user id", user_id),
+                        ("Session created_at", session_created.isoformat() if session_created else None),
+                        ("Summary created_at", summary_created.isoformat() if summary_created else None),
+                    ]
+                )
+
+                rows.append(
+                    {
+                        "title": _title_from(summary_content),
+                        "content": _attach_footer(summary_content, footer),
+                        "type": "context",
+                        "tags": [f"zep-session:{session_id}"] if session_id else [],
+                        "confidence": 0.9,
+                        "source": "zep",
+                        "source_ref": f"summary:{session_id}" if session_id else None,
+                        "provenance": "imported",
+                        "created_at": summary_created or session_created,
+                        "updated_at": migrated_at,
+                    }
+                )
+
+        # --- Map individual messages as event memories ---
+        for msg in session.get("messages", []) or []:
+            content = (msg.get("content") or "").strip()
+            if not content:
+                continue
+
+            role = msg.get("role", "unknown")
+            msg_created = _pick_first_dt(msg, ("created_at", "createdAt"))
+
+            memory_type = "event"
+
+            tags: list[str] = []
+            if session_id:
+                tags.append(f"zep-session:{session_id}")
+            tags.append(f"role:{role}")
+
+            footer = _format_supporting_data(
+                [
+                    ("Source", f"zep:message:{session_id}:{msg.get('id', '')}" if session_id else None),
+                    ("Zep session id", session_id),
+                    ("Zep user id", user_id),
+                    ("Role", role),
+                    ("Message id", msg.get("id")),
+                    ("Message metadata", msg.get("metadata")),
+                    ("Session created_at", session_created.isoformat() if session_created else None),
+                    ("Message created_at", msg_created.isoformat() if msg_created else None),
+                ]
+            )
+
+            display_content = f"[{role}] {content}"
+
+            rows.append(
+                {
+                    "title": _title_from(content),
+                    "content": _attach_footer(display_content, footer),
+                    "type": memory_type,
+                    "tags": tags,
+                    "confidence": 0.7,
+                    "source": "zep",
+                    "source_ref": f"message:{session_id}:{msg.get('id', '')}" if session_id else None,
+                    "provenance": "imported",
+                    "created_at": msg_created or session_created,
+                    "updated_at": migrated_at,
+                }
+            )
+
+    return rows
+
+
 MAPPERS: dict[str, Callable[[dict[str, Any]], list[dict[str, Any]]]] = {
     "mem0": map_mem0,
     "letta": map_letta,
     "supermemory": map_supermemory,
     "okf": map_okf,
+    "zep": map_zep,
 }
 
 
@@ -502,3 +607,4 @@ def type_breakdown(rows: list[dict[str, Any]]) -> dict[str, int]:
         key = row.get("type") or "auto"
         counts[key] = counts.get(key, 0) + 1
     return counts
+

--- a/tests/test_map_zep.py
+++ b/tests/test_map_zep.py
@@ -1,0 +1,206 @@
+"""Tests for the Zep migration mapper."""
+import pytest
+from memanto.cli.migrate.mappers import map_zep, MAPPERS
+
+
+class TestMapZepRegistration:
+    """Verify the mapper is registered."""
+
+    def test_zep_is_registered_in_mappers(self):
+        assert "zep" in MAPPERS
+        assert MAPPERS["zep"] is map_zep
+
+
+class TestMapZepBasic:
+    """Basic mapping tests."""
+
+    def test_empty_export_returns_empty_list(self):
+        assert map_zep({}) == []
+
+    def test_empty_sessions_returns_empty_list(self):
+        assert map_zep({"sessions": []}) == []
+
+    def test_session_without_messages_or_summary(self):
+        result = map_zep({"sessions": [{"id": "s1"}]})
+        assert result == []
+
+    def test_maps_summary_as_context_memory(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "user_id": "u1",
+                "summary": {"content": "Discussion about Python setup.", "created_at": "2024-01-01T10:00:00Z"},
+            }]
+        })
+        assert len(result) == 1
+        assert result[0]["type"] == "context"
+        assert result[0]["source"] == "zep"
+        assert result[0]["confidence"] == 0.9
+        assert "zep-session:s1" in result[0]["tags"]
+
+    def test_maps_message_as_event_memory(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "messages": [
+                    {"role": "user", "content": "Hello", "created_at": "2024-01-01T10:00:00Z", "id": "m1"},
+                ],
+            }]
+        })
+        assert len(result) == 1
+        assert result[0]["type"] == "event"
+        assert result[0]["source"] == "zep"
+        assert "[user]" in result[0]["content"]
+        assert "role:user" in result[0]["tags"]
+
+    def test_maps_both_summary_and_messages(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "summary": {"content": "Summary text"},
+                "messages": [
+                    {"role": "user", "content": "Question", "id": "m1"},
+                    {"role": "assistant", "content": "Answer", "id": "m2"},
+                ],
+            }]
+        })
+        assert len(result) == 3  # 1 summary + 2 messages
+        types = [r["type"] for r in result]
+        assert types == ["context", "event", "event"]
+
+    def test_multiple_sessions(self):
+        result = map_zep({
+            "sessions": [
+                {"id": "s1", "messages": [{"role": "user", "content": "Hi", "id": "m1"}]},
+                {"id": "s2", "messages": [{"role": "user", "content": "Hello", "id": "m2"}]},
+            ]
+        })
+        assert len(result) == 2
+        tags_per_msg = [r["tags"] for r in result]
+        assert "zep-session:s1" in tags_per_msg[0]
+        assert "zep-session:s2" in tags_per_msg[1]
+
+
+class TestMapZepEdgeCases:
+    """Edge case handling."""
+
+    def test_empty_message_content_skipped(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "messages": [
+                    {"role": "user", "content": "", "id": "m1"},
+                    {"role": "user", "content": "   ", "id": "m2"},
+                    {"role": "user", "content": None, "id": "m3"},
+                    {"role": "user", "content": "Valid", "id": "m4"},
+                ],
+            }]
+        })
+        assert len(result) == 1  # Only the valid message
+
+    def test_empty_summary_content_skipped(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "summary": {"content": ""},
+                "messages": [{"role": "user", "content": "Hi", "id": "m1"}],
+            }]
+        })
+        assert len(result) == 1  # Only the message, not the empty summary
+
+    def test_missing_session_id_handled(self):
+        result = map_zep({
+            "sessions": [{
+                "messages": [{"role": "user", "content": "Hi", "id": "m1"}],
+            }]
+        })
+        assert len(result) == 1
+        # No zep-session tag when session_id is missing
+        assert not any("zep-session:" in t for t in result[0]["tags"])
+
+    def test_missing_message_id_handled(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "messages": [{"role": "user", "content": "Hi"}],
+            }]
+        })
+        assert len(result) == 1
+        assert result[0]["source_ref"] is not None  # Still has session-based ref
+
+    def test_preserves_user_id_in_footer(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "user_id": "user-abc",
+                "messages": [{"role": "user", "content": "Hi", "id": "m1"}],
+            }]
+        })
+        assert len(result) == 1
+        assert "user-abc" in result[0]["content"]
+
+    def test_preserves_role_in_content_and_tags(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "messages": [
+                    {"role": "user", "content": "Question", "id": "m1"},
+                    {"role": "assistant", "content": "Answer", "id": "m2"},
+                ],
+            }]
+        })
+        assert len(result) == 2
+        assert "[user]" in result[0]["content"]
+        assert "[assistant]" in result[1]["content"]
+        assert "role:user" in result[0]["tags"]
+        assert "role:assistant" in result[1]["tags"]
+
+    def test_preserves_timestamps(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "created_at": "2024-01-01T10:00:00Z",
+                "summary": {"content": "Summary", "created_at": "2024-01-01T10:30:00Z"},
+                "messages": [
+                    {"role": "user", "content": "Hi", "created_at": "2024-01-01T10:00:00Z", "id": "m1"},
+                ],
+            }]
+        })
+        assert len(result) == 2
+        # Summary uses summary's created_at
+        assert result[0]["created_at"] is not None
+        # Message uses message's created_at
+        assert result[1]["created_at"] is not None
+
+    def test_invalid_timestamp_becomes_none(self):
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "messages": [{"role": "user", "content": "Hi", "created_at": "invalid", "id": "m1"}],
+            }]
+        })
+        assert len(result) == 1
+        assert result[0]["created_at"] is None
+
+    def test_all_fields_populated(self):
+        """Every required field in the memory dict is present."""
+        result = map_zep({
+            "sessions": [{
+                "id": "s1",
+                "user_id": "u1",
+                "created_at": "2024-01-01T10:00:00Z",
+                "summary": {"content": "Summary"},
+                "messages": [{"role": "user", "content": "Hi", "id": "m1", "created_at": "2024-01-01T10:00:00Z"}],
+            }]
+        })
+        for mem in result:
+            assert "title" in mem
+            assert "content" in mem
+            assert "type" in mem
+            assert "tags" in mem
+            assert "confidence" in mem
+            assert mem["source"] == "zep"
+            assert "source_ref" in mem
+            assert mem["provenance"] == "imported"
+            assert "created_at" in mem
+            assert "updated_at" in mem


### PR DESCRIPTION
## Summary

Adds `map_zep()` migration mapper for **Zep** — a popular open-source memory service for AI applications. Zep stores conversation history as sessions with messages and auto-generated summaries.

This addresses **Path B: The New Frontier** from the #1609 bounty — building a new migration adapter for a source not yet supported. Zep is explicitly listed in the bounty description ("Zep/Graphiti") and no existing PR covers Zep.

## What this adds

### `memanto/cli/migrate/mappers.py` — `map_zep()` function
- Transforms Zep session exports into Memanto memory payloads
- Session summaries → `context` type memories (confidence: 0.9)
- Individual messages → `event` type memories (confidence: 0.7)
- Preserves session ID, user ID, role, and timestamps
- Role prefixed in content for recall clarity: `[user] ...`, `[assistant] ...`
- Tags: `zep-session:<id>`, `role:<role>`
- All Zep-specific metadata in `[Supporting data]` footer
- Registered in `MAPPERS` dict as `"zep"`

### `tests/test_map_zep.py` — 17 tests
- Registration verification
- Basic mapping (summaries, messages, multiple sessions)
- Edge cases (empty exports, missing fields, invalid timestamps, empty content)
- Field completeness validation
- Role and timestamp preservation

### `examples/migrations/zep-export/sample_zep_export.json`
- Example Zep export with 2 sessions, summaries, and 6 messages
- Demonstrates the expected JSON format

## Zep Export Format

The mapper expects a JSON export with a `sessions` array:
```json
{
  "sessions": [
    {
      "id": "session-uuid",
      "user_id": "user-123",
      "created_at": "2024-01-01T10:00:00Z",
      "summary": {"content": "...", "created_at": "..."},
      "messages": [
        {"role": "user", "content": "...", "created_at": "...", "id": "..."},
        {"role": "assistant", "content": "...", "created_at": "...", "id": "..."}
      ]
    }
  ]
}
```

## Verification

```bash
pytest tests/test_map_zep.py -v     # 17/17 pass
pytest tests/ -k "not moorcheh"     # all pass, 0 regressions
```

## AI Assistance Disclosure

This implementation was prepared with an AI coding agent under the GitHub account owner's direction. No social-amplification points are claimed.

Refs #1609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for migrating Zep exports into Memanto memories.
  * Converts session summaries and conversation messages while preserving timestamps, roles, metadata, tags, and source references.
  * Handles multiple sessions, missing identifiers, invalid timestamps, and empty content gracefully.

* **Tests**
  * Added comprehensive coverage for Zep migration scenarios and edge cases.

* **Documentation**
  * Added a sample Zep export for migration testing and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->