### PR TITLE
security: reject cross-site origins on local UI endpoints

### DIFF
--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -93,6 +93,8 @@ def _is_loopback_host(host: str | None) -> bool:
     """Return True when *host* is a loopback address (IPv4/IPv6/mapped)."""
     if not host:
         return False
+    if host.lower().rstrip(".") == "localhost":
+        return True
     import ipaddress
 
     try:

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,6 +4,8 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
+from urllib.parse import urlsplit
+
 from fastapi import Cookie, Header, HTTPException, Request, Response
 
 from memanto.app.models.session import Session
@@ -103,6 +105,21 @@ def _is_loopback_host(host: str | None) -> bool:
     return ipv4_mapped is not None and ipv4_mapped.is_loopback
 
 
+def _origin_is_local(origin: str | None) -> bool:
+    """Return True when a browser Origin/Referer URL targets localhost."""
+    if not origin:
+        return True
+    if not isinstance(origin, str):
+        return True
+    try:
+        parsed = urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    return _is_loopback_host(parsed.hostname)
+
+
 def require_management_access(
     request: Request,
     authorization: str | None = Header(None),
@@ -151,6 +168,16 @@ def require_management_access(
 
     client_host = request.client.host if request.client else None
     if _is_loopback_host(client_host):
+        origin = request.headers.get("origin")
+        referer = request.headers.get("referer")
+        if not _origin_is_local(origin) or not _origin_is_local(referer):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Agent management endpoints only accept same-local browser "
+                    "origins unless a valid management credential is supplied."
+                ),
+            )
         return server_key
 
     raise HTTPException(

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -13,6 +13,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from fastapi import (
     APIRouter,
@@ -64,6 +65,8 @@ def _is_loopback(host: str | None) -> bool:
     """Return True if *host* is any loopback address (IPv4, IPv6, or IPv4-mapped IPv6)."""
     if host is None:
         return False
+    if host.lower() == "localhost":
+        return True
     try:
         addr = ipaddress.ip_address(host)
         if addr.is_loopback:
@@ -73,6 +76,21 @@ def _is_loopback(host: str | None) -> bool:
         return ipv4_mapped is not None and ipv4_mapped.is_loopback
     except ValueError:
         return False
+
+
+def _origin_is_local(origin: str | None) -> bool:
+    """Return True when a browser Origin/Referer URL also targets localhost."""
+    if not origin:
+        return True
+    if not isinstance(origin, str):
+        return True
+    try:
+        parsed = urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    return _is_loopback(parsed.hostname)
 
 
 async def _require_local(request: Request) -> None:
@@ -91,6 +109,13 @@ async def _require_local(request: Request) -> None:
                 "UI management endpoints are only accessible from localhost. "
                 f"Request origin: {client_host}"
             ),
+        )
+    origin = request.headers.get("origin")
+    referer = request.headers.get("referer")
+    if not _origin_is_local(origin) or not _origin_is_local(referer):
+        raise HTTPException(
+            status_code=403,
+            detail="UI management endpoints only accept same-local browser origins.",
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -231,6 +231,35 @@ class TestMEMANTOAPI:
             assert response.json()["agent_id"] == "remote-ok-agent"
 
     @pytest.mark.asyncio
+    async def test_loopback_create_agent_rejects_cross_site_origin(self):
+        """Loopback-only management access must not be triggerable by hostile pages."""
+        transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
+        async with AsyncClient(
+            transport=transport, base_url="http://localhost"
+        ) as local:
+            response = await local.post(
+                "/api/v2/agents",
+                headers={"Origin": "https://evil.example"},
+                json={"agent_id": "csrf-agent", "pattern": "support"},
+            )
+            assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_cross_site_origin_with_valid_credential_succeeds(self, auth_headers):
+        """Explicit management credentials still authorize API clients."""
+        transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
+        async with AsyncClient(
+            transport=transport, base_url="http://localhost"
+        ) as local:
+            response = await local.post(
+                "/api/v2/agents",
+                headers={**auth_headers, "Origin": "https://automation.example"},
+                json={"agent_id": "credential-origin-agent", "pattern": "support"},
+            )
+            assert response.status_code == 201
+            assert response.json()["agent_id"] == "credential-origin-agent"
+
+    @pytest.mark.asyncio
     async def test_status_requires_management_access(self):
         """Active session status must not be readable by unauthenticated remote peers."""
         transport = ASGITransport(app=app, client=("203.0.113.10", 54321))

--- a/tests/test_management_origin_auth.py
+++ b/tests/test_management_origin_auth.py
@@ -1,0 +1,101 @@
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memanto.app.config import settings
+from memanto.app.main import app
+
+os.environ["MOORCHEH_API_KEY"] = "test-api-key"
+
+
+@pytest.fixture(autouse=True)
+def isolated_agent_state():
+    temp_dir = tempfile.mkdtemp()
+    temp_path = Path(temp_dir)
+
+    with (
+        patch("memanto.app.services.agent_service.Path.home", return_value=temp_path),
+        patch("memanto.app.services.session_service.Path.home", return_value=temp_path),
+    ):
+        from memanto.app.routes.sessions import agent_service
+        from memanto.app.services import session_service as session_service_mod
+
+        session_service_mod._session_service = None
+        session_service = session_service_mod.get_session_service()
+
+        original_agents_dir = agent_service.agents_dir
+        agent_service.agents_dir = temp_path / ".memanto" / "agents"
+        agent_service.agents_dir.mkdir(parents=True, exist_ok=True)
+        session_service.sessions_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            yield
+        finally:
+            agent_service.agents_dir = original_agents_dir
+            session_service_mod._session_service = None
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def mock_moorcheh_client():
+    from memanto.app.clients.moorcheh import moorcheh_client
+
+    moorcheh_client.reset_client()
+
+    with (
+        patch(
+            "memanto.app.services.agent_service.get_moorcheh_client"
+        ) as mock_agent_client,
+        patch("memanto.app.clients.moorcheh.MoorchehClient") as mock_moorcheh_cls,
+        patch(
+            "memanto.app.clients.moorcheh.AsyncMoorchehClient"
+        ) as mock_async_moorcheh_cls,
+    ):
+        mock_instance = MagicMock()
+        mock_async_instance = MagicMock()
+        mock_agent_client.return_value = mock_instance
+        mock_moorcheh_cls.return_value = mock_instance
+        mock_async_moorcheh_cls.return_value = mock_async_instance
+        mock_instance.namespaces.create.return_value = {"status": "created"}
+        mock_async_instance.namespaces.create = AsyncMock(
+            return_value={"status": "created"}
+        )
+
+        yield
+
+        moorcheh_client.reset_client()
+
+
+@pytest.mark.asyncio
+async def test_loopback_management_rejects_cross_site_origin():
+    transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
+    async with AsyncClient(transport=transport, base_url="http://localhost") as client:
+        response = await client.post(
+            "/api/v2/agents",
+            headers={"Origin": "https://evil.example"},
+            json={"agent_id": "csrf-agent", "pattern": "support"},
+        )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_valid_management_credential_allows_nonlocal_origin():
+    transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
+    async with AsyncClient(transport=transport, base_url="http://localhost") as client:
+        response = await client.post(
+            "/api/v2/agents",
+            headers={
+                "Authorization": f"Bearer {settings.MOORCHEH_API_KEY}",
+                "Origin": "https://automation.example",
+            },
+            json={"agent_id": "credential-origin-agent", "pattern": "support"},
+        )
+
+    assert response.status_code == 201
+    assert response.json()["agent_id"] == "credential-origin-agent"

--- a/tests/test_management_origin_auth.py
+++ b/tests/test_management_origin_auth.py
@@ -85,6 +85,20 @@ async def test_loopback_management_rejects_cross_site_origin():
 
 
 @pytest.mark.asyncio
+async def test_loopback_management_accepts_localhost_origin_without_credential():
+    transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
+    async with AsyncClient(transport=transport, base_url="http://localhost") as client:
+        response = await client.post(
+            "/api/v2/agents",
+            headers={"Origin": "http://localhost:8000"},
+            json={"agent_id": "localhost-origin-agent", "pattern": "support"},
+        )
+
+    assert response.status_code == 201
+    assert response.json()["agent_id"] == "localhost-origin-agent"
+
+
+@pytest.mark.asyncio
 async def test_valid_management_credential_allows_nonlocal_origin():
     transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
     async with AsyncClient(transport=transport, base_url="http://localhost") as client:

--- a/tests/test_management_origin_auth.py
+++ b/tests/test_management_origin_auth.py
@@ -1,3 +1,5 @@
+"""Regression tests for browser-origin checks on management API access."""
+
 import os
 import shutil
 import tempfile
@@ -15,6 +17,7 @@ os.environ["MOORCHEH_API_KEY"] = "test-api-key"
 
 @pytest.fixture(autouse=True)
 def isolated_agent_state():
+    """Run each management API test with an isolated on-disk agent state."""
     temp_dir = tempfile.mkdtemp()
     temp_path = Path(temp_dir)
 
@@ -43,6 +46,7 @@ def isolated_agent_state():
 
 @pytest.fixture(autouse=True)
 def mock_moorcheh_client():
+    """Replace networked Moorcheh clients with deterministic in-process mocks."""
     from memanto.app.clients.moorcheh import moorcheh_client
 
     moorcheh_client.reset_client()
@@ -73,6 +77,7 @@ def mock_moorcheh_client():
 
 @pytest.mark.asyncio
 async def test_loopback_management_rejects_cross_site_origin():
+    """Reject unauthenticated loopback requests sent from non-local pages."""
     transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
     async with AsyncClient(transport=transport, base_url="http://localhost") as client:
         response = await client.post(
@@ -86,6 +91,7 @@ async def test_loopback_management_rejects_cross_site_origin():
 
 @pytest.mark.asyncio
 async def test_loopback_management_accepts_localhost_origin_without_credential():
+    """Allow local browser origins to keep normal developer workflows working."""
     transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
     async with AsyncClient(transport=transport, base_url="http://localhost") as client:
         response = await client.post(
@@ -100,6 +106,7 @@ async def test_loopback_management_accepts_localhost_origin_without_credential()
 
 @pytest.mark.asyncio
 async def test_valid_management_credential_allows_nonlocal_origin():
+    """Allow credentialed automation even when its browser origin is external."""
     transport = ASGITransport(app=app, client=("127.0.0.1", 54321))
     async with AsyncClient(transport=transport, base_url="http://localhost") as client:
         response = await client.post(

--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -77,6 +77,11 @@ class TestLoopbackDetection:
 
         assert _is_loopback("127.0.0.1") is True
 
+    def test_localhost_name_accepted(self):
+        from memanto.app.ui.routes.ui_router import _is_loopback
+
+        assert _is_loopback("localhost") is True
+
     def test_ipv6_loopback_accepted(self):
         from memanto.app.ui.routes.ui_router import _is_loopback
 
@@ -110,6 +115,7 @@ class TestLoopbackDetection:
 
         mock_request = MagicMock()
         mock_request.client.host = "127.0.0.1"
+        mock_request.headers = {}
         asyncio.run(_require_local(mock_request))  # must not raise
 
     def test_require_local_allows_ipv4_mapped_loopback(self):
@@ -118,4 +124,44 @@ class TestLoopbackDetection:
 
         mock_request = MagicMock()
         mock_request.client.host = "::ffff:127.0.0.1"
+        mock_request.headers = {}
         asyncio.run(_require_local(mock_request))  # must not raise
+
+    def test_require_local_allows_localhost_origin(self):
+        """Same-local browser origins must pass the local UI guard."""
+        from memanto.app.ui.routes.ui_router import _require_local
+
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        mock_request.headers = {"origin": "http://localhost:8000"}
+        asyncio.run(_require_local(mock_request))  # must not raise
+
+    def test_require_local_rejects_cross_site_origin(self):
+        """A malicious page must not be able to POST to localhost management APIs."""
+        import pytest
+        from fastapi import HTTPException
+
+        from memanto.app.ui.routes.ui_router import _require_local
+
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        mock_request.headers = {"origin": "https://evil.example"}
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(_require_local(mock_request))
+        assert exc.value.status_code == 403
+
+    def test_require_local_rejects_cross_site_referer(self):
+        """Reject hostile referers even when Origin is absent."""
+        import pytest
+        from fastapi import HTTPException
+
+        from memanto.app.ui.routes.ui_router import _require_local
+
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        mock_request.headers = {"referer": "https://evil.example/page"}
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(_require_local(mock_request))
+        assert exc.value.status_code == 403


### PR DESCRIPTION
## Summary
- Reject browser requests to local UI/management endpoints when `Origin` or `Referer` points outside loopback.
- Treat `localhost`, IPv4 loopback, IPv6 loopback, and IPv4-mapped loopback hosts as local callers.
- Preserve credentialed automation access from non-local origins.
- Add regression coverage for hostile browser origins while preserving normal local developer flows.

## Flaw Summary
The local UI/API management surfaces already restrict unauthenticated callers to loopback clients. A browser on the same machine can still send cross-site requests from an arbitrary website to localhost, even when CORS prevents reading the response. Without checking browser `Origin`/`Referer` headers, a non-local page can attempt state-changing localhost management requests through the user's browser context.

## Reproduction Steps
1. Start the local Memanto API/UI server with management routes available.
2. From a browser context whose page origin is not loopback, send a request to a local management endpoint such as `POST /api/v2/agents`.
3. Before this patch, loopback client detection allows the request path to proceed as a local unauthenticated caller.
4. After this patch, the same request is rejected with HTTP 403 when `Origin` or `Referer` is non-local.
5. Requests from local browser origins such as `http://localhost:<port>` remain accepted, and non-local origins remain accepted when a valid management credential is supplied.

## Patch
- Add `_origin_is_local` helpers that parse browser origin/referrer URLs and require HTTP(S) loopback hosts.
- Apply the origin/referrer check to local UI and management API guards before allowing unauthenticated loopback access.
- Keep existing credential checks as the bypass for trusted automation clients.

## Validation
Fresh local validation on 2026-08-25:

- `python -m pytest tests/test_management_origin_auth.py tests/test_api.py tests/test_ui_auth.py -q -p no:cacheprovider`
- `python -m ruff check memanto/app/routes/auth_deps.py memanto/app/ui/routes/ui_router.py tests/test_api.py tests/test_management_origin_auth.py tests/test_ui_auth.py`

## Bounty
This is a defense-in-depth hardening submission for the Memanto Security Challenge: #1852.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved protection for local management requests by validating browser origin and referrer headers.
  - Requests from non-local websites are rejected with HTTP 403 when valid credentials are not provided.
  - Localhost and other loopback addresses are recognized as local, including trailing-dot variants.
  - Requests with valid management credentials remain supported, including from non-local origins.

- **Bug Fixes**
  - Prevented cross-site requests from creating agents through loopback-protected endpoints without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->