### PR TITLE
Fix/update bounty labelling

### DIFF
--- a/.github/workflows/bounty-label.yml
+++ b/.github/workflows/bounty-label.yml
@@ -10,6 +10,10 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: bounty-labeling
+  cancel-in-progress: false
+
 permissions:
   pull-requests: write
   issues: write
@@ -22,6 +26,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            function extractSpecificBountyLabel(labels) {
+              for (const label of labels) {
+                const name = typeof label === "string" ? label : label.name;
+                if (/^bounty\s*#?\d+/i.test(name)) {
+                  return name;
+                }
+              }
+              return null;
+            }
+
             async function ensureLabelExists(name) {
               try {
                 await github.rest.issues.getLabel({
@@ -51,16 +65,47 @@ jobs:
                   const color = palette[num % palette.length];
 
                   core.info(`Creating missing label "${name}" with color ${color}.`);
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name,
-                    color: color,
-                  });
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name,
+                      color,
+                    });
+                  } catch (createError) {
+                    // Another concurrent run may create the same label first.
+                    if (createError.status !== 422) {
+                      throw createError;
+                    }
+                  }
                 } else {
-                  core.error(`Failed to check label "${name}": ${error.message}`);
+                  throw new Error(`Failed to check label "${name}": ${error.message}`);
                 }
               }
+            }
+
+            async function findOpenPrsReferencingIssue(issueNumber) {
+              const prs = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+              });
+
+              const refPattern = new RegExp(`#${issueNumber}(?!\\d)`);
+              return prs.filter((pr) => {
+                const text = `${pr.title}\n${pr.body ?? ""}`;
+                return refPattern.test(text);
+              });
+            }
+
+            async function applyLabelsToPr(prNumber, labels) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels,
+              });
             }
 
             async function labelIssue(issue) {
@@ -68,21 +113,13 @@ jobs:
               const hasBountyInTitle = /bounty/i.test(issue.title);
               
               if (!isMaintainer || !hasBountyInTitle) {
-                return;
+                return null;
               }
 
-              let existingSpecificBounty = null;
-
-              for (const label of issue.labels) {
-                const name = typeof label === "string" ? label : label.name;
-                if (/^bounty\s*#?\d+/i.test(name)) {
-                  existingSpecificBounty = name;
-                  break;
-                }
-              }
+              const existingSpecificBounty = extractSpecificBountyLabel(issue.labels);
 
               if (existingSpecificBounty) {
-                return;
+                return existingSpecificBounty;
               }
 
               const allLabels = await github.paginate(github.rest.issues.listLabelsForRepo, {
@@ -114,6 +151,8 @@ jobs:
                 issue_number: issue.number,
                 labels: [newLabel],
               });
+
+              return newLabel;
             }
 
             async function labelPr(pr) {
@@ -142,15 +181,7 @@ jobs:
                   // Skip closed issues so only "active" bounties apply.
                   if (issue.state !== "open") continue;
 
-                  let existingSpecificBounty = null;
-
-                  for (const label of issue.labels) {
-                    const name = typeof label === "string" ? label : label.name;
-                    if (/^bounty\s*#?\d+/i.test(name)) {
-                      existingSpecificBounty = name;
-                      break;
-                    }
-                  }
+                  const existingSpecificBounty = extractSpecificBountyLabel(issue.labels);
 
                   if (existingSpecificBounty) bountyLabels.add(existingSpecificBounty);
                 } catch (error) {
@@ -177,7 +208,15 @@ jobs:
             }
 
             if (context.eventName === "issues") {
-              await labelIssue(context.payload.issue);
+              const bountyLabel = await labelIssue(context.payload.issue);
+              if (bountyLabel) {
+                const referencingPrs = await findOpenPrsReferencingIssue(context.payload.issue.number);
+                for (const pr of referencingPrs) {
+                  core.info(`Issue #${context.payload.issue.number}: propagating ${bountyLabel} to PR #${pr.number}`);
+                  await ensureLabelExists(bountyLabel);
+                  await applyLabelsToPr(pr.number, [bountyLabel]);
+                }
+              }
             } else {
               await labelPr(context.payload.pull_request);
             }

--- a/.github/workflows/bounty-label.yml
+++ b/.github/workflows/bounty-label.yml
@@ -31,12 +31,31 @@ jobs:
                 });
               } catch (error) {
                 if (error.status === 404) {
-                  core.info(`Creating missing label "${name}".`);
+                  // A palette of visually distinct colors
+                  const palette = [
+                    "b60205", // red
+                    "0e8a16", // green
+                    "fbca04", // yellow
+                    "1d76db", // blue
+                    "5319e7", // purple
+                    "d93f0b", // orange
+                    "006b75", // teal
+                    "c5def5", // light blue
+                    "f9d0c4", // light pink
+                    "d4c5f9", // light purple
+                  ];
+                  
+                  // Extract bounty number to deterministically pick a color
+                  const match = name.match(/\d+/);
+                  const num = match ? parseInt(match[0], 10) : 0;
+                  const color = palette[num % palette.length];
+
+                  core.info(`Creating missing label "${name}" with color ${color}.`);
                   await github.rest.issues.createLabel({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     name,
-                    color: "fcf22a",
+                    color: color,
                   });
                 } else {
                   core.error(`Failed to check label "${name}": ${error.message}`);

--- a/.github/workflows/bounty-label.yml
+++ b/.github/workflows/bounty-label.yml
@@ -1,12 +1,12 @@
-name: Auto-label bounty PRs
+name: Auto-label Bounties and PRs
 
-# Labels any pull request that references a bounty issue with "bounty" plus
-# a per-issue "Bounty#N" label (N = the referenced issue number), creating
-# the numbered label if it doesn't exist yet, so PRs submitted against an
-# active bounty are labeled automatically instead of relying on a
-# maintainer to do it by hand.
+# Automatically assigns incremental "Bounty #N" labels to bounty issues.
+# Also labels any pull request that references a bounty issue with the
+# specific "Bounty #N" label from the issue.
 
 on:
+  issues:
+    types: [opened, edited]
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
@@ -22,9 +22,81 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Matches "#123", "issue #123", "closes #123", "fixes #123",
-            // "resolves #123", "refs #123" (case-insensitive), anywhere in
-            // the PR title or body.
+            async function ensureLabelExists(name) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Creating missing label "${name}".`);
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    color: "fcf22a",
+                  });
+                } else {
+                  core.error(`Failed to check label "${name}": ${error.message}`);
+                }
+              }
+            }
+
+            async function labelIssue(issue) {
+              const isMaintainer = ["OWNER", "MEMBER", "COLLABORATOR"].includes(issue.author_association);
+              const hasBountyInTitle = /bounty/i.test(issue.title);
+              
+              if (!isMaintainer || !hasBountyInTitle) {
+                return;
+              }
+
+              let existingSpecificBounty = null;
+
+              for (const label of issue.labels) {
+                const name = typeof label === "string" ? label : label.name;
+                if (/^bounty\s*#?\d+/i.test(name)) {
+                  existingSpecificBounty = name;
+                  break;
+                }
+              }
+
+              if (existingSpecificBounty) {
+                return;
+              }
+
+              const allLabels = await github.paginate(github.rest.issues.listLabelsForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100
+              });
+
+              let maxBountyNum = 0;
+              for (const label of allLabels) {
+                const match = label.name.match(/^bounty\s*#?(\d+)/i);
+                if (match) {
+                  const num = parseInt(match[1], 10);
+                  if (num > maxBountyNum) {
+                    maxBountyNum = num;
+                  }
+                }
+              }
+              
+              const nextBountyNumber = maxBountyNum + 1;
+              const newLabel = `Bounty #${nextBountyNumber}`;
+              
+              await ensureLabelExists(newLabel);
+
+              core.info(`Issue #${issue.number}: applying label ${newLabel}`);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: [newLabel],
+              });
+            }
+
             async function labelPr(pr) {
               const text = `${pr.title}\n${pr.body ?? ""}`;
               const issueNumbers = new Set(
@@ -51,18 +123,17 @@ jobs:
                   // Skip closed issues so only "active" bounties apply.
                   if (issue.state !== "open") continue;
 
-                  const hasBountyLabel = issue.labels.some((label) => {
-                    const name = typeof label === "string" ? label : label.name;
-                    return name === "bounty" || /^Bounty#\d+$/.test(name);
-                  });
-                  if (!hasBountyLabel) continue;
+                  let existingSpecificBounty = null;
 
-                  // Every bounty issue gets its own "Bounty#<issue number>"
-                  // label so PRs against different bounties are visually
-                  // distinguishable, instead of all showing the generic
-                  // "bounty" label.
-                  bountyLabels.add("bounty");
-                  bountyLabels.add(`Bounty#${number}`);
+                  for (const label of issue.labels) {
+                    const name = typeof label === "string" ? label : label.name;
+                    if (/^bounty\s*#?\d+/i.test(name)) {
+                      existingSpecificBounty = name;
+                      break;
+                    }
+                  }
+
+                  if (existingSpecificBounty) bountyLabels.add(existingSpecificBounty);
                 } catch (error) {
                   core.info(`PR #${pr.number}: could not read issue #${number}: ${error?.message ?? String(error)}`);
                 }
@@ -74,21 +145,7 @@ jobs:
               }
 
               for (const name of bountyLabels) {
-                try {
-                  await github.rest.issues.getLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name,
-                  });
-                } catch (error) {
-                  core.info(`Creating missing label "${name}".`);
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name,
-                    color: "fcf22a",
-                  });
-                }
+                await ensureLabelExists(name);
               }
 
               core.info(`PR #${pr.number}: applying labels: ${[...bountyLabels].join(", ")}`);
@@ -100,4 +157,8 @@ jobs:
               });
             }
 
-            await labelPr(context.payload.pull_request);
+            if (context.eventName === "issues") {
+              await labelIssue(context.payload.issue);
+            } else {
+              await labelPr(context.payload.pull_request);
+            }

--- a/.github/workflows/bounty-label.yml
+++ b/.github/workflows/bounty-label.yml
@@ -5,14 +5,10 @@ name: Auto-label bounty PRs
 # the numbered label if it doesn't exist yet, so PRs submitted against an
 # active bounty are labeled automatically instead of relying on a
 # maintainer to do it by hand.
-#
-# The workflow_dispatch trigger runs the same logic across every open PR,
-# for backfilling PRs that were opened before this labeling existed.
 
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
-  workflow_dispatch: {}
 
 permissions:
   pull-requests: write
@@ -104,17 +100,4 @@ jobs:
               });
             }
 
-            if (context.eventName === "workflow_dispatch") {
-              const prs = await github.paginate(github.rest.pulls.list, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: "open",
-                per_page: 100,
-              });
-              core.info(`Backfilling labels across ${prs.length} open PR(s).`);
-              for (const pr of prs) {
-                await labelPr(pr);
-              }
-            } else {
-              await labelPr(context.payload.pull_request);
-            }
+            await labelPr(context.payload.pull_request);


### PR DESCRIPTION
- Remove bounty backfilling logic as PR's are already backfilled
- Assign bounty labels by chronological order over issue #

New logic to automate bounty PR's:
1. When a new bounty issue is created by a maintainer, check the current highest bounty label, increment it by 1 and assign it to that issue.
2. When a new PR is created referencing the issue # of the bounty, copy the bounty label assigned to that issue
3. Label colours cycle through a list of 10 colours to make labels from different bounties more distinguishable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty issues are automatically assigned sequentially numbered labels.
  * Referenced pull requests inherit matching numbered bounty labels from open issues.
  * Missing bounty labels are created automatically with consistent colors.
  * Existing bounty labels are recognized across supported formats.

* **Bug Fixes**
  * Prevented unrelated generic or issue-number-based labels from being applied to pull requests.

* **Chores**
  * Added a tool to apply bounty labels retroactively to eligible open pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->