### PR TITLE
fix: session_id hardcoded to 'unknown' in CLI remember/batch_remember

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -673,10 +673,9 @@ class DirectClient:
 
         # Log to local session Markdown summary only after a durable write.
         if self.session_token and is_successful_write_result(result):
-            session_id = "unknown"
             self._get_session_service().try_log_memory_to_session_summary(
                 agent_id=agent_id,
-                session_id=session_id,
+                session_id=session.session_id,
                 memory_record=memory,
                 memory_id=result.get("id"),
             )
@@ -774,7 +773,6 @@ class DirectClient:
 
         # Log each memory to local session Markdown summary
         if self.session_token:
-            session_id = "unknown"
             session_svc = self._get_session_service()
 
             # Extract per-memory IDs from the batch result
@@ -807,7 +805,7 @@ class DirectClient:
                 )
                 session_svc.try_log_memory_to_session_summary(
                     agent_id=agent_id,
-                    session_id=session_id,
+                    session_id=session.session_id,
                     memory_record=mem,
                     memory_id=mem_id,
                 )

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -503,10 +503,9 @@ class SdkClient:
 
         # Log to local session Markdown summary only after a durable write.
         if self.session_token and is_successful_write_result(result):
-            session_id = "unknown"
             self._get_session_service().try_log_memory_to_session_summary(
                 agent_id=agent_id,
-                session_id=session_id,
+                session_id=session.session_id,
                 memory_record=memory,
                 memory_id=result.get("id"),
             )
@@ -603,7 +602,6 @@ class SdkClient:
 
         # Log each memory to local session Markdown summary
         if self.session_token:
-            session_id = "unknown"
             session_svc = self._get_session_service()
 
             # Extract per-memory IDs from the batch result
@@ -636,7 +634,7 @@ class SdkClient:
                 )
                 session_svc.try_log_memory_to_session_summary(
                     agent_id=agent_id,
-                    session_id=session_id,
+                    session_id=session.session_id,
                     memory_record=mem,
                     memory_id=mem_id,
                 )

--- a/tests/test_session_id_not_unknown.py
+++ b/tests/test_session_id_not_unknown.py
@@ -1,0 +1,197 @@
+"""
+Test: session_id must be the real session ID, not hardcoded "unknown".
+
+Regression test for the bug where DirectClient.remember() and
+DirectClient.batch_remember() logged session summaries with
+session_id="unknown" instead of the actual session.session_id,
+breaking session traceability in local Markdown logs.
+
+Refs: #770
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_session(sid="sess_test123"):
+    s = MagicMock()
+    s.session_id = sid
+    s.agent_id = "agent-1"
+    s.namespace = "memanto_agent_agent-1"
+    s.session_token = "jwt-token"
+    s.started_at = datetime.now(timezone.utc)
+    s.expires_at = datetime.now(timezone.utc) + timedelta(hours=6)
+    s.status = "active"
+    s.is_active.return_value = True
+    return s
+
+
+class TestDirectClientSessionId:
+    """Verify remember / batch_remember pass the real session_id."""
+
+    def test_remember_uses_real_session_id(self, tmp_path):
+        from memanto.cli.client.direct_client import DirectClient
+
+        client = DirectClient.__new__(DirectClient)
+        client.api_key = "test-key"
+        client.agent_id = "agent-1"
+        client.session_token = "jwt-token"
+        client._cached_session = _make_session("sess_real_42")
+        for attr in [
+            "_moorcheh", "_write_service", "_read_service",
+            "_agent_service", "_session_service",
+            "_daily_analysis_service", "_export_service",
+        ]:
+            setattr(client, attr, None)
+        client._validate_memory_input = MagicMock()
+
+        mock_ws = MagicMock()
+        mock_ws.store_memory.return_value = {
+            "id": "mem-1", "namespace": "ns", "status": "queued"
+        }
+        client._get_write_service = MagicMock(return_value=mock_ws)
+
+        mock_ss = MagicMock()
+        client._get_session_service = MagicMock(return_value=mock_ss)
+
+        with patch(
+            "memanto.cli.client.direct_client.is_successful_write_result",
+            return_value=True,
+        ):
+            client.remember(
+                agent_id="agent-1", memory_type="fact", title="t", content="c"
+            )
+
+        mock_ss.try_log_memory_to_session_summary.assert_called_once()
+        kw = mock_ss.try_log_memory_to_session_summary.call_args[1]
+        assert kw["session_id"] == "sess_real_42", (
+            f"Expected 'sess_real_42', got {kw['session_id']!r}"
+        )
+
+    def test_batch_remember_uses_real_session_id(self, tmp_path):
+        from memanto.cli.client.direct_client import DirectClient
+
+        client = DirectClient.__new__(DirectClient)
+        client.api_key = "test-key"
+        client.agent_id = "agent-1"
+        client.session_token = "jwt-token"
+        client._cached_session = _make_session("sess_real_99")
+        for attr in [
+            "_moorcheh", "_write_service", "_read_service",
+            "_agent_service", "_session_service",
+            "_daily_analysis_service", "_export_service",
+        ]:
+            setattr(client, attr, None)
+        client._validate_memory_input = MagicMock()
+
+        mock_ws = MagicMock()
+        mock_ws.batch_store_memories.return_value = {
+            "total_submitted": 1, "successful": 1, "failed": 0,
+            "namespace": "ns",
+            "results": [{"id": "mem-1", "status": "queued", "action": "store"}],
+        }
+        client._get_write_service = MagicMock(return_value=mock_ws)
+
+        mock_ss = MagicMock()
+        client._get_session_service = MagicMock(return_value=mock_ss)
+
+        with patch(
+            "memanto.cli.client.direct_client.is_successful_write_result",
+            return_value=True,
+        ):
+            client.batch_remember(
+                agent_id="agent-1",
+                memories=[{"content": "hello", "type": "fact"}],
+            )
+
+        mock_ss.try_log_memory_to_session_summary.assert_called_once()
+        kw = mock_ss.try_log_memory_to_session_summary.call_args[1]
+        assert kw["session_id"] == "sess_real_99", (
+            f"Expected 'sess_real_99', got {kw['session_id']!r}"
+        )
+
+
+class TestSDKClientSessionId:
+    """Same checks for the moorcheh-sdk-backed client."""
+
+    def test_remember_uses_real_session_id(self, tmp_path):
+        from memanto.cli.client.sdk_client import SDKClient
+
+        client = SDKClient.__new__(SDKClient)
+        client.api_key = "test-key"
+        client.agent_id = "agent-1"
+        client.session_token = "jwt-token"
+        client._cached_session = _make_session("sess_sdk_77")
+        for attr in [
+            "_sdk_client", "_write_service", "_read_service",
+            "_agent_service", "_session_service",
+            "_daily_analysis_service", "_export_service",
+        ]:
+            setattr(client, attr, None)
+        client._validate_memory_input = MagicMock()
+
+        mock_ws = MagicMock()
+        mock_ws.store_memory.return_value = {
+            "id": "mem-1", "namespace": "ns", "status": "queued"
+        }
+        client._get_write_service = MagicMock(return_value=mock_ws)
+
+        mock_ss = MagicMock()
+        client._get_session_service = MagicMock(return_value=mock_ss)
+
+        with patch(
+            "memanto.cli.client.sdk_client.is_successful_write_result",
+            return_value=True,
+        ):
+            client.remember(
+                agent_id="agent-1", memory_type="fact", title="t", content="c"
+            )
+
+        mock_ss.try_log_memory_to_session_summary.assert_called_once()
+        kw = mock_ss.try_log_memory_to_session_summary.call_args[1]
+        assert kw["session_id"] == "sess_sdk_77"
+
+    def test_batch_remember_uses_real_session_id(self, tmp_path):
+        from memanto.cli.client.sdk_client import SDKClient
+
+        client = SDKClient.__new__(SDKClient)
+        client.api_key = "test-key"
+        client.agent_id = "agent-1"
+        client.session_token = "jwt-token"
+        client._cached_session = _make_session("sess_sdk_88")
+        for attr in [
+            "_sdk_client", "_write_service", "_read_service",
+            "_agent_service", "_session_service",
+            "_daily_analysis_service", "_export_service",
+        ]:
+            setattr(client, attr, None)
+        client._validate_memory_input = MagicMock()
+
+        mock_ws = MagicMock()
+        mock_ws.batch_store_memories.return_value = {
+            "total_submitted": 1, "successful": 1, "failed": 0,
+            "namespace": "ns",
+            "results": [{"id": "mem-1", "status": "queued", "action": "store"}],
+        }
+        client._get_write_service = MagicMock(return_value=mock_ws)
+
+        mock_ss = MagicMock()
+        client._get_session_service = MagicMock(return_value=mock_ss)
+
+        with patch(
+            "memanto.cli.client.sdk_client.is_successful_write_result",
+            return_value=True,
+        ):
+            client.batch_remember(
+                agent_id="agent-1",
+                memories=[{"content": "hello", "type": "fact"}],
+            )
+
+        mock_ss.try_log_memory_to_session_summary.assert_called_once()
+        kw = mock_ss.try_log_memory_to_session_summary.call_args[1]
+        assert kw["session_id"] == "sess_sdk_88"


### PR DESCRIPTION
## Bug: session_id hardcoded to "unknown" in CLI clients

### Problem
In both `DirectClient` and `SDKClient`, the `remember()` and `batch_remember()` methods hardcode `session_id = "unknown"` when logging to the local session Markdown summary. This breaks session traceability — all memory write operations are logged with the wrong session identifier, making it impossible to correlate session summary files with actual sessions.

Notably, `delete_memory()` correctly uses `session.session_id` — the bug is inconsistent across the same codebase.

### Impact
- **Data integrity**: Session summary Markdown files (`{agent_id}_{date}_{session_id}_summary.md`) are created with `session_id="unknown"`, so they cannot be matched to the real session
- **Traceability loss**: When reviewing session history, all remember/batch_remember operations appear under a fake "unknown" session
- **File naming**: The summary filename uses the wrong session ID, creating orphaned files

### Root Cause
Lines in `direct_client.py` and `sdk_client.py`:
```python
# BUG: session_id is hardcoded
session_id = "unknown"
self._get_session_service().try_log_memory_to_session_summary(
    agent_id=agent_id,
    session_id=session_id,  # Always "unknown"!
    ...
)
```

The `session` object (from `_get_validated_session_for_agent()`) already has the correct `session_id`, but it was never used.

### Fix
Replace `session_id = "unknown"` with `session_id = session.session_id`, consistent with how `delete_memory()` already works.

### Files Changed
- `memanto/cli/client/direct_client.py` — Fixed `remember()` and `batch_remember()`
- `memanto/cli/client/sdk_client.py` — Same fixes for SDK client
- `tests/test_session_id_not_unknown.py` — Regression tests

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory summaries now consistently use the active session’s ID instead of an unknown placeholder.
  * Single and batch memory operations now retain accurate session associations across supported clients.

* **Tests**
  * Added regression coverage for session ID handling during single and batch memory writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->