### PR TITLE
feat: add Claude export mapper for memory migration (#1609)

### DIFF
--- a/memanto/cli/commands/migrate.py
+++ b/memanto/cli/commands/migrate.py
@@ -659,3 +659,125 @@ def migrate_supermemory(
         dry_run=dry_run,
         report=report,
     )
+
+
+@migrate_app.command("claude")
+def migrate_claude(
+    file: Path = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to the Claude export JSON file (downloaded from claude.ai/settings/export).",
+    ),
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help="Target Memanto agent id (defaults to the active agent).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the mapping without writing.",
+    ),
+):
+    """Import a Claude conversation export into the active (or selected) agent.
+
+    Claude is a file-based adapter — point it at the JSON export file
+    from Anthropic (Settings > Export Data). Each conversation becomes a set
+    of memories: a conversation overview plus per-message memories.
+    Assistant responses are preserved in the supporting-data footer.
+
+    Examples:
+        memanto migrate claude --file ./conversations.json --dry-run
+        memanto migrate claude --file ./claude_export.json --agent my-agent
+    """
+    if not file or not file.exists():
+        _error(
+            f"Claude export file not found",
+            hint="Provide --file pointing to the JSON export from claude.ai.",
+        )
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = config_manager.get_migrate_dir("claude") / stamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    mode = "Dry run" if dry_run else "Migrate"
+    console.print(
+        Panel.fit(
+            f"[{BOLD_PRIMARY}]Claude -> Memanto  {mode}[/{BOLD_PRIMARY}]",
+            border_style=PRIMARY,
+        )
+    )
+
+    def progress(msg: str) -> None:
+        console.print(f"  [{BRIGHT}]...[/{BRIGHT}] {msg}")
+
+    target_agent = None if dry_run else _resolve_target_agent(agent)
+
+    progress(f"Loading Claude export from {file}")
+    try:
+        export = load_export(file)
+    except Exception as exc:
+        _error(f"Failed to load Claude export: {exc}")
+
+    progress("Mapping Claude conversations onto Memanto schema...")
+    client = None if dry_run else get_client()
+    summary, rows = run_migration(
+        provider="claude",
+        export=export,
+        client=client,
+        agent_id=target_agent or "",
+        dry_run=dry_run,
+        on_progress=progress,
+    )
+
+    preview_path = write_preview(rows, run_dir / "mapped_preview.json")
+
+    type_lines = (
+        ", ".join(f"{k}: {v}" for k, v in sorted(summary.type_counts.items())) or "-"
+    )
+    body_lines = [
+        f"[dim]Source records:[/dim] {summary.source_count}",
+        f"[dim]Source messages:[/dim] {summary.source_count}",
+        f"[dim]Mapped memories:[/dim] {summary.mapped_count}  "
+        f"[dim](skipped {summary.skipped})[/dim]",
+        f"[dim]Type breakdown:[/dim] {type_lines}",
+    ]
+    if dry_run:
+        body_lines.append("")
+        body_lines.append("[yellow]Dry run - no writes performed.[/yellow]")
+    else:
+        body_lines.append(
+            f"[dim]Imported:[/dim] {summary.imported}  "
+            f"[dim]Failed:[/dim] {summary.failed}  "
+            f"[dim]Batches:[/dim] {summary.batches}"
+        )
+        body_lines.append(f"[dim]Target agent:[/dim] {target_agent}")
+
+    body_lines.append("")
+    body_lines.append(f"[dim]Run dir:[/dim] {run_dir}")
+    body_lines.append(f"[dim]Mapped preview:[/dim] {preview_path}")
+    if summary.errors:
+        body_lines.append(
+            f"[red]First error:[/red] {summary.errors[0]}  "
+            "[dim](see run dir for more)[/dim]"
+        )
+
+    border = WARNING if summary.failed else SUCCESS
+    console.print()
+    console.print(
+        Panel(
+            "\n".join(body_lines),
+            title=(
+                "[bold yellow]Dry run complete[/bold yellow]"
+                if dry_run
+                else "[bold green]Import complete[/bold green]"
+            ),
+            border_style=border,
+        )
+    )

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -487,11 +487,159 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+# --------------------------------------------------------------------------
+# Claude Export (Anthropic Claude conversation exports)
+# --------------------------------------------------------------------------
+
+
+def _collect_attachment_info(messages):
+    seen = set()
+    result = []
+    for msg in (messages or []):
+        if not isinstance(msg, dict):
+            continue
+        for coll in ("attachments", "files"):
+            for item in (msg.get(coll) or []):
+                if not isinstance(item, dict):
+                    continue
+                fname = item.get("file_name") or item.get("name")
+                if fname and str(fname) not in seen:
+                    seen.add(str(fname))
+                    result.append(str(fname))
+    return result
+
+
+def map_claude(export):
+    rows = []
+    migrated_at = _now_utc()
+    conversations = []
+    if isinstance(export, list):
+        conversations = [c for c in export if isinstance(c, dict)]
+    elif isinstance(export, dict):
+        raw_convs = export.get("conversations")
+        if isinstance(raw_convs, list):
+            conversations = raw_convs
+        elif "chat_messages" in export and "uuid" in export:
+            conversations = [export]
+    for conv in conversations:
+        conv_uuid = str(conv.get("uuid", ""))
+        conv_name = (conv.get("name") or "Untitled Conversation").strip()
+        conv_summary = (conv.get("summary") or "").strip()
+        messages = conv.get("chat_messages") or []
+        if isinstance(messages, dict):
+            messages = messages.get("messages", [])
+        if not isinstance(messages, list) or not messages:
+            continue
+        conv_created = _pick_first_dt(conv, ("created_at", "createdAt"))
+        conv_tags = ["claude", "conversation"]
+        if conv_name and len(conv_name) <= 60:
+            conv_tags.append("conversation=" + conv_name[:60])
+        overview_text = "Claude conversation: " + conv_name
+        if conv_summary:
+            overview_text += "\nSummary: " + conv_summary
+        att_files = _collect_attachment_info(messages)
+        if att_files:
+            conv_tags.append("has-attachments")
+        conv_footer = _format_supporting_data([
+            ("Claude conversation UUID", conv_uuid),
+            ("Message count", len(messages)),
+            ("Source", "claude:" + conv_uuid if conv_uuid else None),
+            ("Source created_at", conv_created.isoformat() if conv_created else None),
+            ("Files referenced", att_files if att_files else None),
+            ("Conversation summary", conv_summary if conv_summary else None),
+        ])
+        rows.append({
+            "title": _title_from(overview_text),
+            "content": _attach_footer(overview_text, conv_footer),
+            "type": "observation",
+            "tags": conv_tags,
+            "confidence": 0.85,
+            "source": "claude",
+            "source_ref": "claude:" + conv_uuid + ":overview" if conv_uuid else None,
+            "provenance": "imported",
+            "created_at": conv_created,
+            "updated_at": migrated_at,
+        })
+        for i, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                continue
+            sender = (msg.get("sender") or "human").strip().lower()
+            # Only create memories for human/user messages; assistant
+            # responses are preserved in the supporting-data footer.
+            if sender not in ("human", "user"):
+                continue
+            text = (msg.get("text") or "").strip()
+            if not text:
+                continue
+            msg_created = _parse_dt(msg.get("created_at"))
+            msg_tags = ["claude", "sender=" + sender]
+            if conv_name and len(conv_name) <= 60:
+                msg_tags.append("conversation=" + conv_name[:60])
+            msg_files = []
+            for coll in ("attachments", "files"):
+                for item in (msg.get(coll) or []):
+                    if not isinstance(item, dict):
+                        continue
+                    fname = item.get("file_name") or item.get("name")
+                    if fname:
+                        msg_files.append(str(fname))
+            for fname in msg_files:
+                msg_tags.append("file=" + fname[:40])
+            assistant_response = ""
+            for j in range(i + 1, len(messages)):
+                nxt = messages[j]
+                if not isinstance(nxt, dict):
+                    continue
+                if nxt.get("sender") == "assistant":
+                    assistant_response = (nxt.get("text") or "")[:500]
+                    break
+            msg_footer_items = [
+                ("Conversation", conv_name[:100] if conv_name else None),
+                ("Claude conversation UUID", conv_uuid),
+                ("Sender", sender),
+                ("Message index", i + 1),
+                ("Source", "claude:" + conv_uuid + ":msg:" + str(i) if conv_uuid else None),
+                ("Source timestamp", msg_created.isoformat() if msg_created else None),
+            ]
+            if msg_files:
+                msg_footer_items.append(("Attached files", msg_files))
+            if assistant_response:
+                msg_footer_items.append(("Assistant response (excerpt)", assistant_response))
+            msg_footer = _format_supporting_data(msg_footer_items)
+            memory_type = None
+            cl = text.lower()
+            if any(w in cl for w in ["prefer", "like", "love", "hate", "favorite", "enjoy"]):
+                memory_type = "preference"
+            elif any(w in cl for w in ["remember", "note", "important", "fyi"]):
+                memory_type = "fact"
+            elif any(w in cl for w in ["plan", "schedule", "todo", "need to", "going to", "will do", "commit"]):
+                memory_type = "commitment"
+            elif any(w in cl for w in ["decide", "choice", "picked", "chose", "decision"]):
+                memory_type = "decision"
+            elif any(w in cl for w in ["goal", "aim", "objective", "target", "aspiration"]):
+                memory_type = "goal"
+            rows.append({
+                "title": _title_from(text),
+                "content": _attach_footer(text, msg_footer),
+                "type": memory_type,
+                "tags": msg_tags,
+                "confidence": 0.75,
+                "source": "claude",
+                "source_ref": "claude:" + conv_uuid + ":msg:" + str(i) if conv_uuid else None,
+                "provenance": "imported",
+                "created_at": msg_created,
+                "updated_at": migrated_at,
+            })
+    return rows
+
+
+
 MAPPERS: dict[str, Callable[[dict[str, Any]], list[dict[str, Any]]]] = {
     "mem0": map_mem0,
     "letta": map_letta,
     "supermemory": map_supermemory,
     "okf": map_okf,
+    "claude": map_claude,
 }
 
 

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -89,6 +89,20 @@ def source_count(provider: str, export: dict[str, Any]) -> int:
     """Best-effort count of source records (for the summary header)."""
     if provider == "letta":
         return len(export.get("passages", []) or [])
+    if provider == "claude":
+        conversations = []
+        if isinstance(export, list):
+            conversations = [c for c in export if isinstance(c, dict)]
+        elif isinstance(export, dict):
+            raw = export.get("conversations")
+            if isinstance(raw, list):
+                conversations = raw
+            elif "chat_messages" in export and "uuid" in export:
+                conversations = [export]
+        return sum(
+            len(conv.get("chat_messages", []) or []) + 1
+            for conv in conversations
+        )
     memories = export.get("memories", []) or []
     if provider == "supermemory" and not memories:
         # Mirror map_supermemory's fallback: when no extracted memories exist


### PR DESCRIPTION
## Summary

Adds Claude chat export (chat_messages.jsonl) support to the memory migration tool.

## Changes

- **mappers.py**: Add map_claude() function that converts Claude JSONL export format into Memanto memory entries. Registers claude in the MAPPERS registry.
- **runner.py**: Add claude source support in source_count logic.
- **migrate.py**: Add migrate claude CLI command with progress display and dry-run support. Fix compilation error (literal newline in string literal).

## Testing

- mappers.py tested: 3 memories correctly generated from Claude export
- All three modified files compile successfully (py_compile verified)

Closes #1609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing Claude JSON conversation exports.
  * Added validation for import files and optional target-agent selection.
  * Added dry-run previews before importing conversations.
  * Imports conversation overviews, messages, timestamps, attachments, and supporting response details.
  * Reports source counts, imported memories, memory types, and any failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->