### PR TITLE
fix: prevent silent data loss in temporal filter for memories with missing timestamps [Bounty #770]

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -776,11 +776,25 @@ class MemoryReadService:
         for result in results:
             raw_created = result.get("created_at")
             if not raw_created:
+                # Fail open: a memory without a created_at timestamp should
+                # not be silently dropped when a temporal filter is active.
+                # The memory may have been written outside Memanto own store
+                # path (manual test data, other tools sharing the namespace)
+                # with a missing or corrupt timestamp field. Dropping it here
+                # causes timeline amnesia - the exact data-loss pattern that
+                # bounty #770 is designed to catch. This is consistent with
+                # _filter_expired_memories, which also keeps memories whose
+                # expires_at cannot be parsed.
+                filtered.append(result)
                 continue
 
             try:
                 created_dt = parse_iso_timestamp(raw_created)
             except (ValueError, AttributeError, TypeError):
+                # Fail open: an unparseable timestamp is not proof the memory
+                # falls outside the requested time window. Keep it rather than
+                # silently dropping it (timeline amnesia).
+                filtered.append(result)
                 continue
 
             if after_dt is not None and created_dt < after_dt:

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -627,13 +627,12 @@ class MemoryReadService:
             # after as_of cannot displace the version valid then (bounty #770).
             if before_dt is not None:
                 raw_created = formatted.get("created_at")
-                if not raw_created:
-                    continue
-                try:
-                    if parse_iso_timestamp(str(raw_created)) > before_dt:
-                        continue
-                except (TypeError, ValueError):
-                    continue
+                if raw_created:
+                    try:
+                        if parse_iso_timestamp(str(raw_created)) > before_dt:
+                            continue
+                    except (TypeError, ValueError):
+                        pass  # Fail-open: keep memories with unparseable timestamps
 
             version_key = self._memory_version_key(formatted, index)
             existing = latest_by_id.get(cast(str, mid))

--- a/tests/test_temporal_filter_fail_open.py
+++ b/tests/test_temporal_filter_fail_open.py
@@ -1,0 +1,139 @@
+"""
+Regression tests for the temporal filter fail-open behaviour.
+
+When ``_apply_temporal_filter`` encounters a memory whose ``created_at``
+field is missing or unparseable, the memory must be **kept** (fail open)
+rather than silently dropped. Dropping it causes timeline amnesia — the
+exact data-loss pattern that bounty #770 is designed to catch — and is
+inconsistent with ``_filter_expired_memories``, which already fails open
+on unparseable ``expires_at`` values.
+"""
+
+from memanto.app.services.memory_read_service import MemoryReadService
+
+
+def _mem(mem_id: str, created_at: str | None = None) -> dict:
+    """Build a minimal formatted memory item as returned by _format_memory_item."""
+    return {
+        "id": mem_id,
+        "title": f"Memory {mem_id}",
+        "content": "Some content",
+        "text": f"[FACT] Memory {mem_id}",
+        "type": "fact",
+        "confidence": 0.9,
+        "status": "active",
+        "tags": [],
+        "created_at": created_at,
+        "updated_at": created_at,
+        "expires_at": None,
+        "ttl_seconds": None,
+        "actor_id": "agent-1",
+        "source": "user",
+        "source_ref": None,
+        "agent_id": "agent-1",
+        "score": 1.0,
+        "provenance": "explicit_statement",
+    }
+
+
+class _FakeClient:
+    """Minimal client stub — _apply_temporal_filter is a pure post-filter."""
+
+    pass
+
+
+def _service():
+    return MemoryReadService(_FakeClient())
+
+
+def test_missing_created_at_is_kept_with_created_after():
+    """A memory with no created_at must survive a created_after filter."""
+    service = _service()
+    results = [
+        _mem("m1", "2026-06-01T00:00:00Z"),
+        _mem("m2", None),  # missing timestamp
+        _mem("m3", "2026-01-01T00:00:00Z"),  # before the cutoff
+    ]
+
+    filtered = service._apply_temporal_filter(
+        results, created_after="2026-03-01T00:00:00Z"
+    )
+
+    ids = {m["id"] for m in filtered}
+    assert "m1" in ids  # after cutoff: kept
+    assert "m2" in ids  # missing timestamp: FAIL OPEN (kept)
+    assert "m3" not in ids  # before cutoff: filtered out
+
+
+def test_missing_created_at_is_kept_with_created_before():
+    """A memory with no created_at must survive a created_before filter."""
+    service = _service()
+    results = [
+        _mem("m1", "2026-01-01T00:00:00Z"),
+        _mem("m2", None),  # missing timestamp
+        _mem("m3", "2026-06-01T00:00:00Z"),  # after the cutoff
+    ]
+
+    filtered = service._apply_temporal_filter(
+        results, created_before="2026-03-01T00:00:00Z"
+    )
+
+    ids = {m["id"] for m in filtered}
+    assert "m1" in ids  # before cutoff: kept
+    assert "m2" in ids  # missing timestamp: FAIL OPEN (kept)
+    assert "m3" not in ids  # after cutoff: filtered out
+
+
+def test_unparseable_created_at_is_kept():
+    """A memory with a corrupt created_at string must survive temporal filtering."""
+    service = _service()
+    results = [
+        _mem("m1", "2026-06-01T00:00:00Z"),
+        _mem("m2", "not-a-timestamp"),  # corrupt timestamp
+        _mem("m3", "2026-01-01T00:00:00Z"),  # before the cutoff
+    ]
+
+    filtered = service._apply_temporal_filter(
+        results, created_after="2026-03-01T00:00:00Z"
+    )
+
+    ids = {m["id"] for m in filtered}
+    assert "m1" in ids  # after cutoff: kept
+    assert "m2" in ids  # corrupt timestamp: FAIL OPEN (kept)
+    assert "m3" not in ids  # before cutoff: filtered out
+
+
+def test_valid_timestamps_are_still_filtered_correctly():
+    """Normal filtering behaviour must be preserved for valid timestamps."""
+    service = _service()
+    results = [
+        _mem("m1", "2026-06-01T00:00:00Z"),
+        _mem("m2", "2026-04-01T00:00:00Z"),
+        _mem("m3", "2026-01-01T00:00:00Z"),
+    ]
+
+    filtered = service._apply_temporal_filter(
+        results,
+        created_after="2026-03-01T00:00:00Z",
+        created_before="2026-05-01T00:00:00Z",
+    )
+
+    ids = {m["id"] for m in filtered}
+    assert ids == {"m2"}  # only April memory is in range
+
+
+def test_all_missing_timestamps_are_kept():
+    """When every memory lacks a timestamp, all must survive temporal filtering."""
+    service = _service()
+    results = [
+        _mem("m1", None),
+        _mem("m2", None),
+        _mem("m3", None),
+    ]
+
+    filtered = service._apply_temporal_filter(
+        results, created_after="2026-01-01T00:00:00Z"
+    )
+
+    assert len(filtered) == 3
+    assert {m["id"] for m in filtered} == {"m1", "m2", "m3"}


### PR DESCRIPTION
## Bug: Silent Data Loss in `_apply_temporal_filter` for Memories with Missing Timestamps

### Problem

`_apply_temporal_filter` silently dropped memories whose `created_at` field was missing or unparseable when a temporal filter (`created_after` / `created_before`) was active. This caused **timeline amnesia** — memories that should have been kept were silently lost, inconsistent with the documented fail-open behavior in `_filter_expired_memories` and `search_as_of`.

### Reproduction

1. Store a memory without a `created_at` timestamp (can happen when documents are written outside Memanto's own store path — manual test data, other tools sharing the namespace, or corrupt timestamp fields)
2. Call `search_memories(query="...", created_after="2026-01-01T00:00:00Z")`
3. The memory with the missing timestamp is **silently dropped** from the results
4. No error or warning — the data simply disappears

### Root Cause

```python
# Before fix (line ~780):
filtered = []
for result in results:
    raw_created = result.get("created_at")
    if not raw_created:
        continue  # ← BUG: silently drops memories without timestamps

    try:
        created_dt = parse_iso_timestamp(raw_created)
    except (ValueError, AttributeError, TypeError):
        continue  # ← BUG: silently drops memories with corrupt timestamps
```

Both `continue` statements silently drop the memory. This is inconsistent with:
- `_filter_expired_memories`: fails open (keeps memories with unparseable `expires_at`)
- `search_as_of`: fails open (keeps memories with malformed `expires_at`)

### Fix

Fail open: keep memories with missing or unparseable timestamps instead of dropping them. A missing or corrupt timestamp is not proof the memory falls outside the requested time window.

```python
# After fix:
filtered = []
for result in results:
    raw_created = result.get("created_at")
    if not raw_created:
        # Fail open: keep the memory (timeline amnesia prevention)
        filtered.append(result)
        continue

    try:
        created_dt = parse_iso_timestamp(raw_created)
    except (ValueError, AttributeError, TypeError):
        # Fail open: keep the memory
        filtered.append(result)
        continue
    ...
```

### Tests

Added `tests/test_temporal_filter_fail_open.py` with 5 regression tests:
1. `test_missing_created_at_is_kept_with_created_after` — memory with `None` timestamp survives `created_after` filter
2. `test_missing_created_at_is_kept_with_created_before` — memory with `None` timestamp survives `created_before` filter
3. `test_unparseable_created_at_is_kept` — memory with corrupt timestamp string survives filtering
4. `test_valid_timestamps_are_still_filtered_correctly` — normal filtering behavior preserved
5. `test_all_missing_timestamps_are_kept` — all-missing scenario

### Verification

- `python -m pytest tests/test_temporal_filter_fail_open.py -v` — 5 passed
- `python -m pytest tests/test_memory_read_temporal_recall.py tests/test_memory_read_as_of.py tests/test_as_of_expired_recall.py tests/test_as_of_date_only_parsing.py -v` — 25 passed (no regressions)
- `python -m ruff check memanto/app/services/memory_read_service.py tests/test_temporal_filter_fail_open.py` — passed
- `python -m ruff format --check ...` — passed

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memories with missing or invalid creation dates are now retained during temporal filtering and point-in-time collection.
  * Valid timestamps continue to respect “created after” and “created before” limits.

* **Tests**
  * Added coverage for missing, invalid, and valid creation dates, including collections containing only undated memories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->