### PR TITLE
fix(services): bound conflict-detection retrieval query to embedding context budget [Fixes #1329]

### DIFF
--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -267,10 +267,15 @@ If there are NO conflicts, return an empty array: []
 Example response format:
 [{{"type": "contradiction", "title": "Database preference changed", "old_memory_id": "abc-123", "old_content": "We use PostgreSQL", "new_memory_id": "def-456", "new_content": "We migrated to MongoDB", "description": "New memory contradicts old database preference", "recommendation": "keep_new"}}]
 """
+        retrieval_query = _truncate_embedding_query(
+            full_text,
+            model=get_active_embedding_model(),
+        )
         try:
             generate_kwargs = {
                 "namespace": namespace,
-                "query": conflict_prompt,
+                "query": retrieval_query,
+                "header_prompt": conflict_prompt,
                 "top_k": 50,
             }
             ai_model = get_active_llm_model(settings.SUMMARY_MODEL)


### PR DESCRIPTION
## Summary

Fixes **Issue #1329** — detect-conflicts fails with HTTP 400 on active days because generate_conflict_report passes the full conflict_prompt (including all session content) as the retrieval query, exceeding the embedding model's 2048-token context window.

## Root Cause

generate_conflict_report() passed the entire conflict prompt (instructions + full day's session text) as the query argument to client.answer.generate(). The on-prem embedding path sends this query to Ollama without truncation, causing failures when the query exceeds the 
omic-embed-text 2048-token limit.

## Fix

- Applied _truncate_embedding_query(full_text, model=get_active_embedding_model()) to bound the retrieval embedding query within the context budget.
- Moved the full conflict detection instructions into header_prompt so they reach the LLM without being embedded.

This follows the same pattern already used by generate_summary() (lines 158-161).

## Scope

This PR touches **only** memanto/app/services/daily_analysis_service.py — no unrelated changes.

## Payout Target Wallet
/claim 0xBd6B1B6118eC9D736EE1d5E476f86BCA1b3739f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conflict analysis accuracy by refining how session information is retrieved and interpreted.
  * Prevented overly long retrieval queries while preserving the full conflict-analysis instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->