### PR TITLE
feat(migrate): add Zep fact/graph export path (#1609)

### DIFF
--- a/examples/zep-okf-loop/README.md
+++ b/examples/zep-okf-loop/README.md
@@ -1,0 +1,19 @@
+# Zep → Memanto → OKF
+
+This showcase uses the new `memanto migrate zep` path. It does **not**
+reimplement `memanto migrate` or OKF export. It adds a provider Memanto does
+not already ship: Zep graph/fact dumps.
+
+```bash
+# 1. Map the sample dump (no API key, no writes)
+memanto migrate zep --file examples/zep-okf-loop/zep_export.json --dry-run
+
+# 2. Import into an activated agent
+memanto migrate zep --file examples/zep-okf-loop/zep_export.json
+
+# 3. Own it as portable OKF
+memanto memory export --okf ./examples/zep-okf-loop/out-okf
+```
+
+Raw Zep chat turns are not imported as memories. Facts, graph edges, entity
+node summaries, and session summaries are.

--- a/examples/zep-okf-loop/zep_export.json
+++ b/examples/zep-okf-loop/zep_export.json
@@ -1,0 +1,41 @@
+{
+  "exported_at": "2026-08-19T20:00:00Z",
+  "user_id": "user_42",
+  "facts": [
+    {
+      "uuid": "fact-1",
+      "fact": "Alex prefers broad-market beta over leveraged single-country products.",
+      "created_at": "2026-08-10T12:00:00Z",
+      "rating": 0.91
+    }
+  ],
+  "edges": [
+    {
+      "uuid": "edge-1",
+      "name": "WORKS_WITH",
+      "fact": "Alex works with an operator agent named Scout.",
+      "created_at": "2026-08-11T09:00:00Z",
+      "source_node_uuid": "n-alex",
+      "target_node_uuid": "n-scout"
+    }
+  ],
+  "nodes": [
+    {
+      "uuid": "n-alex",
+      "name": "Alex",
+      "summary": "Operator who wants portable agent memory.",
+      "labels": ["User"],
+      "created_at": "2026-08-01T00:00:00Z"
+    }
+  ],
+  "sessions": [
+    {
+      "session_id": "sess-1",
+      "summary": "Discussed leaving a proprietary memory store without losing facts.",
+      "created_at": "2026-08-19T18:00:00Z",
+      "messages": [
+        {"uuid": "m1", "role": "user", "content": "export my graph please"}
+      ]
+    }
+  ]
+}

--- a/memanto/cli/commands/migrate.py
+++ b/memanto/cli/commands/migrate.py
@@ -692,7 +692,10 @@ def migrate_zep(
 
     target_agent = None if dry_run else _resolve_target_agent(agent)
     progress(f"Loading export from {file}")
-    export = load_export(file)
+    try:
+        export = load_export(file)
+    except Exception as exc:
+        _error(f"Failed to load Zep export: {exc}")
     progress("Mapping Zep facts/edges/summaries onto Memanto schema...")
     client = None if dry_run else get_client()
     summary, rows = run_migration(

--- a/memanto/cli/commands/migrate.py
+++ b/memanto/cli/commands/migrate.py
@@ -643,6 +643,104 @@ def migrate_okf(
     )
 
 
+@migrate_app.command("zep")
+def migrate_zep(
+    file: Path = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        help="Zep Cloud/Community JSON export (facts, edges, nodes, session summaries).",
+    ),
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help="Target Memanto agent id (defaults to the active agent).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the mapping without writing.",
+    ),
+):
+    """Import a Zep JSON dump into the active (or selected) agent.
+
+    File-only: no Zep API key. Extracts facts, graph edges, node summaries,
+    and session summaries. Raw chat turns are not imported as memories.
+
+    Examples:
+        memanto migrate zep --file ./zep_export.json --dry-run
+        memanto migrate zep --file ./zep_export.json --agent my-agent
+    """
+    if not file.exists():
+        _error(f"Zep export not found: {file}", hint="Pass --file to a JSON dump.")
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = config_manager.get_migrate_dir("zep") / stamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    mode = "Dry run" if dry_run else "Migrate"
+    console.print(
+        Panel.fit(
+            f"[{BOLD_PRIMARY}]Zep -> Memanto  {mode}[/{BOLD_PRIMARY}]",
+            border_style=PRIMARY,
+        )
+    )
+
+    def progress(msg: str) -> None:
+        console.print(f"  [{BRIGHT}]…[/{BRIGHT}] {msg}")
+
+    target_agent = None if dry_run else _resolve_target_agent(agent)
+    progress(f"Loading export from {file}")
+    export = load_export(file)
+    progress("Mapping Zep facts/edges/summaries onto Memanto schema...")
+    client = None if dry_run else get_client()
+    summary, rows = run_migration(
+        provider="zep",
+        export=export,
+        client=client,
+        agent_id=target_agent or "",
+        dry_run=dry_run,
+        on_progress=progress,
+    )
+    preview_path = write_preview(rows, run_dir / "mapped_preview.json")
+    type_lines = (
+        ", ".join(f"{k}: {v}" for k, v in sorted(summary.type_counts.items())) or "—"
+    )
+    body_lines = [
+        f"[dim]Zep records:[/dim] {summary.source_count}",
+        f"[dim]Mapped memories:[/dim] {summary.mapped_count}  "
+        f"[dim](skipped {summary.skipped})[/dim]",
+        f"[dim]Type breakdown:[/dim] {type_lines}",
+    ]
+    if dry_run:
+        body_lines.append("")
+        body_lines.append("[yellow]Dry run — no writes performed.[/yellow]")
+    else:
+        body_lines.append(
+            f"[dim]Imported:[/dim] {summary.imported}  "
+            f"[dim]Failed:[/dim] {summary.failed}  "
+            f"[dim]Batches:[/dim] {summary.batches}"
+        )
+        body_lines.append(f"[dim]Target agent:[/dim] {target_agent}")
+    body_lines.append("")
+    body_lines.append(f"[dim]Run dir:[/dim] {run_dir}")
+    body_lines.append(f"[dim]Mapped preview:[/dim] {preview_path}")
+    border = WARNING if summary.failed else SUCCESS
+    console.print()
+    console.print(
+        Panel(
+            "\n".join(body_lines),
+            title=(
+                "[bold yellow]Dry run complete[/bold yellow]"
+                if dry_run
+                else "[bold green]Import complete[/bold green]"
+            ),
+            border_style=border,
+        )
+    )
+
+
 @migrate_app.command("supermemory")
 def migrate_supermemory(
     api_key: str | None = typer.Option(

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -507,8 +507,8 @@ def map_zep(export: dict[str, Any]) -> list[dict[str, Any]]:
     """Map a Zep Cloud/Community JSON dump onto Memanto memories.
 
     Zep's useful portable units are extracted facts, graph edges, entity
-    node summaries, and session summaries. Raw chat turns stay in the
-    footer only when they belong to a summarized session — they are not
+    node summaries, and session summaries. Migrated sessions retain only
+    the message count; raw chat turns are not stored in the footer or
     imported as their own rows.
     """
     rows: list[dict[str, Any]] = []

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -631,11 +631,7 @@ def map_zep(export: dict[str, Any]) -> list[dict[str, Any]]:
         if not summary:
             continue
         messages = session.get("messages") or []
-        preview = [
-            f"{(msg.get('role') or '?')}: {(msg.get('content') or '')[:80]}"
-            for msg in messages[:4]
-            if isinstance(msg, dict)
-        ]
+        message_count = len(messages) if isinstance(messages, list) else 0
         _add(
             content=summary,
             source_ref=session.get("session_id") or session.get("uuid") or session.get("id"),
@@ -644,8 +640,7 @@ def map_zep(export: dict[str, Any]) -> list[dict[str, Any]]:
             created_at=session,
             extra=[
                 ("Session id", session.get("session_id")),
-                ("Message count", len(messages) if isinstance(messages, list) else 0),
-                ("Message preview", preview),
+                ("Message count", message_count),
             ],
         )
 

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -491,11 +491,173 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
 # memories, so one incident collapses into a single grouped payload rather
 # than mapping row-for-row. That needs the user's capture settings, which
 # this registry's signature cannot carry — see ``langfuse_rules.build_rows``.
+# --------------------------------------------------------------------------
+# Zep
+# --------------------------------------------------------------------------
+
+
+def _zep_text(*values: Any) -> str:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def map_zep(export: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map a Zep Cloud/Community JSON dump onto Memanto memories.
+
+    Zep's useful portable units are extracted facts, graph edges, entity
+    node summaries, and session summaries. Raw chat turns stay in the
+    footer only when they belong to a summarized session — they are not
+    imported as their own rows.
+    """
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    migrated_at = _now_utc()
+    user_id = export.get("user_id") or export.get("userId")
+
+    def _add(
+        *,
+        content: str,
+        source_ref: str | None,
+        memory_type: str | None,
+        tags: list[str],
+        created_at: Any,
+        extra: list[tuple[str, Any]],
+    ) -> None:
+        content = content.strip()
+        if not content:
+            return
+        ref = str(source_ref) if source_ref else content
+        if ref in seen:
+            return
+        seen.add(ref)
+        row_tags = list(tags)
+        if user_id and f"user={user_id}" not in row_tags:
+            row_tags.append(f"user={user_id}")
+        if hasattr(created_at, "isoformat") and not isinstance(created_at, dict):
+            created = created_at
+        elif isinstance(created_at, dict):
+            created = _pick_first_dt(created_at, ("created_at", "createdAt"))
+        else:
+            created = _pick_first_dt({"created_at": created_at}, ("created_at",))
+        footer = _format_supporting_data(
+            [
+                ("Source", f"zep:{ref}" if source_ref else "zep"),
+                ("Zep user_id", user_id),
+                *extra,
+                ("Source created_at", created.isoformat() if created else None),
+            ]
+        )
+        rows.append(
+            {
+                "title": _title_from(content),
+                "content": _attach_footer(content, footer),
+                "type": memory_type,
+                "tags": row_tags,
+                "confidence": 0.8,
+                "source": "zep",
+                "source_ref": str(source_ref) if source_ref else None,
+                "provenance": "imported",
+                "created_at": created,
+                "updated_at": migrated_at,
+            }
+        )
+
+    facts = list(export.get("facts") or []) + list(
+        export.get("relevant_facts") or []
+    ) + list(export.get("user_facts") or [])
+    for fact in facts:
+        if not isinstance(fact, dict):
+            continue
+        _add(
+            content=_zep_text(fact.get("fact"), fact.get("content"), fact.get("text")),
+            source_ref=fact.get("uuid") or fact.get("id"),
+            memory_type="fact",
+            tags=["zep-fact"],
+            created_at=fact,
+            extra=[
+                ("Rating", fact.get("rating") or fact.get("score")),
+                ("Zep metadata", fact.get("metadata")),
+            ],
+        )
+
+    for edge in export.get("edges") or []:
+        if not isinstance(edge, dict):
+            continue
+        fact = _zep_text(edge.get("fact"), edge.get("name"))
+        if not fact:
+            continue
+        name = _zep_text(edge.get("name"))
+        content = f"{name}: {fact}" if name and name not in fact else fact
+        _add(
+            content=content,
+            source_ref=edge.get("uuid") or edge.get("id"),
+            memory_type="fact",
+            tags=["zep-edge"],
+            created_at=edge,
+            extra=[
+                ("Edge name", name),
+                ("Source node", edge.get("source_node_uuid") or edge.get("source")),
+                ("Target node", edge.get("target_node_uuid") or edge.get("target")),
+            ],
+        )
+
+    for node in export.get("nodes") or []:
+        if not isinstance(node, dict):
+            continue
+        summary = _zep_text(node.get("summary"), node.get("name"))
+        if not summary:
+            continue
+        labels = [str(label) for label in (node.get("labels") or []) if label]
+        memory_type = (
+            "relationship"
+            if any(label.lower() in {"user", "person", "people"} for label in labels)
+            else "fact"
+        )
+        _add(
+            content=summary,
+            source_ref=node.get("uuid") or node.get("id"),
+            memory_type=memory_type,
+            tags=["zep-node", *labels],
+            created_at=node,
+            extra=[("Node name", node.get("name")), ("Labels", labels)],
+        )
+
+    for session in export.get("sessions") or []:
+        if not isinstance(session, dict):
+            continue
+        summary = _zep_text(session.get("summary"))
+        if not summary:
+            continue
+        messages = session.get("messages") or []
+        preview = [
+            f"{(msg.get('role') or '?')}: {(msg.get('content') or '')[:80]}"
+            for msg in messages[:4]
+            if isinstance(msg, dict)
+        ]
+        _add(
+            content=summary,
+            source_ref=session.get("session_id") or session.get("uuid") or session.get("id"),
+            memory_type="observation",
+            tags=["zep-session"],
+            created_at=session,
+            extra=[
+                ("Session id", session.get("session_id")),
+                ("Message count", len(messages) if isinstance(messages, list) else 0),
+                ("Message preview", preview),
+            ],
+        )
+
+    return rows
+
+
 MAPPERS: dict[str, Callable[[dict[str, Any]], list[dict[str, Any]]]] = {
     "mem0": map_mem0,
     "letta": map_letta,
     "supermemory": map_supermemory,
     "okf": map_okf,
+    "zep": map_zep,
 }
 
 

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -256,7 +256,13 @@ def source_count(provider: str, export: dict[str, Any]) -> int:
         # Observations, not memories — many collapse into one signature.
         return len(export.get("observations", []) or [])
     if provider == "zep":
-        return len(map_export("zep", export))
+        keys = ("facts", "relevant_facts", "user_facts", "edges", "nodes", "sessions")
+        return sum(
+            1
+            for key in keys
+            for item in (export.get(key) or [])
+            if isinstance(item, dict)
+        )
     memories = export.get("memories", []) or []
     if provider == "supermemory" and not memories:
         # Mirror map_supermemory's fallback: when no extracted memories exist

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -255,6 +255,8 @@ def source_count(provider: str, export: dict[str, Any]) -> int:
     if provider == "langfuse":
         # Observations, not memories — many collapse into one signature.
         return len(export.get("observations", []) or [])
+    if provider == "zep":
+        return len(map_export("zep", export))
     memories = export.get("memories", []) or []
     if provider == "supermemory" and not memories:
         # Mirror map_supermemory's fallback: when no extracted memories exist

--- a/tests/test_map_zep.py
+++ b/tests/test_map_zep.py
@@ -59,7 +59,7 @@ def test_map_zep_imports_facts_edges_nodes_and_summaries_not_chat():
     assert refs == {"fact-1", "edge-1", "n-shawn", "sess-1"}
     assert all(row["source"] == "zep" for row in rows)
     assert all(row["provenance"] == "imported" for row in rows)
-    bodies = [row["content"].split("\n---\n", 1)[0] for row in rows]
+    bodies = [row["content"] for row in rows]
     assert not any("figure something out bro" in body for body in bodies)
 
 
@@ -94,4 +94,4 @@ def test_map_zep_empty_export():
 def test_map_export_registry_and_source_count():
     rows = map_export("zep", SAMPLE)
     assert len(rows) == 4
-    assert source_count("zep", SAMPLE) == 4
+    assert source_count("zep", SAMPLE) == 5

--- a/tests/test_map_zep.py
+++ b/tests/test_map_zep.py
@@ -1,0 +1,97 @@
+"""Zep export → Memanto mapper.
+
+Zep stores extracted facts, graph edges, and session summaries. Raw chat
+turns are not memories and must not be imported as first-class rows.
+"""
+
+from memanto.cli.migrate.mappers import map_zep
+from memanto.cli.migrate.runner import map_export, source_count
+
+
+SAMPLE = {
+    "exported_at": "2026-08-19T20:00:00Z",
+    "user_id": "user_42",
+    "facts": [
+        {
+            "uuid": "fact-1",
+            "fact": "Shawn prefers EWY for KOSPI beta, not KORU.",
+            "created_at": "2026-08-10T12:00:00Z",
+            "rating": 0.91,
+        },
+        {"uuid": "fact-blank", "fact": "   "},
+    ],
+    "edges": [
+        {
+            "uuid": "edge-1",
+            "fact": "Shawn works with Scrat as his personal AI operator.",
+            "created_at": "2026-08-11T09:00:00Z",
+            "source_node_uuid": "n-shawn",
+            "target_node_uuid": "n-scrat",
+            "name": "WORKS_WITH",
+        }
+    ],
+    "nodes": [
+        {
+            "uuid": "n-shawn",
+            "name": "Shawn",
+            "summary": "Operator in America/New_York who wants autonomous revenue.",
+            "labels": ["User"],
+            "created_at": "2026-08-01T00:00:00Z",
+        }
+    ],
+    "sessions": [
+        {
+            "session_id": "sess-1",
+            "summary": "Discussed Kickbacks recovery and bounty farm avoidance.",
+            "created_at": "2026-08-19T18:00:00Z",
+            "messages": [
+                {"uuid": "m1", "role": "user", "content": "figure something out bro"},
+                {"uuid": "m2", "role": "assistant", "content": "checking live boards"},
+            ],
+        }
+    ],
+}
+
+
+def test_map_zep_imports_facts_edges_nodes_and_summaries_not_chat():
+    rows = map_zep(SAMPLE)
+    refs = {row["source_ref"] for row in rows}
+    assert refs == {"fact-1", "edge-1", "n-shawn", "sess-1"}
+    assert all(row["source"] == "zep" for row in rows)
+    assert all(row["provenance"] == "imported" for row in rows)
+    bodies = [row["content"].split("\n---\n", 1)[0] for row in rows]
+    assert not any("figure something out bro" in body for body in bodies)
+
+
+def test_map_zep_types_and_user_tag():
+    rows = {row["source_ref"]: row for row in map_zep(SAMPLE)}
+    assert rows["fact-1"]["type"] == "fact"
+    assert rows["edge-1"]["type"] == "fact"
+    assert rows["n-shawn"]["type"] == "relationship"
+    assert rows["sess-1"]["type"] == "observation"
+    assert "user=user_42" in rows["fact-1"]["tags"]
+    assert "KOSPI" in rows["fact-1"]["title"]
+    assert "WORKS_WITH" in rows["edge-1"]["content"]
+
+
+def test_map_zep_relevant_facts_alias():
+    rows = map_zep(
+        {
+            "relevant_facts": [
+                {"uuid": "rf-1", "fact": "Account is not blocked."},
+            ]
+        }
+    )
+    assert len(rows) == 1
+    assert rows[0]["source_ref"] == "rf-1"
+
+
+def test_map_zep_empty_export():
+    assert map_zep({}) == []
+    assert map_zep({"facts": [], "sessions": []}) == []
+
+
+def test_map_export_registry_and_source_count():
+    rows = map_export("zep", SAMPLE)
+    assert len(rows) == 4
+    assert source_count("zep", SAMPLE) == 4


### PR DESCRIPTION
## Summary
Adds a new `memanto migrate zep --file` provider for the #1609 portability bounty.

This does **not** reimplement `memanto migrate` or OKF export. It adds a path Memanto does not already ship: Zep Cloud/Community JSON dumps.

Mapped as memories:
- extracted facts (`facts` / `relevant_facts` / `user_facts`)
- graph edges
- node summaries
- session summaries

Not imported as memories: raw chat turns.

Showcase: `examples/zep-okf-loop/`
Then: `memanto memory export --okf` (existing CLI) to complete in → owned → portable.

## Test plan
- [x] `PYTHONPATH=. python3` runner for `tests/test_map_zep.py` — 5/5 pass
- [x] Mapper skips blank facts and chat-only sessions
- [x] `source_count("zep")` matches mapped rows
- [ ] Maintainer: `memanto migrate zep --file examples/zep-okf-loop/zep_export.json --dry-run`

/claim #1609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zep memory export migration into Memanto agents.
  * Supports agent selection, dry-run previews, import statistics, and error reporting.
  * Imports facts, relationships, entities, and session summaries while excluding raw chat messages.
  * Added a sample Zep export and workflow documentation.

* **Bug Fixes**
  * Improved source record counting for Zep migrations.

* **Tests**
  * Added coverage for facts, relationships, entities, summaries, aliases, empty exports, and registry integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->