### PR TITLE
feat(examples): migrate Codex CLI sessions to privacy-safe OKF

### DIFF
--- a/examples/migrations/codex_cli_sessions/README.md
+++ b/examples/migrations/codex_cli_sessions/README.md
@@ -96,13 +96,15 @@ uv run python examples/migrations/codex_cli_sessions/run_live_demo.py \
 The live runner creates a fresh empty agent, records no-result recall before
 import, invokes the shipped `memanto migrate okf` command, repeats all five
 golden recalls, asks the same questions through `memanto answer`, and exports
-the cloud memories back to a new portable OKF bundle. It streams the real CLI
-output for screen recording and writes a transcript plus a secret-free JSON
-report with command exit codes and exported-file hashes. The command fails
-closed unless every pre-import recall is empty, every post-import recall returns
-the exact expected OKF title, and every requested RAG answer cites that same
-title in its context. It never reads or prints the key value and refuses to
-overwrite an existing evidence directory.
+the cloud memories back to a new portable OKF bundle. It then prints the
+portable index and one exported memory as readable Markdown, so a recording
+shows ownership rather than merely reporting a directory path. It streams the
+real CLI output for screen recording and writes a transcript plus a secret-free
+JSON report with command exit codes, exported-file hashes, and preview hashes.
+The command fails closed unless every pre-import recall is empty, every
+post-import recall returns the exact expected OKF title, and every requested RAG
+answer cites that same title in its context. It never reads or prints the key
+value and refuses to overwrite an existing evidence directory.
 
 ## Source-to-OKF mapping
 

--- a/examples/migrations/codex_cli_sessions/README.md
+++ b/examples/migrations/codex_cli_sessions/README.md
@@ -16,22 +16,26 @@ a credential, email address, JWT, or long base58 account identifier.
 `sample_okf/` was generated from a lived-in, multi-day Codex session used for a
 real software delivery workflow—not handwritten fixture data. The private raw
 rollout is not published because doing so would defeat the privacy story.
-Instead, the bundle carries cryptographic provenance:
+Instead, the bundle carries cryptographic source linkage and integrity metadata:
 
 - the manifest records the SHA-256 digest and byte size of the frozen raw
   rollout without recording its local path;
 - every OKF document carries the SHA-256 digest of its canonical source
   envelope and its privacy-redacted body;
-- the validator re-reads the private source, proves every selected source
-  record exists, verifies exact body parity, and runs the privacy gate;
+- the validator re-reads the private source, verifies every selected source
+  record exists, compares each body hash with both its frontmatter and the
+  matching manifest record, and runs the privacy gate;
 - `artifacts/roundtrip_report.json` records 100% source-to-OKF coverage, exact
   content-hash parity, and zero privacy findings;
 - five golden questions retrieve the same expected memory before and after the
   migration, with 5/5 answer-evidence and recall-parity checks passing;
 - Memanto's shipped loader maps all 14 sample OKF nodes and skips zero.
 
-The raw source remains genuinely verifiable during review or a live demo while
-the public artifact remains safe to inspect and fork.
+The raw source remains reproducibly checkable during review or a live demo while
+the public artifact remains safe to inspect and fork. The bundle is unsigned:
+its self-recorded digests detect accidental or partial changes, but establishing
+origin against a hostile rewriter requires a separately trusted digest or
+signature.
 
 ## One-command reproducibility
 
@@ -63,6 +67,10 @@ The command performs the full non-live proof:
 5. runs any `golden_questions.json` against source and OKF memories;
 6. loads and maps the bundle through Memanto's shipped OKF code;
 7. writes `roundtrip_report.json` and `memanto_dry_run_report.json`.
+
+The output path must not already exist. To rerun against an existing bundle
+created by this adapter, add `--force`; the command refuses to recursively
+remove files, symlinks, or directories without this adapter's manifest marker.
 
 For the actual CLI dry-run:
 
@@ -103,8 +111,10 @@ The source-record digest is calculated from canonical JSON containing the
 session id, JSONL line number, timestamp, role, and original text. Validation
 recomputes those digests from the raw rollout and checks that the selected set
 matches the OKF and manifest sets exactly. It then hashes each redacted Markdown
-body and compares it with the recorded digest. A modified, missing, or invented
-entry fails validation.
+body and compares it with both the entry's digest and the corresponding manifest
+record. A modified, missing, or invented entry fails validation unless an
+attacker can rewrite the entire unsigned bundle; use an externally trusted
+digest or signature when adversarial authenticity matters.
 
 The sample's five golden questions use the same deterministic lexical retriever
 against the frozen source messages and the migrated OKF bodies. Each question
@@ -132,8 +142,8 @@ and redaction counts. Both source and migration API-call counts are zero.
 
 ## Privacy model and limitations
 
-- `--include` and `--exclude` run before redaction; do not publish those private
-  selector values if they identify a person or project.
+- `--include` and `--exclude` run before redaction. Their values are never
+  persisted; the manifest records only whether each filter was applied.
 - `--redact-literal` values are applied case-insensitively and are never stored
   in the manifest.
 - Automated redaction is defense in depth, not a substitute for reviewing a

--- a/examples/migrations/codex_cli_sessions/README.md
+++ b/examples/migrations/codex_cli_sessions/README.md
@@ -86,6 +86,21 @@ memanto migrate okf ./codex-okf-demo --agent your-agent
 memanto memory export --agent your-agent --okf
 ```
 
+For a recordable end-to-end proof, set `MOORCHEH_API_KEY` and run:
+
+```bash
+uv run python examples/migrations/codex_cli_sessions/run_live_demo.py \
+  --output ./codex-okf-live-evidence
+```
+
+The live runner creates a fresh empty agent, records no-result recall before
+import, invokes the shipped `memanto migrate okf` command, repeats all five
+golden recalls, asks the same questions through `memanto answer`, and exports
+the cloud memories back to a new portable OKF bundle. It streams the real CLI
+output for screen recording and writes a transcript plus a secret-free JSON
+report with command exit codes and exported-file hashes. It never reads or
+prints the key value and refuses to overwrite an existing evidence directory.
+
 ## Source-to-OKF mapping
 
 | Codex rollout concept | Selection rule | OKF representation | Memanto behavior |

--- a/examples/migrations/codex_cli_sessions/README.md
+++ b/examples/migrations/codex_cli_sessions/README.md
@@ -98,8 +98,11 @@ import, invokes the shipped `memanto migrate okf` command, repeats all five
 golden recalls, asks the same questions through `memanto answer`, and exports
 the cloud memories back to a new portable OKF bundle. It streams the real CLI
 output for screen recording and writes a transcript plus a secret-free JSON
-report with command exit codes and exported-file hashes. It never reads or
-prints the key value and refuses to overwrite an existing evidence directory.
+report with command exit codes and exported-file hashes. The command fails
+closed unless every pre-import recall is empty, every post-import recall returns
+the exact expected OKF title, and every requested RAG answer cites that same
+title in its context. It never reads or prints the key value and refuses to
+overwrite an existing evidence directory.
 
 ## Source-to-OKF mapping
 

--- a/examples/migrations/codex_cli_sessions/README.md
+++ b/examples/migrations/codex_cli_sessions/README.md
@@ -26,6 +26,8 @@ Instead, the bundle carries cryptographic provenance:
   record exists, verifies exact body parity, and runs the privacy gate;
 - `artifacts/roundtrip_report.json` records 100% source-to-OKF coverage, exact
   content-hash parity, and zero privacy findings;
+- five golden questions retrieve the same expected memory before and after the
+  migration, with 5/5 answer-evidence and recall-parity checks passing;
 - Memanto's shipped loader maps all 14 sample OKF nodes and skips zero.
 
 The raw source remains genuinely verifiable during review or a live demo while
@@ -58,8 +60,9 @@ The command performs the full non-live proof:
 2. selects and privacy-redacts conversation memories;
 3. writes an OKF bundle and provenance manifest;
 4. validates source coverage and exact content parity;
-5. loads and maps the bundle through Memanto's shipped OKF code;
-6. writes `roundtrip_report.json` and `memanto_dry_run_report.json`.
+5. runs any `golden_questions.json` against source and OKF memories;
+6. loads and maps the bundle through Memanto's shipped OKF code;
+7. writes `roundtrip_report.json` and `memanto_dry_run_report.json`.
 
 For the actual CLI dry-run:
 
@@ -102,6 +105,14 @@ recomputes those digests from the raw rollout and checks that the selected set
 matches the OKF and manifest sets exactly. It then hashes each redacted Markdown
 body and compares it with the recorded digest. A modified, missing, or invented
 entry fails validation.
+
+The sample's five golden questions use the same deterministic lexical retriever
+against the frozen source messages and the migrated OKF bodies. Each question
+declares its expected source-record digest and required answer evidence. The
+report counts a question only when both sides retrieve that exact record, the
+retrieval identifiers agree, and the answer evidence exists on both sides. This
+is a reproducible 5/5 before/after recall-parity check; a live Memanto recall run
+can use the same questions after import.
 
 Run the focused checks:
 

--- a/examples/migrations/codex_cli_sessions/README.md
+++ b/examples/migrations/codex_cli_sessions/README.md
@@ -1,0 +1,134 @@
+# Codex CLI sessions to portable OKF
+
+This Path B adapter liberates conversational memory from a real Codex CLI
+rollout (`rollout-*.jsonl`) into a human-readable Open Knowledge Format bundle.
+It feeds Memanto's shipped `migrate okf` path; it does not reimplement Memanto's
+loader or migration engine.
+
+The important twist is privacy. Codex rollouts can contain tool output,
+reasoning, credentials, paths, and pasted account data. This adapter exports
+only user/assistant text, excludes internal context and images, applies
+deterministic redaction, and fails closed if the published text still resembles
+a credential, email address, JWT, or long base58 account identifier.
+
+## What the included real-data artifact proves
+
+`sample_okf/` was generated from a lived-in, multi-day Codex session used for a
+real software delivery workflow—not handwritten fixture data. The private raw
+rollout is not published because doing so would defeat the privacy story.
+Instead, the bundle carries cryptographic provenance:
+
+- the manifest records the SHA-256 digest and byte size of the frozen raw
+  rollout without recording its local path;
+- every OKF document carries the SHA-256 digest of its canonical source
+  envelope and its privacy-redacted body;
+- the validator re-reads the private source, proves every selected source
+  record exists, verifies exact body parity, and runs the privacy gate;
+- `artifacts/roundtrip_report.json` records 100% source-to-OKF coverage, exact
+  content-hash parity, and zero privacy findings;
+- Memanto's shipped loader maps all 14 sample OKF nodes and skips zero.
+
+The raw source remains genuinely verifiable during review or a live demo while
+the public artifact remains safe to inspect and fork.
+
+## One-command reproducibility
+
+From the repository root, install the project and point the demo at any real
+Codex rollout:
+
+```bash
+uv sync --group dev
+uv run python examples/migrations/codex_cli_sessions/run_demo.py \
+  ~/.codex/sessions/2026/08/01/rollout-....jsonl \
+  --output ./codex-okf-demo \
+  --include "architecture|decision|preference" \
+  --max-records 25 \
+  --redact-literal "Your Name"
+```
+
+On Windows PowerShell, quote the rollout path and keep the command on one line:
+
+```powershell
+uv run python examples/migrations/codex_cli_sessions/run_demo.py "C:\Users\you\.codex\sessions\2026\08\01\rollout-....jsonl" --output .\codex-okf-demo --include "architecture|decision|preference" --max-records 25 --redact-literal "Your Name"
+```
+
+The command performs the full non-live proof:
+
+1. parses a real rollout;
+2. selects and privacy-redacts conversation memories;
+3. writes an OKF bundle and provenance manifest;
+4. validates source coverage and exact content parity;
+5. loads and maps the bundle through Memanto's shipped OKF code;
+6. writes `roundtrip_report.json` and `memanto_dry_run_report.json`.
+
+For the actual CLI dry-run:
+
+```bash
+memanto migrate okf ./codex-okf-demo --dry-run
+```
+
+No Moorcheh API key is required for either dry-run. A live import uses the
+normal Memanto flow:
+
+```bash
+memanto migrate okf ./codex-okf-demo --agent your-agent
+memanto memory export --agent your-agent --okf
+```
+
+## Source-to-OKF mapping
+
+| Codex rollout concept | Selection rule | OKF representation | Memanto behavior |
+| --- | --- | --- | --- |
+| `session_meta` | Used only to bind following messages to a session | Hashed `resource: codex://session/...` | Preserved as pseudonymous source reference |
+| `response_item/message`, role `user` | Text blocks only; internal context excluded | One OKF document tagged `user` | Auto-classified on import |
+| `response_item/message`, role `assistant` | Public `output_text` only | One OKF document tagged `assistant` | Auto-classified on import |
+| Message timestamp | Preserved | `timestamp` | Preserved as creation time |
+| Canonical source envelope | SHA-256 only; raw text stays private | `source_record_sha256` extension | Preserved in supporting data |
+| Redacted message body | Exact UTF-8 text | Markdown body + `content_sha256` | Imported as memory content |
+| Tool calls and tool outputs | Always excluded | None | Never ingested |
+| Reasoning records | Always excluded | None | Never ingested |
+| Developer instructions | Always excluded | None | Never ingested |
+| Images and attachments | Always excluded | None | Never ingested |
+
+Unknown frontmatter fields are intentionally used for provenance. Memanto's OKF
+loader preserves them in the imported memory's supporting-data footer, so the
+round trip is lossless without forcing Codex concepts into Memanto's schema.
+
+## Fidelity and validation
+
+The source-record digest is calculated from canonical JSON containing the
+session id, JSONL line number, timestamp, role, and original text. Validation
+recomputes those digests from the raw rollout and checks that the selected set
+matches the OKF and manifest sets exactly. It then hashes each redacted Markdown
+body and compares it with the recorded digest. A modified, missing, or invented
+entry fails validation.
+
+Run the focused checks:
+
+```bash
+uv run pytest examples/migrations/codex_cli_sessions/tests -q
+uv run ruff check examples/migrations/codex_cli_sessions
+uv run ruff format --check examples/migrations/codex_cli_sessions
+```
+
+## Honest savings report
+
+Codex rollouts and OKF bundles are local files. There is no provider API call,
+token bill, or retrieval-latency baseline to compare, so this showcase does not
+invent one. The generated manifest reports only measurable values: raw rollout
+bytes, selected source-text bytes, published redacted-text bytes, record counts,
+and redaction counts. Both source and migration API-call counts are zero.
+
+## Privacy model and limitations
+
+- `--include` and `--exclude` run before redaction; do not publish those private
+  selector values if they identify a person or project.
+- `--redact-literal` values are applied case-insensitively and are never stored
+  in the manifest.
+- Automated redaction is defense in depth, not a substitute for reviewing a
+  public artifact. Run the validator and inspect the final Markdown before
+  publishing it.
+- The adapter preserves conversation memory, not hidden chain-of-thought. That
+  exclusion is deliberate and permanent.
+- A source digest proves which frozen file was used; a reviewer can reproduce
+  the proof when given that file privately without requiring it in git.

--- a/examples/migrations/codex_cli_sessions/artifacts/memanto_dry_run_report.json
+++ b/examples/migrations/codex_cli_sessions/artifacts/memanto_dry_run_report.json
@@ -1,6 +1,6 @@
 {
   "command": "memanto migrate okf examples/migrations/codex_cli_sessions/sample_okf --dry-run",
-  "executed_at": "2026-08-01T21:45:48Z",
+  "executed_at": "2026-08-01T22:25:15.985747Z",
   "okf_nodes": 14,
   "mapped_memories": 14,
   "skipped": 0,

--- a/examples/migrations/codex_cli_sessions/artifacts/memanto_dry_run_report.json
+++ b/examples/migrations/codex_cli_sessions/artifacts/memanto_dry_run_report.json
@@ -1,0 +1,9 @@
+{
+  "command": "memanto migrate okf examples/migrations/codex_cli_sessions/sample_okf --dry-run",
+  "executed_at": "2026-08-01T21:45:48Z",
+  "okf_nodes": 14,
+  "mapped_memories": 14,
+  "skipped": 0,
+  "writes_performed": 0,
+  "api_key_required": false
+}

--- a/examples/migrations/codex_cli_sessions/artifacts/roundtrip_report.json
+++ b/examples/migrations/codex_cli_sessions/artifacts/roundtrip_report.json
@@ -55,6 +55,6 @@
       }
     ]
   },
-  "bundle_sha256": "2b15029153677059fc2e2c2cd6d16519c08d603011224076fb456888808afd5b",
+  "bundle_sha256": "e983c43dc6f1cc9d800652e9b5d2084b3b5da25dc69d3373f58ae184b9292404",
   "failures": []
 }

--- a/examples/migrations/codex_cli_sessions/artifacts/roundtrip_report.json
+++ b/examples/migrations/codex_cli_sessions/artifacts/roundtrip_report.json
@@ -1,0 +1,13 @@
+{
+  "valid": true,
+  "adapter_version": "0.1.0",
+  "source_sha256_match": true,
+  "selected_source_records": 14,
+  "okf_entries": 14,
+  "source_to_okf_matched": 14,
+  "source_to_okf_coverage": 1.0,
+  "content_hash_parity": true,
+  "privacy_gate_findings": 0,
+  "bundle_sha256": "2b15029153677059fc2e2c2cd6d16519c08d603011224076fb456888808afd5b",
+  "failures": []
+}

--- a/examples/migrations/codex_cli_sessions/artifacts/roundtrip_report.json
+++ b/examples/migrations/codex_cli_sessions/artifacts/roundtrip_report.json
@@ -8,6 +8,53 @@
   "source_to_okf_coverage": 1.0,
   "content_hash_parity": true,
   "privacy_gate_findings": 0,
+  "golden_qa": {
+    "questions": 5,
+    "fully_correct": 5,
+    "recall_parity_score": 1.0,
+    "results": [
+      {
+        "id": "memo-ambiguity",
+        "source_retrieved_expected": true,
+        "okf_retrieved_expected": true,
+        "retrieval_parity": true,
+        "source_answer_evidence": true,
+        "okf_answer_evidence": true
+      },
+      {
+        "id": "proofpatch-suite",
+        "source_retrieved_expected": true,
+        "okf_retrieved_expected": true,
+        "retrieval_parity": true,
+        "source_answer_evidence": true,
+        "okf_answer_evidence": true
+      },
+      {
+        "id": "disconnected-output",
+        "source_retrieved_expected": true,
+        "okf_retrieved_expected": true,
+        "retrieval_parity": true,
+        "source_answer_evidence": true,
+        "okf_answer_evidence": true
+      },
+      {
+        "id": "three-round-replay",
+        "source_retrieved_expected": true,
+        "okf_retrieved_expected": true,
+        "retrieval_parity": true,
+        "source_answer_evidence": true,
+        "okf_answer_evidence": true
+      },
+      {
+        "id": "server-outage",
+        "source_retrieved_expected": true,
+        "okf_retrieved_expected": true,
+        "retrieval_parity": true,
+        "source_answer_evidence": true,
+        "okf_answer_evidence": true
+      }
+    ]
+  },
   "bundle_sha256": "2b15029153677059fc2e2c2cd6d16519c08d603011224076fb456888808afd5b",
   "failures": []
 }

--- a/examples/migrations/codex_cli_sessions/codex_to_okf.py
+++ b/examples/migrations/codex_cli_sessions/codex_to_okf.py
@@ -24,90 +24,93 @@ from typing import Any
 
 ADAPTER_VERSION = "0.1.0"
 OKF_TYPE = "Codex CLI Conversation"
+BUNDLE_ADAPTER = "codex-cli-sessions-to-okf"
 
 INTERNAL_MESSAGE_RE = re.compile(
-    r"^\s*<(?:codex_internal_context|environment_context|permissions instructions)\b",
+    r"<(?:codex_internal_context|environment_context|permissions instructions)\b",
     re.IGNORECASE,
 )
 
+# A single specification keeps redaction and the fail-closed privacy gate in
+# sync. The gate intentionally uses a stricter OpenAI-key boundary than the
+# replacement rule, while every other category shares the same pattern.
 # Order matters: redact assignment lines before matching individual token shapes.
-REDACTION_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+PRIVACY_RULE_SPECS: tuple[tuple[str, str, str], ...] = (
     (
         "secret_assignment",
-        re.compile(
-            r"(?im)^.*(?:api[_ -]?key|access[_ -]?token|password|private[_ -]?key)"
-            r"\s*(?::|=).*$"
-        ),
+        r"(?im)^.*(?:api[_ -]?key|access[_ -]?token|password|private[_ -]?key)"
+        r"\s*(?::|=).*$",
+        r"(?im)^.*(?:api[_ -]?key|access[_ -]?token|password|private[_ -]?key)"
+        r"\s*(?::|=).*$",
     ),
     (
         "openai_key",
-        re.compile(r"\bsk-[A-Za-z0-9_\-\s]{12,120}", re.IGNORECASE),
+        r"(?i)\bsk-[A-Za-z0-9_-]{12,120}",
+        r"(?i)\bsk-[A-Za-z0-9_-]{12,}\b",
     ),
     (
         "github_token",
-        re.compile(r"\bgh[opusr]_[A-Za-z0-9]{20,}\b", re.IGNORECASE),
+        r"(?i)\bgh[opusr]_[A-Za-z0-9]{20,}\b",
+        r"(?i)\bgh[opusr]_[A-Za-z0-9]{20,}\b",
     ),
     (
         "jwt",
-        re.compile(
-            r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\."
-            r"[A-Za-z0-9_-]{8,}\b"
-        ),
+        r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\."
+        r"[A-Za-z0-9_-]{8,}\b",
+        r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\."
+        r"[A-Za-z0-9_-]{8,}\b",
     ),
     (
         "email",
-        re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE),
+        r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b",
+        r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b",
     ),
     (
         "phone",
-        re.compile(r"(?<!\w)(?:\+?\d[\s().-]*){9,15}(?!\w)"),
+        r"(?<!\w)(?:\+?\d[\s().-]*){9,15}(?!\w)",
+        r"(?<!\w)(?:\+?\d[\s().-]*){9,15}(?!\w)",
     ),
     (
         "private_url_parameter",
-        re.compile(r"(?i)([?&](?:token|key|secret|auth|signature)=)[^&\s)]+"),
+        r"(?i)([?&](?:token|key|secret|auth|signature)=)[^&\s)]+",
+        r"(?i)([?&](?:token|key|secret|auth|signature)=)[^&\s)]+",
     ),
     (
         "user_home",
-        re.compile(r"(?i)(?:[A-Z]:\\Users\\|/home/)[^\\/\s]+"),
+        r"(?i)(?:[A-Z]:\\Users\\|/home/)[^\\/\s]+",
+        r"(?i)(?:[A-Z]:\\Users\\|/home/)[^\\/\s]+",
     ),
     # Solana addresses and similar long base58 account identifiers. Hex digests
     # are intentionally left intact because they are useful provenance evidence.
     (
         "base58_account",
-        re.compile(r"(?<![A-Za-z0-9])[1-9A-HJ-NP-Za-km-z]{32,44}(?![A-Za-z0-9])"),
+        r"(?<![A-Za-z0-9])[1-9A-HJ-NP-Za-km-z]{32,44}(?![A-Za-z0-9])",
+        r"(?<![A-Za-z0-9])[1-9A-HJ-NP-Za-km-z]{32,44}(?![A-Za-z0-9])",
+    ),
+    (
+        "credential_transfer_instruction",
+        r"(?is)\b(?:send|share|paste|env[ií]a(?:me)?|comparte)\b"
+        r"[^.\n]{0,160}\b(?:credentials?|private\s+keys?|api\s*keys?|secrets?|"
+        r"credenciales?|claves?\s+privadas?|tokens?)\b[^.\n]*[.!]?",
+        r"(?is)\b(?:send|share|paste|env[ií]a(?:me)?|comparte)\b"
+        r"[^.\n]{0,160}\b(?:credentials?|private\s+keys?|api\s*keys?|secrets?|"
+        r"credenciales?|claves?\s+privadas?|tokens?)\b[^.\n]*[.!]?",
     ),
 )
 
-PRIVACY_GATE_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
-    (
-        "secret_assignment",
-        re.compile(
-            r"(?im)^.*(?:api[_ -]?key|access[_ -]?token|password|private[_ -]?key)"
-            r"\s*(?::|=).*$"
-        ),
-    ),
-    ("openai_key", re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b", re.IGNORECASE)),
-    ("github_token", re.compile(r"\bgh[opusr]_[A-Za-z0-9]{20,}\b", re.IGNORECASE)),
-    (
-        "jwt",
-        re.compile(
-            r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\."
-            r"[A-Za-z0-9_-]{8,}\b"
-        ),
-    ),
-    (
-        "email",
-        re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE),
-    ),
-    (
-        "base58_account",
-        re.compile(r"(?<![A-Za-z0-9])[1-9A-HJ-NP-Za-km-z]{32,44}(?![A-Za-z0-9])"),
-    ),
+REDACTION_RULES: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
+    (name, re.compile(redaction_pattern))
+    for name, redaction_pattern, _ in PRIVACY_RULE_SPECS
+)
+PRIVACY_GATE_RULES: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
+    (name, re.compile(gate_pattern)) for name, _, gate_pattern in PRIVACY_RULE_SPECS
 )
 
 
 @dataclass(frozen=True)
 class MessageRecord:
+    """One eligible public conversation message and its source provenance."""
+
     line_number: int
     timestamp: str
     session_id: str
@@ -118,6 +121,8 @@ class MessageRecord:
 
 @dataclass(frozen=True)
 class ExportedRecord:
+    """One privacy-redacted message prepared for OKF rendering."""
+
     record: MessageRecord
     entry_id: str
     title: str
@@ -126,15 +131,25 @@ class ExportedRecord:
     redactions: dict[str, int]
 
 
+@dataclass
+class ParseStats:
+    """Counts source records deliberately skipped during JSONL parsing."""
+
+    unparseable_lines: int = 0
+
+
 def _sha256_bytes(value: bytes) -> str:
+    """Return a lowercase SHA-256 digest for bytes."""
     return hashlib.sha256(value).hexdigest()
 
 
 def _sha256_text(value: str) -> str:
+    """Return a lowercase SHA-256 digest for UTF-8 text."""
     return _sha256_bytes(value.encode("utf-8"))
 
 
 def _sha256_file(path: Path) -> str:
+    """Stream a file into SHA-256 without loading it all into memory."""
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
@@ -145,6 +160,7 @@ def _sha256_file(path: Path) -> str:
 def _source_envelope_hash(
     session_id: str, line_number: int, timestamp: str, role: str, text: str
 ) -> str:
+    """Hash the canonical source envelope used as the provenance identity."""
     envelope = {
         "line_number": line_number,
         "role": role,
@@ -159,6 +175,7 @@ def _source_envelope_hash(
 
 
 def _message_text(payload: dict[str, Any]) -> str:
+    """Extract only public text blocks from a rollout message payload."""
     blocks = payload.get("content")
     if not isinstance(blocks, list):
         return ""
@@ -174,14 +191,18 @@ def _message_text(payload: dict[str, Any]) -> str:
     return "\n\n".join(texts).strip()
 
 
-def iter_message_records(source: Path) -> Iterable[MessageRecord]:
+def iter_message_records(
+    source: Path, stats: ParseStats | None = None
+) -> Iterable[MessageRecord]:
     """Yield public conversation messages from a Codex rollout JSONL file."""
+    parse_stats = stats if stats is not None else ParseStats()
     current_session_id = "unknown"
     with source.open("r", encoding="utf-8") as handle:
         for line_number, raw_line in enumerate(handle, start=1):
             try:
                 item = json.loads(raw_line)
             except json.JSONDecodeError:
+                parse_stats.unparseable_lines += 1
                 continue
             if not isinstance(item, dict):
                 continue
@@ -199,7 +220,7 @@ def iter_message_records(source: Path) -> Iterable[MessageRecord]:
             if role not in {"user", "assistant"}:
                 continue
             text = _message_text(payload)
-            if not text or INTERNAL_MESSAGE_RE.match(text):
+            if not text or INTERNAL_MESSAGE_RE.search(text):
                 continue
             timestamp = str(item.get("timestamp") or "")
             yield MessageRecord(
@@ -219,11 +240,10 @@ def redact_text(text: str, literals: Sequence[str] = ()) -> tuple[str, dict[str,
     redacted = text
     counts: Counter[str] = Counter()
     for literal in sorted({v for v in literals if v}, key=len, reverse=True):
-        count = redacted.lower().count(literal.lower())
+        redacted, count = re.subn(
+            re.escape(literal), "[REDACTED_LITERAL]", redacted, flags=re.I
+        )
         if count:
-            redacted = re.sub(
-                re.escape(literal), "[REDACTED_LITERAL]", redacted, flags=re.I
-            )
             counts["literal"] += count
     replacements = {
         "secret_assignment": "[REDACTED_SECRET_ASSIGNMENT]",
@@ -235,6 +255,10 @@ def redact_text(text: str, literals: Sequence[str] = ()) -> tuple[str, dict[str,
         "private_url_parameter": r"\1[REDACTED]",
         "user_home": "[USER_HOME]",
         "base58_account": "[REDACTED_ACCOUNT]",
+        "credential_transfer_instruction": (
+            "[SAFETY_SUMMARY: Private credentials must remain confidential and "
+            "must not be sent or shared.]"
+        ),
     }
     for name, pattern in REDACTION_RULES:
         redacted, count = pattern.subn(replacements[name], redacted)
@@ -244,6 +268,7 @@ def redact_text(text: str, literals: Sequence[str] = ()) -> tuple[str, dict[str,
 
 
 def privacy_findings(text: str) -> list[str]:
+    """Return privacy-rule names still present in published message text."""
     return [name for name, pattern in PRIVACY_GATE_RULES if pattern.search(text)]
 
 
@@ -256,6 +281,7 @@ def select_records(
     max_records: int,
     take: str,
 ) -> list[MessageRecord]:
+    """Apply role, regex, ordering, and count selection deterministically."""
     selected = [
         record
         for record in records
@@ -271,6 +297,7 @@ def select_records(
 
 
 def _safe_timestamp(value: str) -> str:
+    """Return a source timestamp or a valid UTC fallback."""
     if not value:
         return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     return value
@@ -282,6 +309,7 @@ def _json_yaml(value: Any) -> str:
 
 
 def _render_entry(item: ExportedRecord) -> str:
+    """Render one exported record as an OKF-compatible Markdown document."""
     record = item.record
     tags = ["codex-cli", "conversation", record.role, "privacy-redacted"]
     session_ref = _sha256_text(record.session_id)[:16]
@@ -313,6 +341,7 @@ def _render_entry(item: ExportedRecord) -> str:
 
 
 def _slug(item: ExportedRecord) -> str:
+    """Build a stable chronological filename for an exported record."""
     stamp = re.sub(r"[^0-9]", "", item.record.timestamp)[:14] or "undated"
     return f"{stamp}-{item.record.role}-{item.entry_id}.md"
 
@@ -320,6 +349,7 @@ def _slug(item: ExportedRecord) -> str:
 def _build_exported(
     records: Sequence[MessageRecord], literals: Sequence[str]
 ) -> list[ExportedRecord]:
+    """Redact selected records and fail closed before any output is created."""
     exported: list[ExportedRecord] = []
     for index, record in enumerate(records, start=1):
         redacted, counts = redact_text(record.text, literals)
@@ -345,6 +375,7 @@ def _build_exported(
 
 
 def _bundle_digest(memory_dir: Path) -> str:
+    """Hash the complete ordered set of conversation-memory files."""
     digest = hashlib.sha256()
     for path in sorted(memory_dir.glob("*.md")):
         digest.update(path.name.encode("utf-8"))
@@ -354,10 +385,25 @@ def _bundle_digest(memory_dir: Path) -> str:
     return digest.hexdigest()
 
 
+def _is_adapter_bundle(path: Path) -> bool:
+    """Return whether a directory has this adapter's recognizable marker."""
+    if not path.is_dir() or path.is_symlink():
+        return False
+    manifest_path = path / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    adapter = manifest.get("adapter")
+    return isinstance(adapter, str) and adapter == BUNDLE_ADAPTER
+
+
 def export_bundle(args: argparse.Namespace) -> dict[str, Any]:
+    """Export selected rollout messages into a validated OKF bundle."""
     source = args.source.resolve()
     output = args.output.resolve()
-    records = list(iter_message_records(source))
+    parse_stats = ParseStats()
+    records = list(iter_message_records(source, parse_stats))
     include = re.compile(args.include, re.IGNORECASE) if args.include else None
     exclude = re.compile(args.exclude, re.IGNORECASE) if args.exclude else None
     selected = select_records(
@@ -375,6 +421,10 @@ def export_bundle(args: argparse.Namespace) -> dict[str, Any]:
     if output.exists():
         if not args.force:
             raise FileExistsError(f"output already exists: {output} (use --force)")
+        if not _is_adapter_bundle(output):
+            raise ValueError(
+                f"refusing --force for non-{BUNDLE_ADAPTER} output: {output}"
+            )
         shutil.rmtree(output)
     memory_dir = output / "memories" / "conversation"
     memory_dir.mkdir(parents=True)
@@ -408,19 +458,20 @@ def export_bundle(args: argparse.Namespace) -> dict[str, Any]:
     )
     role_counts = Counter(item.record.role for item in exported)
     manifest = {
-        "adapter": "codex-cli-sessions-to-okf",
+        "adapter": BUNDLE_ADAPTER,
         "adapter_version": ADAPTER_VERSION,
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "source": {
             "sha256": _sha256_file(source),
             "bytes": source_size,
             "conversation_messages": len(records),
+            "unparseable_lines_skipped": parse_stats.unparseable_lines,
             "path_published": False,
         },
         "selection": {
             "roles": sorted(set(args.roles)),
-            "include_regex": args.include,
-            "exclude_regex": args.exclude,
+            "include_filter_applied": bool(args.include),
+            "exclude_filter_applied": bool(args.exclude),
             "take": args.take,
             "max_records": args.max_records,
             "selected": len(exported),
@@ -464,9 +515,6 @@ def export_bundle(args: argparse.Namespace) -> dict[str, Any]:
         ],
     }
     manifest_path = output / "manifest.json"
-    manifest_path.write_text(
-        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-    )
     manifest["bundle_sha256"] = _bundle_digest(memory_dir)
     manifest_path.write_text(
         json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
@@ -480,6 +528,7 @@ FRONTMATTER_FIELD_RE = re.compile(
 
 
 def _parse_entry_for_validation(path: Path) -> dict[str, Any]:
+    """Parse the small frontmatter subset emitted by this adapter."""
     text = path.read_text(encoding="utf-8")
     if not text.startswith("---\n") or "\n---\n" not in text[4:]:
         raise ValueError(f"invalid OKF frontmatter: {path}")
@@ -526,6 +575,7 @@ STOPWORDS = {
 
 
 def _tokens(text: str) -> set[str]:
+    """Return normalized lexical tokens for deterministic recall checks."""
     return {
         token
         for token in TOKEN_RE.findall(text.casefold())
@@ -534,6 +584,7 @@ def _tokens(text: str) -> set[str]:
 
 
 def _retrieve(query: str, documents: dict[str, str]) -> str | None:
+    """Retrieve one document with a deterministic lexical-overlap score."""
     query_tokens = _tokens(query)
     if not query_tokens:
         return None
@@ -553,6 +604,7 @@ def _retrieve(query: str, documents: dict[str, str]) -> str | None:
 
 
 def _normalize_evidence(text: str) -> str:
+    """Normalize whitespace and case for answer-evidence comparisons."""
     return " ".join(text.casefold().split())
 
 
@@ -613,11 +665,13 @@ def validate_golden_recall(
 
 
 def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
+    """Validate source linkage, entry integrity, privacy, and golden recall."""
     source = args.source.resolve()
     bundle = args.bundle.resolve()
     manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
     source_digest = _sha256_file(source)
-    source_records = list(iter_message_records(source))
+    parse_stats = ParseStats()
+    source_records = list(iter_message_records(source, parse_stats))
     source_documents = {
         record.source_record_sha256: record.text for record in source_records
     }
@@ -628,15 +682,20 @@ def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
     ]
 
     failures: list[str] = []
+    content_hash_mismatches = 0
+    privacy_gate_issue_count = 0
     if source_digest != manifest["source"]["sha256"]:
         failures.append("source digest differs from manifest")
+    if parse_stats.unparseable_lines != manifest["source"].get(
+        "unparseable_lines_skipped", 0
+    ):
+        failures.append("unparseable source-line count differs from manifest")
     manifest_records = {
         row["source_record_sha256"]: row for row in manifest.get("records", [])
     }
     okf_source_hashes: set[str] = set()
     okf_documents: dict[str, str] = {}
     for entry in okf_entries:
-        published_text = Path(str(entry["_path"])).read_text(encoding="utf-8")
         source_hash = str(entry.get("source_record_sha256", ""))
         okf_source_hashes.add(source_hash)
         okf_documents[source_hash] = str(entry.get("_content", ""))
@@ -647,9 +706,20 @@ def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
         expected = str(entry.get("content_sha256", ""))
         actual = _sha256_text(str(entry.get("_content", "")))
         if actual != expected:
+            content_hash_mismatches += 1
             failures.append(f"content hash mismatch: {entry['_path']}")
-        findings = privacy_findings(published_text)
+        manifest_expected = str(
+            manifest_records.get(source_hash, {}).get("content_sha256", "")
+        )
+        if actual != manifest_expected:
+            content_hash_mismatches += 1
+            failures.append(f"manifest content hash mismatch: {entry['_path']}")
+        # The adapter controls frontmatter metadata and hashes. Scan the only
+        # user-derived published field so timestamps and digests cannot be
+        # mistaken for phone numbers.
+        findings = privacy_findings(str(entry.get("_content", "")))
         if findings:
+            privacy_gate_issue_count += len(findings)
             failures.append(
                 f"privacy gate failed for {entry['_path']}: {', '.join(findings)}"
             )
@@ -681,8 +751,8 @@ def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
         "okf_entries": len(okf_entries),
         "source_to_okf_matched": matched,
         "source_to_okf_coverage": matched / selected if selected else 0.0,
-        "content_hash_parity": not any("content hash" in item for item in failures),
-        "privacy_gate_findings": sum("privacy gate" in item for item in failures),
+        "content_hash_parity": content_hash_mismatches == 0,
+        "privacy_gate_findings": privacy_gate_issue_count,
         "golden_qa": golden_report,
         "bundle_sha256": digest,
         "failures": failures,
@@ -695,6 +765,7 @@ def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the export and validation command-line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -732,6 +803,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """Run the requested CLI action and return a shell-friendly exit code."""
     args = build_parser().parse_args(argv)
     try:
         if args.command == "export":

--- a/examples/migrations/codex_cli_sessions/codex_to_okf.py
+++ b/examples/migrations/codex_cli_sessions/codex_to_okf.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+"""Export real Codex CLI rollout messages to a privacy-safe OKF bundle.
+
+The adapter intentionally reads only user/assistant conversation messages. It
+never exports reasoning, tool calls, tool outputs, developer instructions, or
+embedded images. Every exported entry carries a hash of its source envelope so
+the included validator can prove provenance without publishing the raw rollout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import sys
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ADAPTER_VERSION = "0.1.0"
+OKF_TYPE = "Codex CLI Conversation"
+
+INTERNAL_MESSAGE_RE = re.compile(
+    r"^\s*<(?:codex_internal_context|environment_context|permissions instructions)\b",
+    re.IGNORECASE,
+)
+
+# Order matters: redact assignment lines before matching individual token shapes.
+REDACTION_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "secret_assignment",
+        re.compile(
+            r"(?im)^.*(?:api[_ -]?key|access[_ -]?token|password|private[_ -]?key)"
+            r"\s*(?::|=).*$"
+        ),
+    ),
+    (
+        "openai_key",
+        re.compile(r"\bsk-[A-Za-z0-9_\-\s]{12,120}", re.IGNORECASE),
+    ),
+    (
+        "github_token",
+        re.compile(r"\bgh[opusr]_[A-Za-z0-9]{20,}\b", re.IGNORECASE),
+    ),
+    (
+        "jwt",
+        re.compile(
+            r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\."
+            r"[A-Za-z0-9_-]{8,}\b"
+        ),
+    ),
+    (
+        "email",
+        re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE),
+    ),
+    (
+        "phone",
+        re.compile(r"(?<!\w)(?:\+?\d[\s().-]*){9,15}(?!\w)"),
+    ),
+    (
+        "private_url_parameter",
+        re.compile(r"(?i)([?&](?:token|key|secret|auth|signature)=)[^&\s)]+"),
+    ),
+    (
+        "user_home",
+        re.compile(r"(?i)(?:[A-Z]:\\Users\\|/home/)[^\\/\s]+"),
+    ),
+    # Solana addresses and similar long base58 account identifiers. Hex digests
+    # are intentionally left intact because they are useful provenance evidence.
+    (
+        "base58_account",
+        re.compile(r"(?<![A-Za-z0-9])[1-9A-HJ-NP-Za-km-z]{32,44}(?![A-Za-z0-9])"),
+    ),
+)
+
+PRIVACY_GATE_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "secret_assignment",
+        re.compile(
+            r"(?im)^.*(?:api[_ -]?key|access[_ -]?token|password|private[_ -]?key)"
+            r"\s*(?::|=).*$"
+        ),
+    ),
+    ("openai_key", re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b", re.IGNORECASE)),
+    ("github_token", re.compile(r"\bgh[opusr]_[A-Za-z0-9]{20,}\b", re.IGNORECASE)),
+    (
+        "jwt",
+        re.compile(
+            r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\."
+            r"[A-Za-z0-9_-]{8,}\b"
+        ),
+    ),
+    (
+        "email",
+        re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE),
+    ),
+    (
+        "base58_account",
+        re.compile(r"(?<![A-Za-z0-9])[1-9A-HJ-NP-Za-km-z]{32,44}(?![A-Za-z0-9])"),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class MessageRecord:
+    line_number: int
+    timestamp: str
+    session_id: str
+    role: str
+    text: str
+    source_record_sha256: str
+
+
+@dataclass(frozen=True)
+class ExportedRecord:
+    record: MessageRecord
+    entry_id: str
+    title: str
+    redacted_text: str
+    content_sha256: str
+    redactions: dict[str, int]
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_text(value: str) -> str:
+    return _sha256_bytes(value.encode("utf-8"))
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_envelope_hash(
+    session_id: str, line_number: int, timestamp: str, role: str, text: str
+) -> str:
+    envelope = {
+        "line_number": line_number,
+        "role": role,
+        "session_id": session_id,
+        "text": text,
+        "timestamp": timestamp,
+    }
+    canonical = json.dumps(
+        envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    return _sha256_text(canonical)
+
+
+def _message_text(payload: dict[str, Any]) -> str:
+    blocks = payload.get("content")
+    if not isinstance(blocks, list):
+        return ""
+    texts: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") not in {"input_text", "output_text"}:
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text.strip():
+            texts.append(text.strip())
+    return "\n\n".join(texts).strip()
+
+
+def iter_message_records(source: Path) -> Iterable[MessageRecord]:
+    """Yield public conversation messages from a Codex rollout JSONL file."""
+    current_session_id = "unknown"
+    with source.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            try:
+                item = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(item, dict):
+                continue
+            payload = item.get("payload")
+            if item.get("type") == "session_meta" and isinstance(payload, dict):
+                candidate = payload.get("session_id") or payload.get("id")
+                if isinstance(candidate, str) and candidate:
+                    current_session_id = candidate
+                continue
+            if item.get("type") != "response_item" or not isinstance(payload, dict):
+                continue
+            if payload.get("type") != "message":
+                continue
+            role = payload.get("role")
+            if role not in {"user", "assistant"}:
+                continue
+            text = _message_text(payload)
+            if not text or INTERNAL_MESSAGE_RE.match(text):
+                continue
+            timestamp = str(item.get("timestamp") or "")
+            yield MessageRecord(
+                line_number=line_number,
+                timestamp=timestamp,
+                session_id=current_session_id,
+                role=role,
+                text=text,
+                source_record_sha256=_source_envelope_hash(
+                    current_session_id, line_number, timestamp, role, text
+                ),
+            )
+
+
+def redact_text(text: str, literals: Sequence[str] = ()) -> tuple[str, dict[str, int]]:
+    """Return deterministic redacted text and per-rule replacement counts."""
+    redacted = text
+    counts: Counter[str] = Counter()
+    for literal in sorted({v for v in literals if v}, key=len, reverse=True):
+        count = redacted.lower().count(literal.lower())
+        if count:
+            redacted = re.sub(
+                re.escape(literal), "[REDACTED_LITERAL]", redacted, flags=re.I
+            )
+            counts["literal"] += count
+    replacements = {
+        "secret_assignment": "[REDACTED_SECRET_ASSIGNMENT]",
+        "openai_key": "[REDACTED_OPENAI_KEY]",
+        "github_token": "[REDACTED_GITHUB_TOKEN]",
+        "jwt": "[REDACTED_JWT]",
+        "email": "[REDACTED_EMAIL]",
+        "phone": "[REDACTED_PHONE]",
+        "private_url_parameter": r"\1[REDACTED]",
+        "user_home": "[USER_HOME]",
+        "base58_account": "[REDACTED_ACCOUNT]",
+    }
+    for name, pattern in REDACTION_RULES:
+        redacted, count = pattern.subn(replacements[name], redacted)
+        if count:
+            counts[name] += count
+    return redacted.strip(), dict(sorted(counts.items()))
+
+
+def privacy_findings(text: str) -> list[str]:
+    return [name for name, pattern in PRIVACY_GATE_RULES if pattern.search(text)]
+
+
+def select_records(
+    records: Iterable[MessageRecord],
+    *,
+    roles: set[str],
+    include: re.Pattern[str] | None,
+    exclude: re.Pattern[str] | None,
+    max_records: int,
+    take: str,
+) -> list[MessageRecord]:
+    selected = [
+        record
+        for record in records
+        if record.role in roles
+        and (include is None or include.search(record.text))
+        and (exclude is None or not exclude.search(record.text))
+    ]
+    if max_records > 0 and len(selected) > max_records:
+        selected = (
+            selected[:max_records] if take == "first" else selected[-max_records:]
+        )
+    return selected
+
+
+def _safe_timestamp(value: str) -> str:
+    if not value:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return value
+
+
+def _json_yaml(value: Any) -> str:
+    """JSON scalars/lists are valid YAML and avoid handwritten escaping bugs."""
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _render_entry(item: ExportedRecord) -> str:
+    record = item.record
+    tags = ["codex-cli", "conversation", record.role, "privacy-redacted"]
+    session_ref = _sha256_text(record.session_id)[:16]
+    frontmatter = [
+        "---",
+        f"type: {_json_yaml(OKF_TYPE)}",
+        f"title: {_json_yaml(item.title)}",
+        "description: "
+        + _json_yaml(
+            "A privacy-redacted conversational memory from a real Codex CLI run."
+        ),
+        f"resource: {_json_yaml(f'codex://session/{session_ref}#line-{record.line_number}')}",
+        f"tags: {_json_yaml(tags)}",
+        f"timestamp: {_json_yaml(_safe_timestamp(record.timestamp))}",
+        f"source_tool: {_json_yaml('codex-cli')}",
+        f"source_role: {_json_yaml(record.role)}",
+        f"source_line: {record.line_number}",
+        f"source_record_sha256: {_json_yaml(record.source_record_sha256)}",
+        f"content_sha256: {_json_yaml(item.content_sha256)}",
+        f"redaction_count: {sum(item.redactions.values())}",
+        "---",
+        "",
+        f"# {item.title}",
+        "",
+        item.redacted_text,
+        "",
+    ]
+    return "\n".join(frontmatter)
+
+
+def _slug(item: ExportedRecord) -> str:
+    stamp = re.sub(r"[^0-9]", "", item.record.timestamp)[:14] or "undated"
+    return f"{stamp}-{item.record.role}-{item.entry_id}.md"
+
+
+def _build_exported(
+    records: Sequence[MessageRecord], literals: Sequence[str]
+) -> list[ExportedRecord]:
+    exported: list[ExportedRecord] = []
+    for index, record in enumerate(records, start=1):
+        redacted, counts = redact_text(record.text, literals)
+        findings = privacy_findings(redacted)
+        if findings:
+            raise ValueError(
+                f"privacy gate rejected source line {record.line_number}: "
+                + ", ".join(findings)
+            )
+        entry_id = record.source_record_sha256[:16]
+        title = f"Codex {record.role} memory {index:03d}"
+        exported.append(
+            ExportedRecord(
+                record=record,
+                entry_id=entry_id,
+                title=title,
+                redacted_text=redacted,
+                content_sha256=_sha256_text(redacted),
+                redactions=counts,
+            )
+        )
+    return exported
+
+
+def _bundle_digest(memory_dir: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(memory_dir.glob("*.md")):
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def export_bundle(args: argparse.Namespace) -> dict[str, Any]:
+    source = args.source.resolve()
+    output = args.output.resolve()
+    records = list(iter_message_records(source))
+    include = re.compile(args.include, re.IGNORECASE) if args.include else None
+    exclude = re.compile(args.exclude, re.IGNORECASE) if args.exclude else None
+    selected = select_records(
+        records,
+        roles=set(args.roles),
+        include=include,
+        exclude=exclude,
+        max_records=args.max_records,
+        take=args.take,
+    )
+    if not selected:
+        raise ValueError("no conversation records matched the selection")
+    exported = _build_exported(selected, args.redact_literal)
+
+    if output.exists():
+        if not args.force:
+            raise FileExistsError(f"output already exists: {output} (use --force)")
+        shutil.rmtree(output)
+    memory_dir = output / "memories" / "conversation"
+    memory_dir.mkdir(parents=True)
+    for item in exported:
+        (memory_dir / _slug(item)).write_text(_render_entry(item), encoding="utf-8")
+
+    index_lines = [
+        "---",
+        "type: index",
+        'title: "Codex CLI conversation memories"',
+        "---",
+        "",
+        "# Codex CLI conversation memories",
+        "",
+    ]
+    for path in sorted(memory_dir.glob("*.md")):
+        index_lines.append(f"- [{path.stem}](conversation/{path.name})")
+    (output / "memories" / "index.md").write_text(
+        "\n".join(index_lines) + "\n", encoding="utf-8"
+    )
+
+    redaction_totals: Counter[str] = Counter()
+    for item in exported:
+        redaction_totals.update(item.redactions)
+    source_size = source.stat().st_size
+    selected_source_text_bytes = sum(
+        len(item.record.text.encode("utf-8")) for item in exported
+    )
+    published_content_bytes = sum(
+        len(item.redacted_text.encode("utf-8")) for item in exported
+    )
+    role_counts = Counter(item.record.role for item in exported)
+    manifest = {
+        "adapter": "codex-cli-sessions-to-okf",
+        "adapter_version": ADAPTER_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "source": {
+            "sha256": _sha256_file(source),
+            "bytes": source_size,
+            "conversation_messages": len(records),
+            "path_published": False,
+        },
+        "selection": {
+            "roles": sorted(set(args.roles)),
+            "include_regex": args.include,
+            "exclude_regex": args.exclude,
+            "take": args.take,
+            "max_records": args.max_records,
+            "selected": len(exported),
+        },
+        "migration_summary": {
+            "source_conversation_messages": len(records),
+            "selected_source_records": len(exported),
+            "mapped_okf_memories": len(exported),
+            "skipped_selected_records": 0,
+            "per_role": dict(sorted(role_counts.items())),
+        },
+        "privacy": {
+            "raw_text_published": False,
+            "literal_values_persisted": False,
+            "redactions": dict(sorted(redaction_totals.items())),
+            "gate_findings": 0,
+        },
+        "savings_report": {
+            "source_rollout_bytes": source_size,
+            "selected_source_text_bytes": selected_source_text_bytes,
+            "published_redacted_text_bytes": published_content_bytes,
+            "source_api_calls": 0,
+            "migration_api_calls": 0,
+            "token_savings": "not_applicable_local_source",
+            "latency_savings": "not_applicable_local_source",
+            "note": (
+                "Codex rollouts and OKF are local files; no cost or latency "
+                "baseline is invented."
+            ),
+        },
+        "records": [
+            {
+                "entry_id": item.entry_id,
+                "role": item.record.role,
+                "source_line": item.record.line_number,
+                "source_record_sha256": item.record.source_record_sha256,
+                "content_sha256": item.content_sha256,
+                "redaction_count": sum(item.redactions.values()),
+            }
+            for item in exported
+        ],
+    }
+    manifest_path = output / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    manifest["bundle_sha256"] = _bundle_digest(memory_dir)
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+FRONTMATTER_FIELD_RE = re.compile(
+    r"^(?P<key>[A-Za-z_][A-Za-z0-9_]*):\s*(?P<value>.*)$", re.MULTILINE
+)
+
+
+def _parse_entry_for_validation(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n") or "\n---\n" not in text[4:]:
+        raise ValueError(f"invalid OKF frontmatter: {path}")
+    frontmatter, body = text[4:].split("\n---\n", 1)
+    fields: dict[str, Any] = {}
+    for match in FRONTMATTER_FIELD_RE.finditer(frontmatter):
+        raw_value = match.group("value")
+        try:
+            fields[match.group("key")] = json.loads(raw_value)
+        except json.JSONDecodeError:
+            fields[match.group("key")] = raw_value
+    body_lines = body.strip().splitlines()
+    content = "\n".join(body_lines[2:]).strip() if len(body_lines) >= 2 else ""
+    fields["_content"] = content
+    fields["_path"] = str(path)
+    return fields
+
+
+def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
+    source = args.source.resolve()
+    bundle = args.bundle.resolve()
+    manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
+    source_digest = _sha256_file(source)
+    source_records = list(iter_message_records(source))
+    source_hashes = {record.source_record_sha256 for record in source_records}
+    okf_entries = [
+        _parse_entry_for_validation(path)
+        for path in sorted((bundle / "memories" / "conversation").glob("*.md"))
+    ]
+
+    failures: list[str] = []
+    if source_digest != manifest["source"]["sha256"]:
+        failures.append("source digest differs from manifest")
+    manifest_records = {
+        row["source_record_sha256"]: row for row in manifest.get("records", [])
+    }
+    okf_source_hashes: set[str] = set()
+    for entry in okf_entries:
+        published_text = Path(str(entry["_path"])).read_text(encoding="utf-8")
+        source_hash = str(entry.get("source_record_sha256", ""))
+        okf_source_hashes.add(source_hash)
+        if source_hash not in source_hashes:
+            failures.append(
+                f"OKF entry has no matching source record: {source_hash[:16]}"
+            )
+        expected = str(entry.get("content_sha256", ""))
+        actual = _sha256_text(str(entry.get("_content", "")))
+        if actual != expected:
+            failures.append(f"content hash mismatch: {entry['_path']}")
+        findings = privacy_findings(published_text)
+        if findings:
+            failures.append(
+                f"privacy gate failed for {entry['_path']}: {', '.join(findings)}"
+            )
+    if set(manifest_records) != okf_source_hashes:
+        failures.append("manifest and OKF source-record sets differ")
+    digest = _bundle_digest(bundle / "memories" / "conversation")
+    if digest != manifest.get("bundle_sha256"):
+        failures.append("bundle digest differs from manifest")
+
+    selected = len(manifest_records)
+    matched = len(okf_source_hashes & source_hashes)
+    report = {
+        "valid": not failures,
+        "adapter_version": ADAPTER_VERSION,
+        "source_sha256_match": source_digest == manifest["source"]["sha256"],
+        "selected_source_records": selected,
+        "okf_entries": len(okf_entries),
+        "source_to_okf_matched": matched,
+        "source_to_okf_coverage": matched / selected if selected else 0.0,
+        "content_hash_parity": not any("content hash" in item for item in failures),
+        "privacy_gate_findings": sum("privacy gate" in item for item in failures),
+        "bundle_sha256": digest,
+        "failures": failures,
+    }
+    if args.report:
+        args.report.write_text(
+            json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    export = subparsers.add_parser("export", help="export a rollout JSONL to OKF")
+    export.add_argument("source", type=Path)
+    export.add_argument("--output", type=Path, required=True)
+    export.add_argument(
+        "--roles",
+        nargs="+",
+        choices=("user", "assistant"),
+        default=["user", "assistant"],
+    )
+    export.add_argument(
+        "--include", help="case-insensitive regex applied before redaction"
+    )
+    export.add_argument("--exclude", help="case-insensitive exclusion regex")
+    export.add_argument("--max-records", type=int, default=100)
+    export.add_argument("--take", choices=("first", "last"), default="last")
+    export.add_argument(
+        "--redact-literal",
+        action="append",
+        default=[],
+        help="private literal to replace; repeatable and never stored",
+    )
+    export.add_argument("--force", action="store_true")
+
+    validate = subparsers.add_parser(
+        "validate", help="prove source provenance, content parity, and privacy"
+    )
+    validate.add_argument("source", type=Path)
+    validate.add_argument("bundle", type=Path)
+    validate.add_argument("--report", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "export":
+            result = export_bundle(args)
+            summary = {
+                "selected": result["selection"]["selected"],
+                "redactions": result["privacy"]["redactions"],
+                "bundle_sha256": result["bundle_sha256"],
+            }
+        else:
+            result = validate_bundle(args)
+            summary = result
+        print(json.dumps(summary, indent=2, ensure_ascii=False))
+        return 0 if result.get("valid", True) else 1
+    except (FileNotFoundError, FileExistsError, ValueError, KeyError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/migrations/codex_cli_sessions/codex_to_okf.py
+++ b/examples/migrations/codex_cli_sessions/codex_to_okf.py
@@ -498,13 +498,130 @@ def _parse_entry_for_validation(path: Path) -> dict[str, Any]:
     return fields
 
 
+TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
+STOPWORDS = {
+    "a",
+    "al",
+    "and",
+    "como",
+    "con",
+    "de",
+    "del",
+    "el",
+    "en",
+    "for",
+    "how",
+    "la",
+    "las",
+    "los",
+    "of",
+    "por",
+    "que",
+    "the",
+    "to",
+    "un",
+    "una",
+    "y",
+}
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in TOKEN_RE.findall(text.casefold())
+        if len(token) > 1 and token not in STOPWORDS
+    }
+
+
+def _retrieve(query: str, documents: dict[str, str]) -> str | None:
+    query_tokens = _tokens(query)
+    if not query_tokens:
+        return None
+    ranked: list[tuple[float, str]] = []
+    for record_hash, text in documents.items():
+        document_tokens = _tokens(text)
+        overlap = query_tokens & document_tokens
+        if not overlap:
+            continue
+        # Reward coverage first and mildly penalize very broad documents. The
+        # same deterministic scorer is used before and after migration.
+        score = len(overlap) / len(query_tokens) + len(overlap) / max(
+            len(document_tokens), 1
+        )
+        ranked.append((score, record_hash))
+    return max(ranked, default=(0.0, None))[1]
+
+
+def _normalize_evidence(text: str) -> str:
+    return " ".join(text.casefold().split())
+
+
+def validate_golden_recall(
+    golden_path: Path,
+    source_documents: dict[str, str],
+    okf_documents: dict[str, str],
+) -> dict[str, Any]:
+    """Score deterministic golden-Q&A recall before and after migration."""
+    payload = json.loads(golden_path.read_text(encoding="utf-8"))
+    questions = payload.get("questions", [])
+    if not isinstance(questions, list) or not questions:
+        raise ValueError(f"golden Q&A has no questions: {golden_path}")
+    results: list[dict[str, Any]] = []
+    for item in questions:
+        if not isinstance(item, dict):
+            raise ValueError("golden Q&A entries must be objects")
+        question = str(item.get("question") or "")
+        expected = str(item.get("expected_source_record_sha256") or "")
+        evidence = item.get("answer_contains") or []
+        if isinstance(evidence, str):
+            evidence = [evidence]
+        if not question or not expected or not isinstance(evidence, list):
+            raise ValueError("golden Q&A entry is missing required fields")
+        source_match = _retrieve(question, source_documents)
+        okf_match = _retrieve(question, okf_documents)
+        source_text = _normalize_evidence(source_documents.get(expected, ""))
+        okf_text = _normalize_evidence(okf_documents.get(expected, ""))
+        evidence_values = [
+            _normalize_evidence(str(value)) for value in evidence if str(value).strip()
+        ]
+        source_evidence = all(value in source_text for value in evidence_values)
+        okf_evidence = all(value in okf_text for value in evidence_values)
+        results.append(
+            {
+                "id": str(item.get("id") or len(results) + 1),
+                "source_retrieved_expected": source_match == expected,
+                "okf_retrieved_expected": okf_match == expected,
+                "retrieval_parity": source_match == okf_match,
+                "source_answer_evidence": source_evidence,
+                "okf_answer_evidence": okf_evidence,
+            }
+        )
+    correct = sum(
+        row["source_retrieved_expected"]
+        and row["okf_retrieved_expected"]
+        and row["retrieval_parity"]
+        and row["source_answer_evidence"]
+        and row["okf_answer_evidence"]
+        for row in results
+    )
+    return {
+        "questions": len(results),
+        "fully_correct": correct,
+        "recall_parity_score": correct / len(results),
+        "results": results,
+    }
+
+
 def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
     source = args.source.resolve()
     bundle = args.bundle.resolve()
     manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
     source_digest = _sha256_file(source)
     source_records = list(iter_message_records(source))
-    source_hashes = {record.source_record_sha256 for record in source_records}
+    source_documents = {
+        record.source_record_sha256: record.text for record in source_records
+    }
+    source_hashes = set(source_documents)
     okf_entries = [
         _parse_entry_for_validation(path)
         for path in sorted((bundle / "memories" / "conversation").glob("*.md"))
@@ -517,10 +634,12 @@ def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
         row["source_record_sha256"]: row for row in manifest.get("records", [])
     }
     okf_source_hashes: set[str] = set()
+    okf_documents: dict[str, str] = {}
     for entry in okf_entries:
         published_text = Path(str(entry["_path"])).read_text(encoding="utf-8")
         source_hash = str(entry.get("source_record_sha256", ""))
         okf_source_hashes.add(source_hash)
+        okf_documents[source_hash] = str(entry.get("_content", ""))
         if source_hash not in source_hashes:
             failures.append(
                 f"OKF entry has no matching source record: {source_hash[:16]}"
@@ -540,6 +659,18 @@ def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
     if digest != manifest.get("bundle_sha256"):
         failures.append("bundle digest differs from manifest")
 
+    golden_path = getattr(args, "golden", None)
+    if golden_path is None:
+        default_golden = bundle / "golden_questions.json"
+        golden_path = default_golden if default_golden.exists() else None
+    golden_report = None
+    if golden_path is not None:
+        golden_report = validate_golden_recall(
+            Path(golden_path), source_documents, okf_documents
+        )
+        if golden_report["recall_parity_score"] != 1.0:
+            failures.append("golden Q&A recall parity is below 100%")
+
     selected = len(manifest_records)
     matched = len(okf_source_hashes & source_hashes)
     report = {
@@ -552,6 +683,7 @@ def validate_bundle(args: argparse.Namespace) -> dict[str, Any]:
         "source_to_okf_coverage": matched / selected if selected else 0.0,
         "content_hash_parity": not any("content hash" in item for item in failures),
         "privacy_gate_findings": sum("privacy gate" in item for item in failures),
+        "golden_qa": golden_report,
         "bundle_sha256": digest,
         "failures": failures,
     }
@@ -595,6 +727,7 @@ def build_parser() -> argparse.ArgumentParser:
     validate.add_argument("source", type=Path)
     validate.add_argument("bundle", type=Path)
     validate.add_argument("--report", type=Path)
+    validate.add_argument("--golden", type=Path, help="optional golden Q&A JSON")
     return parser
 
 

--- a/examples/migrations/codex_cli_sessions/run_demo.py
+++ b/examples/migrations/codex_cli_sessions/run_demo.py
@@ -37,6 +37,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-records", type=int, default=25)
     parser.add_argument("--take", choices=("first", "last"), default="last")
     parser.add_argument(
+        "--golden", type=Path, help="golden Q&A JSON tied to the selected source"
+    )
+    parser.add_argument(
         "--redact-literal",
         action="append",
         default=[],
@@ -69,6 +72,7 @@ def main() -> int:
             source=args.source,
             bundle=args.output,
             report=report_path,
+            golden=args.golden,
         )
     )
 
@@ -91,6 +95,7 @@ def main() -> int:
         "source_to_okf_coverage": validation["source_to_okf_coverage"],
         "content_hash_parity": validation["content_hash_parity"],
         "privacy_gate_findings": validation["privacy_gate_findings"],
+        "golden_qa": validation["golden_qa"],
         "memanto_dry_run": dry_run,
         "output": str(args.output.resolve()),
     }

--- a/examples/migrations/codex_cli_sessions/run_demo.py
+++ b/examples/migrations/codex_cli_sessions/run_demo.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from collections.abc import Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 
 from codex_to_okf import export_bundle, validate_bundle
 
 
 def _normalize_debug_env() -> None:
+    """Normalize unrelated ambient DEBUG values before importing Memanto."""
     # Some shells use DEBUG=release as a generic build marker, while Memanto
     # expects DEBUG to be boolean. Isolate the demo from that ambient convention.
     if os.environ.get("DEBUG", "").lower() not in {
@@ -29,6 +32,7 @@ def _normalize_debug_env() -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the one-command demo CLI parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("source", type=Path, help="real Codex rollout JSONL")
     parser.add_argument("--output", type=Path, default=Path("codex-okf-demo"))
@@ -36,6 +40,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--exclude", help="case-insensitive exclusion regex")
     parser.add_argument("--max-records", type=int, default=25)
     parser.add_argument("--take", choices=("first", "last"), default="last")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="replace an existing bundle created by this adapter",
+    )
     parser.add_argument(
         "--golden", type=Path, help="golden Q&A JSON tied to the selected source"
     )
@@ -48,12 +57,13 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main() -> int:
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run export, validation, and Memanto's pure dry-run mapping workflow."""
     _normalize_debug_env()
     from memanto.cli.migrate.mappers import map_okf
     from memanto.cli.migrate.okf_loader import load_okf_bundle
 
-    args = build_parser().parse_args()
+    args = build_parser().parse_args(argv)
     export_args = argparse.Namespace(
         source=args.source,
         output=args.output,
@@ -63,7 +73,7 @@ def main() -> int:
         max_records=args.max_records,
         take=args.take,
         redact_literal=args.redact_literal,
-        force=True,
+        force=args.force,
     )
     manifest = export_bundle(export_args)
     report_path = args.output / "roundtrip_report.json"
@@ -81,10 +91,13 @@ def main() -> int:
     loaded = load_okf_bundle(args.output)
     mapped = map_okf(loaded)
     dry_run = {
+        "command": f"memanto migrate okf {args.output.as_posix()} --dry-run",
+        "executed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "okf_nodes": len(loaded["memories"]),
         "mapped_memories": len(mapped),
         "skipped": len(loaded["memories"]) - len(mapped),
         "writes_performed": 0,
+        "api_key_required": False,
     }
     (args.output / "memanto_dry_run_report.json").write_text(
         json.dumps(dry_run, indent=2) + "\n", encoding="utf-8"

--- a/examples/migrations/codex_cli_sessions/run_demo.py
+++ b/examples/migrations/codex_cli_sessions/run_demo.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Run the Codex rollout -> OKF -> Memanto dry-run proof in one command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from codex_to_okf import export_bundle, validate_bundle
+
+
+def _normalize_debug_env() -> None:
+    # Some shells use DEBUG=release as a generic build marker, while Memanto
+    # expects DEBUG to be boolean. Isolate the demo from that ambient convention.
+    if os.environ.get("DEBUG", "").lower() not in {
+        "",
+        "0",
+        "1",
+        "false",
+        "no",
+        "off",
+        "on",
+        "true",
+        "yes",
+    }:
+        os.environ["DEBUG"] = "false"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="real Codex rollout JSONL")
+    parser.add_argument("--output", type=Path, default=Path("codex-okf-demo"))
+    parser.add_argument("--include", help="case-insensitive selection regex")
+    parser.add_argument("--exclude", help="case-insensitive exclusion regex")
+    parser.add_argument("--max-records", type=int, default=25)
+    parser.add_argument("--take", choices=("first", "last"), default="last")
+    parser.add_argument(
+        "--redact-literal",
+        action="append",
+        default=[],
+        help="private literal to redact; repeatable and never persisted",
+    )
+    return parser
+
+
+def main() -> int:
+    _normalize_debug_env()
+    from memanto.cli.migrate.mappers import map_okf
+    from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+    args = build_parser().parse_args()
+    export_args = argparse.Namespace(
+        source=args.source,
+        output=args.output,
+        roles=["user", "assistant"],
+        include=args.include,
+        exclude=args.exclude,
+        max_records=args.max_records,
+        take=args.take,
+        redact_literal=args.redact_literal,
+        force=True,
+    )
+    manifest = export_bundle(export_args)
+    report_path = args.output / "roundtrip_report.json"
+    validation = validate_bundle(
+        argparse.Namespace(
+            source=args.source,
+            bundle=args.output,
+            report=report_path,
+        )
+    )
+
+    # Exercise the same pure loader/mapper used by `memanto migrate okf
+    # --dry-run` without requiring a configured agent or Moorcheh API key.
+    loaded = load_okf_bundle(args.output)
+    mapped = map_okf(loaded)
+    dry_run = {
+        "okf_nodes": len(loaded["memories"]),
+        "mapped_memories": len(mapped),
+        "skipped": len(loaded["memories"]) - len(mapped),
+        "writes_performed": 0,
+    }
+    (args.output / "memanto_dry_run_report.json").write_text(
+        json.dumps(dry_run, indent=2) + "\n", encoding="utf-8"
+    )
+    result = {
+        "valid": validation["valid"] and dry_run["skipped"] == 0,
+        "selected": manifest["selection"]["selected"],
+        "source_to_okf_coverage": validation["source_to_okf_coverage"],
+        "content_hash_parity": validation["content_hash_parity"],
+        "privacy_gate_findings": validation["privacy_gate_findings"],
+        "memanto_dry_run": dry_run,
+        "output": str(args.output.resolve()),
+    }
+    print(json.dumps(result, indent=2))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/migrations/codex_cli_sessions/run_live_demo.py
+++ b/examples/migrations/codex_cli_sessions/run_live_demo.py
@@ -68,9 +68,7 @@ def _load_golden_cases(path: Path, bundle: Path) -> list[dict[str, str]]:
     items = payload.get("questions", [])
     manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
     record_by_source = {
-        str(record.get("source_record_sha256") or ""): str(
-            record.get("entry_id") or ""
-        )
+        str(record.get("source_record_sha256") or ""): str(record.get("entry_id") or "")
         for record in manifest.get("records", [])
         if isinstance(record, dict)
     }

--- a/examples/migrations/codex_cli_sessions/run_live_demo.py
+++ b/examples/migrations/codex_cli_sessions/run_live_demo.py
@@ -307,6 +307,39 @@ def _file_manifest(root: Path) -> list[dict[str, Any]]:
     return rows
 
 
+def _show_okf_preview(root: Path, transcript: Any) -> list[dict[str, Any]]:
+    """Print human-readable OKF files and return their secret-free metadata."""
+    candidates = [root / "memories" / "index.md"]
+    candidates.extend(
+        sorted(
+            path
+            for path in (root / "memories").rglob("*.md")
+            if path.name != "index.md"
+        )[:1]
+    )
+    previews: list[dict[str, Any]] = []
+    for path in candidates:
+        if not path.is_file():
+            continue
+        content = _sanitize_output(path.read_text(encoding="utf-8"))
+        relative = path.relative_to(root).as_posix()
+        heading = f"\n=== readable_okf: {relative} ===\n"
+        block = heading + content.rstrip() + "\n"
+        print(block, end="", flush=True)
+        transcript.write(block)
+        previews.append(
+            {
+                "path": relative,
+                "bytes": len(content.encode("utf-8")),
+                "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            }
+        )
+    transcript.flush()
+    if not previews:
+        raise FileNotFoundError(f"portable OKF contains no readable Markdown: {root}")
+    return previews
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Execute the live proof and persist a secret-free evidence package."""
     args = build_parser().parse_args(argv)
@@ -344,6 +377,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         environment = dict(os.environ)
         environment.update({"DEBUG": "false", "NO_COLOR": "1", "PYTHONUTF8": "1"})
         results: list[dict[str, Any]] = []
+        okf_previews: list[dict[str, Any]] = []
         transcript_path = output / "live_transcript.txt"
         started_at = _utc_now()
         with transcript_path.open("w", encoding="utf-8", newline="\n") as transcript:
@@ -356,6 +390,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         environment=environment,
                     )
                 )
+            okf_previews = _show_okf_preview(portable_output, transcript)
         verification = verify_live_results(results, cases, args.answer_count)
         public_results = []
         for result in results:
@@ -375,6 +410,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "commands": public_results,
             "verification": verification,
             "portable_okf_files": _file_manifest(portable_output),
+            "readable_okf_previews": okf_previews,
             "secrets_persisted": False,
         }
         (output / "live_demo_report.json").write_text(

--- a/examples/migrations/codex_cli_sessions/run_live_demo.py
+++ b/examples/migrations/codex_cli_sessions/run_live_demo.py
@@ -62,19 +62,47 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def _load_questions(path: Path) -> list[str]:
-    """Load non-empty golden questions from a validated JSON document."""
+def _load_golden_cases(path: Path, bundle: Path) -> list[dict[str, str]]:
+    """Load questions and derive the exact OKF title each must retrieve."""
     payload = json.loads(path.read_text(encoding="utf-8"))
     items = payload.get("questions", [])
-    questions = [
-        str(item.get("question") or "").strip()
-        for item in items
-        if isinstance(item, dict)
-    ]
-    questions = [question for question in questions if question]
-    if not questions:
+    manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
+    record_by_source = {
+        str(record.get("source_record_sha256") or ""): str(
+            record.get("entry_id") or ""
+        )
+        for record in manifest.get("records", [])
+        if isinstance(record, dict)
+    }
+    cases: list[dict[str, str]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        question = str(item.get("question") or "").strip()
+        source_hash = str(item.get("expected_source_record_sha256") or "").strip()
+        entry_id = record_by_source.get(source_hash, "")
+        if not question or not entry_id:
+            continue
+        matches = list((bundle / "memories").rglob(f"*{entry_id}*.md"))
+        if len(matches) != 1:
+            raise ValueError(
+                f"expected one OKF memory for golden source {source_hash}, "
+                f"found {len(matches)}"
+            )
+        text = matches[0].read_text(encoding="utf-8")
+        title_match = re.search(r'^title:\s*["\'](?P<title>.*?)["\']\s*$', text, re.M)
+        if not title_match:
+            raise ValueError(f"OKF memory has no quoted title: {matches[0]}")
+        cases.append(
+            {
+                "id": str(item.get("id") or entry_id),
+                "question": question,
+                "expected_title": title_match.group("title"),
+            }
+        )
+    if not cases:
         raise ValueError(f"golden Q&A has no questions: {path}")
-    return questions
+    return cases
 
 
 def build_command_plan(
@@ -183,6 +211,7 @@ def _run_command(
     transcript.write(heading)
     started = time.perf_counter()
     digest = hashlib.sha256()
+    captured_output: list[str] = []
     process = subprocess.Popen(
         list(command),
         stdout=subprocess.PIPE,
@@ -198,6 +227,7 @@ def _run_command(
         print(safe_line, end="", flush=True)
         transcript.write(safe_line)
         digest.update(safe_line.encode("utf-8"))
+        captured_output.append(safe_line)
     return_code = process.wait()
     elapsed = time.perf_counter() - started
     transcript.flush()
@@ -207,10 +237,59 @@ def _run_command(
         "return_code": return_code,
         "elapsed_seconds": round(elapsed, 3),
         "stdout_sha256": digest.hexdigest(),
+        # Kept only in memory for semantic verification and removed before the
+        # public JSON report is written; the full safe output stays in the
+        # transcript where a reviewer can inspect it.
+        "_stdout": "".join(captured_output),
     }
     if return_code:
         raise RuntimeError(f"{label} failed with exit code {return_code}")
     return result
+
+
+def verify_live_results(
+    results: Sequence[dict[str, Any]],
+    cases: Sequence[dict[str, str]],
+    answer_count: int,
+) -> dict[str, Any]:
+    """Prove the fresh agent was empty and each query retrieved its exact title."""
+    by_label = {str(item["label"]): item for item in results}
+    checks: list[dict[str, Any]] = []
+    for index, case in enumerate(cases, start=1):
+        before = str(by_label[f"before_recall_{index}"].get("_stdout") or "")
+        after = str(by_label[f"after_recall_{index}"].get("_stdout") or "")
+        title = case["expected_title"]
+        row: dict[str, Any] = {
+            "id": case["id"],
+            "before_import_empty": "No memories found" in before,
+            "after_import_exact_title_recalled": title in after,
+        }
+        if index <= max(answer_count, 0):
+            answer = str(by_label[f"after_answer_{index}"].get("_stdout") or "")
+            row["rag_context_includes_exact_title"] = title in answer
+        checks.append(row)
+    verified = all(
+        row["before_import_empty"]
+        and row["after_import_exact_title_recalled"]
+        and row.get("rag_context_includes_exact_title", True)
+        for row in checks
+    )
+    return {
+        "verified": verified,
+        "checks": checks,
+        "recall_passed": sum(
+            bool(row["after_import_exact_title_recalled"]) for row in checks
+        ),
+        "recall_total": len(checks),
+        "rag_context_passed": sum(
+            bool(row.get("rag_context_includes_exact_title"))
+            for row in checks
+            if "rag_context_includes_exact_title" in row
+        ),
+        "rag_context_total": sum(
+            "rag_context_includes_exact_title" in row for row in checks
+        ),
+    }
 
 
 def _file_manifest(root: Path) -> list[dict[str, Any]]:
@@ -250,7 +329,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         "codex-okf-live-%Y%m%d%H%M%S"
     )
     try:
-        questions = _load_questions(golden)
+        cases = _load_golden_cases(golden, bundle)
+        questions = [case["question"] for case in cases]
         output.mkdir(parents=True)
         portable_output = output / "portable_okf"
         bundle_cli = Path(os.path.relpath(bundle, Path.cwd()))
@@ -278,6 +358,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                         environment=environment,
                     )
                 )
+        verification = verify_live_results(results, cases, args.answer_count)
+        public_results = []
+        for result in results:
+            public_result = dict(result)
+            public_result.pop("_stdout", None)
+            public_results.append(public_result)
         report = {
             "schema_version": "1.0",
             "started_at": started_at,
@@ -288,7 +374,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             ).hexdigest(),
             "golden_questions": len(questions),
             "rag_answers_requested": min(max(args.answer_count, 0), len(questions)),
-            "commands": results,
+            "commands": public_results,
+            "verification": verification,
             "portable_okf_files": _file_manifest(portable_output),
             "secrets_persisted": False,
         }
@@ -296,8 +383,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             json.dumps(report, indent=2, ensure_ascii=False) + "\n",
             encoding="utf-8",
         )
-        print(f"\nPASS: live evidence written to {args.output}")
-        return 0
+        if verification["verified"]:
+            print(f"\nPASS: live evidence written to {args.output}")
+            return 0
+        print(
+            f"\nFAIL: live commands completed but semantic checks failed; "
+            f"evidence written to {args.output}",
+            file=sys.stderr,
+        )
+        return 1
     except (FileNotFoundError, ValueError, RuntimeError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/examples/migrations/codex_cli_sessions/run_live_demo.py
+++ b/examples/migrations/codex_cli_sessions/run_live_demo.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Run and record the live OKF -> Memanto -> portable OKF freedom loop.
+
+The script deliberately shells out to Memanto's shipped CLI so the transcript
+is evidence of the same public commands a user runs. It never reads or prints
+the Moorcheh key; the key is inherited by child processes from the environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the live-demo command-line parser."""
+    example_dir = Path(__file__).resolve().parent
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", type=Path, default=example_dir / "sample_okf")
+    parser.add_argument(
+        "--golden",
+        type=Path,
+        help="golden Q&A JSON (defaults to <bundle>/golden_questions.json)",
+    )
+    parser.add_argument(
+        "--agent",
+        help="new Memanto agent id (defaults to a timestamped demo id)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("codex-okf-live-evidence"),
+        help="new directory for transcript, report, and exported OKF",
+    )
+    parser.add_argument(
+        "--answer-count",
+        type=int,
+        default=5,
+        help="number of golden questions to answer with RAG after import",
+    )
+    parser.add_argument(
+        "--memanto-bin",
+        help="Memanto executable (defaults to the executable on PATH)",
+    )
+    return parser
+
+
+def _utc_now() -> str:
+    """Return the current UTC time in an ISO-8601 form."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _load_questions(path: Path) -> list[str]:
+    """Load non-empty golden questions from a validated JSON document."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    items = payload.get("questions", [])
+    questions = [
+        str(item.get("question") or "").strip()
+        for item in items
+        if isinstance(item, dict)
+    ]
+    questions = [question for question in questions if question]
+    if not questions:
+        raise ValueError(f"golden Q&A has no questions: {path}")
+    return questions
+
+
+def build_command_plan(
+    *,
+    memanto_bin: str,
+    agent_id: str,
+    bundle: Path,
+    portable_output: Path,
+    questions: Sequence[str],
+    answer_count: int,
+) -> list[tuple[str, list[str]]]:
+    """Build the exact shipped-CLI command sequence for the freedom loop."""
+    plan: list[tuple[str, list[str]]] = [
+        (
+            "create_empty_agent",
+            [
+                memanto_bin,
+                "agent",
+                "create",
+                agent_id,
+                "--pattern",
+                "project",
+                "--description",
+                "Live Codex CLI to OKF portability proof",
+            ],
+        )
+    ]
+    for index, question in enumerate(questions, start=1):
+        plan.append(
+            (
+                f"before_recall_{index}",
+                [memanto_bin, "recall", question, "--limit", "1"],
+            )
+        )
+    plan.append(
+        (
+            "import_okf",
+            [memanto_bin, "migrate", "okf", str(bundle), "--agent", agent_id],
+        )
+    )
+    for index, question in enumerate(questions, start=1):
+        plan.append(
+            (
+                f"after_recall_{index}",
+                [memanto_bin, "recall", question, "--limit", "1"],
+            )
+        )
+    for index, question in enumerate(questions[: max(answer_count, 0)], start=1):
+        plan.append(
+            (
+                f"after_answer_{index}",
+                [memanto_bin, "answer", question, "--limit", "3"],
+            )
+        )
+    plan.append(
+        (
+            "export_portable_okf",
+            [
+                memanto_bin,
+                "memory",
+                "export",
+                "--agent",
+                agent_id,
+                "--output",
+                str(portable_output),
+                "--limit",
+                "100",
+                "--okf",
+            ],
+        )
+    )
+    return plan
+
+
+def _public_command(command: Sequence[str]) -> str:
+    """Format a command without exposing the executable's local absolute path."""
+    public = ["memanto", *command[1:]]
+    return shlex.join(public)
+
+
+def _sanitize_output(text: str) -> str:
+    """Remove machine-specific home and working-directory paths from evidence."""
+    sanitized = text
+    replacements = (
+        (str(Path.cwd()), "."),
+        (str(Path.home()), "$HOME"),
+    )
+    for private_path, public_path in replacements:
+        sanitized = re.sub(
+            re.escape(private_path), public_path, sanitized, flags=re.IGNORECASE
+        )
+    return sanitized
+
+
+def _run_command(
+    label: str,
+    command: Sequence[str],
+    *,
+    transcript: Any,
+    environment: dict[str, str],
+) -> dict[str, Any]:
+    """Stream one command to screen and transcript, returning safe metadata."""
+    display = _public_command(command)
+    heading = f"\n=== {label} ===\n$ {display}\n"
+    print(heading, end="", flush=True)
+    transcript.write(heading)
+    started = time.perf_counter()
+    digest = hashlib.sha256()
+    process = subprocess.Popen(
+        list(command),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=environment,
+    )
+    assert process.stdout is not None
+    for line in process.stdout:
+        safe_line = _sanitize_output(line)
+        print(safe_line, end="", flush=True)
+        transcript.write(safe_line)
+        digest.update(safe_line.encode("utf-8"))
+    return_code = process.wait()
+    elapsed = time.perf_counter() - started
+    transcript.flush()
+    result = {
+        "label": label,
+        "command": display,
+        "return_code": return_code,
+        "elapsed_seconds": round(elapsed, 3),
+        "stdout_sha256": digest.hexdigest(),
+    }
+    if return_code:
+        raise RuntimeError(f"{label} failed with exit code {return_code}")
+    return result
+
+
+def _file_manifest(root: Path) -> list[dict[str, Any]]:
+    """Return hashes and sizes for every file in a portable OKF export."""
+    if not root.is_dir():
+        raise FileNotFoundError(f"portable OKF export was not created: {root}")
+    rows: list[dict[str, Any]] = []
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        content = path.read_bytes()
+        rows.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "bytes": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+        )
+    return rows
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Execute the live proof and persist a secret-free evidence package."""
+    args = build_parser().parse_args(argv)
+    if not os.environ.get("MOORCHEH_API_KEY"):
+        print("error: MOORCHEH_API_KEY is not set", file=sys.stderr)
+        return 2
+    memanto_bin = args.memanto_bin or shutil.which("memanto")
+    if not memanto_bin:
+        print("error: memanto executable not found on PATH", file=sys.stderr)
+        return 2
+    bundle = args.bundle.resolve()
+    golden = (args.golden or bundle / "golden_questions.json").resolve()
+    output = args.output.resolve()
+    if output.exists():
+        print(f"error: output already exists: {output}", file=sys.stderr)
+        return 2
+    agent_id = args.agent or datetime.now(timezone.utc).strftime(
+        "codex-okf-live-%Y%m%d%H%M%S"
+    )
+    try:
+        questions = _load_questions(golden)
+        output.mkdir(parents=True)
+        portable_output = output / "portable_okf"
+        bundle_cli = Path(os.path.relpath(bundle, Path.cwd()))
+        portable_output_cli = Path(os.path.relpath(portable_output, Path.cwd()))
+        plan = build_command_plan(
+            memanto_bin=memanto_bin,
+            agent_id=agent_id,
+            bundle=bundle_cli,
+            portable_output=portable_output_cli,
+            questions=questions,
+            answer_count=args.answer_count,
+        )
+        environment = dict(os.environ)
+        environment.update({"DEBUG": "false", "NO_COLOR": "1", "PYTHONUTF8": "1"})
+        results: list[dict[str, Any]] = []
+        transcript_path = output / "live_transcript.txt"
+        started_at = _utc_now()
+        with transcript_path.open("w", encoding="utf-8", newline="\n") as transcript:
+            for label, command in plan:
+                results.append(
+                    _run_command(
+                        label,
+                        command,
+                        transcript=transcript,
+                        environment=environment,
+                    )
+                )
+        report = {
+            "schema_version": "1.0",
+            "started_at": started_at,
+            "completed_at": _utc_now(),
+            "agent_id": agent_id,
+            "source_bundle_manifest_sha256": hashlib.sha256(
+                (bundle / "manifest.json").read_bytes()
+            ).hexdigest(),
+            "golden_questions": len(questions),
+            "rag_answers_requested": min(max(args.answer_count, 0), len(questions)),
+            "commands": results,
+            "portable_okf_files": _file_manifest(portable_output),
+            "secrets_persisted": False,
+        }
+        (output / "live_demo_report.json").write_text(
+            json.dumps(report, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print(f"\nPASS: live evidence written to {args.output}")
+        return 0
+    except (FileNotFoundError, ValueError, RuntimeError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/migrations/codex_cli_sessions/sample_okf/golden_questions.json
+++ b/examples/migrations/codex_cli_sessions/sample_okf/golden_questions.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.0",
+  "language": "es",
+  "questions": [
+    {
+      "id": "memo-ambiguity",
+      "question": "¿Qué ambigüedad corrigió la auditoría de la transacción Memo?",
+      "expected_source_record_sha256": "74beffcf844ccd992371b12dd3b3ebe27ed38a66daa83a6c8efe62f5befec98c",
+      "answer_contains": [
+        "exactamente una",
+        "instrucción Memo"
+      ]
+    },
+    {
+      "id": "proofpatch-suite",
+      "question": "¿Cuántas pruebas aprobó la suite final de ProofPatch?",
+      "expected_source_record_sha256": "0a6fc07da6f13a74578fa7415fccc8869bc96620504559321276d6b0b64b1b62",
+      "answer_contains": [
+        "190 aprobadas",
+        "0 fallos"
+      ]
+    },
+    {
+      "id": "disconnected-output",
+      "question": "¿Por qué se detenía el proceso al intentar registrar cada acción?",
+      "expected_source_record_sha256": "16401806659fd927a08e10d43c62462ce99b87ffc1b01e28f4ef345997a38c02",
+      "answer_contains": [
+        "salida desconectada",
+        "registrar cada acción"
+      ]
+    },
+    {
+      "id": "three-round-replay",
+      "question": "¿Cuántas firmas autorizadas, solicitudes y acciones indebidas produjo la reproducción?",
+      "expected_source_record_sha256": "a42f7f14223fc2d1134db3a1a408f21f03783e1aec675c12e5006db44966558f",
+      "answer_contains": [
+        "6 firmas autorizadas",
+        "9 solicitudes",
+        "0 acciones indebidas"
+      ]
+    },
+    {
+      "id": "server-outage",
+      "question": "¿Qué hacía el supervisor cuando el servidor del torneo quedó fuera de servicio?",
+      "expected_source_record_sha256": "69b7b063097d6d3606558bb4e5a9829ffeae06fb058a6f43e5363f4b6dfee0a0",
+      "answer_contains": [
+        "supervisor continúa intentando"
+      ]
+    }
+  ]
+}

--- a/examples/migrations/codex_cli_sessions/sample_okf/manifest.json
+++ b/examples/migrations/codex_cli_sessions/sample_okf/manifest.json
@@ -1,11 +1,12 @@
 {
   "adapter": "codex-cli-sessions-to-okf",
   "adapter_version": "0.1.0",
-  "generated_at": "2026-08-01T21:53:42.359551Z",
+  "generated_at": "2026-08-01T22:25:14.791164Z",
   "source": {
     "sha256": "85ced504bf42bf80d6ff46919d58c52b7b723fa8929b277d68cdd9d4793d9198",
     "bytes": 62938881,
-    "conversation_messages": 294,
+    "conversation_messages": 293,
+    "unparseable_lines_skipped": 0,
     "path_published": false
   },
   "selection": {
@@ -13,14 +14,14 @@
       "assistant",
       "user"
     ],
-    "include_regex": "ProofPatch|Solana|receipt|recibo|reproduc",
-    "exclude_regex": null,
+    "include_filter_applied": true,
+    "exclude_filter_applied": false,
     "take": "last",
     "max_records": 14,
     "selected": 14
   },
   "migration_summary": {
-    "source_conversation_messages": 294,
+    "source_conversation_messages": 293,
     "selected_source_records": 14,
     "mapped_okf_memories": 14,
     "skipped_selected_records": 0,
@@ -31,13 +32,15 @@
   "privacy": {
     "raw_text_published": false,
     "literal_values_persisted": false,
-    "redactions": {},
+    "redactions": {
+      "credential_transfer_instruction": 1
+    },
     "gate_findings": 0
   },
   "savings_report": {
     "source_rollout_bytes": 62938881,
     "selected_source_text_bytes": 4750,
-    "published_redacted_text_bytes": 4750,
+    "published_redacted_text_bytes": 4716,
     "source_api_calls": 0,
     "migration_api_calls": 0,
     "token_savings": "not_applicable_local_source",
@@ -106,8 +109,8 @@
       "role": "assistant",
       "source_line": 6068,
       "source_record_sha256": "0ced6cea986bfc2ecc76a8dbb63d5ab82005468757e46eaba5d64550cad54621",
-      "content_sha256": "2334d2d52ff0047b5d6b4c84a6f45fd91adda0b59757545cce54ff869ec043da",
-      "redaction_count": 0
+      "content_sha256": "a1c28f4ea1be36a6682c50c1a83efe587b03f3024f88d14e4d7f81511366f52c",
+      "redaction_count": 1
     },
     {
       "entry_id": "17beb66c9ee6b2d8",
@@ -158,5 +161,5 @@
       "redaction_count": 0
     }
   ],
-  "bundle_sha256": "2b15029153677059fc2e2c2cd6d16519c08d603011224076fb456888808afd5b"
+  "bundle_sha256": "e983c43dc6f1cc9d800652e9b5d2084b3b5da25dc69d3373f58ae184b9292404"
 }

--- a/examples/migrations/codex_cli_sessions/sample_okf/manifest.json
+++ b/examples/migrations/codex_cli_sessions/sample_okf/manifest.json
@@ -1,0 +1,162 @@
+{
+  "adapter": "codex-cli-sessions-to-okf",
+  "adapter_version": "0.1.0",
+  "generated_at": "2026-08-01T21:53:42.359551Z",
+  "source": {
+    "sha256": "85ced504bf42bf80d6ff46919d58c52b7b723fa8929b277d68cdd9d4793d9198",
+    "bytes": 62938881,
+    "conversation_messages": 294,
+    "path_published": false
+  },
+  "selection": {
+    "roles": [
+      "assistant",
+      "user"
+    ],
+    "include_regex": "ProofPatch|Solana|receipt|recibo|reproduc",
+    "exclude_regex": null,
+    "take": "last",
+    "max_records": 14,
+    "selected": 14
+  },
+  "migration_summary": {
+    "source_conversation_messages": 294,
+    "selected_source_records": 14,
+    "mapped_okf_memories": 14,
+    "skipped_selected_records": 0,
+    "per_role": {
+      "assistant": 14
+    }
+  },
+  "privacy": {
+    "raw_text_published": false,
+    "literal_values_persisted": false,
+    "redactions": {},
+    "gate_findings": 0
+  },
+  "savings_report": {
+    "source_rollout_bytes": 62938881,
+    "selected_source_text_bytes": 4750,
+    "published_redacted_text_bytes": 4750,
+    "source_api_calls": 0,
+    "migration_api_calls": 0,
+    "token_savings": "not_applicable_local_source",
+    "latency_savings": "not_applicable_local_source",
+    "note": "Codex rollouts and OKF are local files; no cost or latency baseline is invented."
+  },
+  "records": [
+    {
+      "entry_id": "40c4c3fdc04d4eea",
+      "role": "assistant",
+      "source_line": 4702,
+      "source_record_sha256": "40c4c3fdc04d4eeab6d50fea857f90f9d51045e6a91589b2f37ad5643f77b2b3",
+      "content_sha256": "5620cc4f5a9884739061ad39df75bfe911d581fbfd8d99542a37a2ea5aa733c6",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "303736d7bf9322db",
+      "role": "assistant",
+      "source_line": 4822,
+      "source_record_sha256": "303736d7bf9322db12d6defa0e9fdcad02e244058c4e5a44bea10010624d5a3e",
+      "content_sha256": "6ef393234b65b151c6a70787004af319634ec85bd58d1f144058e323aa7433f1",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "74beffcf844ccd99",
+      "role": "assistant",
+      "source_line": 5071,
+      "source_record_sha256": "74beffcf844ccd992371b12dd3b3ebe27ed38a66daa83a6c8efe62f5befec98c",
+      "content_sha256": "18badb4b79eeea9ed31379b61bde4c8d584ee5d2cebc5d0656076673f785f9e7",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "e9ce49caf0456533",
+      "role": "assistant",
+      "source_line": 5163,
+      "source_record_sha256": "e9ce49caf0456533021b0868f3a7cefd7d5867c1eccbc82bce4cbe80c26ffab2",
+      "content_sha256": "20f5f4c4586d0a3eedf8841d27de455ddc5fa69f6800693901282a9de66c01b0",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "8101b1c5357227ee",
+      "role": "assistant",
+      "source_line": 5484,
+      "source_record_sha256": "8101b1c5357227ee75dcb2ce246bba64161d547db534f350a960f692658bde8c",
+      "content_sha256": "d8ee106f4b9ba0986987165d26322330f9caa7ce25402492c7b1c8a7b5029839",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "c9e1ccf2028bfa02",
+      "role": "assistant",
+      "source_line": 5831,
+      "source_record_sha256": "c9e1ccf2028bfa0268478f207832272194fec792db952a06a7c7f703b2b0e741",
+      "content_sha256": "a4812b33a1a1475c915a33ecbfe1bc0f6c1f01619327c16f694fefa390c9cd46",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "0a6fc07da6f13a74",
+      "role": "assistant",
+      "source_line": 5916,
+      "source_record_sha256": "0a6fc07da6f13a74578fa7415fccc8869bc96620504559321276d6b0b64b1b62",
+      "content_sha256": "9a97ebd5ddb5916467a6657d0983c8f3dbe2166166a5a9f8c9ea16fbea91e780",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "0ced6cea986bfc2e",
+      "role": "assistant",
+      "source_line": 6068,
+      "source_record_sha256": "0ced6cea986bfc2ecc76a8dbb63d5ab82005468757e46eaba5d64550cad54621",
+      "content_sha256": "2334d2d52ff0047b5d6b4c84a6f45fd91adda0b59757545cce54ff869ec043da",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "17beb66c9ee6b2d8",
+      "role": "assistant",
+      "source_line": 6916,
+      "source_record_sha256": "17beb66c9ee6b2d82aecb35d3371306c15df120e2c475696ed8d3e16069e15b9",
+      "content_sha256": "1aea453b2abecefb7003ee952fa9bbb4f00c4d386af2ece03a3efcbbdb1a4959",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "16401806659fd927",
+      "role": "assistant",
+      "source_line": 7173,
+      "source_record_sha256": "16401806659fd927a08e10d43c62462ce99b87ffc1b01e28f4ef345997a38c02",
+      "content_sha256": "2884c155cd1072c12cd0728580d36262545de2bd879bc4fce35d6f6fddcdc143",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "a42f7f14223fc2d1",
+      "role": "assistant",
+      "source_line": 7206,
+      "source_record_sha256": "a42f7f14223fc2d1134db3a1a408f21f03783e1aec675c12e5006db44966558f",
+      "content_sha256": "fa0b1a8c08aa0695fbbe0257b96c03b02d3d6e04b1b29354bf0337e19d149177",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "4d0d3a71a5563a5e",
+      "role": "assistant",
+      "source_line": 7443,
+      "source_record_sha256": "4d0d3a71a5563a5e97271dd077b41f983c2e05a662608f0a73299a25d026299f",
+      "content_sha256": "78e0a17f31b910ead0f48789114fcb9b2cf765b990a4d22287678d683dda20a9",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "da6447f2ba127cf3",
+      "role": "assistant",
+      "source_line": 9124,
+      "source_record_sha256": "da6447f2ba127cf316c0a5e4033c4a3b43d537502c1bfd456c954ff086f73a56",
+      "content_sha256": "7191f84141104697067d88ac95b88f0f0ac8e541c910a58b33ed0be59ceac71e",
+      "redaction_count": 0
+    },
+    {
+      "entry_id": "69b7b063097d6d36",
+      "role": "assistant",
+      "source_line": 9722,
+      "source_record_sha256": "69b7b063097d6d3606558bb4e5a9829ffeae06fb058a6f43e5363f4b6dfee0a0",
+      "content_sha256": "b43a957ef468c3da013c86b00d6322fb8a6f521da804d87252c98f8b879af8b0",
+      "redaction_count": 0
+    }
+  ],
+  "bundle_sha256": "2b15029153677059fc2e2c2cd6d16519c08d603011224076fb456888808afd5b"
+}

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731084808-assistant-40c4c3fdc04d4eea.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731084808-assistant-40c4c3fdc04d4eea.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 001"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-4702"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-07-31T08:48:08.322Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 4702
+source_record_sha256: "40c4c3fdc04d4eeab6d50fea857f90f9d51045e6a91589b2f37ad5643f77b2b3"
+content_sha256: "5620cc4f5a9884739061ad39df75bfe911d581fbfd8d99542a37a2ea5aa733c6"
+redaction_count: 0
+---
+
+# Codex assistant memory 001
+
+La herramienta oficial de prueba de trabajo de Solana terminó de compilar correctamente (`devnet-pow 0.1.4`). Esto nos da una vía legítima para financiar la transacción de demostración sin usar fondos reales; ahora estoy comprobando que exista un faucet activo antes de firmar nada.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731085246-assistant-303736d7bf9322db.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731085246-assistant-303736d7bf9322db.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 002"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-4822"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-07-31T08:52:46.466Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 4822
+source_record_sha256: "303736d7bf9322db12d6defa0e9fdcad02e244058c4e5a44bea10010624d5a3e"
+content_sha256: "6ef393234b65b151c6a70787004af319634ec85bd58d1f144058e323aa7433f1"
+redaction_count: 0
+---
+
+# Codex assistant memory 002
+
+El verificador ya superó la revisión de navegador, móvil, TypeScript, build estático y OpenNext. También preparé la estrategia defensiva para The Email Game: pedir firmas ampliamente, pero firmar únicamente cuando la identidad autorizada sea inequívoca, para evitar la penalización más peligrosa del juego. Estoy añadiendo ahora el publicador reproducible de la primera prueba on-chain.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731090554-assistant-74beffcf844ccd99.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731090554-assistant-74beffcf844ccd99.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 003"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-5071"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-07-31T09:05:54.325Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 5071
+source_record_sha256: "74beffcf844ccd992371b12dd3b3ebe27ed38a66daa83a6c8efe62f5befec98c"
+content_sha256: "18badb4b79eeea9ed31379b61bde4c8d584ee5d2cebc5d0656076673f785f9e7"
+redaction_count: 0
+---
+
+# Codex assistant memory 003
+
+La auditoría independiente detectó una ambigüedad real: una transacción con el recibo correcto más un segundo Memo ajeno podía aceptarse. Ya la corregí; ahora se exige **exactamente una** instrucción Memo total. La nueva regresión y el conjunto combinado pasan con **120 pruebas aprobadas, 0 fallos** y una omisión exclusiva de enlaces simbólicos en Windows.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731090941-assistant-e9ce49caf0456533.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731090941-assistant-e9ce49caf0456533.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 004"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-5163"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-07-31T09:09:41.282Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 5163
+source_record_sha256: "e9ce49caf0456533021b0868f3a7cefd7d5867c1eccbc82bce4cbe80c26ffab2"
+content_sha256: "20f5f4c4586d0a3eedf8841d27de455ddc5fa69f6800693901282a9de66c01b0"
+redaction_count: 0
+---
+
+# Codex assistant memory 004
+
+Ya está confirmada la inscripción; también dejé activo el recordatorio automático para las **12:45 p. m.** de mañana. Ahora estoy aprovechando la espera para cerrar y publicar una versión verificable de ProofPatch, sin tocar tus cuentas ni exponer credenciales.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731092342-assistant-8101b1c5357227ee.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731092342-assistant-8101b1c5357227ee.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 005"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-5484"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-07-31T09:23:42.193Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 5484
+source_record_sha256: "8101b1c5357227ee75dcb2ce246bba64161d547db534f350a960f692658bde8c"
+content_sha256: "d8ee106f4b9ba0986987165d26322330f9caa7ce25402492c7b1c8a7b5029839"
+redaction_count: 0
+---
+
+# Codex assistant memory 005
+
+Estoy convirtiendo una mejora real del sitio en evidencia reproducible: ya guardé tres mediciones públicas “antes” y eliminé una hidratación innecesaria en la portada. La versión móvil y de escritorio quedó revisada visualmente; después de la auditoría de seguridad la publicaré y mediré tres veces en la misma URL.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731093911-assistant-c9e1ccf2028bfa02.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260731093911-assistant-c9e1ccf2028bfa02.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 006"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-5831"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-07-31T09:39:11.386Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 5831
+source_record_sha256: "c9e1ccf2028bfa0268478f207832272194fec792db952a06a7c7f703b2b0e741"
+content_sha256: "a4812b33a1a1475c915a33ecbfe1bc0f6c1f01619327c16f694fefa390c9cd46"
+redaction_count: 0
+---
+
+# Codex assistant memory 006
+
+Confirmado: no tienes que pagar ni instalar nada para la competencia. Ya dejé listo Python, el recordatorio y una estrategia defensiva para sumar puntos sin firmar mensajes no autorizados. En paralelo, la auditoría de ProofPatch ya cerró varios riesgos reales; estoy terminando la última revisión antes de publicarlo y medir el resultado.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801013941-assistant-0a6fc07da6f13a74.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801013941-assistant-0a6fc07da6f13a74.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 007"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-5916"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-08-01T01:39:41.066Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 5916
+source_record_sha256: "0a6fc07da6f13a74578fa7415fccc8869bc96620504559321276d6b0b64b1b62"
+content_sha256: "9a97ebd5ddb5916467a6657d0983c8f3dbe2166166a5a9f8c9ea16fbea91e780"
+redaction_count: 0
+---
+
+# Codex assistant memory 007
+
+La suite final de ProofPatch ya está en **190 aprobadas, 0 fallos y 1 omisión esperada de symlink en Windows**. Haré ahora el control de publicación: alcance exacto del diff, build estático/Cloudflare, commit, push y despliegue; después correré las tres mediciones públicas “después”.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801014845-assistant-0ced6cea986bfc2e.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801014845-assistant-0ced6cea986bfc2e.md
@@ -9,12 +9,12 @@ source_tool: "codex-cli"
 source_role: "assistant"
 source_line: 6068
 source_record_sha256: "0ced6cea986bfc2ecc76a8dbb63d5ab82005468757e46eaba5d64550cad54621"
-content_sha256: "2334d2d52ff0047b5d6b4c84a6f45fd91adda0b59757545cce54ff869ec043da"
-redaction_count: 0
+content_sha256: "a1c28f4ea1be36a6682c50c1a83efe587b03f3024f88d14e4d7f81511366f52c"
+redaction_count: 1
 ---
 
 # Codex assistant memory 008
 
-Perfecto: ese correo confirma que estás dentro. Pulsa **“Sí”** en la invitación; mañana, sábado 1 de agosto, empieza a la **1:00 p. m. hora de Perú**. A esa hora, envíame el enlace del repositorio y las credenciales privadas que te lleguen; no las publiques ni las compartas con nadie más.
+Perfecto: ese correo confirma que estás dentro. Pulsa **“Sí”** en la invitación; mañana, sábado 1 de agosto, empieza a la **1:00 p. m. hora de Perú**. A esa hora, [SAFETY_SUMMARY: Private credentials must remain confidential and must not be sent or shared.]
 
 Mientras tanto sigo cerrando ProofPatch: voy a publicar la versión auditada y medir el resultado real para fortalecer la solicitud de 200 USDG.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801014845-assistant-0ced6cea986bfc2e.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801014845-assistant-0ced6cea986bfc2e.md
@@ -1,0 +1,20 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 008"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-6068"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-08-01T01:48:45.649Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 6068
+source_record_sha256: "0ced6cea986bfc2ecc76a8dbb63d5ab82005468757e46eaba5d64550cad54621"
+content_sha256: "2334d2d52ff0047b5d6b4c84a6f45fd91adda0b59757545cce54ff869ec043da"
+redaction_count: 0
+---
+
+# Codex assistant memory 008
+
+Perfecto: ese correo confirma que estás dentro. Pulsa **“Sí”** en la invitación; mañana, sábado 1 de agosto, empieza a la **1:00 p. m. hora de Perú**. A esa hora, envíame el enlace del repositorio y las credenciales privadas que te lleguen; no las publiques ni las compartas con nadie más.
+
+Mientras tanto sigo cerrando ProofPatch: voy a publicar la versión auditada y medir el resultado real para fortalecer la solicitud de 200 USDG.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801180952-assistant-17beb66c9ee6b2d8.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801180952-assistant-17beb66c9ee6b2d8.md
@@ -1,0 +1,20 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 009"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-6916"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-08-01T18:09:52.242Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 6916
+source_record_sha256: "17beb66c9ee6b2d82aecb35d3371306c15df120e2c475696ed8d3e16069e15b9"
+content_sha256: "1aea453b2abecefb7003ee952fa9bbb4f00c4d386af2ece03a3efcbbdb1a4959"
+redaction_count: 0
+---
+
+# Codex assistant memory 009
+
+Perfecto: **ya está conectado y en la cola**, con presupuesto completo de **$30**. Falta sólo 1 jugador (`3/4 listo`).
+
+Pulsa ahora **“Reproduce la introducción”** y mírala completa mientras espera. Deja esa pestaña abierta; cuando aparezca el cuarto jugador comenzará automáticamente. Yo prepararé la versión optimizada en paralelo sin interrumpir esta primera partida.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801182652-assistant-16401806659fd927.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801182652-assistant-16401806659fd927.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 010"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-7173"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-08-01T18:26:52.753Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 7173
+source_record_sha256: "16401806659fd927a08e10d43c62462ce99b87ffc1b01e28f4ef345997a38c02"
+content_sha256: "2884c155cd1072c12cd0728580d36262545de2bd879bc4fce35d6f6fddcdc143"
+redaction_count: 0
+---
+
+# Codex assistant memory 010
+
+El historial privado aclaró el fallo: la lógica nueva sí era correcta, pero el proceso quedó con la salida desconectada al cambiarlo y se detenía al intentar registrar cada acción. La prueba real muestra que, con esas mismas autorizaciones, debía haber firmado **seis solicitudes válidas**. Estoy endureciendo el registro para que nunca pueda detener el juego y reproduciendo las tres rondas completas de esa partida antes del próximo cambio.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801182814-assistant-a42f7f14223fc2d1.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801182814-assistant-a42f7f14223fc2d1.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 011"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-7206"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-08-01T18:28:14.283Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 7206
+source_record_sha256: "a42f7f14223fc2d1134db3a1a408f21f03783e1aec675c12e5006db44966558f"
+content_sha256: "fa0b1a8c08aa0695fbbe0257b96c03b02d3d6e04b1b29354bf0337e19d149177"
+redaction_count: 0
+---
+
+# Codex assistant memory 011
+
+Sí, estoy al pendiente en tiempo real. Acaba de cerrar otra partida: consiguió una firma, pero cometió una firma no autorizada, así que el resultado neto fue 0. Estamos justo en el intervalo seguro y voy a cambiarlo ahora por la versión corregida, que en la reproducción exacta de tres rondas produjo **6 firmas autorizadas, 9 solicitudes y 0 acciones indebidas**.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801184054-assistant-4d0d3a71a5563a5e.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801184054-assistant-4d0d3a71a5563a5e.md
@@ -1,0 +1,22 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 012"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-7443"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-08-01T18:40:54.247Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 7443
+source_record_sha256: "4d0d3a71a5563a5e97271dd077b41f983c2e05a662608f0a73299a25d026299f"
+content_sha256: "78e0a17f31b910ead0f48789114fcb9b2cf765b990a4d22287678d683dda20a9"
+redaction_count: 0
+---
+
+# Codex assistant memory 012
+
+Código optimizado respaldado correctamente en el servidor de premios. Recibo verificable:
+
+`a1f0b05ca9e0017fe8f9c6d8855910b9a5ba0924d0df65d5cfe3fb8819b88b53`
+
+La primera llamada no heredó la clave del proceso de juego y fue rechazada sin efecto; la repetí cargando la credencial localmente, sin mostrarla, y quedó **SUBMITTED** a las 18:40:36 UTC. La última entrega antes del límite reemplazará esta copia.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801202819-assistant-da6447f2ba127cf3.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801202819-assistant-da6447f2ba127cf3.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 013"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-9124"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-08-01T20:28:19.285Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 9124
+source_record_sha256: "da6447f2ba127cf316c0a5e4033c4a3b43d537502c1bfd456c954ff086f73a56"
+content_sha256: "7191f84141104697067d88ac95b88f0f0ac8e541c910a58b33ed0be59ceac71e"
+redaction_count: 0
+---
+
+# Codex assistant memory 013
+
+La nueva versión ya quedó aceptada por el servidor con recibo. Detecté además un reenvío duplicado del moderador que estaba generando recordatorios repetidos; lo estoy cerrando para reducir carga y conservar velocidad.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801211402-assistant-69b7b063097d6d36.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/conversation/20260801211402-assistant-69b7b063097d6d36.md
@@ -1,0 +1,18 @@
+---
+type: "Codex CLI Conversation"
+title: "Codex assistant memory 014"
+description: "A privacy-redacted conversational memory from a real Codex CLI run."
+resource: "codex://session/2071a0fbdc12af99#line-9722"
+tags: ["codex-cli", "conversation", "assistant", "privacy-redacted"]
+timestamp: "2026-08-01T21:14:02.298Z"
+source_tool: "codex-cli"
+source_role: "assistant"
+source_line: 9722
+source_record_sha256: "69b7b063097d6d3606558bb4e5a9829ffeae06fb058a6f43e5363f4b6dfee0a0"
+content_sha256: "b43a957ef468c3da013c86b00d6322fb8a6f521da804d87252c98f8b879af8b0"
+redaction_count: 0
+---
+
+# Codex assistant memory 014
+
+El servidor del torneo está temporalmente fuera de servicio; el supervisor continúa intentando. Aprovecho la pausa para avanzar la publicación verificable de ProofPatch.

--- a/examples/migrations/codex_cli_sessions/sample_okf/memories/index.md
+++ b/examples/migrations/codex_cli_sessions/sample_okf/memories/index.md
@@ -1,0 +1,21 @@
+---
+type: index
+title: "Codex CLI conversation memories"
+---
+
+# Codex CLI conversation memories
+
+- [20260731084808-assistant-40c4c3fdc04d4eea](conversation/20260731084808-assistant-40c4c3fdc04d4eea.md)
+- [20260731085246-assistant-303736d7bf9322db](conversation/20260731085246-assistant-303736d7bf9322db.md)
+- [20260731090554-assistant-74beffcf844ccd99](conversation/20260731090554-assistant-74beffcf844ccd99.md)
+- [20260731090941-assistant-e9ce49caf0456533](conversation/20260731090941-assistant-e9ce49caf0456533.md)
+- [20260731092342-assistant-8101b1c5357227ee](conversation/20260731092342-assistant-8101b1c5357227ee.md)
+- [20260731093911-assistant-c9e1ccf2028bfa02](conversation/20260731093911-assistant-c9e1ccf2028bfa02.md)
+- [20260801013941-assistant-0a6fc07da6f13a74](conversation/20260801013941-assistant-0a6fc07da6f13a74.md)
+- [20260801014845-assistant-0ced6cea986bfc2e](conversation/20260801014845-assistant-0ced6cea986bfc2e.md)
+- [20260801180952-assistant-17beb66c9ee6b2d8](conversation/20260801180952-assistant-17beb66c9ee6b2d8.md)
+- [20260801182652-assistant-16401806659fd927](conversation/20260801182652-assistant-16401806659fd927.md)
+- [20260801182814-assistant-a42f7f14223fc2d1](conversation/20260801182814-assistant-a42f7f14223fc2d1.md)
+- [20260801184054-assistant-4d0d3a71a5563a5e](conversation/20260801184054-assistant-4d0d3a71a5563a5e.md)
+- [20260801202819-assistant-da6447f2ba127cf3](conversation/20260801202819-assistant-da6447f2ba127cf3.md)
+- [20260801211402-assistant-69b7b063097d6d36](conversation/20260801211402-assistant-69b7b063097d6d36.md)

--- a/examples/migrations/codex_cli_sessions/tests/test_codex_to_okf.py
+++ b/examples/migrations/codex_cli_sessions/tests/test_codex_to_okf.py
@@ -149,7 +149,25 @@ def test_validation_proves_source_and_content_parity(tmp_path: Path) -> None:
     output = tmp_path / "bundle"
     report_path = tmp_path / "report.json"
     _rollout(source)
-    export_bundle(_export_args(source, output))
+    manifest = export_bundle(_export_args(source, output))
+    user_record = next(row for row in manifest["records"] if row["role"] == "user")
+    (output / "golden_questions.json").write_text(
+        json.dumps(
+            {
+                "questions": [
+                    {
+                        "id": "cedar-port",
+                        "question": "What port does Project Cedar use?",
+                        "expected_source_record_sha256": user_record[
+                            "source_record_sha256"
+                        ],
+                        "answer_contains": "port 8042",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
 
     report = validate_bundle(
         argparse.Namespace(source=source, bundle=output, report=report_path)
@@ -158,6 +176,9 @@ def test_validation_proves_source_and_content_parity(tmp_path: Path) -> None:
     assert report["source_to_okf_coverage"] == 1.0
     assert report["content_hash_parity"] is True
     assert report["privacy_gate_findings"] == 0
+    assert report["golden_qa"]["questions"] == 1
+    assert report["golden_qa"]["fully_correct"] == 1
+    assert report["golden_qa"]["recall_parity_score"] == 1.0
     assert json.loads(report_path.read_text(encoding="utf-8"))["valid"] is True
 
 

--- a/examples/migrations/codex_cli_sessions/tests/test_codex_to_okf.py
+++ b/examples/migrations/codex_cli_sessions/tests/test_codex_to_okf.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+from codex_to_okf import (  # noqa: E402
+    export_bundle,
+    iter_message_records,
+    privacy_findings,
+    redact_text,
+    validate_bundle,
+)
+
+
+def _line(timestamp: str, item_type: str, payload: dict) -> str:
+    return json.dumps(
+        {"timestamp": timestamp, "type": item_type, "payload": payload},
+        ensure_ascii=False,
+    )
+
+
+def _rollout(path: Path) -> None:
+    lines = [
+        _line(
+            "2026-08-01T12:00:00Z",
+            "session_meta",
+            {"session_id": "real-session-1", "cli_version": "1.2.3"},
+        ),
+        _line(
+            "2026-08-01T12:00:01Z",
+            "response_item",
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": "Never export me"}],
+            },
+        ),
+        _line(
+            "2026-08-01T12:00:02Z",
+            "response_item",
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "Remember Project Cedar uses port 8042. Email me at a@b.com.",
+                    },
+                    {"type": "input_image", "image_url": "data:private"},
+                ],
+            },
+        ),
+        _line(
+            "2026-08-01T12:00:03Z",
+            "response_item",
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": (
+                            "Saved the Cedar decision. OPENAI_API_KEY="
+                            + "sk-"
+                            + "secretsecretsecret"
+                        ),
+                    }
+                ],
+            },
+        ),
+        _line(
+            "2026-08-01T12:00:04Z",
+            "response_item",
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": '<codex_internal_context source="goal">hidden</codex_internal_context>',
+                    }
+                ],
+            },
+        ),
+        _line(
+            "2026-08-01T12:00:05Z",
+            "response_item",
+            {"type": "reasoning", "summary": [{"text": "Private reasoning"}]},
+        ),
+        _line(
+            "2026-08-01T12:00:06Z",
+            "response_item",
+            {"type": "function_call_output", "output": "private tool output"},
+        ),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _export_args(source: Path, output: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        source=source,
+        output=output,
+        roles=["user", "assistant"],
+        include="Cedar",
+        exclude=None,
+        max_records=10,
+        take="last",
+        redact_literal=["Project Cedar"],
+        force=False,
+    )
+
+
+def test_exports_only_public_messages_and_redacts(tmp_path: Path) -> None:
+    source = tmp_path / "rollout.jsonl"
+    output = tmp_path / "bundle"
+    _rollout(source)
+
+    records = list(iter_message_records(source))
+    assert len(records) == 2
+    assert {record.role for record in records} == {"user", "assistant"}
+
+    manifest = export_bundle(_export_args(source, output))
+    assert manifest["selection"]["selected"] == 2
+    assert manifest["privacy"]["raw_text_published"] is False
+    assert manifest["privacy"]["literal_values_persisted"] is False
+    assert manifest["privacy"]["redactions"]["literal"] == 1
+    assert manifest["privacy"]["redactions"]["email"] == 1
+    assert manifest["privacy"]["redactions"]["secret_assignment"] == 1
+
+    published = "\n".join(
+        path.read_text(encoding="utf-8") for path in output.rglob("*.md")
+    )
+    assert "Project Cedar" not in published
+    assert "a@b.com" not in published
+    assert "sk-secret" not in published
+    assert "Never export me" not in published
+    assert "Private reasoning" not in published
+    assert "private tool output" not in published
+    assert not privacy_findings(published)
+
+
+def test_validation_proves_source_and_content_parity(tmp_path: Path) -> None:
+    source = tmp_path / "rollout.jsonl"
+    output = tmp_path / "bundle"
+    report_path = tmp_path / "report.json"
+    _rollout(source)
+    export_bundle(_export_args(source, output))
+
+    report = validate_bundle(
+        argparse.Namespace(source=source, bundle=output, report=report_path)
+    )
+    assert report["valid"] is True
+    assert report["source_to_okf_coverage"] == 1.0
+    assert report["content_hash_parity"] is True
+    assert report["privacy_gate_findings"] == 0
+    assert json.loads(report_path.read_text(encoding="utf-8"))["valid"] is True
+
+
+def test_validation_detects_tampering(tmp_path: Path) -> None:
+    source = tmp_path / "rollout.jsonl"
+    output = tmp_path / "bundle"
+    _rollout(source)
+    export_bundle(_export_args(source, output))
+    entry = next((output / "memories" / "conversation").glob("*.md"))
+    entry.write_text(entry.read_text(encoding="utf-8") + "tampered\n", encoding="utf-8")
+
+    report = validate_bundle(
+        argparse.Namespace(source=source, bundle=output, report=None)
+    )
+    assert report["valid"] is False
+    assert any("content hash mismatch" in failure for failure in report["failures"])
+    assert any("bundle digest" in failure for failure in report["failures"])
+
+
+def test_redaction_handles_tokens_accounts_and_home_paths() -> None:
+    text = (
+        "token " + "gho_" + "abcdefghijklmnopqrstuvwxyz123456 and wallet "
+        "CDwfgnTvm7HfBDmqSSsjWTxEM48fQwdqtExtYg8Def2z at C:\\Users\\Alice\\repo"
+    )
+    redacted, counts = redact_text(text)
+    assert "gho_" not in redacted
+    assert "CDwfgn" not in redacted
+    assert "Alice" not in redacted
+    assert counts == {"base58_account": 1, "github_token": 1, "user_home": 1}
+    assert not privacy_findings(redacted)

--- a/examples/migrations/codex_cli_sessions/tests/test_codex_to_okf.py
+++ b/examples/migrations/codex_cli_sessions/tests/test_codex_to_okf.py
@@ -5,10 +5,15 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 EXAMPLE_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(EXAMPLE_DIR))
 
+import codex_to_okf  # noqa: E402
+import run_demo  # noqa: E402
 from codex_to_okf import (  # noqa: E402
+    _parse_entry_for_validation,
     export_bundle,
     iter_message_records,
     privacy_findings,
@@ -49,7 +54,10 @@ def _rollout(path: Path) -> None:
                 "content": [
                     {
                         "type": "input_text",
-                        "text": "Remember Project Cedar uses port 8042. Email me at a@b.com.",
+                        "text": (
+                            "Remember Project Cedar uses port 8042. Bare token "
+                            "sk-abcdefghijklmnop must be removed. Email me at a@b.com."
+                        ),
                     },
                     {"type": "input_image", "image_url": "data:private"},
                 ],
@@ -82,7 +90,10 @@ def _rollout(path: Path) -> None:
                 "content": [
                     {
                         "type": "input_text",
-                        "text": '<codex_internal_context source="goal">hidden</codex_internal_context>',
+                        "text": (
+                            "innocent prefix <environment_context>hidden"
+                            "</environment_context>"
+                        ),
                     }
                 ],
             },
@@ -97,6 +108,7 @@ def _rollout(path: Path) -> None:
             "response_item",
             {"type": "function_call_output", "output": "private tool output"},
         ),
+        "not valid json",
     ]
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -130,7 +142,11 @@ def test_exports_only_public_messages_and_redacts(tmp_path: Path) -> None:
     assert manifest["privacy"]["literal_values_persisted"] is False
     assert manifest["privacy"]["redactions"]["literal"] == 1
     assert manifest["privacy"]["redactions"]["email"] == 1
+    assert manifest["privacy"]["redactions"]["openai_key"] == 1
     assert manifest["privacy"]["redactions"]["secret_assignment"] == 1
+    assert manifest["source"]["unparseable_lines_skipped"] == 1
+    assert manifest["selection"]["include_filter_applied"] is True
+    assert "include_regex" not in manifest["selection"]
 
     published = "\n".join(
         path.read_text(encoding="utf-8") for path in output.rglob("*.md")
@@ -141,7 +157,8 @@ def test_exports_only_public_messages_and_redacts(tmp_path: Path) -> None:
     assert "Never export me" not in published
     assert "Private reasoning" not in published
     assert "private tool output" not in published
-    assert not privacy_findings(published)
+    for path in (output / "memories" / "conversation").glob("*.md"):
+        assert not privacy_findings(_parse_entry_for_validation(path)["_content"])
 
 
 def test_validation_proves_source_and_content_parity(tmp_path: Path) -> None:
@@ -198,6 +215,26 @@ def test_validation_detects_tampering(tmp_path: Path) -> None:
     assert any("bundle digest" in failure for failure in report["failures"])
 
 
+def test_validation_compares_content_hash_with_manifest(tmp_path: Path) -> None:
+    source = tmp_path / "rollout.jsonl"
+    output = tmp_path / "bundle"
+    _rollout(source)
+    export_bundle(_export_args(source, output))
+    manifest_path = output / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["records"][0]["content_sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = validate_bundle(
+        argparse.Namespace(source=source, bundle=output, report=None)
+    )
+    assert report["valid"] is False
+    assert report["content_hash_parity"] is False
+    assert any(
+        "manifest content hash mismatch" in failure for failure in report["failures"]
+    )
+
+
 def test_redaction_handles_tokens_accounts_and_home_paths() -> None:
     text = (
         "token " + "gho_" + "abcdefghijklmnopqrstuvwxyz123456 and wallet "
@@ -209,3 +246,75 @@ def test_redaction_handles_tokens_accounts_and_home_paths() -> None:
     assert "Alice" not in redacted
     assert counts == {"base58_account": 1, "github_token": 1, "user_home": 1}
     assert not privacy_findings(redacted)
+
+
+def test_privacy_gate_fails_closed_before_creating_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "rollout.jsonl"
+    output = tmp_path / "bundle"
+    _rollout(source)
+    monkeypatch.setattr(codex_to_okf, "privacy_findings", lambda _text: ["forced"])
+
+    with pytest.raises(ValueError, match="privacy gate rejected"):
+        export_bundle(_export_args(source, output))
+    assert not output.exists()
+
+
+def test_force_refuses_to_delete_non_bundle_directory(tmp_path: Path) -> None:
+    source = tmp_path / "rollout.jsonl"
+    output = tmp_path / "not-a-bundle"
+    output.mkdir()
+    sentinel = output / "keep.txt"
+    sentinel.write_text("keep", encoding="utf-8")
+    _rollout(source)
+    args = _export_args(source, output)
+    args.force = True
+
+    with pytest.raises(ValueError, match="refusing --force"):
+        export_bundle(args)
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+
+
+def test_demo_main_reports_schema_and_exit_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "rollout.jsonl"
+    output = tmp_path / "demo"
+    _rollout(source)
+    common = [
+        str(source),
+        "--include",
+        "Cedar",
+        "--max-records",
+        "10",
+    ]
+
+    assert run_demo.main([*common, "--output", str(output)]) == 0
+    dry_run = json.loads(
+        (output / "memanto_dry_run_report.json").read_text(encoding="utf-8")
+    )
+    assert set(dry_run) == {
+        "command",
+        "executed_at",
+        "okf_nodes",
+        "mapped_memories",
+        "skipped",
+        "writes_performed",
+        "api_key_required",
+    }
+    assert dry_run["api_key_required"] is False
+    assert dry_run["skipped"] == 0
+
+    monkeypatch.setattr(
+        run_demo,
+        "validate_bundle",
+        lambda _args: {
+            "valid": False,
+            "source_to_okf_coverage": 1.0,
+            "content_hash_parity": False,
+            "privacy_gate_findings": 0,
+            "golden_qa": None,
+        },
+    )
+    assert run_demo.main([*common, "--output", str(tmp_path / "invalid-demo")]) == 1

--- a/examples/migrations/codex_cli_sessions/tests/test_run_live_demo.py
+++ b/examples/migrations/codex_cli_sessions/tests/test_run_live_demo.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+from run_live_demo import build_command_plan, main  # noqa: E402
+
+
+def test_live_plan_uses_shipped_cli_for_complete_freedom_loop(
+    tmp_path: Path,
+) -> None:
+    questions = ["Question one?", "Question two?"]
+    plan = build_command_plan(
+        memanto_bin="memanto",
+        agent_id="codex-okf-test",
+        bundle=tmp_path / "sample_okf",
+        portable_output=tmp_path / "portable_okf",
+        questions=questions,
+        answer_count=1,
+    )
+
+    labels = [label for label, _ in plan]
+    assert labels == [
+        "create_empty_agent",
+        "before_recall_1",
+        "before_recall_2",
+        "import_okf",
+        "after_recall_1",
+        "after_recall_2",
+        "after_answer_1",
+        "export_portable_okf",
+    ]
+    import_command = dict(plan)["import_okf"]
+    assert import_command[:4] == [
+        "memanto",
+        "migrate",
+        "okf",
+        str(tmp_path / "sample_okf"),
+    ]
+    assert import_command[-2:] == ["--agent", "codex-okf-test"]
+    export_command = dict(plan)["export_portable_okf"]
+    assert export_command[-1] == "--okf"
+    assert "--output" in export_command
+
+
+def test_live_demo_fails_cleanly_without_api_key(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("MOORCHEH_API_KEY", raising=False)
+    assert main(["--output", str(tmp_path / "evidence")]) == 2
+    assert not (tmp_path / "evidence").exists()

--- a/examples/migrations/codex_cli_sessions/tests/test_run_live_demo.py
+++ b/examples/migrations/codex_cli_sessions/tests/test_run_live_demo.py
@@ -6,7 +6,12 @@ from pathlib import Path
 EXAMPLE_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(EXAMPLE_DIR))
 
-from run_live_demo import build_command_plan, main  # noqa: E402
+from run_live_demo import (  # noqa: E402
+    _load_golden_cases,
+    build_command_plan,
+    main,
+    verify_live_results,
+)
 
 
 def test_live_plan_uses_shipped_cli_for_complete_freedom_loop(
@@ -50,3 +55,43 @@ def test_live_demo_fails_cleanly_without_api_key(tmp_path: Path, monkeypatch) ->
     monkeypatch.delenv("MOORCHEH_API_KEY", raising=False)
     assert main(["--output", str(tmp_path / "evidence")]) == 2
     assert not (tmp_path / "evidence").exists()
+
+
+def test_golden_cases_derive_exact_titles_from_sample_okf() -> None:
+    bundle = EXAMPLE_DIR / "sample_okf"
+    cases = _load_golden_cases(bundle / "golden_questions.json", bundle)
+
+    assert len(cases) == 5
+    assert cases[0]["id"] == "memo-ambiguity"
+    assert cases[0]["expected_title"] == "Codex assistant memory 003"
+    assert cases[-1]["expected_title"] == "Codex assistant memory 014"
+
+
+def test_live_result_verification_checks_empty_then_exact_recall_and_rag() -> None:
+    cases = [
+        {
+            "id": "proof",
+            "question": "What happened?",
+            "expected_title": "Codex assistant memory 003",
+        }
+    ]
+    results = [
+        {"label": "before_recall_1", "_stdout": "No memories found"},
+        {
+            "label": "after_recall_1",
+            "_stdout": "Found 1 memories\nCodex assistant memory 003",
+        },
+        {
+            "label": "after_answer_1",
+            "_stdout": "Used 1 memories\nCodex assistant memory 003",
+        },
+    ]
+
+    report = verify_live_results(results, cases, answer_count=1)
+    assert report["verified"] is True
+    assert report["recall_passed"] == report["recall_total"] == 1
+    assert report["rag_context_passed"] == report["rag_context_total"] == 1
+
+    results[-1]["_stdout"] = "Used unrelated memory"
+    failed = verify_live_results(results, cases, answer_count=1)
+    assert failed["verified"] is False

--- a/examples/migrations/codex_cli_sessions/tests/test_run_live_demo.py
+++ b/examples/migrations/codex_cli_sessions/tests/test_run_live_demo.py
@@ -8,10 +8,22 @@ sys.path.insert(0, str(EXAMPLE_DIR))
 
 from run_live_demo import (  # noqa: E402
     _load_golden_cases,
+    _show_okf_preview,
     build_command_plan,
     main,
     verify_live_results,
 )
+
+
+class _Transcript:
+    def __init__(self) -> None:
+        self.text = ""
+
+    def write(self, value: str) -> None:
+        self.text += value
+
+    def flush(self) -> None:
+        pass
 
 
 def test_live_plan_uses_shipped_cli_for_complete_freedom_loop(
@@ -95,3 +107,26 @@ def test_live_result_verification_checks_empty_then_exact_recall_and_rag() -> No
     results[-1]["_stdout"] = "Used unrelated memory"
     failed = verify_live_results(results, cases, answer_count=1)
     assert failed["verified"] is False
+
+
+def test_live_demo_prints_readable_portable_okf(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "portable_okf"
+    memory_dir = root / "memories" / "conversation"
+    memory_dir.mkdir(parents=True)
+    (root / "memories" / "index.md").write_text(
+        "# Portable memory index\n", encoding="utf-8"
+    )
+    (memory_dir / "decision.md").write_text(
+        '---\ntitle: "Readable decision"\n---\n\nOwned memory.\n',
+        encoding="utf-8",
+    )
+    transcript = _Transcript()
+
+    previews = _show_okf_preview(root, transcript)
+
+    assert [item["path"] for item in previews] == [
+        "memories/index.md",
+        "memories/conversation/decision.md",
+    ]
+    assert "Readable decision" in transcript.text
+    assert "Owned memory." in capsys.readouterr().out


### PR DESCRIPTION
## What changed

Adds a Path B migration showcase for real Codex CLI rollout sessions:

- a privacy-first `rollout-*.jsonl` to OKF adapter;
- deterministic redaction and a fail-closed privacy gate;
- source-envelope and content SHA-256 provenance;
- a one-command export, validation, and Memanto dry-run workflow;
- a recordable live runner for empty-agent baseline, import, recall, RAG answer,
  portable re-export, and readable Markdown previews, with fail-closed
  exact-title checks;
- a privacy-safe sample OKF bundle generated from a lived-in multi-day session;
- focused tests, mapping documentation, and reproducibility evidence.

The adapter deliberately excludes developer instructions, reasoning, tool calls,
tool outputs, internal context, and images. It feeds the existing
`memanto migrate okf` loader/mapper instead of reimplementing migration logic.

## Why

Codex CLI sessions accumulate valuable decisions and working context, but their
rollout format is not a portable memory format and can contain sensitive data.
This example creates a permanent, inspectable migration path while proving the
source relationship without publishing the private raw archive.

## Migration summary

- Frozen real rollout: 62,938,881 bytes and 293 public conversation messages
  after embedded internal-context filtering.
- Selected source records: 14.
- Mapped OKF memories: 14.
- Skipped selected records: 0.
- Source-to-OKF provenance coverage: 100%.
- Exact redacted-content hash parity: 100%.
- Golden Q&A recall parity: 5/5 source and OKF retrievals with matching answer evidence.
- Privacy-gate findings: 0.
- `memanto migrate okf --dry-run`: 14 mapped, 0 skipped.

The manifest reports only measurable local-file values. Codex rollouts and OKF
are local, so no API-cost, token, or latency savings baseline is invented.

## Validation

```text
uv run ruff check examples/migrations/codex_cli_sessions
uv run ruff format --check examples/migrations/codex_cli_sessions
uv run mypy examples/migrations/codex_cli_sessions/codex_to_okf.py examples/migrations/codex_cli_sessions/run_demo.py examples/migrations/codex_cli_sessions/run_live_demo.py
DEBUG=false uv run pytest tests/test_okf.py examples/migrations/codex_cli_sessions/tests -q
```

Result: Ruff clean, formatting clean, mypy clean, and 18 tests passed.

## Bounty completion checklist

- [x] New unsupported-source adapter under `/examples/migrations/`.
- [x] Real-data sample artifact with cryptographic source linkage and explicit
  unsigned-integrity limitations.
- [x] Mapping table, single-command workflow, and privacy documentation.
- [x] Round-trip validation, 5/5 golden Q&A parity, and Memanto dry-run evidence.
- [ ] Live Moorcheh import/export evidence.
- [ ] Public demo video link.
- [ ] Fresh social showcase links and analytics.
- [ ] BountyHub claim linked to this PR.

This PR intentionally remains **draft** until the unchecked bounty requirements
are complete and the description contains their public evidence.

Addresses #1609.
