### PR TITLE
fix: keep OKF imports inside the selected bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ memanto recall "deployment policy" --as-of 2026-08-05
 memanto recall "deployment policy" --changed-since v2.1
 ```
 
-macOS, Linux, Windows. `memanto ui` opens a local dashboard over the whole estate — browse it, search it, audit it.
+macOS and Linux have full support. On Windows, the core CLI and dashboard are available, but secure OKF import is not currently supported. `memanto ui` opens a local dashboard over the whole estate — browse it, search it, audit it.
 
 ---
 
@@ -92,7 +92,7 @@ This is the part that matters in two years, and it's the part every platform-nat
 
 **Your estate is a file.** `memanto memory export --okf` gives you the [Open Knowledge Format](https://docs.memanto.ai/integrations/okf) — plain Markdown, readable, diffable, committable, greppable. Not a proprietary dump you can technically request. The actual working format.
 
-**It moves.** `memanto migrate` imports from Mem0, Letta, Supermemory, or any OKF bundle. The same command works in reverse. OKF is an open interchange format any framework or vendor can implement — including ours' competitors, deliberately.
+**It moves.** On macOS and Linux, `memanto migrate` imports from Mem0, Letta, Supermemory, or any OKF bundle. Windows can export OKF, but secure OKF import is not currently supported there. The same command works in reverse on supported platforms. OKF is an open interchange format any framework or vendor can implement — including ours' competitors, deliberately.
 
 **It runs on your machine.** Local Docker + Ollama, no account, no API key, nothing leaves your infrastructure. Or free cloud, or your own hosting. `memanto config backend` switches between them in one command, and the estate comes with you.
 

--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -52,6 +52,16 @@ _SECURE_DIR_FD = (
     and os.scandir in os.supports_fd
 )
 _READ_FLAGS = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+_NOFOLLOW_ERRNOS: set[int] = {
+    code
+    for code in (
+        errno.ELOOP,
+        errno.ENOTDIR,
+        getattr(errno, "EMLINK", None),
+        getattr(errno, "EFTYPE", None),
+    )
+    if isinstance(code, int)
+}
 
 
 def _read_open_regular_file(fd: int, display_path: Path) -> str:
@@ -74,7 +84,7 @@ def _read_document_at(directory_fd: int, name: str, display_path: Path) -> str:
         )
         return _read_open_regular_file(document_fd, display_path)
     except OSError as exc:
-        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+        if exc.errno in _NOFOLLOW_ERRNOS:
             raise ValueError(
                 f"OKF bundle contains a symbolic-link path: {display_path}"
             ) from exc
@@ -121,25 +131,24 @@ def _read_directory_documents(
         if stat.S_ISDIR(entry_stat.st_mode):
             if is_markdown:
                 raise ValueError(f"OKF document is not a regular file: {relative_path}")
-            child_fd: int | None = None
             try:
                 child_fd = os.open(
                     name,
                     _READ_FLAGS | os.O_DIRECTORY | os.O_NOFOLLOW,
                     dir_fd=directory_fd,
                 )
+            except OSError as exc:
+                raise ValueError(
+                    f"OKF bundle contains an unsafe directory: {relative_path}"
+                ) from exc
+            try:
                 if not stat.S_ISDIR(os.fstat(child_fd).st_mode):
                     raise ValueError(
                         f"OKF bundle contains an unsafe directory: {relative_path}"
                     )
                 documents.extend(_read_directory_documents(child_fd, relative_path))
-            except OSError as exc:
-                raise ValueError(
-                    f"OKF bundle contains an unsafe directory: {relative_path}"
-                ) from exc
             finally:
-                if child_fd is not None:
-                    os.close(child_fd)
+                os.close(child_fd)
             continue
         if not is_markdown:
             continue
@@ -202,7 +211,7 @@ def _load_documents_secure(
     except FileNotFoundError as exc:
         raise FileNotFoundError(f"OKF bundle not found: {original_path}") from exc
     except OSError as exc:
-        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+        if exc.errno in _NOFOLLOW_ERRNOS:
             raise ValueError(
                 f"OKF bundle path must not be a symbolic link: {original_path}"
             ) from exc

--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -82,6 +82,8 @@ def _extract_links(body: str) -> list[tuple[str, str]]:
 def load_okf_bundle(path: str | Path) -> dict[str, Any]:
     """Load an OKF bundle directory (or a single ``.md`` file) into an export dict."""
     root = Path(path)
+    if root.is_symlink():
+        raise ValueError(f"OKF bundle path must not be a symbolic link: {path}")
     # Hold the corresponding reader lock through discovery and every file
     # read, so an exporter cannot move the bundle aside midway through a load.
     with okf_bundle_lock(_bundle_lock_root(root), shared=True):
@@ -110,8 +112,11 @@ def _load_okf_bundle(root: Path, display_path: str | Path) -> dict[str, Any]:
     if not root.exists():
         raise FileNotFoundError(f"OKF bundle not found: {display_path}")
 
+    root = root.resolve()
+
     if root.is_file():
         files = [root]
+        bundle_root = root.parent
         rel_base = root.parent
     else:
         # Memanto's own bundles nest importable memories under ``memories/``
@@ -119,20 +124,39 @@ def _load_okf_bundle(root: Path, display_path: str | Path) -> dict[str, Any]:
         # Scope import to ``memories/`` when present so context logs are never
         # re-ingested as memories; foreign bundles (no ``memories/``) scan fully.
         memories_dir = root / "memories"
+        if memories_dir.is_symlink():
+            raise ValueError(
+                f"OKF bundle directory must not be a symbolic link: {memories_dir}"
+            )
         scan_root = memories_dir if memories_dir.is_dir() else root
         files = sorted(
             f for f in scan_root.rglob("*.md") if f.name.lower() not in _SKIP_FILENAMES
         )
+        bundle_root = root
         rel_base = root
 
     memories: list[dict[str, Any]] = []
     for file_path in files:
-        text = file_path.read_text(encoding="utf-8")
+        if file_path.is_symlink():
+            raise ValueError(
+                f"OKF bundle contains a symbolic-link document: {file_path}"
+            )
+        resolved_file = file_path.resolve(strict=True)
+        try:
+            resolved_file.relative_to(bundle_root)
+        except ValueError as exc:
+            raise ValueError(
+                f"OKF document escapes the selected bundle: {file_path}"
+            ) from exc
+        if not resolved_file.is_file():
+            raise ValueError(f"OKF document is not a regular file: {file_path}")
+
+        text = resolved_file.read_text(encoding="utf-8")
         for chunk in text.split(ENTRY_DELIMITER):
             chunk = chunk.strip()
             if not chunk:
                 continue
-            entry = _parse_entry(chunk, file_path, rel_base)
+            entry = _parse_entry(chunk, resolved_file, rel_base)
             if entry is not None:
                 memories.append(entry)
 

--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -13,7 +13,10 @@ are skipped.
 
 from __future__ import annotations
 
+import errno
+import os
 import re
+import stat
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +42,117 @@ _KNOWN_FIELDS = {
     "timestamp",
     "x_memanto",
 }
+
+_SECURE_DIR_FD = (
+    hasattr(os, "O_NOFOLLOW")
+    and hasattr(os, "O_DIRECTORY")
+    and os.open in os.supports_dir_fd
+    and os.stat in os.supports_dir_fd
+    and os.stat in os.supports_follow_symlinks
+    and os.scandir in os.supports_fd
+)
+_READ_FLAGS = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+
+
+def _read_open_regular_file(fd: int, display_path: Path) -> str:
+    """Read a regular file from an already validated, stable descriptor."""
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        raise ValueError(f"OKF document is not a regular file: {display_path}")
+
+    with os.fdopen(os.dup(fd), "r", encoding="utf-8") as stream:
+        return stream.read()
+
+
+def _read_document_at(directory_fd: int, name: str, display_path: Path) -> str:
+    """Open and read one regular document without following a final symlink."""
+    document_fd: int | None = None
+    try:
+        document_fd = os.open(
+            name,
+            _READ_FLAGS | os.O_NOFOLLOW,
+            dir_fd=directory_fd,
+        )
+        return _read_open_regular_file(document_fd, display_path)
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+            raise ValueError(
+                f"OKF bundle contains a symbolic-link path: {display_path}"
+            ) from exc
+        raise
+    finally:
+        if document_fd is not None:
+            os.close(document_fd)
+
+
+def _read_directory_documents(
+    directory_fd: int, prefix: Path = Path()
+) -> list[tuple[Path, str]]:
+    """Read Markdown documents recursively from a pinned directory."""
+    try:
+        with os.scandir(directory_fd) as entries:
+            names = sorted(entry.name for entry in entries)
+    except OSError as exc:
+        raise ValueError(f"Could not scan OKF bundle directory: {prefix}") from exc
+
+    documents: list[tuple[Path, str]] = []
+    for name in names:
+        relative_path = prefix / name
+        try:
+            entry_stat = os.stat(
+                name,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            raise ValueError(
+                f"OKF bundle changed during import: {relative_path}"
+            ) from exc
+
+        lower_name = name.lower()
+        is_markdown = lower_name.endswith(".md")
+        if is_markdown and lower_name in _SKIP_FILENAMES:
+            continue
+        if stat.S_ISLNK(entry_stat.st_mode):
+            if is_markdown:
+                raise ValueError(
+                    f"OKF bundle contains a symbolic-link document: {relative_path}"
+                )
+            continue
+        if stat.S_ISDIR(entry_stat.st_mode):
+            if is_markdown:
+                raise ValueError(f"OKF document is not a regular file: {relative_path}")
+            child_fd: int | None = None
+            try:
+                child_fd = os.open(
+                    name,
+                    _READ_FLAGS | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+                if not stat.S_ISDIR(os.fstat(child_fd).st_mode):
+                    raise ValueError(
+                        f"OKF bundle contains an unsafe directory: {relative_path}"
+                    )
+                documents.extend(_read_directory_documents(child_fd, relative_path))
+            except OSError as exc:
+                raise ValueError(
+                    f"OKF bundle contains an unsafe directory: {relative_path}"
+                ) from exc
+            finally:
+                if child_fd is not None:
+                    os.close(child_fd)
+            continue
+        if not is_markdown:
+            continue
+        if not stat.S_ISREG(entry_stat.st_mode):
+            raise ValueError(f"OKF document is not a regular file: {relative_path}")
+        documents.append(
+            (
+                relative_path,
+                _read_document_at(directory_fd, name, relative_path),
+            )
+        )
+
+    return documents
 
 
 def _extract_links(body: str) -> list[tuple[str, str]]:
@@ -79,9 +193,97 @@ def _extract_links(body: str) -> list[tuple[str, str]]:
     return links
 
 
+def _load_documents_secure(
+    root: Path, original_path: str | Path
+) -> tuple[Path, list[tuple[Path, str]]]:
+    """Pin the bundle root and read documents through no-follow descriptors."""
+    try:
+        root_fd = os.open(root, _READ_FLAGS | os.O_NOFOLLOW)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"OKF bundle not found: {original_path}") from exc
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+            raise ValueError(
+                f"OKF bundle path must not be a symbolic link: {original_path}"
+            ) from exc
+        raise
+
+    scan_fd: int | None = None
+    try:
+        root_stat = os.fstat(root_fd)
+        if stat.S_ISREG(root_stat.st_mode):
+            return root.parent, [(root, _read_open_regular_file(root_fd, root))]
+        if not stat.S_ISDIR(root_stat.st_mode):
+            raise ValueError(f"OKF bundle is not a file or directory: {original_path}")
+
+        scan_fd = root_fd
+        scan_prefix = Path()
+        try:
+            memories_stat = os.stat(
+                "memories",
+                dir_fd=root_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            memories_stat = None
+
+        if memories_stat is not None and stat.S_ISLNK(memories_stat.st_mode):
+            raise ValueError(
+                f"OKF bundle directory must not be a symbolic link: {root / 'memories'}"
+            )
+        if memories_stat is not None and stat.S_ISDIR(memories_stat.st_mode):
+            try:
+                scan_fd = os.open(
+                    "memories",
+                    _READ_FLAGS | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=root_fd,
+                )
+            except OSError as exc:
+                raise ValueError(
+                    "OKF bundle directory changed or became a symbolic link: "
+                    f"{root / 'memories'}"
+                ) from exc
+            if not stat.S_ISDIR(os.fstat(scan_fd).st_mode):
+                raise ValueError(
+                    f"OKF bundle directory is not a directory: {root / 'memories'}"
+                )
+            scan_prefix = Path("memories")
+
+        relative_documents = sorted(
+            _read_directory_documents(scan_fd, scan_prefix),
+            key=lambda item: item[0],
+        )
+        documents = [
+            (root / relative_path, text) for relative_path, text in relative_documents
+        ]
+        return root, documents
+    finally:
+        if scan_fd is not None and scan_fd != root_fd:
+            os.close(scan_fd)
+        os.close(root_fd)
+
+
+def _load_documents_portable(
+    root: Path, original_path: str | Path
+) -> tuple[Path, list[tuple[Path, str]]]:
+    """Fail closed when the platform cannot enforce no-follow directory reads."""
+    try:
+        root_stat = root.lstat()
+    except FileNotFoundError:
+        raise FileNotFoundError(f"OKF bundle not found: {original_path}")
+    if stat.S_ISLNK(root_stat.st_mode):
+        raise ValueError(
+            f"OKF bundle path must not be a symbolic link: {original_path}"
+        )
+    raise RuntimeError(
+        "Secure OKF import requires descriptor-relative no-follow filesystem "
+        "support on this platform."
+    )
+
+
 def load_okf_bundle(path: str | Path) -> dict[str, Any]:
     """Load an OKF bundle directory (or a single ``.md`` file) into an export dict."""
-    root = Path(path)
+    root = Path(os.path.abspath(os.fspath(path)))
     if root.is_symlink():
         raise ValueError(f"OKF bundle path must not be a symbolic link: {path}")
     # Hold the corresponding reader lock through discovery and every file
@@ -109,54 +311,18 @@ def _bundle_lock_root(path: Path) -> Path:
 
 def _load_okf_bundle(root: Path, display_path: str | Path) -> dict[str, Any]:
     """Load ``root`` while the caller holds its bundle reader lock."""
-    if not root.exists():
-        raise FileNotFoundError(f"OKF bundle not found: {display_path}")
-
-    root = root.resolve()
-
-    if root.is_file():
-        files = [root]
-        bundle_root = root.parent
-        rel_base = root.parent
+    if _SECURE_DIR_FD:
+        rel_base, documents = _load_documents_secure(root, display_path)
     else:
-        # Memanto's own bundles nest importable memories under ``memories/``
-        # alongside export-only context (daily-summaries/, sessions/, metrics/).
-        # Scope import to ``memories/`` when present so context logs are never
-        # re-ingested as memories; foreign bundles (no ``memories/``) scan fully.
-        memories_dir = root / "memories"
-        if memories_dir.is_symlink():
-            raise ValueError(
-                f"OKF bundle directory must not be a symbolic link: {memories_dir}"
-            )
-        scan_root = memories_dir if memories_dir.is_dir() else root
-        files = sorted(
-            f for f in scan_root.rglob("*.md") if f.name.lower() not in _SKIP_FILENAMES
-        )
-        bundle_root = root
-        rel_base = root
+        rel_base, documents = _load_documents_portable(root, display_path)
 
     memories: list[dict[str, Any]] = []
-    for file_path in files:
-        if file_path.is_symlink():
-            raise ValueError(
-                f"OKF bundle contains a symbolic-link document: {file_path}"
-            )
-        resolved_file = file_path.resolve(strict=True)
-        try:
-            resolved_file.relative_to(bundle_root)
-        except ValueError as exc:
-            raise ValueError(
-                f"OKF document escapes the selected bundle: {file_path}"
-            ) from exc
-        if not resolved_file.is_file():
-            raise ValueError(f"OKF document is not a regular file: {file_path}")
-
-        text = resolved_file.read_text(encoding="utf-8")
+    for file_path, text in documents:
         for chunk in text.split(ENTRY_DELIMITER):
             chunk = chunk.strip()
             if not chunk:
                 continue
-            entry = _parse_entry(chunk, resolved_file, rel_base)
+            entry = _parse_entry(chunk, file_path, rel_base)
             if entry is not None:
                 memories.append(entry)
 

--- a/memanto/cli/migrate/okf_loader.py
+++ b/memanto/cli/migrate/okf_loader.py
@@ -275,7 +275,7 @@ def _load_documents_secure(
 def _load_documents_portable(
     root: Path, original_path: str | Path
 ) -> tuple[Path, list[tuple[Path, str]]]:
-    """Fail closed when the platform cannot enforce no-follow directory reads."""
+    """Report unsupported platforms without weakening no-follow guarantees."""
     try:
         root_stat = root.lstat()
     except FileNotFoundError:
@@ -285,8 +285,8 @@ def _load_documents_portable(
             f"OKF bundle path must not be a symbolic link: {original_path}"
         )
     raise RuntimeError(
-        "Secure OKF import requires descriptor-relative no-follow filesystem "
-        "support on this platform."
+        "OKF import is unsupported on this platform because secure import "
+        "requires descriptor-relative no-follow filesystem support."
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -8,9 +8,9 @@ foreign OKF bundle whose free-form ``type`` and unknown keys must land in the
 ``[Supporting data]`` footer without loss.
 """
 
+import os
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeout
-import os
 from pathlib import Path
 from threading import Event
 from time import perf_counter
@@ -18,9 +18,10 @@ from time import perf_counter
 import pytest
 import yaml  # type: ignore[import-untyped]
 
+import memanto.cli.migrate.okf_loader as okf_loader
 from memanto.app.services.okf_export_service import OkfExportService
 from memanto.cli.migrate.mappers import map_okf
-from memanto.cli.migrate.okf_loader import _SECURE_DIR_FD, load_okf_bundle
+from memanto.cli.migrate.okf_loader import load_okf_bundle
 
 
 def _mem(mem_id, title, content, **extra):
@@ -444,7 +445,7 @@ def test_loader_rejects_symlinked_memories_directory(tmp_path):
 
 def test_loader_rejects_document_swapped_to_symlink_before_open(tmp_path, monkeypatch):
     """A pathname swap after listing must not redirect the opened document."""
-    if not _SECURE_DIR_FD:
+    if not okf_loader._SECURE_DIR_FD:
         pytest.skip("descriptor-relative no-follow opens are unavailable")
 
     outside = tmp_path / "outside.txt"
@@ -474,7 +475,7 @@ def test_loader_rejects_document_swapped_to_symlink_before_open(tmp_path, monkey
 
 def test_loader_reads_pinned_root_when_selected_path_is_replaced(tmp_path, monkeypatch):
     """Replacing the selected pathname must not redirect an opened root."""
-    if not _SECURE_DIR_FD:
+    if not okf_loader._SECURE_DIR_FD:
         pytest.skip("descriptor-relative no-follow opens are unavailable")
 
     bundle = tmp_path / "bundle"
@@ -524,6 +525,24 @@ def test_loader_fails_closed_without_secure_directory_descriptors(
 
     with pytest.raises(RuntimeError, match="descriptor-relative no-follow"):
         load_okf_bundle(bundle)
+
+
+def test_loader_preserves_nested_document_read_errors(tmp_path, monkeypatch):
+    """A nested file error must not be mislabeled as an unsafe parent directory."""
+    if not okf_loader._SECURE_DIR_FD:
+        pytest.skip("descriptor-relative no-follow opens are unavailable")
+
+    nested = tmp_path / "bundle" / "memories" / "nested"
+    nested.mkdir(parents=True)
+    (nested / "memory.md").write_text("Ordinary content", encoding="utf-8")
+
+    def fail_document_read(directory_fd, name, display_path):
+        raise PermissionError("synthetic nested read failure")
+
+    monkeypatch.setattr(okf_loader, "_read_document_at", fail_document_read)
+
+    with pytest.raises(PermissionError, match="synthetic nested read failure"):
+        load_okf_bundle(tmp_path / "bundle")
 
 
 def test_loader_extracts_multiple_links_around_malformed_markup(tmp_path):

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -10,6 +10,7 @@ foreign OKF bundle whose free-form ``type`` and unknown keys must land in the
 
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeout
+import os
 from pathlib import Path
 from threading import Event
 from time import perf_counter
@@ -19,7 +20,7 @@ import yaml  # type: ignore[import-untyped]
 
 from memanto.app.services.okf_export_service import OkfExportService
 from memanto.cli.migrate.mappers import map_okf
-from memanto.cli.migrate.okf_loader import load_okf_bundle
+from memanto.cli.migrate.okf_loader import _SECURE_DIR_FD, load_okf_bundle
 
 
 def _mem(mem_id, title, content, **extra):
@@ -438,6 +439,90 @@ def test_loader_rejects_symlinked_memories_directory(tmp_path):
     with pytest.raises(
         ValueError, match="bundle directory must not be a symbolic link"
     ):
+        load_okf_bundle(bundle)
+
+
+def test_loader_rejects_document_swapped_to_symlink_before_open(tmp_path, monkeypatch):
+    """A pathname swap after listing must not redirect the opened document."""
+    if not _SECURE_DIR_FD:
+        pytest.skip("descriptor-relative no-follow opens are unavailable")
+
+    outside = tmp_path / "outside.txt"
+    outside.write_text("SYNTHETIC_RACE_VALUE", encoding="utf-8")
+    memories = tmp_path / "bundle" / "memories"
+    memories.mkdir(parents=True)
+    victim = memories / "memory.md"
+    victim.write_text("Ordinary content", encoding="utf-8")
+
+    real_open = os.open
+    swapped = False
+
+    def swap_then_open(path, flags, *args, **kwargs):
+        nonlocal swapped
+        if path == "memory.md" and kwargs.get("dir_fd") is not None and not swapped:
+            victim.unlink()
+            victim.symlink_to(outside)
+            swapped = True
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", swap_then_open)
+
+    with pytest.raises(ValueError, match="symbolic-link path"):
+        load_okf_bundle(memories.parent)
+    assert swapped
+
+
+def test_loader_reads_pinned_root_when_selected_path_is_replaced(tmp_path, monkeypatch):
+    """Replacing the selected pathname must not redirect an opened root."""
+    if not _SECURE_DIR_FD:
+        pytest.skip("descriptor-relative no-follow opens are unavailable")
+
+    bundle = tmp_path / "bundle"
+    memories = bundle / "memories"
+    memories.mkdir(parents=True)
+    (memories / "memory.md").write_text("Ordinary content", encoding="utf-8")
+
+    outside = tmp_path / "outside"
+    outside_memories = outside / "memories"
+    outside_memories.mkdir(parents=True)
+    (outside_memories / "memory.md").write_text(
+        "SYNTHETIC_OUTSIDE_VALUE", encoding="utf-8"
+    )
+    moved_bundle = tmp_path / "opened-bundle"
+
+    real_fstat = os.fstat
+    swapped = False
+
+    def replace_path_after_root_open(fd):
+        nonlocal swapped
+        result = real_fstat(fd)
+        if not swapped:
+            bundle.rename(moved_bundle)
+            bundle.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return result
+
+    monkeypatch.setattr(os, "fstat", replace_path_after_root_open)
+
+    export = load_okf_bundle(bundle)
+
+    assert swapped
+    assert export["memories"][0]["body"] == "Ordinary content"
+
+
+def test_loader_fails_closed_without_secure_directory_descriptors(
+    tmp_path, monkeypatch
+):
+    """A platform without no-follow directory handles must not use path checks."""
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "memory.md").write_text("Ordinary content", encoding="utf-8")
+    monkeypatch.setattr(
+        "memanto.cli.migrate.okf_loader._SECURE_DIR_FD",
+        False,
+    )
+
+    with pytest.raises(RuntimeError, match="descriptor-relative no-follow"):
         load_okf_bundle(bundle)
 
 

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -511,10 +511,10 @@ def test_loader_reads_pinned_root_when_selected_path_is_replaced(tmp_path, monke
     assert export["memories"][0]["body"] == "Ordinary content"
 
 
-def test_loader_fails_closed_without_secure_directory_descriptors(
+def test_loader_reports_unsupported_without_secure_directory_descriptors(
     tmp_path, monkeypatch
 ):
-    """A platform without no-follow directory handles must not use path checks."""
+    """Unsupported platforms fail explicitly instead of using path checks."""
     bundle = tmp_path / "bundle"
     bundle.mkdir()
     (bundle / "memory.md").write_text("Ordinary content", encoding="utf-8")
@@ -523,7 +523,7 @@ def test_loader_fails_closed_without_secure_directory_descriptors(
         False,
     )
 
-    with pytest.raises(RuntimeError, match="descriptor-relative no-follow"):
+    with pytest.raises(RuntimeError, match="OKF import is unsupported"):
         load_okf_bundle(bundle)
 
 

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -376,6 +376,71 @@ def test_single_file_loader_uses_bundle_lock(tmp_path, monkeypatch):
     assert [memory["body"] for memory in imported] == ["New snapshot."]
 
 
+def test_loader_rejects_symlinked_document_outside_bundle(tmp_path):
+    """An untrusted bundle must not import a local file through a .md symlink."""
+    outside = tmp_path / "synthetic-private.txt"
+    outside.write_text("SYNTHETIC_PRIVATE_VALUE", encoding="utf-8")
+    memories = tmp_path / "attacker-bundle" / "memories"
+    memories.mkdir(parents=True)
+    link = memories / "innocent-memory.md"
+    try:
+        link.symlink_to(outside)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable on this platform")
+
+    with pytest.raises(ValueError, match="symbolic-link document"):
+        load_okf_bundle(memories.parent)
+
+
+def test_loader_rejects_symlinked_bundle_root(tmp_path):
+    """Selecting a symlink as the bundle root must fail before traversal."""
+    real_bundle = tmp_path / "real-bundle"
+    real_bundle.mkdir()
+    (real_bundle / "memory.md").write_text("Synthetic memory", encoding="utf-8")
+    bundle_link = tmp_path / "selected-bundle"
+    try:
+        bundle_link.symlink_to(real_bundle, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable on this platform")
+
+    with pytest.raises(ValueError, match="bundle path must not be a symbolic link"):
+        load_okf_bundle(bundle_link)
+
+
+def test_loader_rejects_symlinked_single_document(tmp_path):
+    """The single-file import form must not follow a selected symlink."""
+    outside = tmp_path / "synthetic-private.md"
+    outside.write_text("Synthetic private value", encoding="utf-8")
+    link = tmp_path / "selected-memory.md"
+    try:
+        link.symlink_to(outside)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable on this platform")
+
+    with pytest.raises(ValueError, match="bundle path must not be a symbolic link"):
+        load_okf_bundle(link)
+
+
+def test_loader_rejects_symlinked_memories_directory(tmp_path):
+    """A Memanto bundle must not redirect its import subtree elsewhere."""
+    outside = tmp_path / "outside-memories"
+    outside.mkdir()
+    (outside / "synthetic-private.md").write_text(
+        "Synthetic private value", encoding="utf-8"
+    )
+    bundle = tmp_path / "attacker-bundle"
+    bundle.mkdir()
+    try:
+        (bundle / "memories").symlink_to(outside, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable on this platform")
+
+    with pytest.raises(
+        ValueError, match="bundle directory must not be a symbolic link"
+    ):
+        load_okf_bundle(bundle)
+
+
 def test_loader_extracts_multiple_links_around_malformed_markup(tmp_path):
     """Malformed candidates do not hide valid links that follow them."""
     okf_file = tmp_path / "links.md"


### PR DESCRIPTION
## Summary

OKF imports previously accepted a `.md` symlink that pointed outside the selected bundle. The loader matched the link name and read its target, so a normal import could turn unrelated local text into a memory row and send it to the configured backend. A pathname could also be replaced after validation but before the read.

This change opens and pins the selected root before inspecting it. Directory enumeration and document reads use descriptor-relative `O_NOFOLLOW` operations, and `fstat()` verifies every opened document as a regular file. Platform-specific no-follow errors share one fail-closed mapping. A platform that lacks the required directory-descriptor support stops before resolving or reading the bundle instead of using a weaker pathname fallback.

I reported the finding privately under #1852. The Memanto team cleared the fix for a public PR before publication.

## Reproduction

1. Create a temporary text file outside an OKF bundle and write a synthetic marker to it.
2. Add `memories/innocent-memory.md` as a symlink to that file.
3. Call `load_okf_bundle()` on the bundle.

At the previous `main`, the returned memory body contained the outside marker. The earlier patch also remained vulnerable if a regular document or the selected root changed after its pathname check. The regression tests reproduce those swaps without using real secrets.

With this patch, static links and mid-import replacements cannot redirect the pinned descriptors. The unsupported-platform branch stops before `resolve()`, enumeration, or file reads. Nested file errors retain their original path and cause.

## Validation

- `uv run pytest tests/test_okf.py -q`: 23 passed
- `MOORCHEH_API_KEY=test-api-key uv run pytest tests/ -q`: 887 passed, 24 live E2E tests skipped because a placeholder key was supplied
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `uv run mypy .`: passed
- Gitleaks scan of all four PR commits: no leaks found
- Independent read-only security re-review: FIXED, 0 boundary regressions
- CodeRabbit re-review of `cd87a70`: 0 actionable comments, Minimal merge risk

Refs #1852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OKF bundle import security and reliability by rejecting unsafe files, symbolic links, and filesystem changes during reads.
  * Preserved recursive `memories/` scanning while skipping navigation files.
  * Added safer handling for concurrent bundle changes and failed publishing, including rollback.
  * Preserved valid temporal and provenance metadata during import and export.
  * Continued support for single-file bundles and clearer handling of nested read errors.
* **Documentation**
  * Clarified platform support: secure OKF import is supported on macOS and Linux, but not Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->