### PR TITLE
fix: correct confidence pairing in SummaryVisualizationService

### DIFF
--- a/memanto/app/services/summary_visualization_service.py
+++ b/memanto/app/services/summary_visualization_service.py
@@ -147,13 +147,21 @@ class SummaryVisualizationService:
                 except ValueError:
                     continue
 
-                # Try to pair with the nearest confidence value
+                # Pair with the confidence line that falls between this
+                # heading and the next heading (or end of text). The previous
+                # index-based pairing (confidences[i]) misaligned when any
+                # heading lacked a confidence line — e.g. a manually edited
+                # summary or a malformed entry — causing every subsequent
+                # heading to inherit the wrong confidence value.
                 conf = 0.8  # default
-                if i < len(confidences):
-                    try:
-                        conf = float(confidences[i].group(1))
-                    except (ValueError, IndexError):
-                        pass
+                heading_end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
+                for conf_match in confidences:
+                    if match.start() < conf_match.start() < heading_end:
+                        try:
+                            conf = float(conf_match.group(1))
+                        except (ValueError, IndexError):
+                            pass
+                        break
 
                 memories.append(
                     {

--- a/tests/test_summary_visualization_confidence.py
+++ b/tests/test_summary_visualization_confidence.py
@@ -1,0 +1,209 @@
+"""
+Tests for SummaryVisualizationService confidence pairing.
+
+Verifies that headings and confidence values are correctly paired by
+position rather than by index, so a missing confidence line on one entry
+does not misalign the confidence values of all subsequent entries.
+"""
+
+import re
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from memanto.app.services.summary_visualization_service import (
+    SummaryVisualizationService,
+)
+
+
+def _write_session_file(tmp_path: Path, agent_id: str, date: str, content: str) -> Path:
+    """Write a session summary MD file and return its path."""
+    fname = f"{agent_id}_{date}_sess_test_summary.md"
+    p = tmp_path / fname
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_confidence_pairing_aligned(tmp_path: Path):
+    """Normal case: each heading has a matching confidence line."""
+    agent_id = "agent1"
+    date = "2026-01-01"
+    md = (
+        "# Session Summary
+"
+        "**Session ID:** `sess_1`
+"
+        "---
+
+"
+        "### [2026-01-01 10:00:00] [FACT] First memory
+"
+        "- **Memory ID**: `mem1`
+"
+        "- **Confidence**: `0.9`
+"
+        "---
+
+"
+        "### [2026-01-01 11:00:00] [FACT] Second memory
+"
+        "- **Memory ID**: `mem2`
+"
+        "- **Confidence**: `0.5`
+"
+        "---
+
+"
+    )
+    _write_session_file(tmp_path, agent_id, date, md)
+
+    svc = SummaryVisualizationService()
+    memories = svc._parse_session_files(agent_id, date, tmp_path)
+
+    assert len(memories) == 2
+    assert memories[0]["confidence"] == 0.9
+    assert memories[1]["confidence"] == 0.5
+
+
+def test_confidence_pairing_with_missing_confidence(tmp_path: Path):
+    """A heading without a confidence line must not shift subsequent pairings."""
+    agent_id = "agent2"
+    date = "2026-01-02"
+    md = (
+        "# Session Summary
+"
+        "**Session ID:** `sess_2`
+"
+        "---
+
+"
+        "### [2026-01-02 10:00:00] [FACT] Has confidence
+"
+        "- **Memory ID**: `mem1`
+"
+        "- **Confidence**: `0.9`
+"
+        "---
+
+"
+        "### [2026-01-02 11:00:00] [FACT] No confidence line
+"
+        "- **Memory ID**: `mem2`
+"
+        "- **Content**:
+"
+        "> Something
+"
+        "---
+
+"
+        "### [2026-01-02 12:00:00] [FACT] Has confidence again
+"
+        "- **Memory ID**: `mem3`
+"
+        "- **Confidence**: `0.3`
+"
+        "---
+
+"
+    )
+    _write_session_file(tmp_path, agent_id, date, md)
+
+    svc = SummaryVisualizationService()
+    memories = svc._parse_session_files(agent_id, date, tmp_path)
+
+    assert len(memories) == 3
+    # First entry: confidence 0.9
+    assert memories[0]["confidence"] == 0.9
+    # Second entry: no confidence line, should get default 0.8
+    assert memories[1]["confidence"] == 0.8
+    # Third entry: confidence 0.3 (NOT 0.9 from the first entry)
+    assert memories[2]["confidence"] == 0.3
+
+
+def test_confidence_pairing_with_deletion_entry(tmp_path: Path):
+    """Deletion entries have confidence=1.0; must not misalign neighbours."""
+    agent_id = "agent3"
+    date = "2026-01-03"
+    md = (
+        "# Session Summary
+"
+        "**Session ID:** `sess_3`
+"
+        "---
+
+"
+        "### [2026-01-03 10:00:00] [FACT] Normal memory
+"
+        "- **Memory ID**: `mem1`
+"
+        "- **Confidence**: `0.7`
+"
+        "---
+
+"
+        "### [2026-01-03 11:00:00] [DELETED] Memory Deleted
+"
+        "- **Memory ID**: `mem2`
+"
+        "- **Confidence**: `1.0`
+"
+        "---
+
+"
+        "### [2026-01-03 12:00:00] [FACT] Another normal memory
+"
+        "- **Memory ID**: `mem3`
+"
+        "- **Confidence**: `0.4`
+"
+        "---
+
+"
+    )
+    _write_session_file(tmp_path, agent_id, date, md)
+
+    svc = SummaryVisualizationService()
+    memories = svc._parse_session_files(agent_id, date, tmp_path)
+
+    assert len(memories) == 3
+    assert memories[0]["confidence"] == 0.7
+    assert memories[1]["confidence"] == 1.0
+    assert memories[2]["confidence"] == 0.4
+
+
+def test_confidence_pairing_all_missing(tmp_path: Path):
+    """All headings lack confidence lines; all should get default 0.8."""
+    agent_id = "agent4"
+    date = "2026-01-04"
+    md = (
+        "# Session Summary
+"
+        "**Session ID:** `sess_4`
+"
+        "---
+
+"
+        "### [2026-01-04 10:00:00] [FACT] First
+"
+        "- **Content**: something
+"
+        "---
+
+"
+        "### [2026-01-04 11:00:00] [FACT] Second
+"
+        "- **Content**: something else
+"
+        "---
+
+"
+    )
+    _write_session_file(tmp_path, agent_id, date, md)
+
+    svc = SummaryVisualizationService()
+    memories = svc._parse_session_files(agent_id, date, tmp_path)
+
+    assert len(memories) == 2
+    assert memories[0]["confidence"] == 0.8
+    assert memories[1]["confidence"] == 0.8


### PR DESCRIPTION
## Bug: Confidence pairing misalignment in SummaryVisualizationService

### Summary

`SummaryVisualizationService._parse_session_files` pairs heading regex matches with confidence regex matches **by index** (`confidences[i]`). When any heading lacks a corresponding confidence line — e.g. a manually edited summary, a malformed entry, or an entry where the confidence line was accidentally removed — every subsequent heading inherits the **wrong confidence value**, silently corrupting:

1. The **Confidence Overview** table (avg, high/medium/low counts)
2. The **Memory Type Distribution** chart (if confidence-based filtering were added later)
3. Any downstream analysis that reads the parsed memory records

### Reproduction

A session MD file with 3 headings where the 2nd heading has no confidence line:

```
### [2026-01-02 10:00:00] [FACT] Has confidence
- **Confidence**: `0.9`

### [2026-01-02 11:00:00] [FACT] No confidence line
- **Content**: Something

### [2026-01-02 12:00:00] [FACT] Has confidence again
- **Confidence**: `0.3`
```

**Before fix (buggy):**
- Heading 0 → confidences[0] = 0.9 ✅
- Heading 1 → confidences[1] = 0.3 ❌ (should be default 0.8)
- Heading 2 → no confidence left, gets default 0.8 ❌ (should be 0.3)

**After fix:**
- Heading 0 → confidence between heading 0 and heading 1 = 0.9 ✅
- Heading 1 → no confidence between heading 1 and heading 2 → default 0.8 ✅
- Heading 2 → confidence between heading 2 and end = 0.3 ✅

### Fix

Instead of pairing by index, pair each heading with the confidence line that falls **between it and the next heading** (or end of text), using regex match positions. This ensures that a missing confidence line only affects that one entry, not all subsequent entries.

### Test plan

- [x] `test_confidence_pairing_aligned` — normal case, all entries have confidence
- [x] `test_confidence_pairing_with_missing_confidence` — missing confidence in middle entry
- [x] `test_confidence_pairing_with_deletion_entry` — deletion entries with confidence=1.0
- [x] `test_confidence_pairing_all_missing` — all entries lack confidence lines

References #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence value assignment in summary visualizations.
  * Missing, invalid, or unmatched confidence values now safely default to 0.8.
  * Preserved confidence values for deletion entries and prevented malformed data from affecting subsequent entries.

* **Tests**
  * Added coverage for aligned, missing, invalid, and multiple confidence values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->