### PR TITLE
fix: memory sync to run fresh export

### DIFF
--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1772,41 +1772,43 @@ class DirectClient:
         """
         Sync agent memories to a project directory's MEMORY.md.
 
-        Uses the cached export in the active backend's data directory
-        when available. Falls back to a fresh export if
-        the cache file does not exist.
+        Always runs a fresh export first, so memories written earlier in the
+        same session are included. Falls back to the previous cached export
+        when the backend is unreachable, rather than leaving the project's
+        MEMORY.md untouched or wiping it.
 
         Args:
             agent_id: Target agent.
             project_dir: Path to the project directory.
-            limit_per_type: Max memories per type for fresh export (default 25).
+            limit_per_type: Max memories per type for the export (default 25).
 
         Returns:
             Dict with ``output_path``, ``total_memories``, ``source``
-            (``"cache"`` or ``"fresh"``).
+            (``"fresh"``, or ``"stale-cache"`` if the refresh failed and a
+            previous export was reused instead).
         """
-
         validate_safe_id(agent_id, "agent_id")
         cache_path = get_data_dir() / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if cache_path.exists():
-            # Fast path: copy cached export without an API-backed refresh.
+        logger.debug("Refreshing memory export before syncing '%s'", agent_id)
+        try:
+            export_result = self.export_memory_md(
+                agent_id=agent_id, limit_per_type=limit_per_type
+            )
+        except ConnectionError:
+            if not cache_path.exists():
+                raise
+            # Backend unreachable, but we have a previously good export —
+            # serve that instead of wiping the project's MEMORY.md.
             shutil.copy2(str(cache_path), str(target_path))
             content = cache_path.read_text(encoding="utf-8")
-            mem_count = content.count("### ")
             return {
                 "output_path": str(target_path.resolve()),
-                "total_memories": mem_count,
-                "source": "cache",
+                "total_memories": content.count("### "),
+                "source": "stale-cache",
             }
-
-        logger.debug("Refreshing memory export before syncing '%s'", agent_id)
-        export_result = self.export_memory_md(
-            agent_id=agent_id,
-            limit_per_type=limit_per_type,
-        )
 
         exported_path = Path(export_result["output_path"])
         if exported_path.exists():

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -1637,50 +1637,42 @@ class SdkClient:
         """
         Sync agent memories to a project directory's MEMORY.md.
 
+        Always runs a fresh export first, so memories written earlier in the
+        same session are included. Falls back to the previous cached export
+        when the backend is unreachable, rather than leaving the project's
+        MEMORY.md untouched or wiping it.
+
         Args:
             agent_id: Target agent.
             project_dir: Path to the project directory.
-            limit_per_type: Max memories per type for fresh export (default 25).
+            limit_per_type: Max memories per type for the export (default 25).
 
         Returns:
             Dict with ``output_path``, ``total_memories``, ``source``
-            (``"cache"``, ``"fresh"``, or ``"stale-cache"`` if a refresh
-            failed and a previous export was reused instead).
+            (``"fresh"``, or ``"stale-cache"`` if the refresh failed and a
+            previous export was reused instead).
         """
         validate_safe_id(agent_id, "agent_id")
         cache_path = get_data_dir() / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if cache_path.exists():
-            # Fast path: copy cached export without an API-backed refresh.
-            shutil.copy2(str(cache_path), str(target_path))
-            content = cache_path.read_text(encoding="utf-8")
-            mem_count = content.count("### ")
-            return {
-                "output_path": str(target_path.resolve()),
-                "total_memories": mem_count,
-                "source": "cache",
-            }
-
         try:
-            # Run export function first (ensures ~/.memanto/exports/... is fresh)
             export_result = self.export_memory_md(
                 agent_id=agent_id, limit_per_type=limit_per_type
             )
         except ConnectionError:
-            if cache_path.exists():
-                # Backend unreachable, but we have a previously good export —
-                # serve that instead of wiping the project's MEMORY.md.
-                shutil.copy2(str(cache_path), str(target_path))
-                content = cache_path.read_text(encoding="utf-8")
-                mem_count = content.count("### ")
-                return {
-                    "output_path": str(target_path.resolve()),
-                    "total_memories": mem_count,
-                    "source": "stale-cache",
-                }
-            raise
+            if not cache_path.exists():
+                raise
+            # Backend unreachable, but we have a previously good export —
+            # serve that instead of wiping the project's MEMORY.md.
+            shutil.copy2(str(cache_path), str(target_path))
+            content = cache_path.read_text(encoding="utf-8")
+            return {
+                "output_path": str(target_path.resolve()),
+                "total_memories": content.count("### "),
+                "source": "stale-cache",
+            }
 
         exported_path = Path(export_result["output_path"])
         if exported_path.exists():

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -188,7 +188,7 @@ def memory_sync(
         25,
         "--limit",
         "-n",
-        help="Maximum memories per type if fresh export needed (default 25)",
+        help="Maximum memories per type in the export (default 25)",
     ),
     okf: bool = typer.Option(
         False,
@@ -299,9 +299,7 @@ def memory_sync(
     source = result.get("source", "unknown")
     out_path = result.get("output_path", "unknown")
 
-    if source == "cache":
-        source_label = "cached export"
-    elif source == "stale-cache":
+    if source == "stale-cache":
         source_label = "stale cache (backend unreachable)"
     else:
         source_label = "fresh export"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -389,18 +389,19 @@ class TestExportDataDirRouting:
         for client_cls in (DirectClient, SdkClient):
             client = client_cls(api_key="dummy-key")
             export_calls = []
-            monkeypatch.setattr(
-                client,
-                "export_memory_md",
-                lambda export_calls=export_calls, **kwargs: export_calls.append(kwargs)
-                or {"output_path": str(on_prem_cache)},
-            )
+
+            def failing_export(export_calls=export_calls, **kwargs):
+                # Force the stale-cache fallback so the cache lookup is exercised.
+                export_calls.append(kwargs)
+                raise ConnectionError("backend unreachable")
+
+            monkeypatch.setattr(client, "export_memory_md", failing_export)
             project_dir = tmp_path / "projects" / client_cls.__name__
 
             result = client.sync_memory_to_project("agent-1", str(project_dir))
 
-            assert result["source"] == "cache"
-            assert not export_calls
+            assert result["source"] == "stale-cache"
+            assert export_calls
             assert (project_dir / "MEMORY.md").read_text(encoding="utf-8") == (
                 "# on-prem export"
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1391,7 +1391,7 @@ class TestMEMANTOCLI:
         """Test 'memanto memory sync'"""
         mock_all_clients.sync_memory_to_project.return_value = {
             "total_memories": 5,
-            "source": "cache",
+            "source": "fresh",
             "output_path": "project/memory.md",
         }
         result = runner.invoke(app, ["memory", "sync"])

--- a/tests/test_export_resilience.py
+++ b/tests/test_export_resilience.py
@@ -1,6 +1,6 @@
 """Regression coverage: ``export_memory_md`` must not silently write an
 empty export when every ``recall`` call fails (e.g. the on-prem backend is
-unreachable), and ``SdkClient.sync_memory_to_project`` must fall back to a
+unreachable), and ``sync_memory_to_project`` must fall back to a
 previous good export instead of overwriting a project's ``MEMORY.md`` with
 nothing.
 
@@ -73,11 +73,13 @@ class TestExportMemoryMdRefusesEmptyOnTotalFailure:
             client.export_memory_md(agent_id="test-agent")
 
 
-class TestSyncUsesCacheFastPath:
-    """A cached export is copied without requiring a reachable backend."""
+class TestSyncFallsBackToCache:
+    """Sync refreshes first, so a cached export is only reused when the
+    refresh fails — never in place of memories written this session."""
 
-    def test_cache_used_when_backend_down(self, monkeypatch, tmp_path):
-        client = _build_client(SdkClient, monkeypatch, tmp_path)
+    @pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+    def test_cache_used_when_backend_down(self, client_cls, monkeypatch, tmp_path):
+        client = _build_client(client_cls, monkeypatch, tmp_path)
 
         cache_file = tmp_path / ".memanto" / "exports" / "test-agent_memory.md"
         cache_file.parent.mkdir(parents=True, exist_ok=True)
@@ -92,11 +94,36 @@ class TestSyncUsesCacheFastPath:
             agent_id="test-agent", project_dir=str(project_dir)
         )
 
-        client.recall.assert_not_called()
-        assert result["source"] == "cache"
+        client.recall.assert_called()
+        assert result["source"] == "stale-cache"
         assert result["total_memories"] == 1
         written = (project_dir / "MEMORY.md").read_text(encoding="utf-8")
         assert "good content" in written
+
+    @pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+    def test_fresh_export_replaces_stale_cache(self, client_cls, monkeypatch, tmp_path):
+        """A cache written before this session must not shadow new memories."""
+        client = _build_client(client_cls, monkeypatch, tmp_path)
+
+        cache_file = tmp_path / ".memanto" / "exports" / "test-agent_memory.md"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text("### Old Memory\n\nstale content\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            client,
+            "recall",
+            MagicMock(return_value={"memories": [{"content": "fresh content"}]}),
+        )
+
+        project_dir = tmp_path / "project"
+        result = client.sync_memory_to_project(
+            agent_id="test-agent", project_dir=str(project_dir)
+        )
+
+        assert result["source"] == "fresh"
+        written = (project_dir / "MEMORY.md").read_text(encoding="utf-8")
+        assert "stale content" not in written
+        assert "fresh content" in written
 
     def test_raises_when_no_cache_and_backend_down(self, monkeypatch, tmp_path):
         client = _build_client(SdkClient, monkeypatch, tmp_path)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2412,7 +2412,7 @@ def test_batch_upload_error_counts_each_pending_memory_as_failed():
     )
 
 
-def test_direct_sync_uses_cached_export_fast_path(tmp_path, monkeypatch):
+def test_direct_sync_exports_fresh_before_copying(tmp_path, monkeypatch):
     from memanto.cli.client.direct_client import DirectClient
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -2447,13 +2447,13 @@ def test_direct_sync_uses_cached_export_fast_path(tmp_path, monkeypatch):
     )
 
     target = project_dir / "MEMORY.md"
-    assert export_calls == []
+    assert export_calls == [("agent-1", 7)]
     assert target.read_text(encoding="utf-8") == cache_path.read_text(encoding="utf-8")
-    assert "stale memory" in target.read_text(encoding="utf-8")
+    assert "stale memory" not in target.read_text(encoding="utf-8")
     assert result == {
         "output_path": str(target.resolve()),
-        "total_memories": 1,
-        "source": "cache",
+        "total_memories": 2,
+        "source": "fresh",
     }
 
 


### PR DESCRIPTION
- update memanto memory sync to export fresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory synchronization now attempts a fresh export before copying memory files.
  * If the service is unavailable, an existing cached export is used as a fallback and clearly marked as stale.
  * Connection errors are still reported when no cached export is available.
  * Synchronization results now consistently identify fresh exports versus stale cached data.

* **Documentation**
  * Updated command help text to clarify export limits and synchronization sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->