### PR TITLE
fix: use versioned marker to distinguish serialized tags from user content

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -113,7 +113,7 @@ class MemoryRecord(BaseModel):
         # Format text as standardized card for semantic search
         text = f"[{memory_type.upper()}] {self.title}\n\n{self.content}"
         if self.tags:
-            text += f"\n\nTags: {', '.join(self.tags)}"
+            text += f"\n\n<!--memanto-tags:v1-->\nTags: {', '.join(self.tags)}"
 
         # Build document with flat metadata fields (not nested!)
         document = {

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -1009,9 +1009,7 @@ class MemoryReadService:
                 if _TAGS_MARKER in content:
                     content = content[:content.index(_TAGS_MARKER)].rstrip()
                 else:
-                    footer_marker = "
-
-Tags: "
+                    footer_marker = "\n\nTags: "
                     content_without_footer, marker, footer_tags = content.rpartition(
                         footer_marker
                     )

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -1005,16 +1005,22 @@ class MemoryReadService:
             # footer while preserving arbitrary paragraphs (including a
             # user-authored ``Tags:`` paragraph) in the original content.
             if tags:
-                footer_marker = "\n\nTags: "
-                content_without_footer, marker, footer_tags = content.rpartition(
-                    footer_marker
-                )
-                normalized_footer_tags = [
-                    value.strip() for value in footer_tags.split(",") if value.strip()
-                ]
-                normalized_metadata_tags = [str(value).strip() for value in tags]
-                if marker and normalized_footer_tags == normalized_metadata_tags:
-                    content = content_without_footer
+                _TAGS_MARKER = "<!--memanto-tags:v1-->"
+                if _TAGS_MARKER in content:
+                    content = content[:content.index(_TAGS_MARKER)].rstrip()
+                else:
+                    footer_marker = "
+
+Tags: "
+                    content_without_footer, marker, footer_tags = content.rpartition(
+                        footer_marker
+                    )
+                    normalized_footer_tags = [
+                        value.strip() for value in footer_tags.split(",") if value.strip()
+                    ]
+                    normalized_metadata_tags = [str(value).strip() for value in tags]
+                    if marker and normalized_footer_tags == normalized_metadata_tags:
+                        content = content_without_footer
 
         # Build basic formatted item
         formatted = {


### PR DESCRIPTION
## Problem

When a memory record has tags, the serializer appends a trailing `\n\nTags: tag1, tag2` block to the content. The reader strips this block on readback.

However, if the user's actual content ends with `\n\nTags: python, ai` and the record's tags are `["python", "ai"]`, the reader cannot distinguish between serialized metadata and legitimate user content — it silently strips the user's content.

## Fix

### Serializer (`core.py`)
Add a unique, versioned marker before the tags block:
```python
# Before: text += f"\n\nTags: {', '.join(self.tags)}"
# After:  text += f"\n\n<!--memanto-tags:v1-->\nTags: {', '.join(self.tags)}"
```

### Reader (`memory_read_service.py`)
Check for the marker first:
- If `<!--memanto-tags:v1-->` is present → strip from marker onwards (definitely serialized metadata)
- If marker not found → fall back to old behavior for backward compatibility (check `Tags: ` prefix + verify tags match)

## Test

Added regression test in `tests/test_format_memory_tags_bug.py` covering:
1. User content ending with `Tags: python, ai` is preserved (not stripped)
2. Serialized tags block with marker is correctly stripped
3. Old-format records (without marker) still work

## Backward Compatibility

Old records without the marker are handled by the fallback path, which uses the same tag-matching logic as before. No data loss for existing records.

Refs #770

> Note: This is a rebase of PR #1810 onto current main to resolve merge conflicts.