### PR TITLE
fix: memory-integrity fixes — extraction truncation, summary archiving, JWT payload validation, session duration, export timestamps (Bounty #770 round 7)

### DIFF
--- a/memanto/app/services/conversation_memory_extraction_service.py
+++ b/memanto/app/services/conversation_memory_extraction_service.py
@@ -98,12 +98,25 @@ class ConversationMemoryExtractionService:
     def _conversation_text(self, messages: list[dict[str, str]]) -> str:
         lines: list[str] = []
         total = 0
-        for message in messages:
+        # Messages arrive in chronological order; the newest turns are the
+        # ones this extraction request is actually about. Walk from the END
+        # so truncation drops the oldest messages first and the query always
+        # ends with the latest context. Without this, an oversized transcript
+        # was cut from the front, leaving a query of stale messages — or, for
+        # a single oversized message, an empty string that made the caller
+        # raise a 400 on input that should be accepted.
+        for message in reversed(messages):
             line = f"{message['role'].strip()}: {message['content'].strip()}"
-            total += len(line)
-            if total > self.MAX_CONTENT_CHARS:
+            if lines and total + len(line) > self.MAX_CONTENT_CHARS:
+                # Budget exhausted before this (older) message: stop.
                 break
             lines.append(line)
+            total += len(line)
+            if total > self.MAX_CONTENT_CHARS:
+                # A single message exceeds the budget on its own; keep it
+                # anyway (truncated) rather than returning an empty query.
+                break
+        lines.reverse()
         return "\n".join(lines)
 
     def _header_prompt(self, max_memories: int) -> str:

--- a/memanto/app/services/memory_export_service.py
+++ b/memanto/app/services/memory_export_service.py
@@ -5,7 +5,7 @@ Generates a structured memory.md file with all 13 memory types
 organized into sections, ready for agent consumption.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -138,7 +138,9 @@ class MemoryExportService:
         Returns:
             Formatted Markdown string.
         """
-        generated_at = generated_at or datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        generated_at = generated_at or datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
 
         total = sum(len(mems) for mems in memories_by_type.values())
         type_counts = {t: len(mems) for t, mems in memories_by_type.items() if mems}

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -311,6 +311,18 @@ class SessionService:
         if duration_hours is None:
             duration_hours = settings.SESSION_DEFAULT_DURATION_HOURS
 
+        # Fail closed on non-positive durations: timedelta(hours=0) makes the
+        # session expire at its start instant and negative values mint an
+        # already-expired token. The CLI would otherwise print "OK Agent
+        # activated!" for a session whose very first validate_session call
+        # raises SessionExpiredError (and every subsequent remember/recall
+        # fails), so reject the contract violation before signing anything.
+        if not isinstance(duration_hours, (int, float)) or duration_hours <= 0:
+            raise ValueError(
+                "duration_hours must be a positive number of hours, "
+                f"got {duration_hours!r}"
+            )
+
         session_id = self._generate_session_id()
         namespace = self._generate_namespace(agent_id)
         started_at = utc_now()
@@ -367,8 +379,18 @@ class SessionService:
             # Decode JWT
             payload = jwt.decode(session_token, self.secret_key, algorithms=["HS256"])
 
-            # Convert to SessionToken
-            token = SessionToken(**payload)
+            # Convert to SessionToken. A signature-valid token can still be
+            # missing required payload fields (hand-rolled tokens, tokens
+            # signed by a previous schema version, corrupted-but-valid-sig
+            # payloads). ValidationError is a ValueError subclass that the
+            # JWT except branches below do not catch; without this guard it
+            # escapes as an unhandled 500 instead of a clean client error.
+            try:
+                token = SessionToken(**payload)
+            except (ValidationError, TypeError, ValueError) as exc:
+                raise InvalidSessionTokenError(
+                    f"Session token payload is invalid: {exc}"
+                ) from exc
 
             # Validate expiration
             if utc_now() > as_utc_aware(token.expires_at):
@@ -615,10 +637,16 @@ class SessionService:
             memory_record: The MemoryRecord object
             memory_id: The Moorcheh memory ID (if available)
         """
-        # Get the timestamp of memory to determine the date string
+        # Archive the summary under the WRITE time, not memory.created_at.
+        # Daily analysis globs f"{agent_id}_{today}_*_summary.md"; a memory
+        # imported/backfilled with an old created_at (provenance="imported")
+        # would otherwise be filed under its historical date and never appear
+        # in any daily summary — today's activity permanently lost, and
+        # deletion entries (written with the current time) would land in a
+        # different file than the memory they refer to.
         validate_safe_id(agent_id, "agent_id")
         validate_safe_id(session_id, "session_id")
-        dt_now = getattr(memory_record, "created_at", utc_now())
+        dt_now = utc_now()
         timestamp = dt_now.strftime("%Y-%m-%d %H:%M:%S")
         date_str = dt_now.strftime("%Y-%m-%d")
 

--- a/memanto/cli/commands/agent.py
+++ b/memanto/cli/commands/agent.py
@@ -109,7 +109,11 @@ def agent_list():
 def agent_activate(
     agent_id: str = typer.Argument(..., help="Agent ID to activate"),
     duration_hours: int = typer.Option(
-        6, "--hours", "-h", help="Activation duration in hours (default: 6)"
+        6,
+        "--hours",
+        "-h",
+        min=1,
+        help="Activation duration in hours (default: 6)",
     ),
 ):
     """Activate an agent and start its active session."""

--- a/tests/failing_tests/test_bounty_770_round7.py
+++ b/tests/failing_tests/test_bounty_770_round7.py
@@ -1,0 +1,216 @@
+"""Bounty #770 round 7 — memory-integrity fixes across extraction, session
+summary archiving, JWT validation, export timestamps, and session duration.
+
+Run:  python -m pytest tests/failing_tests/test_bounty_770_round7.py -v
+      (or:  python tests/failing_tests/test_bounty_770_round7.py)
+
+Bugs covered:
+  1. conversation_memory_extraction_service._conversation_text truncated the
+     NEWEST messages (the ones this request is actually about) instead of the
+     oldest, and returned "" for a single oversized message -> the extraction
+     query became empty (ValueError / 400) or stale.
+  2. session_service.log_memory_to_session_summary archived summary files by
+     memory.created_at; imported/backfilled memories with an old created_at
+     were written to an old date's file that daily_analysis_service (glob on
+     today) never reads -> today's activity permanently missing from summaries.
+  3. session_service.validate_session did not catch pydantic.ValidationError
+     when a signature-valid token lacked payload fields -> unhandled 500
+     instead of InvalidSessionTokenError.
+  4. memory_export_service.format_memory_md used naive local datetime.now()
+     for "Generated:" while every memory timestamp is UTC ISO -> mixed time
+     bases in one exported file (off-by-one-day near midnight UTC+8).
+  5. session_service._create_session accepted duration_hours <= 0, producing
+     an immediately-expired session while the CLI reported success.
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+# ---------------------------------------------------------------------------
+# 1. _conversation_text keeps newest messages, never returns ""
+# ---------------------------------------------------------------------------
+
+def test_conversation_text_keeps_newest_not_oldest():
+    """When the transcript exceeds the budget, the truncated query must keep
+    the LATEST messages (what this request is about), not the oldest."""
+    import memanto.app.services.conversation_memory_extraction_service as m
+
+    svc = m.ConversationMemoryExtractionService.__new__(
+        m.ConversationMemoryExtractionService
+    )
+    svc.MAX_CONTENT_CHARS = 100
+
+    messages = [
+        {"role": "user", "content": "A" * 40},
+        {"role": "assistant", "content": "B" * 40},
+        {"role": "user", "content": "C" * 40},
+    ]
+    result = svc._conversation_text(messages)
+    # Oldest two messages total 82+ chars > 100, so at least message 3 (C)
+    # must survive; the oldest (A) must be the one dropped.
+    assert "C" * 40 in result, "newest message must survive truncation"
+    assert ("A" * 40) not in result, "oldest message must be dropped first"
+
+
+def test_conversation_text_single_oversized_message_never_empty():
+    """A single message longer than the budget must still produce a non-empty
+    query (the caller raises on empty), instead of returning ''."""
+    import memanto.app.services.conversation_memory_extraction_service as m
+
+    svc = m.ConversationMemoryExtractionService.__new__(
+        m.ConversationMemoryExtractionService
+    )
+    svc.MAX_CONTENT_CHARS = 100
+
+    result = svc._conversation_text(
+        [{"role": "user", "content": "Z" * 500}]
+    )
+    assert result, "oversized single message must not yield an empty query"
+    assert "Z" * 500 in result
+
+
+# ---------------------------------------------------------------------------
+# 2. Session summary files archived by write time, not memory.created_at
+# ---------------------------------------------------------------------------
+
+def test_summary_file_uses_write_time_not_created_at(tmp_path):
+    """Importing a memory with an old created_at must still log it into
+    TODAY's summary file (the one daily_analysis_service globs)."""
+    import memanto.app.services.session_service as m
+
+    svc = m.SessionService.__new__(m.SessionService)
+    svc.sessions_dir = tmp_path
+    svc.sessions_dir.mkdir(parents=True, exist_ok=True)
+    svc._summary_lock = __import__("threading").RLock()
+    svc._harden_session_storage = lambda: None
+
+    class _Rec:
+        created_at = datetime(2020, 3, 1, tzinfo=timezone.utc)
+        type = "fact"
+        title = "t"
+        content = "c"
+        confidence = 0.9
+        id = "m1"
+        source = "user"
+        provenance = "explicit_statement"
+        status = "active"
+        tags = []
+
+    svc.log_memory_to_session_summary("ag1", "sess1", _Rec())
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    old_file = tmp_path / f"ag1_2020-03-01_sess1_summary.md"
+    today_file = tmp_path / f"ag1_{today}_sess1_summary.md"
+    assert not old_file.exists(), (
+        "summary must not be archived by memory.created_at (2020-03-01)"
+    )
+    assert today_file.exists(), (
+        "summary must be written to today's file so daily analysis sees it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. validate_session maps payload ValidationError to InvalidSessionTokenError
+# ---------------------------------------------------------------------------
+
+def test_validate_session_missing_fields_is_invalid_token(tmp_path):
+    """A signature-valid JWT missing required payload fields must raise
+    InvalidSessionTokenError (client error), never a raw ValidationError."""
+    import jwt
+
+    import memanto.app.services.session_service as m
+    from memanto.app.utils.errors import InvalidSessionTokenError
+
+    svc = m.SessionService.__new__(m.SessionService)
+    svc.sessions_dir = tmp_path
+    svc.sessions_dir.mkdir(parents=True, exist_ok=True)
+    svc._secret_key = "test-secret"
+    svc._agent_locks = {}
+    svc._agent_locks_guard = __import__("threading").Lock()
+    svc._active_marker_lock = __import__("threading").RLock()
+    svc._summary_lock = __import__("threading").RLock()
+    svc._storage_hardened = True
+
+    # Signed with the valid key but missing namespace/expires_at/started_at.
+    token = jwt.encode(
+        {"agent_id": "a", "session_id": "s"}, "test-secret", algorithm="HS256"
+    )
+    try:
+        svc.validate_session(token)
+        raise AssertionError("must raise InvalidSessionTokenError")
+    except InvalidSessionTokenError:
+        pass
+    except Exception as exc:  # noqa: BLE001 - assert the exact contract
+        raise AssertionError(
+            f"expected InvalidSessionTokenError, got {type(exc).__name__}: {exc}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Export header timestamp is timezone-aware UTC
+# ---------------------------------------------------------------------------
+
+def test_export_generated_at_is_utc_aware():
+    """'Generated:' must be a UTC ISO timestamp (same time base as every
+    memory created_at), not naive local time."""
+    import memanto.app.services.memory_export_service as m
+
+    svc = m.MemoryExportService.__new__(m.MemoryExportService)
+
+    out = svc.format_memory_md(
+        "ag1",
+        {"fact": [{"title": "t", "content": "c", "created_at": "2026-08-07T08:00:00+00:00"}]},
+        generated_at=None,
+    )
+    gen_line = [ln for ln in out.splitlines() if ln.startswith("> Generated:")]
+    assert gen_line, "header must include Generated:"
+    stamp = gen_line[0].replace("> Generated:", "").strip()
+    assert "+00:00" in stamp or stamp.endswith("Z"), (
+        f"Generated timestamp must carry UTC offset, got: {stamp!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. _create_session rejects non-positive durations
+# ---------------------------------------------------------------------------
+
+def test_create_session_rejects_nonpositive_duration(tmp_path):
+    """duration_hours <= 0 must raise ValueError instead of minting an
+    already-expired session that the CLI then reports as success."""
+    import memanto.app.services.session_service as m
+
+    svc = m.SessionService.__new__(m.SessionService)
+    svc.sessions_dir = tmp_path
+    svc.sessions_dir.mkdir(parents=True, exist_ok=True)
+    svc._secret_key = "test-secret"
+    svc._agent_locks = {}
+    svc._agent_locks_guard = __import__("threading").Lock()
+    svc._active_marker_lock = __import__("threading").RLock()
+    svc._summary_lock = __import__("threading").RLock()
+    svc._storage_hardened = True
+    svc._save_session = lambda s: None
+    svc._set_active_session = lambda a: None
+
+    for bad in (0, -1, -24):
+        try:
+            svc._create_session("ag1", None, duration_hours=bad)
+            raise AssertionError(f"duration_hours={bad} must raise ValueError")
+        except ValueError:
+            pass
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td)
+        test_conversation_text_keeps_newest_not_oldest()
+        test_conversation_text_single_oversized_message_never_empty()
+        test_summary_file_uses_write_time_not_created_at(p)
+        test_validate_session_missing_fields_is_invalid_token(p)
+        test_export_generated_at_is_utc_aware()
+        test_create_session_rejects_nonpositive_duration(p)
+    print("ALL ROUND 7 TESTS PASSED")

--- a/tests/test_session_summary_concurrency.py
+++ b/tests/test_session_summary_concurrency.py
@@ -1,7 +1,7 @@
 """Concurrency regressions for local session-summary persistence."""
 
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from threading import Barrier, BrokenBarrierError
 
@@ -35,6 +35,11 @@ def test_concurrent_summary_writes_create_one_header(monkeypatch, tmp_path):
     monkeypatch.setattr(Path, "exists", synchronize_initial_absence_check)
 
     def log_memory(index):
+        # created_at mirrors a write happening "now": summary files are
+        # archived by WRITE time (see session_service), so a fixed past
+        # created_at would land this entry in a different (historical) file
+        # and the concurrency assertions below could never observe it.
+        now = datetime.now(timezone.utc)
         record = MemoryRecord(
             type="fact",
             title=f"concurrent-{index}",
@@ -42,7 +47,7 @@ def test_concurrent_summary_writes_create_one_header(monkeypatch, tmp_path):
             agent_id="agent-race",
             actor_id="agent-race",
             source="agent",
-            created_at=datetime(2026, 7, 20, 12, 0, index),
+            created_at=now.replace(microsecond=0),
         )
         service.log_memory_to_session_summary(
             agent_id="agent-race",
@@ -54,20 +59,13 @@ def test_concurrent_summary_writes_create_one_header(monkeypatch, tmp_path):
     with ThreadPoolExecutor(max_workers=worker_count) as executor:
         list(executor.map(log_memory, range(worker_count)))
 
-    summary_file = service.sessions_dir / "agent-race_2026-07-20_sess-race_summary.md"
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    summary_file = service.sessions_dir / f"agent-race_{today}_sess-race_summary.md"
     summary = summary_file.read_text(encoding="utf-8")
 
     assert summary.count("# Session Summary for agent-race") == 1
     for index in range(worker_count):
-        entry = (
-            f"### [2026-07-20 12:00:0{index}] [FACT] concurrent-{index}\n"
-            f"- **Memory ID**: `mem-{index}`\n"
-            "- **Confidence**: `0.8`\n"
-            "- **Status**: `active`\n"
-            "- **Source**: `agent`\n"
-            "- **Provenance**: `explicit_statement`\n"
-            "- **Content**:\n"
-            f"> payload-{index}\n\n"
-            "---\n\n"
-        )
-        assert summary.count(entry) == 1
+        # The header's timestamp is the write time (runtime-dependent), so
+        # assert on the stable parts of each entry instead.
+        assert summary.count(f"- **Memory ID**: `mem-{index}`") == 1
+        assert summary.count(f"> payload-{index}") == 1

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -247,22 +247,30 @@ class TestSessionService:
 
     def test_validate_expired_session(self, session_service):
         """Test session validation fails for expired session"""
-        # Create session with very short duration
-        session_service.create_session(
+        # duration_hours <= 0 is now rejected at creation (fail-closed), so
+        # build an expired session by post-dating a valid one's expires_at.
+        session = session_service.create_session(
             agent_id="test-agent",
-            duration_hours=0,  # Expires immediately
+            duration_hours=1,
+        )
+        from datetime import datetime, timedelta, timezone
+
+        session.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        session_service._save_session(session)
+
+        # The stored session is now expired: validation must reject it.
+        # (The JWT payload still carries the original expiry, so validation
+        # reaches the stored-session check and must fail closed there.)
+        from memanto.app.utils.errors import (
+            InvalidSessionTokenError,
+            SessionExpiredError,
         )
 
-        # Manually expire the session by modifying the token
-        # (In real scenario, we'd wait for expiration)
-        import time
-
-        time.sleep(1)
-
-        # This should fail because session is expired
-        # Note: We can't easily test this without manipulating time
-        # Just verify the logic exists
-        print("✅ Session expiration logic exists")
+        try:
+            session_service.validate_session(session.session_token)
+            raise AssertionError("expired session must fail validation")
+        except (SessionExpiredError, InvalidSessionTokenError):
+            pass
 
     def test_auto_renew_is_single_flight_per_agent(self, session_service, monkeypatch):
         """Parallel near-expiry requests must not mint competing tokens."""


### PR DESCRIPTION
## Bounty #770 round 7 — five memory-integrity fixes, each with a failing-then-passing test

### 1. _conversation_text truncated the NEWEST messages, or returned empty
conversation_memory_extraction_service.py built the extraction query from the oldest messages first and broke out once the budget was exceeded — dropping exactly the turns this request is about. A single message over the budget produced an empty query (caller raises 400) on input that should be accepted. Fix: walk from the newest message backwards; a single oversized message is kept rather than yielding an empty query.

### 2. Session summaries archived by memory.created_at — imported memories vanish from daily summaries
log_memory_to_session_summary filed entries under the memory's created_at date. Imported/backfilled memories with an old created_at were written to a historical file that daily_analysis_service (which globs today's date) never reads — today's activity permanently missing, and deletion entries landed in a different file than the memory they refer to. Fix: archive under the write time (utc_now()).

### 3. validate_session leaked ValidationError → HTTP 500 on signature-valid but malformed payloads
A JWT signed with the correct key but missing required fields raised pydantic.ValidationError — uncaught, escaping as a 500. Fix: map ValidationError/TypeError/ValueError to InvalidSessionTokenError (4xx).

### 4. Export header used naive local time mixed with UTC memory timestamps
format_memory_md wrote Generated: with datetime.now() (naive local) while every memory timestamp is UTC ISO — two time bases in one exported file, off-by-one-day near midnight UTC+8. Fix: datetime.now(timezone.utc) ISO with Z suffix.

### 5. duration_hours <= 0 minted already-expired sessions while the CLI reported success
_create_session accepted 0/negative hours → token expired at its own start instant; memanto agent activate --hours 0 printed OK but every subsequent call failed. Fix: reject non-positive durations at the service layer (ValueError) and add min=1 to the CLI option.

### Verification
- tests/failing_tests/test_bounty_770_round7.py: 6 tests, all red before / green after
- Full suite: 590 passed, 26 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation context now prioritizes the newest messages while preserving chronological order.
  * Oversized messages no longer produce empty conversation queries.
  * Session creation rejects invalid or non-positive durations.
  * Malformed session tokens now return a consistent invalid-token error.
  * Memory summary archives use the correct UTC write date.
  * Export timestamps now use UTC ISO 8601 formatting.
  * Agent activation requires at least one hour.

* **Tests**
  * Added regression coverage for conversation trimming, session validation, archiving, and UTC timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->