### PR TITLE
fix: unbreak memanto-mcp on mcp SDK 2.0 and attribute writes per client

### DIFF
--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -20,7 +20,7 @@ custom agents, …) can plug into long-term memory in a single config line.
 pip install memanto-mcp
 ```
 
-Requires Python 3.10+, `memanto>=0.2.11`, and a
+Requires Python 3.10+, `memanto>=0.2.13`, `mcp>=1.2,<2`, and a
 [Moorcheh API key](https://console.moorcheh.ai/api-keys)
 (free tier: 100K ops/month).
 
@@ -114,8 +114,19 @@ Memory types accepted by `remember` / `batch_remember`:
 Provenance values: `explicit_statement`, `inferred`, `corrected`,
 `validated`, `observed`, `imported`.
 
-Source values: `user`, `agent` (default), `tool`, `system`. Memanto core
-validates these at write time — a free-form label is rejected.
+### Source attribution
+
+`source` names *who wrote* a memory, so recall can be attributed and filtered
+per writer. It is open: `user`, `agent`, `tool`, `system`, or a specific
+writer such as `cursor`, `codex`, `claude_code`, `mem0`. Labels are limited to
+64 letters, digits, `.`, `_`, or `-` so that `#source:<value>` stays a usable
+filter.
+
+When a tool call omits `source`, the server attributes the write to the
+**connected MCP client** from the initialize handshake (`cursor`, `codex`,
+`claude-ai`, …), falling back to `mcp-agent` when the client sends no name.
+Two editors sharing one agent therefore stay distinguishable in recall without
+any extra configuration.
 
 ## Configuration
 

--- a/integrations/mcp/memanto_mcp/__init__.py
+++ b/integrations/mcp/memanto_mcp/__init__.py
@@ -7,8 +7,17 @@ can store and retrieve long-term memory.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
+
 from memanto_mcp.config import MCPServerSettings
 from memanto_mcp.server import build_server, run_server
 
 __all__ = ["MCPServerSettings", "build_server", "run_server", "__version__"]
-__version__ = "0.1.0"
+
+try:
+    # Read the installed distribution rather than restating the version here:
+    # a hardcoded literal silently reports a stale number when pyproject is
+    # bumped for a release (0.1.1 shipped announcing itself as 0.1.0).
+    __version__ = version("memanto-mcp")
+except PackageNotFoundError:  # pragma: no cover - running from a source tree
+    __version__ = "0.0.0.dev0"

--- a/integrations/mcp/memanto_mcp/server.py
+++ b/integrations/mcp/memanto_mcp/server.py
@@ -75,6 +75,16 @@ def build_server(settings: MCPServerSettings | None = None) -> FastMCP:
         port=settings.port,
     )
 
+    # FastMCP has no `version` argument and the low-level server falls back to
+    # the MCP SDK's own version, so every release announced itself as the SDK
+    # release (e.g. "1.29.0") in the initialize handshake. Clients surface that
+    # string when reporting which server they are talking to, so set ours.
+    # Imported here rather than at module scope: memanto_mcp/__init__ imports
+    # this module, so the package is only fully initialized by call time.
+    from memanto_mcp import __version__
+
+    mcp._mcp_server.version = __version__
+
     lifecycle = MemantoLifecycle(settings)
     register_tools(mcp, lifecycle)
 

--- a/integrations/mcp/memanto_mcp/tools.py
+++ b/integrations/mcp/memanto_mcp/tools.py
@@ -14,11 +14,18 @@ at tool-registration time, and we use closure-scoped type aliases (e.g.
 """
 
 import logging
-from typing import Annotated, Any, Literal, TypeVar, get_args
+import re
+from typing import Annotated, Any, Literal, TypeVar
 
+from mcp.server.fastmcp import Context
 from memanto.app.constants import (
     VALID_MEMORY_TYPES,
     VALID_PROVENANCE_TYPES,
+)
+from memanto.app.core import (
+    SOURCE_MAX_LENGTH,
+    SOURCE_PATTERN,
+    is_valid_source,
 )
 from memanto.app.utils.errors import (
     AgentAlreadyExistsError,
@@ -64,11 +71,26 @@ ProvenanceLiteral = Literal[
     "imported",
 ]
 
-# Memanto core validates ``MemoryRecord.source`` against this closed set; a
-# free-form label (e.g. an agent name) is rejected at write time.
-SourceLiteral = Literal["user", "agent", "tool", "system"]
+# Attribution fallback when the transport carries no client identity.
+DEFAULT_SOURCE = "mcp-agent"
 
-VALID_SOURCE_TYPES = frozenset(get_args(SourceLiteral))
+# A source names the writer of a memory. Memanto keeps it open ("user",
+# "agent", "cursor", "codex", ...) but bounded, so reuse core's own rule rather
+# than restating it here: the schema we advertise then matches what core will
+# accept at write time.
+SOURCE_CONSTRAINT = Field(
+    default=None,
+    description=(
+        "Who wrote this memory. Defaults to the connected MCP client "
+        "(e.g. 'cursor', 'codex', 'claude-ai'), falling back to "
+        f"'{DEFAULT_SOURCE}'. Up to {SOURCE_MAX_LENGTH} letters, digits, "
+        "'.', '_', or '-'."
+    ),
+    max_length=SOURCE_MAX_LENGTH,
+    pattern=SOURCE_PATTERN,
+)
+
+_SOURCE_SANITIZE_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 # Hard caps mirroring the Memanto core service (see SdkClient).
 _MAX_CONTENT_LENGTH = InputLimits.MAX_TEXT_LENGTH
@@ -209,6 +231,34 @@ def _format_exception(exc: Exception) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
+def _sanitize_source(raw: Any) -> str | None:
+    """Coerce a client-supplied name into a valid Memanto source label.
+
+    Client names are free text ("Visual Studio Code", "Claude Code"), so fold
+    them to the bounded label shape instead of dropping the attribution.
+    """
+    if not raw:
+        return None
+    token = _SOURCE_SANITIZE_RE.sub("-", str(raw).strip().lower()).strip("-")
+    return token[:SOURCE_MAX_LENGTH] or None
+
+
+def _client_source(ctx: Context | None) -> str:
+    """Name the MCP client behind this call so writes stay attributable.
+
+    Clients identify themselves during the initialize handshake ("cursor",
+    "codex", "claude-ai", ...), which is exactly the per-writer observability
+    Memanto's open ``source`` field is for. Falls back to a generic label when
+    no client info reached us (direct calls, clients that omit it).
+    """
+    try:
+        client_params = ctx.session.client_params if ctx is not None else None
+        name = client_params.clientInfo.name if client_params else None
+    except AttributeError:
+        name = None
+    return _sanitize_source(name) or DEFAULT_SOURCE
+
+
 def _normalize_tags(raw: Any) -> list[str]:
     """Accept MCP client tag shapes while preserving SDK list semantics."""
     if raw is None:
@@ -329,18 +379,9 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 ),
             ),
         ] = "explicit_statement",
-        source: Annotated[
-            SourceLiteral,
-            Field(
-                description=(
-                    "Who produced this memory. 'user' means the user supplied "
-                    "it, 'agent' means you did (default), 'tool' means it came "
-                    "out of a tool call, 'system' means it was injected by the "
-                    "platform."
-                ),
-            ),
-        ] = "agent",
+        source: Annotated[str | None, SOURCE_CONSTRAINT] = None,
         agent_id: AgentIdField = None,
+        ctx: Context | None = None,
     ) -> RememberResult:
         """Store a single memory for the resolved agent."""
         try:
@@ -358,7 +399,7 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                 content=content,
                 confidence=confidence,
                 tags=_normalize_tags(tags),
-                source=source,
+                source=source or _client_source(ctx),
                 provenance=provenance,
             )
             return RememberResult(
@@ -398,17 +439,20 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                     "List of memory dicts. Each item supports the same fields "
                     "as `remember` (content [required], type, title, "
                     "confidence, tags, source, provenance) with the same "
-                    "allowed values. Max 100 items."
+                    "allowed values; an item without a source is attributed to "
+                    "the calling client. Max 100 items."
                 ),
                 min_length=1,
                 max_length=_MAX_BATCH_SIZE,
             ),
         ],
         agent_id: AgentIdField = None,
+        ctx: Context | None = None,
     ) -> BatchRememberResult:
         """Validate and store multiple memories for the resolved agent."""
         try:
             resolved = lifecycle.resolve_agent_id(agent_id)
+            default_source = _client_source(ctx)
             # Validate before round-trip so we fail fast with a clear error.
             normalized_memories: list[dict[str, Any]] = []
             for i, item in enumerate(memories):
@@ -432,16 +476,16 @@ def register_tools(mcp: Any, lifecycle: MemantoLifecycle) -> None:
                         f"memories[{i}].provenance={prov!r} is not valid. "
                         f"Choose one of: {sorted(VALID_PROVENANCE_TYPES)}"
                     )
-                src = item.get("source") or "agent"
-                if src not in VALID_SOURCE_TYPES:
+                src = item.get("source") or default_source
+                if not is_valid_source(src):
                     raise ValueError(
-                        f"memories[{i}].source={src!r} is not valid. "
-                        f"Choose one of: {sorted(VALID_SOURCE_TYPES)}"
+                        f"memories[{i}].source={src!r} is not valid. Use up to "
+                        f"{SOURCE_MAX_LENGTH} letters, digits, '.', '_', or '-'."
                     )
                 normalized_item = dict(item)
                 normalized_item["tags"] = _normalize_tags(item.get("tags"))
-                # The SDK defaults a missing source to "user"; keep batch
-                # writes consistent with `remember`, whose default is "agent".
+                # The SDK defaults a missing source to "user"; attribute the
+                # write to the calling client instead, like `remember` does.
                 normalized_item["source"] = src
                 normalized_memories.append(normalized_item)
 

--- a/integrations/mcp/pyproject.toml
+++ b/integrations/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memanto-mcp"
-version = "0.1.1"
+version = "0.1.2"
 description = "Model Context Protocol (MCP) server for Memanto - persistent semantic memory for any MCP-compatible agent"
 readme = "README.md"
 license = { text = "MIT" }
@@ -37,10 +37,15 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mcp[cli]>=1.2.0",
-    # 0.2.11 narrowed MemoryRecord.source to a closed Literal; the tool schema
-    # here mirrors that set, so older cores are not interchangeable.
-    "memanto>=0.2.11",
+    # Upper bound is required, not cautionary: mcp 2.0 removed
+    # `mcp.server.fastmcp` (FastMCP became `mcp.server.mcpserver.MCPServer`),
+    # so an unpinned install resolves to a release this server cannot import.
+    "mcp[cli]>=1.2.0,<2",
+    # Sources are open labels again as of 0.2.13, which is also where
+    # core.MemorySource / is_valid_source (imported by tools.py) land. 0.2.11
+    # and 0.2.12 reject any source outside user/agent/tool/system, so this
+    # server cannot attribute writes to the calling client on those.
+    "memanto>=0.2.13",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",

--- a/integrations/mcp/tests/test_packaging.py
+++ b/integrations/mcp/tests/test_packaging.py
@@ -1,0 +1,52 @@
+"""Dependency-bound regressions.
+
+The declared bounds are load-bearing: this server imports modules that exist
+only in specific dependency majors, and a resolver is free to pick anything a
+bound allows. These tests read the real metadata rather than the environment,
+so a loosened pin fails here instead of in a user's fresh install.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+tomllib = pytest.importorskip("tomllib")
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _requirement(name: str) -> Requirement:
+    """Return the declared runtime requirement for *name*."""
+    metadata = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    for raw in metadata["project"]["dependencies"]:
+        requirement = Requirement(raw)
+        if requirement.name == name:
+            return requirement
+    raise AssertionError(f"{name} is not declared in [project.dependencies]")
+
+
+def test_mcp_dependency_excludes_v2() -> None:
+    """mcp 2.0 deleted `mcp.server.fastmcp`, which server.py imports.
+
+    Without an upper bound a fresh install resolves to 2.x and dies at import
+    with "No module named 'mcp.server.fastmcp'".
+    """
+    specifier = _requirement("mcp").specifier
+
+    assert not specifier.contains(Version("2.0.0"))
+    assert specifier.contains(Version("1.29.0"))
+
+
+def test_memanto_dependency_requires_open_sources() -> None:
+    """tools.py imports MemorySource/is_valid_source, added in memanto 0.2.13.
+
+    0.2.11 and 0.2.12 also reject the open source labels this server writes.
+    """
+    specifier = _requirement("memanto").specifier
+
+    assert not specifier.contains(Version("0.2.12"))
+    assert specifier.contains(Version("0.2.13"))

--- a/integrations/mcp/tests/test_server.py
+++ b/integrations/mcp/tests/test_server.py
@@ -1,20 +1,24 @@
 """Server assembly: build_server must register every tool we ship.
 
-These tests never call a tool — they only inspect the registered schema, so
-no network requests are made.
+These tests inspect the registered schema, or drive a tool over an in-memory
+MCP session with the SDK client patched out, so no network requests are made.
 """
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.types import Implementation
 from memanto.app.constants import (
     VALID_MEMORY_TYPES,
     VALID_PROVENANCE_TYPES,
 )
+from memanto.app.core import SOURCE_MAX_LENGTH, SOURCE_PATTERN
 
 from memanto_mcp.config import MCPServerSettings
 from memanto_mcp.server import build_server
-from memanto_mcp.tools import VALID_SOURCE_TYPES
 
 MAIN_TOOL_NAMES = {
     "remember",
@@ -55,13 +59,11 @@ async def test_admin_tools_registered_when_enabled(
 
 
 @pytest.mark.asyncio
-async def test_advertised_enums_match_memanto_core(fake_api_key: str) -> None:
+async def test_advertised_constraints_match_memanto_core(fake_api_key: str) -> None:
     """The tool schema is a contract with the calling model.
 
-    Memanto core validates these fields at write time, so an enum that drifts
-    from core hands the model a value that is guaranteed to fail on write.
-    Every advertised source is separately round-tripped through a real
-    MemoryRecord in test_tools.py, which is what pins the source list.
+    Memanto core validates these fields at write time, so a constraint that
+    drifts from core hands the model a value guaranteed to fail on write.
     """
     mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
     tools = {t.name: t for t in await mcp.list_tools()}
@@ -69,7 +71,80 @@ async def test_advertised_enums_match_memanto_core(fake_api_key: str) -> None:
 
     assert set(props["type"]["enum"]) == VALID_MEMORY_TYPES
     assert set(props["provenance"]["enum"]) == VALID_PROVENANCE_TYPES
-    assert set(props["source"]["enum"]) == VALID_SOURCE_TYPES
+
+    # Source is open (no enum) but bounded to core's label shape. It is
+    # optional, so the constraints sit in the string branch of the union.
+    source_schema = props["source"]
+    assert "enum" not in source_schema
+    string_branch = next(
+        branch for branch in source_schema["anyOf"] if branch.get("type") == "string"
+    )
+    assert string_branch["pattern"] == SOURCE_PATTERN
+    assert string_branch["maxLength"] == SOURCE_MAX_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_remember_records_the_connected_client_as_source(
+    fake_api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The handshake identity must survive the real FastMCP call path.
+
+    The unit tests hand the tool a hand-built context; only a live session
+    proves FastMCP injects one at all.
+    """
+    monkeypatch.setenv("MEMANTO_DEFAULT_AGENT_ID", "probe-agent")
+    sdk_client = MagicMock()
+    sdk_client.remember.return_value = {"memory_id": "mem-1", "namespace": "ns"}
+
+    with patch(
+        "memanto_mcp.lifecycle.MemantoLifecycle.ensure_ready", return_value=sdk_client
+    ):
+        mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
+        async with create_connected_server_and_client_session(
+            mcp._mcp_server,
+            client_info=Implementation(name="Cursor", version="1.0.0"),
+        ) as session:
+            await session.initialize()
+            result = await session.call_tool(
+                "remember", {"content": "Prefers concise answers."}
+            )
+
+    assert not result.isError
+    assert sdk_client.remember.call_args.kwargs["source"] == "cursor"
+
+
+@pytest.mark.asyncio
+async def test_handshake_reports_our_version_not_the_sdk_version(
+    fake_api_key: str,
+) -> None:
+    """Clients display serverInfo, so it must identify memanto-mcp.
+
+    FastMCP leaves the low-level version unset, which makes the server
+    announce the MCP SDK's version instead of its own.
+    """
+    from importlib.metadata import version
+
+    from memanto_mcp import __version__
+
+    server = build_server(MCPServerSettings())  # type: ignore[call-arg]
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        info = (await session.initialize()).serverInfo
+
+    assert info.name == "memanto"
+    assert info.version == __version__
+    assert info.version != version("mcp")
+
+
+@pytest.mark.asyncio
+async def test_context_parameter_is_hidden_from_the_model(fake_api_key: str) -> None:
+    """`ctx` is injected by FastMCP; exposing it would invite bogus arguments."""
+    mcp = build_server(MCPServerSettings())  # type: ignore[call-arg]
+    tools = {t.name: t for t in await mcp.list_tools()}
+
+    for name in ("remember", "batch_remember"):
+        assert "ctx" not in tools[name].inputSchema["properties"]
 
 
 @pytest.mark.asyncio

--- a/integrations/mcp/tests/test_tools.py
+++ b/integrations/mcp/tests/test_tools.py
@@ -11,7 +11,7 @@ import pytest
 from memanto.app.core import MemoryRecord
 from memanto.cli.client.sdk_client import SdkClient
 
-from memanto_mcp.tools import VALID_SOURCE_TYPES, _normalize_tags, register_tools
+from memanto_mcp.tools import DEFAULT_SOURCE, _normalize_tags, register_tools
 
 
 class FakeMCP:
@@ -166,6 +166,16 @@ def _as_memory_record(call_kwargs: dict[str, Any]) -> MemoryRecord:
     )
 
 
+def _ctx_for_client(name: str | None) -> SimpleNamespace:
+    """Fake the slice of Context that carries the initialize handshake info."""
+    client_params = (
+        SimpleNamespace(clientInfo=SimpleNamespace(name=name))
+        if name is not None
+        else None
+    )
+    return SimpleNamespace(session=SimpleNamespace(client_params=client_params))
+
+
 def test_remember_defaults_are_accepted_by_memanto_core() -> None:
     """Every default the tool ships must survive core's model validation."""
     mcp = FakeMCP()
@@ -176,13 +186,15 @@ def test_remember_defaults_are_accepted_by_memanto_core() -> None:
 
     assert result.status == "ok"
     record = _as_memory_record(lifecycle.client.remember.call_args.kwargs)
-    assert record.source == "agent"
+    assert record.source == DEFAULT_SOURCE
     assert record.provenance == "explicit_statement"
 
 
-@pytest.mark.parametrize("source", sorted(VALID_SOURCE_TYPES))
-def test_remember_accepts_every_advertised_source(source: str) -> None:
-    """Each value the schema offers must be storable by the installed core."""
+@pytest.mark.parametrize(
+    "source", ["user", "agent", "tool", "system", "cursor", "codex", "claude_code"]
+)
+def test_remember_accepts_any_writer_label(source: str) -> None:
+    """Sources are open: an explicit writer name reaches core unchanged."""
     mcp = FakeMCP()
     lifecycle = FakeLifecycle()
     register_tools(mcp, lifecycle)  # type: ignore[arg-type]
@@ -195,31 +207,78 @@ def test_remember_accepts_every_advertised_source(source: str) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("client_name", "expected"),
+    [
+        ("cursor", "cursor"),
+        ("Cursor", "cursor"),
+        ("claude-ai", "claude-ai"),
+        ("Visual Studio Code", "visual-studio-code"),
+        ("Claude Code", "claude-code"),
+        (None, DEFAULT_SOURCE),
+        ("", DEFAULT_SOURCE),
+        ("###", DEFAULT_SOURCE),
+    ],
+)
+def test_remember_attributes_the_write_to_the_calling_client(
+    client_name: str | None, expected: str
+) -> None:
+    """Per-client attribution is the point of an open source field."""
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["remember"](
+        content="A stable fact.", ctx=_ctx_for_client(client_name)
+    )
+
+    assert result.status == "ok"
+    assert _as_memory_record(lifecycle.client.remember.call_args.kwargs).source == (
+        expected
+    )
+
+
+def test_remember_prefers_an_explicit_source_over_the_client_name() -> None:
+    mcp = FakeMCP()
+    lifecycle = FakeLifecycle()
+    register_tools(mcp, lifecycle)  # type: ignore[arg-type]
+
+    result = mcp.tools["remember"](
+        content="A stable fact.", source="mem0", ctx=_ctx_for_client("cursor")
+    )
+
+    assert result.status == "ok"
+    assert lifecycle.client.remember.call_args.kwargs["source"] == "mem0"
+
+
 def test_batch_remember_rejects_source_core_would_refuse() -> None:
     mcp = FakeMCP()
     lifecycle = FakeLifecycle()
     register_tools(mcp, lifecycle)  # type: ignore[arg-type]
 
     result = mcp.tools["batch_remember"](
-        memories=[{"content": "A fact.", "source": "mcp-agent"}]
+        memories=[{"content": "A fact.", "source": "claude code"}]
     )
 
     assert result.status == "error"
-    assert "source='mcp-agent'" in (result.message or "")
+    assert "source='claude code'" in (result.message or "")
     lifecycle.client.batch_remember.assert_not_called()
 
 
-def test_batch_remember_defaults_missing_source_to_agent() -> None:
-    """The SDK defaults an absent source to 'user'; `remember` uses 'agent'."""
+def test_batch_remember_attributes_missing_sources_to_the_client() -> None:
+    """The SDK defaults an absent source to 'user', losing the writer."""
     mcp = FakeMCP()
     lifecycle = FakeLifecycle()
     register_tools(mcp, lifecycle)  # type: ignore[arg-type]
 
-    result = mcp.tools["batch_remember"](memories=[{"content": "A fact."}])
+    result = mcp.tools["batch_remember"](
+        memories=[{"content": "A fact."}, {"content": "Another.", "source": "mem0"}],
+        ctx=_ctx_for_client("codex"),
+    )
 
     assert result.status == "ok"
     sent = lifecycle.client.batch_remember.call_args.kwargs["memories"]
-    assert sent[0]["source"] == "agent"
+    assert [m["source"] for m in sent] == ["codex", "mem0"]
 
 
 def test_recall_delegates_min_similarity_to_the_backend() -> None:


### PR DESCRIPTION
- Sync MCP with latest memanto version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically attributes saved memories to the connected MCP client.
  - Supports custom, validated writer labels with a fallback when client details are unavailable.
  - MCP server handshakes now report the installed Memanto version.

- **Bug Fixes**
  - Improved package version reporting when distribution metadata is unavailable.
  - Added validation for memory source labels and batch submissions.

- **Documentation**
  - Updated installation requirements and source attribution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->