### PR TITLE
test: add route authentication dependency guard

### DIFF
--- a/scripts/verify_route_auth_dependencies.py
+++ b/scripts/verify_route_auth_dependencies.py
@@ -1,0 +1,160 @@
+"""Static regression guard for FastAPI route authentication dependencies.
+
+This source-only check prevents a non-health route from silently omitting both
+Memanto authorization dependencies.  It deliberately makes no network calls
+and does not require API credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+
+PUBLIC_ROUTE_FILES = {"health.py"}
+AUTH_DEPENDENCIES = {"get_current_session", "verify_moorcheh_api_key"}
+HTTP_DECORATORS = {"get", "post", "put", "patch", "delete", "options", "head"}
+
+
+def call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def dependency_name(default: ast.expr | None) -> str | None:
+    if not isinstance(default, ast.Call) or call_name(default.func) != "Depends":
+        return None
+    return call_name(default.args[0]) if default.args else None
+
+
+def handler_dependencies(function: ast.AsyncFunctionDef | ast.FunctionDef) -> set[str]:
+    found: set[str] = set()
+    for default in [*function.args.defaults, *function.args.kw_defaults]:
+        name = dependency_name(default)
+        if name:
+            found.add(name)
+    return found
+
+
+def decorator_dependencies(decorator: ast.Call) -> set[str]:
+    """Find ``dependencies=[Depends(...)]`` declared on a route decorator."""
+    found: set[str] = set()
+    for keyword in decorator.keywords:
+        if keyword.arg != "dependencies" or not isinstance(
+            keyword.value, (ast.List, ast.Tuple, ast.Set)
+        ):
+            continue
+        for item in keyword.value.elts:
+            name = dependency_name(item)
+            if name:
+                found.add(name)
+    return found
+
+
+def router_dependency_map(tree: ast.AST) -> dict[str, set[str]]:
+    """Map APIRouter variable names to their declared dependencies."""
+    routers: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Call) or call_name(value.func) != "APIRouter":
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names = [target.id for target in targets if isinstance(target, ast.Name)]
+        dependencies = decorator_dependencies(value)
+        for name in names:
+            routers[name] = dependencies
+    return routers
+
+
+def decorator_router_name(decorator: ast.Call) -> str | None:
+    receiver = decorator.func.value if isinstance(decorator.func, ast.Attribute) else None
+    return receiver.id if isinstance(receiver, ast.Name) else None
+
+
+def is_http_route(decorator: ast.expr) -> bool:
+    return (
+        isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and decorator.func.attr in HTTP_DECORATORS
+    )
+
+
+def route_records(routes_dir: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for source in sorted(routes_dir.glob("*.py")):
+        if source.name in PUBLIC_ROUTE_FILES:
+            continue
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        router_dependencies = router_dependency_map(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in (d for d in node.decorator_list if is_http_route(d)):
+                assert isinstance(decorator, ast.Call)
+                path = (
+                    decorator.args[0].value
+                    if decorator.args and isinstance(decorator.args[0], ast.Constant)
+                    else None
+                )
+                router_name = decorator_router_name(decorator)
+                records.append(
+                    {
+                        "source": source.name,
+                        "line": node.lineno,
+                        "function": node.name,
+                        "method": decorator.func.attr.upper(),
+                        "path": path,
+                        "dependencies": sorted(
+                            handler_dependencies(node).union(
+                                decorator_dependencies(decorator),
+                                router_dependencies.get(router_name, set()),
+                            )
+                        ),
+                    }
+                )
+    return sorted(records, key=lambda item: (str(item["source"]), int(item["line"])))
+
+
+def audit(routes_dir: Path) -> list[str]:
+    failures: list[str] = []
+    for record in route_records(routes_dir):
+        if not set(record["dependencies"]).intersection(AUTH_DEPENDENCIES):
+            failures.append(
+                f"{record['source']}:{record['line']} {record['function']} "
+                f"-> {record['dependencies']}"
+            )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_root", nargs="?", type=Path, default=Path("."))
+    parser.add_argument("--manifest", type=Path)
+    args = parser.parse_args()
+    routes_dir = args.source_root / "memanto" / "app" / "routes"
+    if not routes_dir.is_dir():
+        raise SystemExit(f"routes directory not found: {routes_dir}")
+    records = route_records(routes_dir)
+    if args.manifest:
+        args.manifest.write_text(
+            json.dumps({"routes": records}, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    failures = audit(routes_dir)
+    if failures:
+        print("AUTH_ROUTE_GUARD=FAIL")
+        print("\n".join(failures))
+        return 1
+    print("AUTH_ROUTE_GUARD=PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_route_auth_dependencies.py
+++ b/tests/test_route_auth_dependencies.py
@@ -1,0 +1,62 @@
+"""Tests for the source-only route authorization regression guard."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "verify_route_auth_dependencies",
+    ROOT / "scripts" / "verify_route_auth_dependencies.py",
+)
+assert SPEC and SPEC.loader
+guard = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(guard)
+
+
+def write_routes(tmp_path: Path, content: str) -> Path:
+    routes = tmp_path / "memanto" / "app" / "routes"
+    routes.mkdir(parents=True)
+    (routes / "example.py").write_text(content, encoding="utf-8")
+    return routes
+
+
+def test_allows_handler_and_decorator_dependencies(tmp_path: Path) -> None:
+    routes = write_routes(
+        tmp_path,
+        """\
+from fastapi import APIRouter, Depends
+router = APIRouter()
+def get_current_session(): pass
+@router.get('/parameter')
+async def parameter_route(session=Depends(get_current_session)): pass
+@router.post('/decorator', dependencies=[Depends(get_current_session)])
+async def decorator_route(): pass
+router_level = APIRouter(dependencies=[Depends(get_current_session)])
+@router_level.patch('/router-level')
+async def router_level_route(): pass
+""",
+    )
+    assert guard.audit(routes) == []
+
+
+def test_rejects_unprotected_non_health_route(tmp_path: Path) -> None:
+    routes = write_routes(
+        tmp_path,
+        """\
+from fastapi import APIRouter
+router = APIRouter()
+@router.get('/missing-auth')
+async def missing_auth(): pass
+""",
+    )
+    failures = guard.audit(routes)
+    assert len(failures) == 1
+    assert "missing_auth" in failures[0]
+
+
+def test_current_route_tree_declares_authorization_dependencies() -> None:
+    routes = ROOT / "memanto" / "app" / "routes"
+    assert guard.audit(routes) == []


### PR DESCRIPTION
## Summary

- add a source-only regression guard that checks non-health FastAPI routes declare an approved authentication dependency
- recognize handler-, decorator-, and router-level dependencies
- cover the current route tree plus focused protected and unprotected examples
- support an optional JSON route manifest for review

## Why

This prevents a route from being introduced without either the session or API-key authorization dependency. The check is static, makes no network calls, and requires no credentials.

## Validation

- `AUTH_ROUTE_GUARD=PASS`
- Python compilation passed
- three focused dependency-free tests passed

Related to #1852.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated check that identifies HTTP routes missing required authorization dependencies.
  * Supports excluding designated health-check routes and optionally generating a JSON route manifest.
  * Reports clear pass/fail results for authorization coverage.

* **Tests**
  * Added regression coverage for supported authorization patterns, unprotected routes, and the current route configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->