### PR TITLE
fix: total_found returns paginated count instead of total matching results

### DIFF
--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -297,7 +297,7 @@ class MemoryReadService:
 
             return {
                 "results": paginated_results,
-                "total_found": len(paginated_results),
+                "total_found": len(all_results),
                 "total_available": len(all_results),
                 "offset": offset,
                 "limit": limit,


### PR DESCRIPTION
## Bug Description

In `search_memories()` in `memory_read_service.py`, the response field `total_found` was incorrectly set to `len(paginated_results)` which returns the count of items in the current page (after offset+limit), not the total number of matching memories.

This caused the API to report incorrect total counts, breaking pagination for consumers who rely on `total_found` to determine how many pages of results exist.

### Example

If a search matches 50 memories and the client requests `limit=10, offset=0`:
- **Before fix**: `total_found: 10` (only the current page count)
- **After fix**: `total_found: 50` (total matching memories)

This makes it impossible for clients to correctly calculate the number of pages or total result count.

## Fix

Changed `total_found: len(paginated_results)` to `total_found: len(all_results)` so it correctly represents the full set of matching memories before pagination is applied.

Note: `total_available` already uses `len(all_results)`, so `total_found` was redundant and incorrect - it should match `total_available` or be removed entirely. This fix makes it correct.

## Testing

The fix has been verified by reviewing the code flow:
- `all_results` contains all matching memories after deduplication, temporal filtering, TTL enforcement, and confidence filtering
- `paginated_results` is a slice of `all_results[offset : offset + limit]`
- The correct value for `total_found` should be the total count of all results, not the paginated slice

## References

- Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now report the total number of matching memories across all pages, rather than only the results shown on the current page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->