### PR TITLE
fix: guard idempotency store with a lock

### DIFF
--- a/memanto/app/legacy/idempotency.py
+++ b/memanto/app/legacy/idempotency.py
@@ -5,9 +5,9 @@ Idempotency Handling for MEMANTO
 import hashlib
 import re
 import time
+import threading
 from dataclasses import dataclass
 from typing import Any
-
 from fastapi import HTTPException
 
 
@@ -33,9 +33,10 @@ class IdempotencyStore:
         self.records: dict[str, IdempotencyRecord] = {}
         self.last_cleanup = time.time()
         self.cleanup_interval = 3600  # 1 hour
+        self._lock = threading.Lock()
 
     def _cleanup_expired(self) -> None:
-        """Remove expired records"""
+        """Remove expired records (lock must be held by caller)."""
         now = time.time()
         if now - self.last_cleanup < self.cleanup_interval:
             return
@@ -51,17 +52,17 @@ class IdempotencyStore:
 
     def get_record(self, idempotency_key: str) -> IdempotencyRecord | None:
         """Get existing idempotency record"""
-        self._cleanup_expired()
+        with self._lock:
+            self._cleanup_expired()
 
-        record = self.records.get(idempotency_key)
-        if record and not record.is_expired():
-            return record
+            record = self.records.get(idempotency_key)
+            if record and not record.is_expired():
+                return record
+            # Remove expired record
+            if record:
+                del self.records[idempotency_key]
 
-        # Remove expired record
-        if record:
-            del self.records[idempotency_key]
-
-        return None
+            return None
 
     def store_record(
         self,
@@ -71,29 +72,31 @@ class IdempotencyStore:
         ttl_seconds: int = 86400,
     ):
         """Store idempotency record"""
-        self._cleanup_expired()
+        with self._lock:
+            self._cleanup_expired()
 
-        record = IdempotencyRecord(
-            memory_id=memory_id,
-            response=response,
-            created_at=time.time(),
-            ttl_seconds=ttl_seconds,
-        )
+            record = IdempotencyRecord(
+                memory_id=memory_id,
+                response=response,
+                created_at=time.time(),
+                ttl_seconds=ttl_seconds,
+            )
 
-        self.records[idempotency_key] = record
+            self.records[idempotency_key] = record
 
     def get_stats(self) -> dict[str, Any]:
         """Get idempotency store statistics"""
-        self._cleanup_expired()
+        with self._lock:
+            self._cleanup_expired()
 
-        return {
-            "total_records": len(self.records),
-            "oldest_record_age": min(
-                (time.time() - record.created_at for record in self.records.values()),
-                default=0,
-            ),
-            "memory_usage_estimate": len(str(self.records)),
-        }
+            return {
+                "total_records": len(self.records),
+                "oldest_record_age": min(
+                    (time.time() - record.created_at for record in self.records.values()),
+                    default=0,
+                ),
+                "memory_usage_estimate": len(str(self.records)),
+            }
 
 
 # Global idempotency store

--- a/memanto/app/legacy/idempotency.py
+++ b/memanto/app/legacy/idempotency.py
@@ -19,6 +19,7 @@ class IdempotencyRecord:
     response: dict[str, Any]
     created_at: float
     ttl_seconds: int = 86400  # 24 hours default
+    in_progress: bool = False
 
     def is_expired(self) -> bool:
         """Check if record is expired"""
@@ -51,27 +52,46 @@ class IdempotencyStore:
         self.last_cleanup = now
 
     def get_record(self, idempotency_key: str) -> IdempotencyRecord | None:
-        """Get existing idempotency record"""
+        """Get existing idempotency record (completed only)"""
         with self._lock:
             self._cleanup_expired()
 
             record = self.records.get(idempotency_key)
-            if record and not record.is_expired():
+            if record and not record.is_expired() and not record.in_progress:
                 return record
             # Remove expired record
-            if record:
+            if record and record.is_expired():
                 del self.records[idempotency_key]
 
             return None
+    def claim_record(self, idempotency_key: str, ttl_seconds: int = 86400) -> tuple[bool, IdempotencyRecord | None]:
+        ""Atomically claim an idempotency key as in-progress."""
+        with self._lock:
+            self._cleanup_expired()
 
-    def store_record(
+            record = self.records.get(idempotency_key)
+            if record:
+                if record.is_expired():
+                    del self.records[idempotency_key]
+                else:
+                    return False, record
+            placeholder = IdempotencyRecord(
+                memory_id="",
+                response={},
+                created_at=time.time(),
+                ttl_seconds=ttl_seconds,
+                in_progress=True,
+            )
+            self.records[idempotency_key] = placeholder
+            return True, placeholder
+    def complete_record(
         self,
         idempotency_key: str,
         memory_id: str,
         response: dict[str, Any],
         ttl_seconds: int = 86400,
-    ):
-        """Store idempotency record"""
+    ) -> None:
+        ""Finalize an in-progress reservation with the response."""
         with self._lock:
             self._cleanup_expired()
 
@@ -80,9 +100,23 @@ class IdempotencyStore:
                 response=response,
                 created_at=time.time(),
                 ttl_seconds=ttl_seconds,
+                in_progress=False,
             )
-
             self.records[idempotency_key] = record
+    def store_record(
+        self,
+        idempotency_key: str,
+        memory_id: str,
+        response: dict[str, Any],
+        ttl_seconds: int = 86400,
+    ):
+        """Store idempotency record"""
+        self.complete_record(
+            idempotency_key=idempotency_key,
+            memory_id=memory_id,
+            response=response,
+            ttl_seconds=ttl_seconds,
+        )
 
     def get_stats(self) -> dict[str, Any]:
         """Get idempotency store statistics"""
@@ -112,11 +146,18 @@ class IdempotencyHandler:
         if not idempotency_key:
             return None
 
-        record = idempotency_store.get_record(idempotency_key)
-        if record:
+        claimed, record = idempotency_store.claim_record(idempotency_key)
+        if not claimed and record:
+            if record.in_progress:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error": "idempotency_in_progress",
+                        "message": "Idempotency key is currently being processed",
+                    },
+                )
             # Return cached response
             return record.response
-
         return None
 
     @staticmethod
@@ -130,7 +171,7 @@ class IdempotencyHandler:
         if not idempotency_key:
             return
 
-        idempotency_store.store_record(
+        idempotency_store.complete_record(
             idempotency_key=idempotency_key,
             memory_id=memory_id,
             response=response,


### PR DESCRIPTION
## Fix: lock idempotency store to prevent TOCTOU duplicates (Bounty #770)

### Root cause
`IdempotencyStore` uses an in-memory dict without synchronization. The check-then-write flow allows concurrent requests with the same key to bypass the check and duplicate writes.

### Fix
- Added a `threading.Lock` to guard `get_record`, `store_record`, and `get_stats`.
- `_cleanup_expired` now assumes the lock is held, preventing races during cleanup.

### Files
- `memanto/app/legacy/idempotency.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when handling duplicate requests concurrently.
  * Added clear conflict responses when an identical request is already being processed.
  * Ensured completed requests return their previously stored responses.
  * Prevented race conditions during record cleanup, retrieval, storage, and statistics operations.
  * Preserved existing expiration and statistics behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->