### PR TITLE
fix: use session.session_id instead of hardcoded 'unknown' in CLI client remember/batch_remember

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -639,7 +639,7 @@ class DirectClient:
         """
         # Ensure there is a valid, non-expired session for this agent
         session = self._get_validated_session_for_agent(agent_id)
-        _ = session
+        # session used below for session_id logging
 
         self._validate_memory_input(memory_type, title, content, confidence)
 
@@ -673,7 +673,7 @@ class DirectClient:
 
         # Log to local session Markdown summary only after a durable write.
         if self.session_token and is_successful_write_result(result):
-            session_id = "unknown"
+            session_id = session.session_id
             self._get_session_service().try_log_memory_to_session_summary(
                 agent_id=agent_id,
                 session_id=session_id,
@@ -710,7 +710,7 @@ class DirectClient:
             ValueError: If batch is empty or exceeds 100 items.
         """
         # Ensure there is a valid, non-expired session for this agent
-        self._get_validated_session_for_agent(agent_id)
+        session = self._get_validated_session_for_agent(agent_id)
 
         if not memories:
             raise ValueError("Batch must contain at least one memory")
@@ -774,7 +774,7 @@ class DirectClient:
 
         # Log each memory to local session Markdown summary
         if self.session_token:
-            session_id = "unknown"
+            session_id = session.session_id
             session_svc = self._get_session_service()
 
             # Extract per-memory IDs from the batch result

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -469,7 +469,7 @@ class SdkClient:
         """
         # Ensure there is a valid, non-expired session for this agent
         session = self._get_validated_session_for_agent(agent_id)
-        _ = session
+        # session used below for session_id logging
 
         self._validate_memory_input(memory_type, title, content, confidence)
 
@@ -503,7 +503,7 @@ class SdkClient:
 
         # Log to local session Markdown summary only after a durable write.
         if self.session_token and is_successful_write_result(result):
-            session_id = "unknown"
+            session_id = session.session_id
             self._get_session_service().try_log_memory_to_session_summary(
                 agent_id=agent_id,
                 session_id=session_id,
@@ -538,7 +538,7 @@ class SdkClient:
             ValueError: If batch is empty or exceeds 100 items.
         """
         # Ensure there is a valid, non-expired session for this agent
-        self._get_validated_session_for_agent(agent_id)
+        session = self._get_validated_session_for_agent(agent_id)
 
         if not memories:
             raise ValueError("Batch must contain at least one memory")
@@ -603,7 +603,7 @@ class SdkClient:
 
         # Log each memory to local session Markdown summary
         if self.session_token:
-            session_id = "unknown"
+            session_id = session.session_id
             session_svc = self._get_session_service()
 
             # Extract per-memory IDs from the batch result

--- a/tests/test_session_id_logging.py
+++ b/tests/test_session_id_logging.py
@@ -1,0 +1,117 @@
+"""Test that remember/batch_remember use session.session_id, not hardcoded 'unknown'.
+
+Regression tests for the bug where session_id was hardcoded to "unknown"
+in SdkClient.remember(), SdkClient.batch_remember(), DirectClient.remember(),
+and DirectClient.batch_remember(), causing session summary files to be named
+with 'unknown' instead of the actual session ID.
+
+Refs #770
+"""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+def _make_session(session_id="sess_abc123"):
+    session = MagicMock()
+    session.session_id = session_id
+    session.agent_id = "agent1"
+    session.namespace = "memanto_agent_agent1"
+    session.is_active.return_value = True
+    return session
+
+
+def _make_write_service():
+    svc = MagicMock()
+    result = {"id": "mem_1", "status": "queued", "namespace": "memanto_agent_agent1", "type": "fact"}
+    svc.store_memory.return_value = result
+    svc.batch_store_memories.return_value = {
+        "total_submitted": 1, "successful": 1, "failed": 0, "results": [result],
+    }
+    return svc
+
+
+def _make_session_service():
+    svc = MagicMock()
+    svc.try_log_memory_to_session_summary.return_value = True
+    return svc
+
+
+class TestSdkClientRememberUsesSessionId:
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_session_service")
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_write_service")
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_validated_session_for_agent")
+    @patch("memanto.cli.client.sdk_client.is_successful_write_result", return_value=True)
+    def test_remember_uses_session_id(self, mock_ok, mock_sess, mock_write, mock_sess_svc):
+        from memanto.cli.client.sdk_client import SdkClient
+        session = _make_session(session_id="sess_real_42")
+        mock_sess.return_value = session
+        mock_write.return_value = _make_write_service()
+        mock_sess_svc.return_value = _make_session_service()
+        client = SdkClient.__new__(SdkClient)
+        client.session_token = "tok"
+        client.agent_id = "agent1"
+        client._cached_session = session
+        client.remember(agent_id="agent1", memory_type="fact", title="T", content="C")
+        kw = mock_sess_svc.return_value.try_log_memory_to_session_summary.call_args.kwargs
+        assert kw.get("session_id") == "sess_real_42", f"got {kw.get('session_id')!r}"
+
+
+class TestSdkClientBatchRememberUsesSessionId:
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_session_service")
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_write_service")
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_validated_session_for_agent")
+    @patch("memanto.cli.client.sdk_client.is_successful_write_result", return_value=True)
+    def test_batch_uses_session_id(self, mock_ok, mock_sess, mock_write, mock_sess_svc):
+        from memanto.cli.client.sdk_client import SdkClient
+        session = _make_session(session_id="sess_batch_99")
+        mock_sess.return_value = session
+        mock_write.return_value = _make_write_service()
+        mock_sess_svc.return_value = _make_session_service()
+        client = SdkClient.__new__(SdkClient)
+        client.session_token = "tok"
+        client.agent_id = "agent1"
+        client._cached_session = session
+        client.batch_remember(agent_id="agent1", memories=[{"content": "C", "type": "fact"}])
+        kw = mock_sess_svc.return_value.try_log_memory_to_session_summary.call_args.kwargs
+        assert kw.get("session_id") == "sess_batch_99", f"got {kw.get('session_id')!r}"
+
+
+class TestDirectClientRememberUsesSessionId:
+    @patch("memanto.cli.client.direct_client.DirectClient._get_session_service")
+    @patch("memanto.cli.client.direct_client.DirectClient._get_write_service")
+    @patch("memanto.cli.client.direct_client.DirectClient._get_validated_session_for_agent")
+    @patch("memanto.cli.client.direct_client.is_successful_write_result", return_value=True)
+    def test_remember_uses_session_id(self, mock_ok, mock_sess, mock_write, mock_sess_svc):
+        from memanto.cli.client.direct_client import DirectClient
+        session = _make_session(session_id="sess_direct_77")
+        mock_sess.return_value = session
+        mock_write.return_value = _make_write_service()
+        mock_sess_svc.return_value = _make_session_service()
+        client = DirectClient.__new__(DirectClient)
+        client.session_token = "tok"
+        client.agent_id = "agent1"
+        client._cached_session = session
+        client.remember(agent_id="agent1", memory_type="fact", title="T", content="C")
+        kw = mock_sess_svc.return_value.try_log_memory_to_session_summary.call_args.kwargs
+        assert kw.get("session_id") == "sess_direct_77", f"got {kw.get('session_id')!r}"
+
+
+class TestDirectClientBatchRememberUsesSessionId:
+    @patch("memanto.cli.client.direct_client.DirectClient._get_session_service")
+    @patch("memanto.cli.client.direct_client.DirectClient._get_write_service")
+    @patch("memanto.cli.client.direct_client.DirectClient._get_validated_session_for_agent")
+    @patch("memanto.cli.client.direct_client.is_successful_write_result", return_value=True)
+    def test_batch_uses_session_id(self, mock_ok, mock_sess, mock_write, mock_sess_svc):
+        from memanto.cli.client.direct_client import DirectClient
+        session = _make_session(session_id="sess_direct_batch_55")
+        mock_sess.return_value = session
+        mock_write.return_value = _make_write_service()
+        mock_sess_svc.return_value = _make_session_service()
+        client = DirectClient.__new__(DirectClient)
+        client.session_token = "tok"
+        client.agent_id = "agent1"
+        client._cached_session = session
+        client.batch_remember(agent_id="agent1", memories=[{"content": "C", "type": "fact"}])
+        kw = mock_sess_svc.return_value.try_log_memory_to_session_summary.call_args.kwargs
+        assert kw.get("session_id") == "sess_direct_batch_55", f"got {kw.get('session_id')!r}"


### PR DESCRIPTION
## Bug: `session_id` hardcoded to `"unknown"` in CLI client remember/batch_remember

### Problem

In both `SdkClient` and `DirectClient`, the `remember()` and `batch_remember()` methods hardcode `session_id = "unknown"` when logging memories to session summary markdown files, instead of using the actual session ID from the validated session object.

### Impact

1. **Session summary files are misnamed**: `log_memory_to_session_summary` uses `session_id` to construct the filename (`{agent_id}_{date}_{session_id}_summary.md`). With `"unknown"`, all session summaries get the same broken filename regardless of which session they belong to.

2. **Session context is lost**: Memories cannot be traced back to their originating session, breaking the session-to-memory audit trail.

3. **Data corruption on multi-session workloads**: If an agent has multiple sessions, all memories are logged to the same `"unknown"` summary file, mixing session contexts.

### Root Cause

In `SdkClient.remember()`:
```python
session = self._get_validated_session_for_agent(agent_id)
_ = session  # session is obtained but DISCARDED
# ...
session_id = "unknown"  # should be session.session_id
```

In `SdkClient.batch_remember()`:
```python
self._get_validated_session_for_agent(agent_id)  # result not captured
# ...
session_id = "unknown"  # should be session.session_id
```

Same pattern in both `DirectClient.remember()` and `DirectClient.batch_remember()`.

### Fix

- Preserve the session reference instead of discarding it
- Use `session.session_id` instead of `"unknown"`

### Comparison with correct code

The `delete_memory()` method in both clients correctly uses `session.session_id`:
```python
session = self._get_validated_session_for_agent(agent_id)
# ...
session_id=session.session_id  # correct!
```

And the FastAPI route handlers also correctly use `session.session_id`:
```python
session: Session = Depends(get_current_session)
# ...
session_id=session.session_id  # correct!
```

### Tests

Added `tests/test_session_id_logging.py` with regression tests for all four methods.

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session summaries now record the correct session ID after successful single or batch memory writes.
  * Removed incorrect “unknown” session ID entries.

* **Tests**
  * Added coverage for session ID logging across direct and SDK-based memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->