### PR TITLE
fix: bound pagination loop, fail-closed temporal limits, truthful total_found, configurable conflict dir (Bounty #770 round 2)

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -16,7 +16,18 @@ from memanto.app.constants import (
 )
 
 MemoryTag = Annotated[
-    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=64,
+        # Commas are the wire-format separator: to_moorcheh_document joins
+        # tags with "," and readers split on ",". A tag containing a comma
+        # is silently corrupted on the write->read round-trip (the tag is
+        # split into two, a phantom tag appears) and makes #tag filtering
+        # match the wrong rows. Reject it at the schema boundary.
+        pattern=r"^[^,]+$",
+    ),
 ]
 BoundedTags = Annotated[list[MemoryTag], Field(max_length=20)]
 

--- a/memanto/app/services/daily_analysis_service.py
+++ b/memanto/app/services/daily_analysis_service.py
@@ -215,7 +215,10 @@ Format the output as a Markdown report:
         validate_safe_id(agent_id, "agent_id")
         validate_safe_id(date, "date")
 
-        conflicts_dir = Path.home() / ".memanto" / "conflicts"
+        # Use the configured data dir (same as summaries) instead of a
+        # hardcoded ~/.memanto path, so MEMANTO_DATA_DIR is honored
+        # consistently across generated artifacts.
+        conflicts_dir = get_data_dir() / "conflicts"
         conflicts_dir.mkdir(parents=True, exist_ok=True)
         pattern = f"{agent_id}_{date}_*_summary.md"
         session_files = list(self.sessions_dir.glob(pattern))

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -295,10 +295,17 @@ class MemoryReadService:
             paginated_results = all_results[offset : offset + limit]
             has_more = len(all_results) > offset + limit
 
+            # total_found is the post-filter match count (what clients use to
+            # decide "are there more" and to render result totals), NOT the
+            # length of the returned page. Reporting the page length here made
+            # every paged recall show total_found == limit even when hundreds
+            # of memories matched, silently lying to paginating clients.
+            match_total = len(all_results)
+
             return {
                 "results": paginated_results,
-                "total_found": len(paginated_results),
-                "total_available": len(all_results),
+                "total_found": match_total,
+                "total_available": match_total,
                 "offset": offset,
                 "limit": limit,
                 "has_more": has_more,
@@ -392,8 +399,17 @@ class MemoryReadService:
 
                 valid_memories.append(memory)
 
-            # Apply limit
+            # Apply limit — fail closed on invalid values instead of silently
+            # slicing with Python negative-index semantics (a negative limit
+            # would return everything-but-the-last-N, a zero limit an empty
+            # window indistinguishable from "no memories"). Mirrors the
+            # validation in search_memories so every recall path has the same
+            # contract.
             if limit is not None:
+                if not isinstance(limit, int) or isinstance(limit, bool):
+                    raise ValueError("limit must be a positive integer")
+                if limit <= 0:
+                    raise ValueError("limit must be a positive integer")
                 valid_memories = valid_memories[:limit]
 
             return {
@@ -487,8 +503,14 @@ class MemoryReadService:
 
             changed_memories.sort(key=_changed_sort_key, reverse=True)
 
-            # Apply limit
+            # Apply limit — fail closed on invalid values (negative limits
+            # would silently return everything-but-the-last-N via Python
+            # negative-index slicing; zero would fake an empty result set).
             if limit is not None:
+                if not isinstance(limit, int) or isinstance(limit, bool):
+                    raise ValueError("limit must be a positive integer")
+                if limit <= 0:
+                    raise ValueError("limit must be a positive integer")
                 changed_memories = changed_memories[:limit]
 
             return {
@@ -550,7 +572,17 @@ class MemoryReadService:
 
             unique_memories.sort(key=_created_sort_key, reverse=True)
 
-            results = unique_memories if limit is None else unique_memories[:limit]
+            # Apply limit — fail closed on invalid values (negative limits
+            # would silently return everything-but-the-last-N via Python
+            # negative-index slicing; zero would fake an empty result set).
+            if limit is not None:
+                if not isinstance(limit, int) or isinstance(limit, bool):
+                    raise ValueError("limit must be a positive integer")
+                if limit <= 0:
+                    raise ValueError("limit must be a positive integer")
+                unique_memories = unique_memories[:limit]
+
+            results = unique_memories
             return {"results": results, "total_found": len(results)}
 
         except Exception as e:
@@ -597,7 +629,17 @@ class MemoryReadService:
         items: list[Any] = []
         for ns in namespaces:
             next_token: str | None = None
+            seen_tokens: set[str] = set()
+            pages_fetched = 0
             while True:
+                # Bound the pagination loop: a storage layer that keeps
+                # returning has_more=True with a repeated (or never-ending)
+                # next_token must not spin forever. 200 pages x 100 docs is
+                # 20k documents — far beyond any single-agent memory set, and
+                # far below what an accidental loop could burn.
+                pages_fetched += 1
+                if pages_fetched > 200:
+                    break
                 kwargs: dict[str, Any] = {"namespace_name": ns, "limit": 100}
                 if next_token:
                     kwargs["next_token"] = next_token
@@ -611,6 +653,11 @@ class MemoryReadService:
                 next_token = pagination.get("next_token")
                 if not next_token:
                     break
+                # A token we have already seen this namespace cannot advance
+                # the cursor — the backend is stuck, so stop rather than loop.
+                if next_token in seen_tokens:
+                    break
+                seen_tokens.add(next_token)
 
         latest_by_id: dict[str, tuple[tuple[datetime, int], dict[str, Any]]] = {}
         for index, item in enumerate(items):

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -1092,10 +1092,19 @@ class MemoryReadService:
 
     @staticmethod
     def _normalize_tags(tags_value: Any) -> list[str]:
+        # Treat string and list serialization identically: the wire format
+        # is comma-separated (to_moorcheh_document joins with ","), so a
+        # comma-bearing element in a list form must split the same way as
+        # the identical CSV string — otherwise filtering/search results
+        # depend on how the storage layer happened to serialize tags.
         if isinstance(tags_value, str):
             parsed_tags = tags_value.split(",")
         elif isinstance(tags_value, list):
-            parsed_tags = tags_value
+            parsed_tags = []
+            for tag in tags_value:
+                if tag is None:
+                    continue
+                parsed_tags.extend(str(tag).split(","))
         else:
             return []
 

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -67,6 +67,24 @@ class MemoryReadService:
         self.client = moorcheh_client
         self._namespace_service = None
 
+    @staticmethod
+    def _validate_limit(limit: int | None) -> None:
+        """Fail closed on invalid limit values.
+
+        Called OUTSIDE the try/except wrappers of the public recall methods
+        so the ValueError contract propagates to callers directly instead of
+        being re-wrapped in MemoryError (which would make an invalid argument
+        indistinguishable from a storage failure). A negative limit would
+        otherwise silently return everything-but-the-last-N via Python's
+        negative-index slicing; zero would fake an empty result set.
+        """
+        if limit is None:
+            return
+        if not isinstance(limit, int) or isinstance(limit, bool):
+            raise ValueError("limit must be a positive integer")
+        if limit <= 0:
+            raise ValueError("limit must be a positive integer")
+
     @property
     def namespace_service(self):
         """Return the namespace service, creating it on first access."""
@@ -341,6 +359,7 @@ class MemoryReadService:
             tags: Optional tag filters
             limit: Max results
         """
+        self._validate_limit(limit)
         try:
             from memanto.app.utils.temporal_helpers import (
                 parse_as_of_timestamp,
@@ -406,10 +425,6 @@ class MemoryReadService:
             # validation in search_memories so every recall path has the same
             # contract.
             if limit is not None:
-                if not isinstance(limit, int) or isinstance(limit, bool):
-                    raise ValueError("limit must be a positive integer")
-                if limit <= 0:
-                    raise ValueError("limit must be a positive integer")
                 valid_memories = valid_memories[:limit]
 
             return {
@@ -442,6 +457,7 @@ class MemoryReadService:
             tags: Optional tag filters
             limit: Max results
         """
+        self._validate_limit(limit)
         try:
             from memanto.app.utils.temporal_helpers import parse_iso_timestamp
 
@@ -507,10 +523,6 @@ class MemoryReadService:
             # would silently return everything-but-the-last-N via Python
             # negative-index slicing; zero would fake an empty result set).
             if limit is not None:
-                if not isinstance(limit, int) or isinstance(limit, bool):
-                    raise ValueError("limit must be a positive integer")
-                if limit <= 0:
-                    raise ValueError("limit must be a positive integer")
                 changed_memories = changed_memories[:limit]
 
             return {
@@ -543,6 +555,7 @@ class MemoryReadService:
             created_after: ISO timestamp - include only memories created at/after this time
             created_before: ISO timestamp - include only memories created at/before this time
         """
+        self._validate_limit(limit)
         try:
             from memanto.app.utils.temporal_helpers import parse_iso_timestamp
 
@@ -576,10 +589,6 @@ class MemoryReadService:
             # would silently return everything-but-the-last-N via Python
             # negative-index slicing; zero would fake an empty result set).
             if limit is not None:
-                if not isinstance(limit, int) or isinstance(limit, bool):
-                    raise ValueError("limit must be a positive integer")
-                if limit <= 0:
-                    raise ValueError("limit must be a positive integer")
                 unique_memories = unique_memories[:limit]
 
             results = unique_memories
@@ -627,10 +636,13 @@ class MemoryReadService:
                 pass  # Fail open: keep newest-version dedup behaviour.
 
         items: list[Any] = []
+        # Retrieval budget is GLOBAL across all namespaces, not per-namespace:
+        # a search over N namespaces must not be able to fetch N x 200 pages
+        # (coderabbit #1815). 200 pages x 100 docs = 20k documents total.
+        pages_fetched = 0
         for ns in namespaces:
             next_token: str | None = None
             seen_tokens: set[str] = set()
-            pages_fetched = 0
             while True:
                 # Bound the pagination loop: a storage layer that keeps
                 # returning has_more=True with a repeated (or never-ending)

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -53,7 +53,13 @@ class OkfExportService:
     """Formats and writes an OKF bundle for an agent."""
 
     def __init__(self, exports_dir: Path | None = None):
-        self.exports_dir = exports_dir or (Path.home() / ".memanto" / "exports")
+        # Align with MemoryExportService: honor the configured data root
+        # (MEMANTO_DATA_DIR / on-prem ~/.memanto/on-prem) so both exporters
+        # write under the same tree instead of splitting on-prem exports
+        # across ~/.memanto/exports and ~/.memanto/on-prem/exports.
+        from memanto.app.config import get_data_dir
+
+        self.exports_dir = exports_dir or (get_data_dir() / "exports")
 
     # Public API
     def write_okf_bundle(

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -246,12 +246,18 @@ async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
 
     if "recall" in updates and isinstance(updates["recall"], dict):
         rec = updates["recall"]
-        _config_manager.set_recall_config(
-            limit=int(rec["limit"]) if "limit" in rec else None,
-            min_similarity=float(rec["min_similarity"])
-            if "min_similarity" in rec and rec["min_similarity"] is not None
-            else None,
-        )
+        try:
+            _config_manager.set_recall_config(
+                limit=int(rec["limit"]) if "limit" in rec else None,
+                min_similarity=float(rec["min_similarity"])
+                if "min_similarity" in rec and rec["min_similarity"] is not None
+                else None,
+            )
+        except ValueError as exc:
+            # int()/float() on a non-numeric value (or an out-of-range value
+            # rejected by set_recall_config) must surface as a clean 400,
+            # matching every other config section, not an unhandled 500.
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return {"status": "updated", "updated_keys": list(updates.keys())}
 
@@ -550,7 +556,12 @@ async def list_conflict_scans(
         agent_id = aid
     _validate_agent_id(str(agent_id))
 
-    conflicts_dir = Path.home() / ".memanto" / "conflicts"
+    # The conflict generator writes under get_data_dir()/conflicts (honoring
+    # MEMANTO_DATA_DIR / on-prem data root); reading the hardcoded
+    # ~/.memanto path would miss every scan on an on-prem install.
+    from memanto.app.config import get_data_dir
+
+    conflicts_dir = get_data_dir() / "conflicts"
     scans: dict[str, dict] = {}
     if conflicts_dir.exists():
         suffix = "_conflicts.json"

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1365,9 +1365,10 @@ class DirectClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        # The generator writes under get_data_dir()/conflicts (honoring
+        # MEMANTO_DATA_DIR / on-prem data root); reading the hardcoded
+        # ~/.memanto path would miss every report on an on-prem install.
+        json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
 
         if not json_path.exists():
             return []
@@ -1409,9 +1410,7 @@ class DirectClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1237,9 +1237,10 @@ class SdkClient:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        # The generator writes under get_data_dir()/conflicts (honoring
+        # MEMANTO_DATA_DIR / on-prem data root); reading the hardcoded
+        # ~/.memanto path would miss every report on an on-prem install.
+        json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
 
         if not json_path.exists():
             return []
@@ -1280,9 +1281,7 @@ class SdkClient:
                 f"Invalid action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}"
             )
 
-        json_path = (
-            Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-        )
+        json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
         if not json_path.exists():
             raise ValueError(f"No conflict report found for {agent_id} on {date}")
 

--- a/memanto/cli/commands/memory.py
+++ b/memanto/cli/commands/memory.py
@@ -1011,9 +1011,12 @@ def conflicts(
 
     # Load full conflict list to get original indices
 
-    json_path = (
-        Path.home() / ".memanto" / "conflicts" / f"{agent_id}_{date}_conflicts.json"
-    )
+    # The generator writes under get_data_dir()/conflicts (honoring
+    # MEMANTO_DATA_DIR / on-prem data root); reading the hardcoded
+    # ~/.memanto path would miss every report on an on-prem install.
+    from memanto.app.config import get_data_dir
+
+    json_path = get_data_dir() / "conflicts" / f"{agent_id}_{date}_conflicts.json"
     with open(json_path, encoding="utf-8") as f:
         all_conflicts = json.load(f)
 

--- a/tests/failing_tests/test_bounty_770_round2.py
+++ b/tests/failing_tests/test_bounty_770_round2.py
@@ -117,8 +117,9 @@ class _FakeClient:
 # 1. Temporal recall limit must reject negative/zero, not silently slice
 # ---------------------------------------------------------------------------
 def test_search_changed_since_rejects_negative_limit():
-    """limit=-1 must raise, not return everything-but-the-last (Python
-    negative-index slicing on the result list)."""
+    """limit=-1 must raise ValueError (not a wrapped MemoryError), never
+    silently return everything-but-the-last via Python negative-index
+    slicing on the result list."""
     from memanto.app.services.memory_read_service import MemoryReadService
 
     svc = MemoryReadService(_FakeClient())
@@ -129,20 +130,20 @@ def test_search_changed_since_rejects_negative_limit():
             limit=-1,
         )
         raise AssertionError("expected an error for negative limit")
-    except Exception as e:
+    except ValueError as e:
         assert "limit must be a positive integer" in str(e)
 
 
 def test_search_recent_rejects_zero_limit():
-    """limit=0 must raise, not return an empty window indistinguishable from
-    'no memories'."""
+    """limit=0 must raise ValueError, not return an empty window
+    indistinguishable from 'no memories'."""
     from memanto.app.services.memory_read_service import MemoryReadService
 
     svc = MemoryReadService(_FakeClient())
     try:
         svc.search_recent(agent_id="agent-1", limit=0)
         raise AssertionError("expected an error for zero limit")
-    except Exception as e:
+    except ValueError as e:
         assert "limit must be a positive integer" in str(e)
 
 
@@ -154,7 +155,7 @@ def test_search_as_of_rejects_negative_limit():
     try:
         svc.search_as_of(as_of_date="2026-01-15", agent_id="agent-1", limit=-3)
         raise AssertionError("expected an error for negative limit")
-    except Exception as e:
+    except ValueError as e:
         assert "limit must be a positive integer" in str(e)
 
 

--- a/tests/failing_tests/test_bounty_770_round2.py
+++ b/tests/failing_tests/test_bounty_770_round2.py
@@ -1,0 +1,329 @@
+"""Bounty #770 round 2 — reproducible regression tests for 4 more bugs.
+
+Run:  python -m pytest tests/failing_tests/test_bounty_770_round2.py -v
+      (or:  python tests/failing_tests/test_bounty_770_round2.py)
+
+Each test documents the bug it guards against; all fail on the pre-fix code
+and pass on the fixed code.
+
+Bugs covered:
+1. HIGH: temporal recall limit slices with negative/zero silently return
+   wrong result windows (Python negative-index slicing), inconsistent with
+   search_memories' fail-closed validation.
+2. MED:  _fetch_all_memories pagination loop has no protection against a
+   repeated next_token from the storage layer -> unbounded HTTP loop.
+3. MED:  search_memories reports total_found as the paginated window length
+   instead of the post-filter match total, so clients using total_found to
+   decide "are there more" / display counts get wrong numbers.
+4. LOW:  generate_conflict_report hardcodes ~/.memanto/conflicts instead of
+   honoring the configured data dir (get_data_dir), so conflict reports land
+   in a different directory than summaries when MEMANTO_DATA_DIR is set.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+def _memory(memory_id: str, created_at: str) -> dict:
+    return {
+        "id": memory_id,
+        "text": f"[FACT] {memory_id}\n\nStored memory",
+        "memory_type": "fact",
+        "agent_id": "agent-1",
+        "actor_id": "agent-1",
+        "source": "user",
+        "confidence": 0.9,
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+
+
+class _StuckPaginationClient:
+    """Storage stub whose next_token never advances (bug 2 repro)."""
+
+    def __init__(self):
+        self.calls = 0
+        self.documents = self
+
+    def fetch_text_data(self, **kwargs):
+        self.calls += 1
+        return {
+            "items": [_memory(f"m{self.calls}", "2026-01-15T09:00:00Z")],
+            "pagination": {"has_more": True, "next_token": "stuck-token"},
+        }
+
+
+class _FakeDocuments:
+    def __init__(self, items=None):
+        self._items = items or [
+            _memory("morning", "2026-01-15T09:00:00Z"),
+            _memory("evening", "2026-01-15T18:00:00Z"),
+            _memory("next-day", "2026-01-16T00:00:00Z"),
+        ]
+
+    def fetch_text_data(self, **kwargs):
+        return {"items": self._items, "pagination": {"has_more": False}}
+
+
+class _FakeClient:
+    documents = _FakeDocuments()
+
+    class _SimilaritySearch:
+        def query(self, **kwargs):
+            return {
+                "results": [
+                    {
+                        "id": "morning",
+                        "text": "[FACT] morning\n\nStored memory",
+                        "score": 0.9,
+                        "metadata": {
+                            "memory_type": "fact",
+                            "created_at": "2026-01-15T09:00:00Z",
+                            "updated_at": "2026-01-15T09:00:00Z",
+                            "confidence": 0.9,
+                        },
+                    },
+                    {
+                        "id": "evening",
+                        "text": "[FACT] evening\n\nStored memory",
+                        "score": 0.8,
+                        "metadata": {
+                            "memory_type": "fact",
+                            "created_at": "2026-01-15T18:00:00Z",
+                            "updated_at": "2026-01-15T18:00:00Z",
+                            "confidence": 0.9,
+                        },
+                    },
+                    {
+                        "id": "next-day",
+                        "text": "[FACT] next-day\n\nStored memory",
+                        "score": 0.7,
+                        "metadata": {
+                            "memory_type": "fact",
+                            "created_at": "2026-01-16T00:00:00Z",
+                            "updated_at": "2026-01-16T00:00:00Z",
+                            "confidence": 0.9,
+                        },
+                    },
+                ]
+            }
+
+    similarity_search = _SimilaritySearch()
+
+
+# ---------------------------------------------------------------------------
+# 1. Temporal recall limit must reject negative/zero, not silently slice
+# ---------------------------------------------------------------------------
+def test_search_changed_since_rejects_negative_limit():
+    """limit=-1 must raise, not return everything-but-the-last (Python
+    negative-index slicing on the result list)."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    svc = MemoryReadService(_FakeClient())
+    try:
+        svc.search_changed_since(
+            since_date="2026-01-01T00:00:00Z",
+            agent_id="agent-1",
+            limit=-1,
+        )
+        raise AssertionError("expected an error for negative limit")
+    except Exception as e:
+        assert "limit must be a positive integer" in str(e)
+
+
+def test_search_recent_rejects_zero_limit():
+    """limit=0 must raise, not return an empty window indistinguishable from
+    'no memories'."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    svc = MemoryReadService(_FakeClient())
+    try:
+        svc.search_recent(agent_id="agent-1", limit=0)
+        raise AssertionError("expected an error for zero limit")
+    except Exception as e:
+        assert "limit must be a positive integer" in str(e)
+
+
+def test_search_as_of_rejects_negative_limit():
+    """Same fail-closed contract for point-in-time recall."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    svc = MemoryReadService(_FakeClient())
+    try:
+        svc.search_as_of(as_of_date="2026-01-15", agent_id="agent-1", limit=-3)
+        raise AssertionError("expected an error for negative limit")
+    except Exception as e:
+        assert "limit must be a positive integer" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# 2. Pagination loop must not spin forever on a repeated next_token
+# ---------------------------------------------------------------------------
+def test_fetch_all_memories_stops_on_repeated_next_token():
+    """A storage layer that keeps returning has_more=True with the same
+    next_token must not produce an unbounded fetch loop."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    client = _StuckPaginationClient()
+    svc = MemoryReadService(client)
+    # If the fix is absent this call loops until timeout/crash. With the fix
+    # it returns after a bounded number of pages (stale token detected).
+    result = svc._fetch_all_memories(["agent-1"])
+    assert client.calls < 1000, "pagination loop did not terminate"
+    assert len(result) >= 1  # still collected the first page
+
+
+def test_fetch_all_memories_bounded_when_backend_keeps_paging():
+    """Even a backend that legitimately pages many times cannot exceed a
+    sane cap on total documents fetched."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    class _ManyPagesDocuments:
+        def __init__(self):
+            self.calls = 0
+
+        def fetch_text_data(self, **kwargs):
+            self.calls += 1
+            return {
+                "items": [_memory(f"m{self.calls}", "2026-01-15T09:00:00Z")],
+                "pagination": {"has_more": True, "next_token": f"tok-{self.calls}"},
+            }
+
+    class _ManyPagesClient:
+        documents = _ManyPagesDocuments()
+
+    client = _ManyPagesClient()
+    svc = MemoryReadService(client)
+    result = svc._fetch_all_memories(["agent-1"])
+    assert client.documents.calls <= 200, "page cap not enforced"
+    assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# 3. total_found must be the post-filter total, not the paginated window
+# ---------------------------------------------------------------------------
+def test_search_memories_total_found_is_match_total():
+    """total_found must report how many memories matched the filters (before
+    offset/limit), not the length of the returned page."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    svc = MemoryReadService(_FakeClient())
+    result = svc.search_memories(query="x", agent_id="agent-1", limit=1, offset=0)
+    # 3 memories exist; page length is 1, but total_found must be 3.
+    assert result["total_found"] == 3, (
+        f"total_found={result['total_found']} should be the match total, "
+        f"total_available={result.get('total_available')}"
+    )
+    assert result["total_available"] == 3
+    assert len(result["results"]) == 1
+
+
+def test_search_memories_total_found_respects_filters():
+    """Type/temporal filters shrink the total; total_found must reflect the
+    filtered match count, not the page size."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    class _SingleTypeDocuments:
+        def fetch_text_data(self, **kwargs):
+            return {
+                "items": [
+                    _memory("fact-a", "2026-01-15T09:00:00Z"),
+                    _memory("pref-b", "2026-01-15T10:00:00Z"),
+                ],
+                "pagination": {"has_more": False},
+            }
+
+    class _SingleTypeSimilarity:
+        def query(self, **kwargs):
+            # Simulate Moorcheh server-side #memory_type filtering: the
+            # enhanced query for type=["preference"] carries the filter token,
+            # and the backend only returns documents that match it.
+            query = kwargs.get("query", "")
+            rows = [
+                {
+                    "id": "fact-a",
+                    "text": "[FACT] fact-a\n\nStored memory",
+                    "score": 0.9,
+                    "metadata": {
+                        "memory_type": "fact",
+                        "created_at": "2026-01-15T09:00:00Z",
+                        "updated_at": "2026-01-15T09:00:00Z",
+                        "confidence": 0.9,
+                    },
+                },
+                {
+                    "id": "pref-b",
+                    "text": "[PREFERENCE] pref-b\n\nStored memory",
+                    "score": 0.8,
+                    "metadata": {
+                        "memory_type": "preference",
+                        "created_at": "2026-01-15T10:00:00Z",
+                        "updated_at": "2026-01-15T10:00:00Z",
+                        "confidence": 0.9,
+                    },
+                },
+            ]
+            if "#memory_type:preference" in query:
+                rows = [r for r in rows if r["metadata"]["memory_type"] == "preference"]
+            return {"results": rows}
+
+    class _SingleTypeClient:
+        documents = _SingleTypeDocuments()
+        similarity_search = _SingleTypeSimilarity()
+
+    svc = MemoryReadService(_SingleTypeClient())
+    result = svc.search_memories(
+        query="x", agent_id="agent-1", type=["preference"], limit=1
+    )
+    assert result["total_found"] == 1, (
+        f"total_found={result['total_found']} should equal the filtered "
+        f"match total (1 preference), not the page length"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Conflict reports must honor the configured data dir
+# ---------------------------------------------------------------------------
+def test_conflict_report_uses_configured_data_dir():
+    """generate_conflict_report must write into get_data_dir()/conflicts,
+    not hardcoded ~/.memanto/conflicts, so a configured MEMANTO_DATA_DIR is
+    respected consistently with summaries."""
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "memanto"
+        / "app"
+        / "services"
+        / "daily_analysis_service.py"
+    ).read_text(encoding="utf-8")
+    # Split out just the generate_conflict_report function body.
+    start = src.find("def generate_conflict_report")
+    end = src.find("\n    def ", start + 10)
+    body = src[start : end if end != -1 else len(src)]
+    assert "Path.home()" not in body, (
+        "generate_conflict_report hardcodes ~/.memanto instead of get_data_dir()"
+    )
+    assert "get_data_dir() / \"conflicts\"" in body
+
+
+if __name__ == "__main__":
+    tests = [
+        test_search_changed_since_rejects_negative_limit,
+        test_search_recent_rejects_zero_limit,
+        test_search_as_of_rejects_negative_limit,
+        test_fetch_all_memories_stops_on_repeated_next_token,
+        test_fetch_all_memories_bounded_when_backend_keeps_paging,
+        test_search_memories_total_found_is_match_total,
+        test_search_memories_total_found_respects_filters,
+        test_conflict_report_uses_configured_data_dir,
+    ]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS: {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL: {t.__name__}: {e}")
+    sys.exit(1 if failures else 0)

--- a/tests/failing_tests/test_bounty_770_round3.py
+++ b/tests/failing_tests/test_bounty_770_round3.py
@@ -1,0 +1,142 @@
+"""Bounty #770 round 3 — reproducible regression tests for 3 more bugs.
+
+Run:  python -m pytest tests/failing_tests/test_bounty_770_round3.py -v
+      (or:  python tests/failing_tests/test_bounty_770_round3.py)
+
+Bugs covered:
+1. HIGH: conflict-report read paths hardcode ~/.memanto/conflicts while the
+   generator uses get_data_dir()/conflicts (regression introduced by the
+   round-2 fix). With MEMANTO_BACKEND=on-prem (data dir
+   ~/.memanto/on-prem), list/resolve can never see generated reports.
+   Affects DirectClient (2 sites), SdkClient (2 sites), and the UI router
+   (1 site).
+2. MED:  PATCH /api/ui/config with a non-numeric recall.limit /
+   recall.min_similarity raises an uncaught ValueError -> HTTP 500
+   instead of a 400, unlike every other config section which maps
+   ValueError to 400.
+3. MED:  OkfExportService defaults to ~/.memanto/exports while
+   MemoryExportService defaults to get_data_dir()/exports; on-prem
+   exports land in different directories depending on which exporter is
+   used.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+# ---------------------------------------------------------------------------
+# 1. Conflict-report read paths must honor get_data_dir()
+# ---------------------------------------------------------------------------
+def test_direct_client_conflict_paths_use_get_data_dir():
+    """list_conflicts / resolve_conflict must read the same directory the
+    generator writes to (get_data_dir()/conflicts), not hardcoded
+    ~/.memanto/conflicts."""
+    import inspect
+
+    from memanto.cli.client.direct_client import DirectClient
+
+    for method_name in ("list_conflicts", "resolve_conflict"):
+        src = inspect.getsource(getattr(DirectClient, method_name))
+        assert "Path.home()" not in src, (
+            f"DirectClient.{method_name} hardcodes ~/.memanto instead of "
+            f"get_data_dir()/conflicts"
+        )
+
+
+def test_sdk_client_conflict_paths_use_get_data_dir():
+    """SdkClient mirrors the same contract."""
+    import inspect
+
+    from memanto.cli.client.sdk_client import SdkClient
+
+    for method_name in ("list_conflicts", "resolve_conflict"):
+        src = inspect.getsource(getattr(SdkClient, method_name))
+        assert "Path.home()" not in src, (
+            f"SdkClient.{method_name} hardcodes ~/.memanto instead of "
+            f"get_data_dir()/conflicts"
+        )
+
+
+def test_ui_conflict_scans_use_get_data_dir():
+    """The UI conflict-scan reader must point at the same directory as the
+    generator."""
+    import inspect
+
+    from memanto.app.ui.routes import ui_router
+
+    src = inspect.getsource(ui_router.list_conflict_scans)
+    assert "Path.home()" not in src, (
+        "ui_router.list_conflict_scans hardcodes ~/.memanto/conflicts"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-numeric recall config must be a 400, not an uncaught 500
+# ---------------------------------------------------------------------------
+def test_update_ui_config_recall_rejects_bad_limit():
+    """A non-numeric recall.limit must produce a clean 400 (ValueError
+    mapped), not bubble up as an unhandled exception -> 500."""
+    import inspect
+
+    from memanto.app.ui.routes import ui_router
+
+    src = inspect.getsource(ui_router.update_ui_config)
+    # The recall branch must be wrapped so ValueError -> 400 like every
+    # other section (session, schedule_time, answer).
+    assert "except ValueError" in src.split('if "recall" in updates')[1], (
+        "update_ui_config recall branch does not map ValueError to 400"
+    )
+
+
+def test_update_ui_config_recall_rejects_bad_min_similarity():
+    """Same contract for recall.min_similarity."""
+    import inspect
+
+    from memanto.app.ui.routes import ui_router
+
+    src = inspect.getsource(ui_router.update_ui_config)
+    recall_part = src.split('if "recall" in updates')[1]
+    # int(rec["limit"]) / float(rec["min_similarity"]) must be inside the
+    # guarded region, not evaluated bare.
+    assert "try:" in recall_part and "except ValueError" in recall_part
+
+
+# ---------------------------------------------------------------------------
+# 3. Export services must agree on the data directory
+# ---------------------------------------------------------------------------
+def test_okf_export_default_dir_matches_memory_export():
+    """OkfExportService and MemoryExportService must share the same default
+    exports root (get_data_dir()/exports) so on-prem data stays under
+    ~/.memanto/on-prem like everything else."""
+    import inspect
+
+    from memanto.app.services import memory_export_service, okf_export_service
+
+    mem_src = inspect.getsource(memory_export_service.MemoryExportService.__init__)
+    okf_src = inspect.getsource(okf_export_service.OkfExportService.__init__)
+    assert "get_data_dir() / \"exports\"" in mem_src
+    assert "get_data_dir() / \"exports\"" in okf_src, (
+        "OkfExportService defaults to ~/.memanto/exports instead of "
+        "get_data_dir()/exports — on-prem exports split across two roots"
+    )
+
+
+if __name__ == "__main__":
+    tests = [
+        test_direct_client_conflict_paths_use_get_data_dir,
+        test_sdk_client_conflict_paths_use_get_data_dir,
+        test_ui_conflict_scans_use_get_data_dir,
+        test_update_ui_config_recall_rejects_bad_limit,
+        test_update_ui_config_recall_rejects_bad_min_similarity,
+        test_okf_export_default_dir_matches_memory_export,
+    ]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS: {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL: {t.__name__}: {e}")
+    sys.exit(1 if failures else 0)

--- a/tests/failing_tests/test_bounty_770_round4.py
+++ b/tests/failing_tests/test_bounty_770_round4.py
@@ -1,0 +1,168 @@
+"""Bounty #770 round 4 — reproducible regression tests for 3 more bugs.
+
+Run:  python -m pytest tests/failing_tests/test_bounty_770_round4.py -v
+      (or:  python tests/failing_tests/test_bounty_770_round4.py)
+
+Bugs covered:
+1. HIGH: tags containing a comma are corrupted on write->read round-trip.
+   MemoryRecord.to_moorcheh_document joins tags with "," (comma-separated
+   filter syntax) while readers split on ",", so a tag like "urgent,high"
+   comes back as ["urgent", "high"] — the original tag is lost and a
+   phantom tag appears. Tag filtering (#tag) then matches the wrong rows.
+2. MED:  CLI `memanto conflicts` (interactive resolver) hardcodes
+   ~/.memanto/conflicts while the generator writes get_data_dir()/conflicts
+   — same on-prem split as the round-3 fixes, but the CLI path was missed.
+3. MED:  _normalize_tags treats list-typed tags differently from
+   string-typed tags: a list with a comma-bearing tag is NOT split while
+   the identical string IS split, so filtering/search results depend on
+   how the storage layer happens to serialize tags.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+# ---------------------------------------------------------------------------
+# 1. Comma-bearing tags must be rejected before they can corrupt storage
+# ---------------------------------------------------------------------------
+def test_comma_tag_roundtrip_is_not_corrupted():
+    """The schema must reject comma-bearing tags so the CSV wire format can
+    never be ambiguous (a comma tag would round-trip as two tags, losing
+    the original and fabricating a phantom)."""
+    from pydantic import ValidationError
+
+    from memanto.app.core import MemoryRecord
+
+    try:
+        MemoryRecord(
+            type="fact",
+            title="t",
+            content="c",
+            agent_id="a1",
+            actor_id="a1",
+            source="user",
+            tags=["urgent,high", "clean"],
+        )
+        raise AssertionError("expected ValidationError for comma in tag")
+    except ValidationError:
+        pass
+
+
+def test_comma_tag_does_not_create_phantom_tag():
+    """A comma-bearing tag must never reach the serializer, so reading back
+    cannot fabricate a 'high' tag from 'urgent,high'."""
+    from pydantic import ValidationError
+
+    from memanto.app.core import MemoryRecord
+
+    try:
+        MemoryRecord(
+            type="fact",
+            title="t",
+            content="c",
+            agent_id="a1",
+            actor_id="a1",
+            source="user",
+            tags=["urgent,high"],
+        )
+        raise AssertionError("expected ValidationError for comma in tag")
+    except ValidationError:
+        pass
+
+
+def test_normal_tags_still_roundtrip():
+    """Tags without commas must serialize and read back unchanged."""
+    from memanto.app.core import MemoryRecord
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    mem = MemoryRecord(
+        type="fact",
+        title="t",
+        content="c",
+        agent_id="a1",
+        actor_id="a1",
+        source="user",
+        tags=["clean", "tag2"],
+    )
+    serialized = mem.to_moorcheh_document()["tags"]
+
+    class FakeClient:
+        class D:
+            def fetch_text_data(self, **kwargs):
+                return {
+                    "items": [
+                        {
+                            "id": "m1",
+                            "text": "[FACT] t\n\nc",
+                            "metadata": {
+                                "memory_type": "fact",
+                                "tags": serialized,
+                                "created_at": "2026-01-01T00:00:00Z",
+                                "updated_at": "2026-01-01T00:00:00Z",
+                            },
+                        }
+                    ],
+                    "pagination": {"has_more": False},
+                }
+
+        documents = D()
+
+    svc = MemoryReadService(FakeClient())
+    result = svc.search_recent(agent_id="a1")
+    tags = result["results"][0]["tags"]
+    assert tags == ["clean", "tag2"], f"normal tags corrupted: {tags}"
+
+
+# ---------------------------------------------------------------------------
+# 2. CLI conflict resolver must honor get_data_dir()
+# ---------------------------------------------------------------------------
+def test_cli_conflicts_command_uses_get_data_dir():
+    """memanto/cli/commands/memory.py (conflicts command) must read the
+    report from get_data_dir()/conflicts, not ~/.memanto/conflicts."""
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "memanto"
+        / "cli"
+        / "commands"
+        / "memory.py"
+    ).read_text(encoding="utf-8")
+    assert "Path.home() / \".memanto\" / \"conflicts\"" not in src, (
+        "CLI conflicts command hardcodes ~/.memanto/conflicts"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. _normalize_tags must treat string and list serialization identically
+# ---------------------------------------------------------------------------
+def test_normalize_tags_string_and_list_agree():
+    """The same tags serialized as CSV string vs list must normalize to the
+    same result — otherwise recall/filter behavior depends on storage
+    serialization."""
+    from memanto.app.services.memory_read_service import MemoryReadService
+
+    svc = MemoryReadService.__new__(MemoryReadService)
+    as_str = svc._normalize_tags("a,b")
+    as_list = svc._normalize_tags(["a,b"])
+    assert as_str == as_list, (
+        f"string serialization {as_str} != list serialization {as_list}"
+    )
+
+
+if __name__ == "__main__":
+    tests = [
+        test_comma_tag_roundtrip_is_not_corrupted,
+        test_comma_tag_does_not_create_phantom_tag,
+        test_normal_tags_still_roundtrip,
+        test_cli_conflicts_command_uses_get_data_dir,
+        test_normalize_tags_string_and_list_agree,
+    ]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS: {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL: {t.__name__}: {e}")
+    sys.exit(1 if failures else 0)

--- a/tests/failing_tests/test_bounty_770_round4.py
+++ b/tests/failing_tests/test_bounty_770_round4.py
@@ -132,6 +132,68 @@ def test_cli_conflicts_command_uses_get_data_dir():
     )
 
 
+def test_cli_conflicts_reads_configured_data_dir_at_runtime(tmp_path, monkeypatch):
+    """Runtime proof: with get_data_dir() pointed at a temp root, the CLI
+    conflicts command must load its report from THAT root, not from
+    ~/.memanto (which would raise FileNotFoundError / read stale data)."""
+    import json
+
+    import memanto.app.config as config_mod
+
+    # Point get_data_dir at a temp root and write the report there.
+    monkeypatch.setattr(config_mod, "get_data_dir", lambda: tmp_path)
+    conflicts_dir = tmp_path / "conflicts"
+    conflicts_dir.mkdir(parents=True, exist_ok=True)
+    report_path = conflicts_dir / "a1_2026-01-15_conflicts.json"
+    report_path.write_text(
+        json.dumps(
+            [
+                {
+                    "type": "CONTRADICTION",
+                    "title": "t",
+                    "old_memory_id": "m1",
+                    "new_memory_id": "m2",
+                    "old_content": "old",
+                    "new_content": "new",
+                    "recommendation": "keep_new",
+                    "resolved": False,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    import typer
+
+    import memanto.cli.commands.memory as mem_cli
+
+    class FakeClient:
+        def list_conflicts(self, agent_id, date):
+            return [
+                {
+                    "type": "CONTRADICTION",
+                    "title": "t",
+                    "old_memory_id": "m1",
+                    "new_memory_id": "m2",
+                    "old_content": "old",
+                    "new_content": "new",
+                    "recommendation": "keep_new",
+                }
+            ]
+
+    monkeypatch.setattr(mem_cli, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(
+        mem_cli.config_manager, "get_active_session", lambda: ("a1", "tok")
+    )
+    # Quit immediately after the first panel so the loop terminates.
+    monkeypatch.setattr(typer, "prompt", lambda *a, **k: "q")
+
+    # Must not raise FileNotFoundError and must report the configured-path
+    # report was found.
+    mem_cli.conflicts(date="2026-01-15", agent_id="a1", list_only=False)
+    assert report_path.exists(), "report fixture missing"
+
+
 # ---------------------------------------------------------------------------
 # 3. _normalize_tags must treat string and list serialization identically
 # ---------------------------------------------------------------------------
@@ -165,4 +227,34 @@ if __name__ == "__main__":
         except Exception as e:
             failures += 1
             print(f"FAIL: {t.__name__}: {e}")
+
+    # The runtime CLI test needs pytest-style fixtures; run it standalone
+    # with hand-rolled stand-ins so `python tests/...py` still exercises it.
+    import tempfile
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+    class _TmpPath:
+        def __init__(self, root):
+            self._root = Path(root)
+
+        def __truediv__(self, other):
+            return self._root / other
+
+        def mkdir(self, *a, **k):
+            return self._root.mkdir(*a, **k)
+
+        def __str__(self):
+            return str(self._root)
+
+    try:
+        tmp_path = _TmpPath(tempfile.mkdtemp(prefix="memanto_r4_"))
+        mp = MonkeyPatch()
+        test_cli_conflicts_reads_configured_data_dir_at_runtime(tmp_path, mp)
+        mp.undo()
+        print("PASS: test_cli_conflicts_reads_configured_data_dir_at_runtime")
+    except Exception as e:
+        failures += 1
+        print(f"FAIL: test_cli_conflicts_reads_configured_data_dir_at_runtime: {e}")
+
     sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Bounty #770 — round 2: 4 more deterministic bugs

Second submission batch on top of PR #1808. All four bugs are reproducible,
covered by failing-then-passing regression tests in
`tests/failing_tests/test_bounty_770_round2.py`.

### 1. HIGH — unbounded pagination loop in `_fetch_all_memories`
`MemoryReadService._fetch_all_memories` iterated `while True` over
`fetch_text_data` pages with no protection against a repeated or
never-ending `next_token`. A storage layer that keeps returning
`has_more=True` with the same (or always-new) token spins unbounded HTTP
fetches. Fix: track seen tokens per namespace and cap at 200 pages
(20k documents), far beyond any real agent memory set.

### 2. MED — temporal recall silently mis-slices with negative/zero limit
`search_as_of` / `search_changed_since` / `search_recent` accepted any
`limit` and applied it with Python slicing. `limit=-1` returned
everything-but-the-last memory; `limit=0` faked an empty result set that
is indistinguishable from "no memories". `search_memories` already fails
closed on invalid limits; these three now do too (ValueError).

### 3. MED — `total_found` lied about match totals
`search_memories` reported `total_found` as the length of the returned
page, so a paged recall with `limit=10` showed `total_found=10` even when
hundreds of memories matched. Paginating clients use `total_found` to
decide "are there more" and render counts. Fix: report the post-filter
match total (consistent with `total_available`).

### 4. LOW — conflict reports ignored `MEMANTO_DATA_DIR`
`DailyAnalysisService.generate_conflict_report` hardcoded
`~/.memanto/conflicts`, so with a configured data dir conflict reports
landed in a different directory than the daily summaries they are meant to
accompany. Fix: `get_data_dir() / "conflicts"`.

### Verification
- 8 new regression tests (all fail on pre-fix code, pass on fixed code)
- Full suite: 592 passed, 2 skipped, 0 failed on latest main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conflict reports and export files now use the configured data directory.
  * Search totals accurately reflect filtered and paginated matches.
  * Invalid time-based search limits and recall settings are rejected safely.
  * Memory retrieval pagination prevents stalled or unbounded searches.
  * Tags containing commas are rejected, preserving consistent tag handling.

* **Tests**
  * Added regression coverage for search, validation, pagination, paths, exports, and tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->