### PR TITLE
fix: preserve expires_at on memory update when ttl_seconds is absent

### DIFF
--- a/memanto/app/services/memory_write_service.py
+++ b/memanto/app/services/memory_write_service.py
@@ -388,6 +388,22 @@ class MemoryWriteService:
                             pass  # Keep the default if the stored timestamp is invalid
                     else:
                         updated_memory.expires_at = raw_expires_at
+            else:
+                # Preserve expires_at when ttl_seconds is absent (bounty #770).
+                # A memory can have expires_at set without ttl_seconds (e.g. via
+                # direct metadata write). Without this branch, any field update
+                # silently drops the expiration, making the memory permanent.
+                raw_expires_at = metadata.get("expires_at")
+                if raw_expires_at:
+                    if isinstance(raw_expires_at, str):
+                        try:
+                            updated_memory.expires_at = datetime.fromisoformat(
+                                raw_expires_at.replace("Z", "+00:00")
+                            )
+                        except (ValueError, AttributeError):
+                            pass
+                    else:
+                        updated_memory.expires_at = raw_expires_at
 
             # Step 3: Upload new version (overwrites existing document with same ID)
             from typing import Any, cast

--- a/tests/test_update_memory_preserves_expires_at.py
+++ b/tests/test_update_memory_preserves_expires_at.py
@@ -1,0 +1,133 @@
+"""
+Test: update_memory preserves expires_at when ttl_seconds is absent.
+
+Bug: When a memory has expires_at set but no ttl_seconds, any field
+update silently drops the expiration, making the memory permanent.
+Refs #770
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_existing_memory(expires_at_str="2026-12-31T23:59:59+00:00", ttl_seconds=None):
+    """Build the dict that MemoryReadService.get_memory returns."""
+    data = {
+        "id": "mem_abc123",
+        "title": "Test Memory",
+        "content": "Some content",
+        "type": "fact",
+        "confidence": 0.9,
+        "status": "active",
+        "tags": [],
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "agent_id": "agent1",
+        "actor_id": "agent1",
+        "source": "system",
+        "provenance": "explicit_statement",
+    }
+    if expires_at_str:
+        data["expires_at"] = expires_at_str
+    if ttl_seconds is not None:
+        data["ttl_seconds"] = ttl_seconds
+    return data
+
+
+@patch("memanto.app.services.memory_write_service.MemoryReadService")
+def test_update_preserves_expires_at_without_ttl_seconds(MockReadService):
+    """Updating a memory with expires_at but no ttl_seconds must keep expires_at."""
+    from memanto.app.services.memory_write_service import MemoryWriteService
+
+    client = MagicMock()
+    # Simulate successful upload
+    client.documents.upload.return_value = {"status": "success"}
+
+    # Mock get_memory to return a memory with expires_at but no ttl_seconds
+    mock_read = MockReadService.return_value
+    mock_read.get_memory.return_value = _make_existing_memory(
+        expires_at_str="2026-12-31T23:59:59+00:00",
+        ttl_seconds=None,
+    )
+
+    service = MemoryWriteService(client)
+    result = service.update_memory(
+        memory_id="mem_abc123",
+        namespace="memanto_agent_agent1",
+        updates={"title": "Updated Title"},
+    )
+
+    # Verify the uploaded document contains expires_at
+    upload_call = client.documents.upload.call_args
+    uploaded_docs = upload_call[1].get("documents") or upload_call[0][1]
+    doc = uploaded_docs[0] if isinstance(uploaded_docs, list) else uploaded_docs
+
+    # The document metadata must include expires_at
+    meta = doc.get("metadata", doc)
+    assert meta.get("expires_at") is not None, (
+        "expires_at was silently dropped during update! "
+        "Memory with expires_at but no ttl_seconds lost its expiration."
+    )
+
+
+@patch("memanto.app.services.memory_write_service.MemoryReadService")
+def test_update_preserves_expires_at_with_ttl_seconds(MockReadService):
+    """Updating a memory with both expires_at and ttl_seconds must keep both."""
+    from memanto.app.services.memory_write_service import MemoryWriteService
+
+    client = MagicMock()
+    client.documents.upload.return_value = {"status": "success"}
+
+    mock_read = MockReadService.return_value
+    mock_read.get_memory.return_value = _make_existing_memory(
+        expires_at_str="2026-12-31T23:59:59+00:00",
+        ttl_seconds=86400,
+    )
+
+    service = MemoryWriteService(client)
+    result = service.update_memory(
+        memory_id="mem_abc123",
+        namespace="memanto_agent_agent1",
+        updates={"title": "Updated Title"},
+    )
+
+    upload_call = client.documents.upload.call_args
+    uploaded_docs = upload_call[1].get("documents") or upload_call[0][1]
+    doc = uploaded_docs[0] if isinstance(uploaded_docs, list) else uploaded_docs
+
+    meta = doc.get("metadata", doc)
+    assert meta.get("expires_at") is not None
+    assert meta.get("ttl_seconds") == 86400
+
+
+@patch("memanto.app.services.memory_write_service.MemoryReadService")
+def test_update_with_new_ttl_seconds_overrides_expires_at(MockReadService):
+    """Setting ttl_seconds in updates should recalculate expires_at."""
+    from memanto.app.services.memory_write_service import MemoryWriteService
+
+    client = MagicMock()
+    client.documents.upload.return_value = {"status": "success"}
+
+    mock_read = MockReadService.return_value
+    mock_read.get_memory.return_value = _make_existing_memory(
+        expires_at_str="2026-12-31T23:59:59+00:00",
+        ttl_seconds=86400,
+    )
+
+    service = MemoryWriteService(client)
+    result = service.update_memory(
+        memory_id="mem_abc123",
+        namespace="memanto_agent_agent1",
+        updates={"ttl_seconds": 3600},
+    )
+
+    upload_call = client.documents.upload.call_args
+    uploaded_docs = upload_call[1].get("documents") or upload_call[0][1]
+    doc = uploaded_docs[0] if isinstance(uploaded_docs, list) else uploaded_docs
+
+    meta = doc.get("metadata", doc)
+    # expires_at should be recalculated from the new ttl_seconds
+    assert meta.get("ttl_seconds") == 3600
+    assert meta.get("expires_at") is not None


### PR DESCRIPTION
## Bug: `update_memory` silently drops `expires_at` when `ttl_seconds` is absent

### Summary

When updating any field on a memory that has `expires_at` set but no `ttl_seconds`, the expiration is silently removed, making the memory permanent. This is a **silent data loss** bug.

### Root Cause

In `memory_write_service.py`, the TTL handling in `update_memory()`:

```python
if "ttl_seconds" in updates:
    updated_memory.set_ttl(updates["ttl_seconds"])
elif metadata.get("ttl_seconds"):
    updated_memory.ttl_seconds = metadata["ttl_seconds"]
    raw_expires_at = metadata.get("expires_at")
    if raw_expires_at:
        updated_memory.expires_at = ...
```

When the existing memory has `expires_at` but **no** `ttl_seconds`:
1. `"ttl_seconds" not in updates` → skip first branch
2. `metadata.get("ttl_seconds")` → `None` (falsy) → skip elif branch
3. `updated_memory.expires_at` stays at default (`None`)
4. **The memory's expiration is silently removed**

This can happen when `expires_at` is set via direct metadata write, or when a memory was imported with an explicit expiration but no TTL duration.

### Fix

Add an `else` branch that preserves `expires_at` from the existing metadata when `ttl_seconds` is not present:

```python
else:
    # Preserve expires_at when ttl_seconds is absent (bounty #770).
    raw_expires_at = metadata.get("expires_at")
    if raw_expires_at:
        if isinstance(raw_expires_at, str):
            try:
                updated_memory.expires_at = datetime.fromisoformat(
                    raw_expires_at.replace("Z", "+00:00")
                )
            except (ValueError, AttributeError):
                pass
        else:
            updated_memory.expires_at = raw_expires_at
```

### Impact

- **Severity**: High — silent data loss
- **Type**: Logic error (missing code path)
- **Affected operations**: Any `PATCH /{agent_id}/memories/{memory_id}` on a memory with `expires_at` but no `ttl_seconds`
- **User impact**: Memories that should expire become permanent without any warning or error

### Testing

Added regression test `tests/test_update_memory_preserves_expires_at.py` covering:
1. Update with `expires_at` but no `ttl_seconds` → `expires_at` preserved
2. Update with both `expires_at` and `ttl_seconds` → both preserved
3. Update with new `ttl_seconds` → `expires_at` recalculated correctly

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory updates now preserve existing expiration settings when no new time-to-live value is provided.
  * Existing expiration timestamps remain intact, including valid timestamp values supplied as strings.
  * Providing a new time-to-live value correctly recalculates the expiration time.

* **Tests**
  * Added coverage for preserving and recalculating expiration settings during memory updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->