### PR TITLE
fix(ts): authenticate remote management requests with X-Api-Key

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -72,6 +72,20 @@ const memanto = new Memanto({ agentId: "my-agent" });
 
 The spawned `memanto serve` inherits the on-prem config from `~/.memanto/`, and the client authenticates with a session token only. Alternatively, point `baseUrl` at an on-prem server you started yourself.
 
+### Connecting to an existing server (`baseUrl`)
+
+When `baseUrl` points to an existing Memanto server (a container, a shared dev server, or a remote/on-prem installation), the client sends the configured `apiKey` as an `X-Api-Key` header on **management requests** — agent lookup, creation, activation, deletion, listing, and status. This is required when the server protects management access with an API key.
+
+```ts
+const memanto = new Memanto({
+  agentId: "my-agent",
+  baseUrl: "https://memanto.example.com",
+  apiKey: process.env.MEMANTO_MGMT_KEY, // required by the protected server
+});
+```
+
+Session-scoped **memory operations** (`remember`, `recall`, `answer`, uploads, …) do **not** send `X-Api-Key` — after activation they authenticate with the `X-Session-Token` issued by the server. If the server does not require a management key, simply omit `apiKey`; no `X-Api-Key` header is sent.
+
 > Requires Docker (for the Moorcheh on-prem server) in addition to `uv`. The SDK does not start the Moorcheh container itself — the `uvx memanto` setup does.
 
 ## API
@@ -81,7 +95,7 @@ The spawned `memanto serve` inherits the on-prem config from `~/.memanto/`, and 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `agentId` | `string` | — | **Required.** Agent identifier. |
-| `apiKey` | `string` | — | Moorcheh API key, passed to the server as `MOORCHEH_API_KEY`. |
+| `apiKey` | `string` | — | Moorcheh API key. Passed to a spawned server as `MOORCHEH_API_KEY`; sent as `X-Api-Key` on management requests when `baseUrl` points to an existing server. |
 | `autoCreate` | `boolean` | `true` | Create the agent if it does not exist. |
 | `baseUrl` | `string` | — | Use an already-running server at this URL instead of spawning one. |
 | `port` | `number` | auto | Bind the spawned server to this port. |

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -140,6 +140,7 @@ export class Memanto {
   private readonly agentId: string;
   private readonly encodedAgentId: string;
   private readonly autoCreate: boolean;
+  private readonly apiKey: string | undefined;
   private sessionToken: string | null = null;
   private starting: Promise<void> | null = null;
 
@@ -148,7 +149,19 @@ export class Memanto {
     this.agentId = opts.agentId;
     this.encodedAgentId = encodeURIComponent(opts.agentId);
     this.autoCreate = opts.autoCreate ?? true;
+    this.apiKey = opts.apiKey;
     this.lifecycle = new ServerLifecycle(opts);
+  }
+
+  /**
+   * Management credential for requests to an existing Memanto server
+   * (`baseUrl` set). Attached to agent management, activation, and status
+   * calls only; session-scoped memory operations keep using
+   * `X-Session-Token`. Returns an empty object when no key is configured so
+   * local `uvx`-spawned servers (unauthenticated by default) are unaffected.
+   */
+  private managementHeaders(): Record<string, string> {
+    return this.apiKey ? { "X-Api-Key": this.apiKey } : {};
   }
 
   // ---------------------------------------------------------------------------
@@ -325,7 +338,10 @@ export class Memanto {
     const baseUrl = this.lifecycle.baseUrl;
     const res = await fetch(`${baseUrl}/api/v2/agents`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...this.managementHeaders(),
+      },
       body: JSON.stringify({
         agent_id: this.agentId,
         pattern: input.pattern,
@@ -398,14 +414,19 @@ export class Memanto {
 
   private async createAgentIfMissing(): Promise<void> {
     const baseUrl = this.lifecycle.baseUrl;
-    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}`);
+    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}`, {
+      headers: this.managementHeaders(),
+    });
     if (res.ok) return;
     if (res.status !== 404) {
       throw await asError(res, "Failed to look up agent");
     }
     const create = await fetch(`${baseUrl}/api/v2/agents`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...this.managementHeaders(),
+      },
       body: JSON.stringify({ agent_id: this.agentId }),
     });
     if (!create.ok && create.status !== 409) {
@@ -417,6 +438,10 @@ export class Memanto {
     const baseUrl = this.lifecycle.baseUrl;
     const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}/activate`, {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...this.managementHeaders(),
+      },
     });
     if (!res.ok) throw await asError(res, "Failed to activate agent");
     const session = (await res.json()) as SessionRecord;
@@ -441,6 +466,10 @@ export class Memanto {
     };
     if (requireSession) {
       headers["X-Session-Token"] = this.sessionToken ?? "";
+    } else {
+      // Management requests (agent lookup/create/delete, status) authenticate
+      // with the configured API key when talking to an existing server.
+      Object.assign(headers, this.managementHeaders());
     }
     const res = await fetch(`${baseUrl}${path}`, {
       method,

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -18,6 +18,23 @@ function startFakeApi(agentId = "test-agent"): Promise<{
   recorded: Recorded[];
   close: () => void;
 }> {
+  return startFakeApiWithAuth(agentId, null);
+}
+
+/**
+ * Variant of the fake API that enforces `X-Api-Key` on management endpoints.
+ * When `requiredKey` is set, agent lookup/creation/activation/deletion/status
+ * return 401 unless the request carries the matching key. Memory endpoints
+ * stay open to any caller so the session-token path is unaffected.
+ */
+function startFakeApiWithAuth(
+  agentId = "test-agent",
+  requiredKey: string | null,
+): Promise<{
+  url: string;
+  recorded: Recorded[];
+  close: () => void;
+}> {
   const encodedAgentId = encodeURIComponent(agentId);
   return new Promise((resolve) => {
     const recorded: Recorded[] = [];
@@ -37,6 +54,28 @@ function startFakeApi(agentId = "test-agent"): Promise<{
         };
 
         if (url === "/health") return reply(200, { status: "ok" });
+
+        const isMemoryOp =
+          /\/remember(\/|$|\?)/.test(url) ||
+          /\/recall(\/|$|\?)/.test(url) ||
+          /\/answer(\/|$|\?)/.test(url) ||
+          /\/upload-file(\/|$|\?)/.test(url) ||
+          /\/daily-summary(\/|$|\?)/.test(url) ||
+          /\/conflicts(\/|$|\?)/.test(url) ||
+          /\/memories(\/|$|\?)/.test(url) ||
+          /\/extract(\/|$|\?)/.test(url);
+        const isManagement =
+          !isMemoryOp &&
+          (url === "/api/v2/status" ||
+            url === "/api/v2/agents" ||
+            url.startsWith(`/api/v2/agents/${encodedAgentId}`));
+        if (isManagement && requiredKey) {
+          const supplied = req.headers["x-api-key"];
+          if (supplied !== requiredKey) {
+            return reply(401, { detail: "missing or invalid api key" });
+          }
+        }
+
         if (url === "/api/v2/status" && req.method === "GET")
           return reply(200, {
             session_id: "existing-session",
@@ -221,6 +260,68 @@ describe("Memanto", () => {
 
   it("rejects empty agentId", () => {
     expect(() => new Memanto({ agentId: "" })).toThrow(/agentId is required/);
+  });
+
+  it("attaches X-Api-Key to management requests but not memory ops", async () => {
+    const api = await startFakeApi();
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({
+      agentId: "test-agent",
+      baseUrl: api.url,
+      apiKey: "secret-mgmt-key",
+    });
+    cleanupFns.push(() => m.close());
+
+    await m.remember({ content: "Het likes coffee" });
+
+    // Management calls: agent lookup, creation, activation.
+    const mgmt = api.recorded.filter((r) => !r.url.endsWith("/remember"));
+    expect(mgmt.length).toBeGreaterThanOrEqual(3);
+    for (const r of mgmt) {
+      expect(r.headers["x-api-key"]).toBe("secret-mgmt-key");
+      expect(r.headers["x-session-token"]).toBeUndefined();
+    }
+
+    // Session-scoped memory call: X-Session-Token only, never the API key.
+    const memory = api.recorded.find((r) => r.url.endsWith("/remember"));
+    expect(memory?.headers["x-session-token"]).toBe("fake-token");
+    expect(memory?.headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("authenticates management requests against a protected server", async () => {
+    const api = await startFakeApiWithAuth("test-agent", "secret-mgmt-key");
+    cleanupFns.push(api.close);
+
+    // First, a client WITHOUT the API key fails bootstrap with 401.
+    const anonymous = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => anonymous.close());
+    await expect(anonymous.remember({ content: "no key" })).rejects.toThrow(
+      /401/,
+    );
+
+    // Then the same bootstrap succeeds when the key is provided.
+    api.recorded.length = 0;
+    const authed = new Memanto({
+      agentId: "test-agent",
+      baseUrl: api.url,
+      apiKey: "secret-mgmt-key",
+    });
+    cleanupFns.push(() => authed.close());
+    await expect(
+      authed.remember({ content: "with key" }),
+    ).resolves.toMatchObject({ memory_id: "mem-1" });
+  });
+
+  it("does not send X-Api-Key when none is configured", async () => {
+    const api = await startFakeApi();
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url });
+    cleanupFns.push(() => m.close());
+
+    await m.status();
+    expect(api.recorded[0]?.headers["x-api-key"]).toBeUndefined();
   });
 
   it("percent-encodes agentId in URL path segments", async () => {


### PR DESCRIPTION
## What this fixes

When `baseUrl` points to an existing Memanto server (container, shared dev server, remote/on-prem installation), the TypeScript SDK previously used `apiKey` only when spawning a local `uvx` server. Agent lookup, creation, activation, deletion, listing, and status requests omitted the management credential entirely — so bootstrap failed with `401 Unauthorized` as soon as management access was protected, blocking all memory operations.

## Changes

- Retain the configured API key in the client
- Attach it as `X-Api-Key` to **management and activation requests** (agent lookup, create, delete, list, status, activate)
- Session-scoped **memory operations** keep using `X-Session-Token` only — the API key is never sent to memory endpoints
- Document the existing-server credential behavior in the SDK README (option table + dedicated section)

## Validation

- `npm test` — **47 tests passed** (3 new regression tests)
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — clean

## Regression coverage

1. Management requests carry `X-Api-Key`; memory ops never do
2. Bootstrap against a protected server: fails with 401 without the key, succeeds with it
3. No `X-Api-Key` sent when none is configured

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authenticating TypeScript SDK management requests with an API key.
  * Management operations now automatically include the configured credential, while session-based memory operations continue using session tokens.
  * Requests requiring management authentication now provide clearer credential handling.

* **Documentation**
  * Documented `baseUrl`, API-key authentication, and the distinction between management requests and session-scoped operations.

* **Tests**
  * Added coverage for authenticated and unauthenticated management requests, session operations, and optional API-key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->