### PR TITLE
fix: use actual session_id instead of hardcoded 'unknown' in DirectClient session summary logging

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -639,7 +639,7 @@ class DirectClient:
         """
         # Ensure there is a valid, non-expired session for this agent
         session = self._get_validated_session_for_agent(agent_id)
-        _ = session
+        # session used below for session_id logging
 
         self._validate_memory_input(memory_type, title, content, confidence)
 
@@ -673,7 +673,7 @@ class DirectClient:
 
         # Log to local session Markdown summary only after a durable write.
         if self.session_token and is_successful_write_result(result):
-            session_id = "unknown"
+            session_id = session.session_id
             self._get_session_service().try_log_memory_to_session_summary(
                 agent_id=agent_id,
                 session_id=session_id,
@@ -710,7 +710,7 @@ class DirectClient:
             ValueError: If batch is empty or exceeds 100 items.
         """
         # Ensure there is a valid, non-expired session for this agent
-        self._get_validated_session_for_agent(agent_id)
+        session = self._get_validated_session_for_agent(agent_id)
 
         if not memories:
             raise ValueError("Batch must contain at least one memory")
@@ -774,7 +774,7 @@ class DirectClient:
 
         # Log each memory to local session Markdown summary
         if self.session_token:
-            session_id = "unknown"
+            session_id = session.session_id
             session_svc = self._get_session_service()
 
             # Extract per-memory IDs from the batch result

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -807,7 +807,7 @@ class DirectClient:
                 )
                 session_svc.try_log_memory_to_session_summary(
                     agent_id=agent_id,
-                    session_id=session_id,
+                    session_id=session.session_id,
                     memory_record=mem,
                     memory_id=mem_id,
                 )

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -469,7 +469,7 @@ class SdkClient:
         """
         # Ensure there is a valid, non-expired session for this agent
         session = self._get_validated_session_for_agent(agent_id)
-        _ = session
+        # session used below for session_id logging
 
         self._validate_memory_input(memory_type, title, content, confidence)
 
@@ -503,7 +503,7 @@ class SdkClient:
 
         # Log to local session Markdown summary only after a durable write.
         if self.session_token and is_successful_write_result(result):
-            session_id = "unknown"
+            session_id = session.session_id
             self._get_session_service().try_log_memory_to_session_summary(
                 agent_id=agent_id,
                 session_id=session_id,
@@ -538,7 +538,7 @@ class SdkClient:
             ValueError: If batch is empty or exceeds 100 items.
         """
         # Ensure there is a valid, non-expired session for this agent
-        self._get_validated_session_for_agent(agent_id)
+        session = self._get_validated_session_for_agent(agent_id)
 
         if not memories:
             raise ValueError("Batch must contain at least one memory")
@@ -603,7 +603,7 @@ class SdkClient:
 
         # Log each memory to local session Markdown summary
         if self.session_token:
-            session_id = "unknown"
+            session_id = session.session_id
             session_svc = self._get_session_service()
 
             # Extract per-memory IDs from the batch result

--- a/tests/test_direct_client_session_id.py
+++ b/tests/test_direct_client_session_id.py
@@ -1,0 +1,133 @@
+"""
+Test that DirectClient uses the actual session_id (not "unknown") when
+logging memories to session summary MD files.
+
+References #770
+"""
+
+from unittest.mock import MagicMock, patch, PropertyMock
+from pathlib import Path
+import json
+
+
+def _make_client():
+    """Create a DirectClient with mocked services."""
+    from memanto.cli.client.direct_client import DirectClient
+
+    client = DirectClient(api_key="test-key")
+    client.session_token = "fake-jwt-token"
+    client.agent_id = "test-agent"
+
+    # Mock the moorcheh client
+    client._moorcheh = MagicMock()
+
+    # Mock write service
+    mock_write = MagicMock()
+    mock_write.store_memory.return_value = {
+        "id": "mem-123",
+        "status": "queued",
+        "namespace": "memanto_agent_test-agent",
+        "type": "fact",
+    }
+    mock_write.batch_store_memories.return_value = {
+        "total_submitted": 1,
+        "successful": 1,
+        "failed": 0,
+        "rejected": 0,
+        "results": [{"id": "mem-123", "status": "queued"}],
+        "namespace": "memanto_agent_test-agent",
+    }
+    client._write_service = mock_write
+
+    # Mock session service
+    mock_session_svc = MagicMock()
+    client._session_service = mock_session_svc
+
+    # Mock session object
+    mock_session = MagicMock()
+    mock_session.session_id = "sess_abc123"
+    mock_session.agent_id = "test-agent"
+    mock_session.namespace = "memanto_agent_test-agent"
+    mock_session.is_active.return_value = True
+    mock_session.pattern = MagicMock()
+    mock_session.pattern.value = "tool"
+
+    # Mock _get_validated_session_for_agent to return our mock session
+    client._get_validated_session_for_agent = MagicMock(return_value=mock_session)
+    client._cached_session = mock_session
+
+    return client, mock_session_svc, mock_session
+
+
+def test_remember_uses_actual_session_id():
+    """remember() should pass the real session_id to session summary logging."""
+    client, mock_session_svc, mock_session = _make_client()
+
+    client.remember(
+        agent_id="test-agent",
+        memory_type="fact",
+        title="Test memory",
+        content="This is a test memory",
+    )
+
+    # Verify session summary logging was called with the real session_id
+    mock_session_svc.try_log_memory_to_session_summary.assert_called_once()
+    call_kwargs = mock_session_svc.try_log_memory_to_session_summary.call_args
+    assert call_kwargs.kwargs["session_id"] == "sess_abc123", (
+        f"Expected session_id='sess_abc123', got '{call_kwargs.kwargs['session_id']}'"
+    )
+
+
+def test_batch_remember_uses_actual_session_id():
+    """batch_remember() should pass the real session_id to session summary logging."""
+    client, mock_session_svc, mock_session = _make_client()
+
+    memories = [
+        {
+            "content": "First memory",
+            "title": "First",
+            "type": "fact",
+        }
+    ]
+
+    client.batch_remember(agent_id="test-agent", memories=memories)
+
+    # Verify session summary logging was called with the real session_id
+    mock_session_svc.try_log_memory_to_session_summary.assert_called_once()
+    call_kwargs = mock_session_svc.try_log_memory_to_session_summary.call_args
+    assert call_kwargs.kwargs["session_id"] == "sess_abc123", (
+        f"Expected session_id='sess_abc123', got '{call_kwargs.kwargs['session_id']}'"
+    )
+
+
+def test_remember_does_not_use_unknown_session_id():
+    """remember() must NOT pass 'unknown' as session_id."""
+    client, mock_session_svc, mock_session = _make_client()
+
+    client.remember(
+        agent_id="test-agent",
+        memory_type="fact",
+        title="Test memory",
+        content="This is a test memory",
+    )
+
+    mock_session_svc.try_log_memory_to_session_summary.assert_called_once()
+    call_kwargs = mock_session_svc.try_log_memory_to_session_summary.call_args
+    assert call_kwargs.kwargs["session_id"] != "unknown", (
+        "session_id should not be 'unknown'"
+    )
+
+
+def test_batch_remember_does_not_use_unknown_session_id():
+    """batch_remember() must NOT pass 'unknown' as session_id."""
+    client, mock_session_svc, mock_session = _make_client()
+
+    memories = [{"content": "Test memory", "type": "fact"}]
+
+    client.batch_remember(agent_id="test-agent", memories=memories)
+
+    mock_session_svc.try_log_memory_to_session_summary.assert_called_once()
+    call_kwargs = mock_session_svc.try_log_memory_to_session_summary.call_args
+    assert call_kwargs.kwargs["session_id"] != "unknown", (
+        "session_id should not be 'unknown'"
+    )

--- a/tests/test_session_id_logging.py
+++ b/tests/test_session_id_logging.py
@@ -1,0 +1,117 @@
+"""Test that remember/batch_remember use session.session_id, not hardcoded 'unknown'.
+
+Regression tests for the bug where session_id was hardcoded to "unknown"
+in SdkClient.remember(), SdkClient.batch_remember(), DirectClient.remember(),
+and DirectClient.batch_remember(), causing session summary files to be named
+with 'unknown' instead of the actual session ID.
+
+Refs #770
+"""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+def _make_session(session_id="sess_abc123"):
+    session = MagicMock()
+    session.session_id = session_id
+    session.agent_id = "agent1"
+    session.namespace = "memanto_agent_agent1"
+    session.is_active.return_value = True
+    return session
+
+
+def _make_write_service():
+    svc = MagicMock()
+    result = {"id": "mem_1", "status": "queued", "namespace": "memanto_agent_agent1", "type": "fact"}
+    svc.store_memory.return_value = result
+    svc.batch_store_memories.return_value = {
+        "total_submitted": 1, "successful": 1, "failed": 0, "results": [result],
+    }
+    return svc
+
+
+def _make_session_service():
+    svc = MagicMock()
+    svc.try_log_memory_to_session_summary.return_value = True
+    return svc
+
+
+class TestSdkClientRememberUsesSessionId:
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_session_service")
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_write_service")
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_validated_session_for_agent")
+    @patch("memanto.cli.client.sdk_client.is_successful_write_result", return_value=True)
+    def test_remember_uses_session_id(self, mock_ok, mock_sess, mock_write, mock_sess_svc):
+        from memanto.cli.client.sdk_client import SdkClient
+        session = _make_session(session_id="sess_real_42")
+        mock_sess.return_value = session
+        mock_write.return_value = _make_write_service()
+        mock_sess_svc.return_value = _make_session_service()
+        client = SdkClient.__new__(SdkClient)
+        client.session_token = "tok"
+        client.agent_id = "agent1"
+        client._cached_session = session
+        client.remember(agent_id="agent1", memory_type="fact", title="T", content="C")
+        kw = mock_sess_svc.return_value.try_log_memory_to_session_summary.call_args.kwargs
+        assert kw.get("session_id") == "sess_real_42", f"got {kw.get('session_id')!r}"
+
+
+class TestSdkClientBatchRememberUsesSessionId:
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_session_service")
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_write_service")
+    @patch("memanto.cli.client.sdk_client.SdkClient._get_validated_session_for_agent")
+    @patch("memanto.cli.client.sdk_client.is_successful_write_result", return_value=True)
+    def test_batch_uses_session_id(self, mock_ok, mock_sess, mock_write, mock_sess_svc):
+        from memanto.cli.client.sdk_client import SdkClient
+        session = _make_session(session_id="sess_batch_99")
+        mock_sess.return_value = session
+        mock_write.return_value = _make_write_service()
+        mock_sess_svc.return_value = _make_session_service()
+        client = SdkClient.__new__(SdkClient)
+        client.session_token = "tok"
+        client.agent_id = "agent1"
+        client._cached_session = session
+        client.batch_remember(agent_id="agent1", memories=[{"content": "C", "type": "fact"}])
+        kw = mock_sess_svc.return_value.try_log_memory_to_session_summary.call_args.kwargs
+        assert kw.get("session_id") == "sess_batch_99", f"got {kw.get('session_id')!r}"
+
+
+class TestDirectClientRememberUsesSessionId:
+    @patch("memanto.cli.client.direct_client.DirectClient._get_session_service")
+    @patch("memanto.cli.client.direct_client.DirectClient._get_write_service")
+    @patch("memanto.cli.client.direct_client.DirectClient._get_validated_session_for_agent")
+    @patch("memanto.cli.client.direct_client.is_successful_write_result", return_value=True)
+    def test_remember_uses_session_id(self, mock_ok, mock_sess, mock_write, mock_sess_svc):
+        from memanto.cli.client.direct_client import DirectClient
+        session = _make_session(session_id="sess_direct_77")
+        mock_sess.return_value = session
+        mock_write.return_value = _make_write_service()
+        mock_sess_svc.return_value = _make_session_service()
+        client = DirectClient.__new__(DirectClient)
+        client.session_token = "tok"
+        client.agent_id = "agent1"
+        client._cached_session = session
+        client.remember(agent_id="agent1", memory_type="fact", title="T", content="C")
+        kw = mock_sess_svc.return_value.try_log_memory_to_session_summary.call_args.kwargs
+        assert kw.get("session_id") == "sess_direct_77", f"got {kw.get('session_id')!r}"
+
+
+class TestDirectClientBatchRememberUsesSessionId:
+    @patch("memanto.cli.client.direct_client.DirectClient._get_session_service")
+    @patch("memanto.cli.client.direct_client.DirectClient._get_write_service")
+    @patch("memanto.cli.client.direct_client.DirectClient._get_validated_session_for_agent")
+    @patch("memanto.cli.client.direct_client.is_successful_write_result", return_value=True)
+    def test_batch_uses_session_id(self, mock_ok, mock_sess, mock_write, mock_sess_svc):
+        from memanto.cli.client.direct_client import DirectClient
+        session = _make_session(session_id="sess_direct_batch_55")
+        mock_sess.return_value = session
+        mock_write.return_value = _make_write_service()
+        mock_sess_svc.return_value = _make_session_service()
+        client = DirectClient.__new__(DirectClient)
+        client.session_token = "tok"
+        client.agent_id = "agent1"
+        client._cached_session = session
+        client.batch_remember(agent_id="agent1", memories=[{"content": "C", "type": "fact"}])
+        kw = mock_sess_svc.return_value.try_log_memory_to_session_summary.call_args.kwargs
+        assert kw.get("session_id") == "sess_direct_batch_55", f"got {kw.get('session_id')!r}"


### PR DESCRIPTION
## Bug Description

In `DirectClient.remember()` and `DirectClient.batch_remember()`, the `session_id` was hardcoded to `"unknown"` when logging memories to session summary Markdown files.

### Impact

This caused several problems:

1. **Incorrect file naming**: Session summary files were named `{agent_id}_{date}_unknown_summary.md` instead of using the real session ID (e.g., `sess_abc123`)

2. **Broken daily summary & conflict report**: `DailyAnalysisService.generate_summary()` and `generate_conflict_report()` search for files matching the pattern `{agent_id}_{date}_*_summary.md`. While the glob still matches, the session ID embedded in the filename is wrong, making it impossible to distinguish which session produced which memories.

3. **Cross-session data merge**: When multiple sessions exist for the same agent on the same day, all session summary logs are written to the same `unknown` file instead of separate per-session files, merging unrelated session data.

### Root Cause

The `remember()` method calls `self._get_validated_session_for_agent(agent_id)` which returns a valid `Session` object with the correct `session_id`. However, when logging to the session summary, the code used `session_id = "unknown"` instead of `session.session_id`.

The same issue existed in `batch_remember()`.

### Fix

Use `session.session_id` (the actual session ID from the validated session object) instead of the hardcoded `"unknown"` string.

The `session` object is already available from the `_get_validated_session_for_agent()` call at the top of both methods, so no additional API calls or state changes are needed.

### Testing

Added `tests/test_direct_client_session_id.py` with 4 test cases:
- `test_remember_uses_actual_session_id`: Verifies `remember()` passes the real session_id
- `test_batch_remember_uses_actual_session_id`: Verifies `batch_remember()` passes the real session_id
- `test_remember_does_not_use_unknown_session_id`: Ensures `remember()` does NOT use "unknown"
- `test_batch_remember_does_not_use_unknown_session_id`: Ensures `batch_remember()` does NOT use "unknown"

References #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session summaries now record the correct session ID when saving individual or batches of memories.
  * Eliminated incorrect `"unknown"` session identifiers in local summary logs.

* **Tests**
  * Added coverage for session ID logging across supported client workflows.
  * Added regression checks for both individual and batch memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->