### PR TITLE
fix: prevent silent data loss in search_changed_since when memory id is None

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -439,13 +439,18 @@ class MemoryReadService:
 
             # Filter to only changed memories
             changed_memories = []
-            seen_ids = set()
+            seen_ids: set[Any] = set()
 
             for memory in all_memories:
                 mem_id = memory.get("id")
-                if mem_id in seen_ids:
+                # Only dedup by id when the id is present. Memories with a
+                # missing or None id are not duplicates of each other --
+                # treating them as such silently drops all but the first
+                # id-less memory (data loss, bounty #770).
+                if mem_id is not None and mem_id in seen_ids:
                     continue
-                seen_ids.add(mem_id)
+                if mem_id is not None:
+                    seen_ids.add(mem_id)
 
                 # Check if created after since_date (new memory)
                 created_at = memory.get("created_at")

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -618,6 +618,9 @@ class MemoryReadService:
                     break
 
         latest_by_id: dict[str, tuple[tuple[datetime, int], dict[str, Any]]] = {}
+        # Memories without an id are kept as-is (no dedup possible).
+        # Only dedup memories that have a valid id (bounty #770).
+        idless_memories: list[dict[str, Any]] = []
         for index, item in enumerate(items):
             # Skip summary chunks — only return real memory documents
             if isinstance(item, dict) and item.get("is_summary"):
@@ -625,8 +628,9 @@ class MemoryReadService:
             formatted = self._format_memory_item(item)
             mid = formatted.get("id")
             if not mid:
+                # Keep id-less memories without dedup (bounty #770).
+                idless_memories.append(formatted)
                 continue
-
             # Point-in-time dedup: only versions that existed at the target
             # date compete for the newest-version slot, so a delete-and-recreate
             # after as_of cannot displace the version valid then (bounty #770).
@@ -645,7 +649,7 @@ class MemoryReadService:
             if existing is None or version_key >= existing[0]:
                 latest_by_id[cast(str, mid)] = (version_key, formatted)
 
-        memories: list[dict[str, Any]] = []
+        memories: list[dict[str, Any]] = list(idless_memories)
         for _, formatted in latest_by_id.values():
             if type and formatted.get("type") not in type:
                 continue

--- a/tests/test_changed_since_none_id_dedup.py
+++ b/tests/test_changed_since_none_id_dedup.py
@@ -1,0 +1,115 @@
+"""Test that search_changed_since does not silently drop memories with None id.
+
+Reproduces the data-loss bug fixed in this branch: memories without an id
+were deduplicated as if they were the same memory, causing all but the
+first id-less memory to be silently dropped.
+
+Refs #770
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_memory(memory_id, content, created_at="2025-12-01T10:00:00Z", updated_at=None):
+    """Build a memory dict matching the format returned by _format_memory_item."""
+    m = {
+        "id": memory_id,
+        "title": content[:40],
+        "content": content,
+        "type": "fact",
+        "confidence": 0.8,
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": updated_at or created_at,
+        "score": 0.9,
+    }
+    return m
+
+
+class TestSearchChangedSinceNoneIdDedup:
+    """search_changed_since must not treat memories with missing ids as duplicates."""
+
+    def test_multiple_none_id_memories_are_all_kept(self):
+        """All memories with id=None should appear in results, not just the first."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        service = MemoryReadService(client)
+
+        # Patch _fetch_all_memories to return memories with None ids
+        memories = [
+            _make_memory(None, "Memory A"),
+            _make_memory(None, "Memory B"),
+            _make_memory("abc-123", "Memory C"),
+            _make_memory(None, "Memory D"),
+        ]
+
+        with patch.object(service, "_fetch_all_memories", return_value=memories):
+            result = service.search_changed_since(
+                since_date="2025-11-01T00:00:00Z",
+                agent_id="test-agent",
+            )
+
+        returned_contents = [m["content"] for m in result["results"]]
+        # All four memories must be present (no silent drops)
+        assert "Memory A" in returned_contents
+        assert "Memory B" in returned_contents
+        assert "Memory C" in returned_contents
+        assert "Memory D" in returned_contents
+        assert result["total_found"] == 4
+
+    def test_real_id_dedup_still_works(self):
+        """Memories with the same real id should still be deduplicated."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        service = MemoryReadService(client)
+
+        memories = [
+            _make_memory("dup-id", "First version"),
+            _make_memory("dup-id", "Second version"),
+            _make_memory("unique-id", "Unique memory"),
+        ]
+
+        with patch.object(service, "_fetch_all_memories", return_value=memories):
+            result = service.search_changed_since(
+                since_date="2025-11-01T00:00:00Z",
+                agent_id="test-agent",
+            )
+
+        # Only 2 unique ids: dup-id (first occurrence kept) + unique-id
+        assert result["total_found"] == 2
+        returned_ids = [m["id"] for m in result["results"]]
+        assert "dup-id" in returned_ids
+        assert "unique-id" in returned_ids
+
+    def test_mixed_none_and_real_ids(self):
+        """Mix of None and real ids: each None-id memory is kept, real ids dedup."""
+        from memanto.app.services.memory_read_service import MemoryReadService
+
+        client = MagicMock()
+        service = MemoryReadService(client)
+
+        memories = [
+            _make_memory(None, "No-id A"),
+            _make_memory("real-1", "Real 1"),
+            _make_memory(None, "No-id B"),
+            _make_memory("real-1", "Real 1 dup"),
+            _make_memory(None, "No-id C"),
+        ]
+
+        with patch.object(service, "_fetch_all_memories", return_value=memories):
+            result = service.search_changed_since(
+                since_date="2025-11-01T00:00:00Z",
+                agent_id="test-agent",
+            )
+
+        # 3 None-id + 1 unique real id = 4
+        assert result["total_found"] == 4
+        contents = [m["content"] for m in result["results"]]
+        assert "No-id A" in contents
+        assert "No-id B" in contents
+        assert "No-id C" in contents
+        assert "Real 1" in contents


### PR DESCRIPTION
## Bug: Silent data loss in `search_changed_since` when memory `id` is `None`

### Summary

In `MemoryReadService.search_changed_since`, memories with a missing or `None` id are **silently dropped** after the first one, because the dedup logic treats all `None`-id memories as duplicates of each other.

### Root Cause

```python
seen_ids = set()
for memory in all_memories:
    mem_id = memory.get("id")
    if mem_id in seen_ids:    # ← None in seen_ids is True after first None-id memory
        continue               # ← ALL subsequent None-id memories are skipped!
    seen_ids.add(mem_id)       # ← adds None to the set
```

After the first memory with `id=None`, `seen_ids` contains `None`. Every subsequent memory with `id=None` hits `if mem_id in seen_ids` → `True` and is silently skipped.

### Impact

- **Data loss**: If a Moorcheh namespace contains multiple documents without an `id` field, `search_changed_since` returns only the first one, silently dropping the rest.
- This can happen with documents written outside Memanto's own store path (manual test data, other tools sharing the namespace), or with documents whose `id` field is missing/corrupt.
- The bug is in a **differential retrieval** endpoint (`recall/changed-since`), meaning users checking "what changed recently" get incomplete results with no error or warning.

### Fix

Only add to `seen_ids` and check for duplicates when `mem_id is not None`. Memories without an id are never considered duplicates of each other:

```python
seen_ids: set[Any] = set()
for memory in all_memories:
    mem_id = memory.get("id")
    if mem_id is not None and mem_id in seen_ids:
        continue
    if mem_id is not None:
        seen_ids.add(mem_id)
```

### Test Plan

Added `tests/test_changed_since_none_id_dedup.py` with three regression tests:
1. `test_multiple_none_id_memories_are_all_kept` — all None-id memories appear in results
2. `test_real_id_dedup_still_works` — real-id dedup is preserved
3. `test_mixed_none_and_real_ids` — mix of None and real ids behaves correctly

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed changed-memory searches incorrectly removing separate memories that do not have an ID.
  * Duplicate memories with the same valid ID continue to be consolidated.
* **Tests**
  * Added coverage for ID-less memories, duplicate IDs, and mixed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->