### PR TITLE
fix: correct confidence-heading pairing in summary visualization

### DIFF
--- a/memanto/app/services/summary_visualization_service.py
+++ b/memanto/app/services/summary_visualization_service.py
@@ -140,20 +140,33 @@ class SummaryVisualizationService:
             headings = list(self._HEADING_RE.finditer(text))
             confidences = list(self._CONFIDENCE_RE.finditer(text))
 
-            for i, match in enumerate(headings):
+            # Build a position-sorted list of confidence values so that each
+            # heading is paired with the confidence line that follows it in the
+            # document, not with the i-th confidence match overall.  DELETED
+            # entries have a heading but no confidence line, so naive index
+            # pairing silently shifts every later confidence value to the
+            # wrong heading (bounty #770).
+            conf_by_pos: dict[int, float] = {}
+            for cm in confidences:
+                try:
+                    conf_by_pos[cm.start()] = float(cm.group(1))
+                except (ValueError, IndexError):
+                    pass
+            sorted_conf_positions = sorted(conf_by_pos)
+
+            for match in headings:
                 ts_str, mem_type, title = match.groups()
                 try:
                     ts = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S")
                 except ValueError:
                     continue
 
-                # Try to pair with the nearest confidence value
+                # Find the nearest confidence value that appears after this heading
                 conf = 0.8  # default
-                if i < len(confidences):
-                    try:
-                        conf = float(confidences[i].group(1))
-                    except (ValueError, IndexError):
-                        pass
+                for cp in sorted_conf_positions:
+                    if cp > match.start():
+                        conf = conf_by_pos[cp]
+                        break
 
                 memories.append(
                     {

--- a/tests/test_summary_viz_confidence_pairing.py
+++ b/tests/test_summary_viz_confidence_pairing.py
@@ -1,0 +1,155 @@
+"""Test confidence-heading pairing in summary visualization (bounty #770)."""
+
+from datetime import datetime
+from pathlib import Path
+import tempfile
+
+from memanto.app.services.summary_visualization_service import SummaryVisualizationService
+
+
+def _write_session_md(tmp_dir: Path, agent_id: str, date: str, sess_id: str, content: str) -> Path:
+    p = tmp_dir / f"{agent_id}_{date}_{sess_id}_summary.md"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_deleted_entry_does_not_shift_confidence():
+    """A DELETED entry has a heading but no confidence line.
+
+    Before the fix, the i-th heading was paired with the i-th confidence
+    value, so the DELETED heading consumed one confidence slot and shifted
+    every later confidence to the wrong heading.
+    """
+    svc = SummaryVisualizationService()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        md = (
+            "# Session Summary for test-agent
+"
+            "**Session ID:** `sess_1`
+
+"
+            "---
+
+"
+            "### [2026-01-15 10:00:00] [DELETED] Memory Deleted
+"
+            "- **Memory ID**: `mem-del`
+"
+            "- **Confidence**: `1.0`
+"
+            "---
+
+"
+            "### [2026-01-15 10:05:00] [FACT] Real fact
+"
+            "- **Memory ID**: `mem-fact`
+"
+            "- **Confidence**: `0.9`
+"
+            "---
+
+"
+            "### [2026-01-15 10:10:00] [PREFERENCE] User preference
+"
+            "- **Memory ID**: `mem-pref`
+"
+            "- **Confidence**: `0.7`
+"
+            "---
+
+"
+        )
+        _write_session_md(tmp_dir, "test-agent", "2026-01-15", "sess_1", md)
+
+        memories = svc._parse_session_files("test-agent", "2026-01-15", tmp_dir)
+
+        # There should be 3 parsed entries (DELETED + FACT + PREFERENCE)
+        assert len(memories) == 3, f"Expected 3, got {len(memories)}"
+
+        # The DELETED entry should have the default confidence (0.8)
+        deleted = memories[0]
+        assert deleted["type"] == "DELETED"
+        assert deleted["confidence"] == 0.8, f"DELETED confidence should be default 0.8, got {deleted['confidence']}"
+
+        # The FACT entry should have 0.9, NOT 1.0 (which was the bug)
+        fact = memories[1]
+        assert fact["type"] == "FACT"
+        assert fact["confidence"] == 0.9, f"FACT confidence should be 0.9, got {fact['confidence']}"
+
+        # The PREFERENCE entry should have 0.7, NOT 0.9 (which was the bug)
+        pref = memories[2]
+        assert pref["type"] == "PREFERENCE"
+        assert pref["confidence"] == 0.7, f"PREFERENCE confidence should be 0.7, got {pref['confidence']}"
+
+
+def test_multiple_deleted_entries_confidence_alignment():
+    """Multiple DELETED entries must not cascade confidence misalignment."""
+    svc = SummaryVisualizationService()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        md = (
+            "# Session Summary for test-agent2
+"
+            "**Session ID:** `sess_2`
+
+"
+            "---
+
+"
+            "### [2026-02-01 08:00:00] [DELETED] Deleted A
+"
+            "- **Memory ID**: `del-a`
+"
+            "- **Confidence**: `1.0`
+"
+            "---
+
+"
+            "### [2026-02-01 08:01:00] [DELETED] Deleted B
+"
+            "- **Memory ID**: `del-b`
+"
+            "- **Confidence**: `1.0`
+"
+            "---
+
+"
+            "### [2026-02-01 08:05:00] [INSTRUCTION] Important rule
+"
+            "- **Memory ID**: `mem-inst`
+"
+            "- **Confidence**: `0.95`
+"
+            "---
+
+"
+            "### [2026-02-01 08:10:00] [GOAL] Project goal
+"
+            "- **Memory ID**: `mem-goal`
+"
+            "- **Confidence**: `0.6`
+"
+            "---
+
+"
+        )
+        _write_session_md(tmp_dir, "test-agent2", "2026-02-01", "sess_2", md)
+
+        memories = svc._parse_session_files("test-agent2", "2026-02-01", tmp_dir)
+
+        assert len(memories) == 4
+
+        # Both DELETED entries get default confidence
+        assert memories[0]["type"] == "DELETED"
+        assert memories[0]["confidence"] == 0.8
+        assert memories[1]["type"] == "DELETED"
+        assert memories[1]["confidence"] == 0.8
+
+        # INSTRUCTION gets 0.95 (not shifted by DELETED entries)
+        assert memories[2]["type"] == "INSTRUCTION"
+        assert memories[2]["confidence"] == 0.95, f"Expected 0.95, got {memories[2]['confidence']}"
+
+        # GOAL gets 0.6 (not shifted by DELETED entries)
+        assert memories[3]["type"] == "GOAL"
+        assert memories[3]["confidence"] == 0.6, f"Expected 0.6, got {memories[3]['confidence']}"


### PR DESCRIPTION
## Bug: Confidence values misaligned with headings in summary visualization

### Problem
In `summary_visualization_service.py`, the `_parse_session_files` method pairs headings with confidence values using simple index matching (`i < len(confidences)`). However, **DELETED entries** have a heading line (`### [timestamp] [DELETED] ...`) but **no confidence line** (`- **Confidence**: ...`). 

This means every DELETED entry causes the confidence value of the *next* heading to be silently consumed and paired with the DELETED heading, shifting all subsequent confidence values to wrong headings.

### Example
Given this session summary markdown:
```
### [10:00] [DELETED] Memory Deleted     ← heading 0
- **Memory ID**: `mem-del`
- **Confidence**: `1.0`                 ← confidence 0 (belongs to DELETED, not paired)

### [10:05] [FACT] Real fact             ← heading 1
- **Memory ID**: `mem-fact`
- **Confidence**: `0.9`                 ← confidence 1

### [10:10] [PREFERENCE] User preference ← heading 2
- **Memory ID**: `mem-pref`
- **Confidence**: `0.7`                 ← confidence 2
```

**Before fix (index pairing):**
- heading 0 (DELETED) → confidence 0 = `1.0` ❌ (DELETED gets wrong confidence)
- heading 1 (FACT) → confidence 1 = `0.7` ❌ (shifted by 1)
- heading 2 (PREFERENCE) → default `0.8` ❌ (shifted out of range)

**After fix (position-based pairing):**
- heading 0 (DELETED) → default `0.8` ✅ (no confidence line follows)
- heading 1 (FACT) → `0.9` ✅ (nearest confidence after heading)
- heading 2 (PREFERENCE) → `0.7` ✅ (nearest confidence after heading)

### Fix
Replace index-based pairing with position-based pairing: for each heading, find the nearest confidence line that appears *after* the heading in the document text. This correctly handles DELETED entries (which have no following confidence line) and any other structural asymmetries.

### Impact
- All agents that have DELETED entries in session summaries get **wrong confidence values** in their daily summary visualizations
- The bug cascades: each DELETED entry shifts all subsequent confidence values
- Affects the confidence overview table and any downstream consumers of the visualization data

Refs #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence assignment for summary headings based on their document position.
  * Invalid confidence values are safely ignored while preserving the default confidence.
  * Prevented deleted entries from shifting confidence values for subsequent summary items.

* **Tests**
  * Added coverage for confidence pairing across deleted, fact, preference, instruction, and goal entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->