### PR TITLE
fix: prevent empty query when first message exceeds MAX_CONTENT_CHARS

### DIFF
--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -84,8 +84,14 @@ class ConversationMemoryExtractionService:
     def _conversation_text(self, messages: list[dict[str, str]]) -> str:
         lines: list[str] = []
         total = 0
-        for message in messages:
+        for index, message in enumerate(messages):
             line = f"{message['role'].strip()}: {message['content'].strip()}"
+            if index == 0 and len(line) > self.MAX_CONTENT_CHARS:
+                # First message alone exceeds the budget: keep a truncated
+                # version instead of returning an empty query.
+                lines.append(line[: self.MAX_CONTENT_CHARS])
+                total = self.MAX_CONTENT_CHARS
+                continue
             total += len(line)
             if total > self.MAX_CONTENT_CHARS:
                 break

--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -92,7 +92,10 @@ class ConversationMemoryExtractionService:
                 lines.append(line[: self.MAX_CONTENT_CHARS])
                 total = self.MAX_CONTENT_CHARS
                 continue
-            total += len(line)
+            # Account for the "\n" separator that will be added when joining
+            # (every line after the first costs len(line) + 1).
+            separator_cost = 1 if lines else 0
+            total += len(line) + separator_cost
             if total > self.MAX_CONTENT_CHARS:
                 break
             lines.append(line)

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -140,3 +140,25 @@ def test_conversation_text_cuts_later_messages_on_cumulative_overflow():
     )
     assert "user: " in out
     assert "assistant: " not in out  # second message exceeds budget, must be cut
+
+
+def test_conversation_text_counts_newline_separator_in_budget():
+    service = ConversationMemoryExtractionService(FakeClient("[]"))
+    # "user: " (6) + 5994 a's = 6000; "assistant: " (11) + 5988 b's = 5999.
+    # Joined with "\n" = 6000 + 1 + 5999 = exactly 12000 = MAX_CONTENT_CHARS.
+    out = service._conversation_text(
+        [{"role": "user", "content": "a" * 5994}, {"role": "assistant", "content": "b" * 5988}]
+    )
+    assert len(out) == service.MAX_CONTENT_CHARS
+    assert out == f"user: {'a' * 5994}\nassistant: {'b' * 5988}"
+
+
+def test_conversation_text_drops_line_when_separator_pushes_over():
+    service = ConversationMemoryExtractionService(FakeClient("[]"))
+    # "user: " (6) + 5994 a's = 6000; "assistant: " (11) + 5989 b's = 6000.
+    # With separator: 6000 + 1 + 6000 = 12001 > MAX → second line must be cut.
+    out = service._conversation_text(
+        [{"role": "user", "content": "a" * 5994}, {"role": "assistant", "content": "b" * 5989}]
+    )
+    assert len(out) == 6000
+    assert "assistant: " not in out

--- a/tests/test_conversation_memory_extraction.py
+++ b/tests/test_conversation_memory_extraction.py
@@ -113,3 +113,30 @@ def test_extract_requires_messages():
 
     with pytest.raises(ValueError, match="at least one message"):
         service.extract(namespace="memanto_agent_test", messages=[])
+
+
+def test_conversation_text_returns_normal_messages():
+    service = ConversationMemoryExtractionService(FakeClient("[]"))
+    out = service._conversation_text(
+        [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+    )
+    assert out == "user: hello\nassistant: world"
+
+
+def test_conversation_text_keeps_truncated_first_message_when_oversized():
+    service = ConversationMemoryExtractionService(FakeClient("[]"))
+    out = service._conversation_text(
+        [{"role": "user", "content": "x" * 15000}, {"role": "assistant", "content": "short"}]
+    )
+    assert out, "query must never be empty when the first message exceeds the budget"
+    assert len(out) == service.MAX_CONTENT_CHARS
+    assert "short" not in out  # later messages dropped once budget consumed
+
+
+def test_conversation_text_cuts_later_messages_on_cumulative_overflow():
+    service = ConversationMemoryExtractionService(FakeClient("[]"))
+    out = service._conversation_text(
+        [{"role": "user", "content": "a" * 8000}, {"role": "assistant", "content": "b" * 8000}]
+    )
+    assert "user: " in out
+    assert "assistant: " not in out  # second message exceeds budget, must be cut


### PR DESCRIPTION
## Bug

When a single conversation message exceeds MAX_CONTENT_CHARS (12,000 chars), `_conversation_text()` returns an empty string. This empty query is passed to `client.answer.generate()`, causing either an API error or garbage extraction results.

## Root Cause

The loop broke before appending ANY line when the first message alone exceeded the budget.

## Fix

Always include at least the first message, truncating to the budget if necessary. Later messages are still dropped once the cumulative budget is consumed.

## Tests Added
- `test_conversation_text_returns_normal_messages` — regression
- `test_conversation_text_keeps_truncated_first_message_when_oversized` — the bug fix
- `test_conversation_text_cuts_later_messages_on_cumulative_overflow` — regression

All 7 tests in `tests/test_conversation_memory_extraction.py` pass.

Refs #1799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation memory extraction when the first message exceeds the character limit.
  * Preserves the beginning of oversized first messages instead of returning an empty result.
  * Accurately accounts for newline separators when enforcing the character budget.
  * Excludes later messages when adding them would exceed the limit.

* **Tests**
  * Added coverage for normal formatting, oversized first messages, cumulative limits, and separator handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->