### PR TITLE
feat(examples): add OrcaRouter as a named LLM provider for LangGraph examples

### DIFF
--- a/examples/langgraph-memanto/.env.example
+++ b/examples/langgraph-memanto/.env.example
@@ -3,11 +3,21 @@
 MOORCHEH_API_KEY=
 
 # Required: LLM API key for the LangGraph agent.
-# The demo scripts accept either OpenRouter or OpenAI.
+# The demo scripts accept OrcaRouter, OpenRouter, or OpenAI.
+# Get an OrcaRouter key at https://www.orcarouter.ai
 # Get an OpenRouter key at https://openrouter.ai/keys (free tier available)
 # Or an OpenAI key at https://platform.openai.com/api-keys.
+#
+# When ORCAROUTER_API_KEY is set, every example routes through OrcaRouter's
+# OpenAI-compatible gateway (https://api.orcarouter.ai/v1) with the
+# smart-routing model `orcarouter/auto` by default.
+ORCAROUTER_API_KEY=
 OPENROUTER_API_KEY=
 # OPENAI_API_KEY=
+
+# Optional: Override the OrcaRouter base URL / model (only when using OrcaRouter).
+# ORCAROUTER_API_BASE=https://api.orcarouter.ai/v1
+# ORCAROUTER_MODEL=orcarouter/auto
 
 # Optional: Override the LLM model used by the LangGraph agent.
 #

--- a/examples/langgraph-memanto/README.md
+++ b/examples/langgraph-memanto/README.md
@@ -12,6 +12,27 @@ cp .env.example .env
 # Edit .env with your Memanto and LLM API keys
 `
 
+## Using OrcaRouter as your LLM gateway
+
+Every example routes its LangGraph agent through a **named** OpenAI-compatible
+provider. By default they use OpenRouter (or OpenAI), but setting
+`ORCAROUTER_API_KEY` in `.env` switches the whole fleet to
+[OrcaRouter](https://www.orcarouter.ai) — a smart model-routing gateway at
+`https://api.orcarouter.ai/v1`:
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-...
+# Optional: pick a specific gateway model (default is the smart-routing `orcarouter/auto`)
+# ORCAROUTER_MODEL=orcarouter/auto
+```
+
+When OrcaRouter is configured, the agent uses its smart-routing model
+`orcarouter/auto` — OrcaRouter picks the best upstream model for each request.
+It also runs gateway-level, zero-trust security for AI agents on the same
+endpoint — screening every prompt/response and governing every tool call on a
+default-deny basis, with no application code changes.
+
 ## Running the Examples
 
 Because the examples share the core tools module, you should run them as Python modules from this root directory:

--- a/examples/langgraph-memanto/basic_integration/agent.py
+++ b/examples/langgraph-memanto/basic_integration/agent.py
@@ -1,10 +1,10 @@
 from typing import Annotated
 
 from langchain_core.messages import SystemMessage
-from langchain_openai import ChatOpenAI
 from langgraph.graph import START, StateGraph
 from langgraph.graph.message import add_messages
 from langgraph.prebuilt import ToolNode, tools_condition
+from orcarouter_llm import build_orcarouter_llm
 from typing_extensions import TypedDict
 
 
@@ -16,16 +16,9 @@ def build_graph(tools: list[callable]):
     """
     Builds the LangGraph state graph for the agent.
     """
-    # Using a fast and capable model
-    import os
-
-    llm = ChatOpenAI(
-        model=os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
-        temperature=0,
-        api_key=os.environ.get("OPENROUTER_API_KEY")
-        or os.environ.get("OPENAI_API_KEY"),
-        base_url=os.environ.get("OPENAI_API_BASE", "https://openrouter.ai/api/v1"),
-    )
+    # Using a fast and capable model. Prefers OrcaRouter when
+    # ORCAROUTER_API_KEY is set, otherwise falls back to OpenRouter/OpenAI.
+    llm = build_orcarouter_llm(temperature=0)
     llm_with_tools = llm.bind_tools(tools)
 
     def chatbot(state: State):

--- a/examples/langgraph-memanto/basic_integration/demo.py
+++ b/examples/langgraph-memanto/basic_integration/demo.py
@@ -26,11 +26,17 @@ def main():
         print("Please set it: export MOORCHEH_API_KEY='your_key'")
         sys.exit(1)
 
-    if not os.getenv("OPENAI_API_KEY") and not os.getenv("OPENROUTER_API_KEY"):
+    if (
+        not os.getenv("OPENAI_API_KEY")
+        and not os.getenv("OPENROUTER_API_KEY")
+        and not os.getenv("ORCAROUTER_API_KEY")
+    ):
         print(
-            "❌ Error: OPENAI_API_KEY or OPENROUTER_API_KEY environment variable is missing."
+            "❌ Error: OPENAI_API_KEY, OPENROUTER_API_KEY, or ORCAROUTER_API_KEY environment variable is missing."
         )
-        print("Please set one: export OPENROUTER_API_KEY='your_key'")
+        print(
+            "Please set one: export OPENROUTER_API_KEY='your_key' or export ORCAROUTER_API_KEY='your_key'"
+        )
         sys.exit(1)
 
     # Initialize Memanto Client

--- a/examples/langgraph-memanto/cross_session_recall/graph.py
+++ b/examples/langgraph-memanto/cross_session_recall/graph.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import Annotated, TypedDict
 
 from langchain_core.messages import BaseMessage
-from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import START, StateGraph
 from langgraph.graph.message import add_messages
 from langgraph.prebuilt import ToolNode, tools_condition
+from orcarouter_llm import build_orcarouter_llm, orcarouter_configured
 
 
 class State(TypedDict):
@@ -15,14 +15,9 @@ class State(TypedDict):
 
 
 def create_research_graph(model_name: str, tools: list):
-    import os
-
-    llm = ChatOpenAI(
-        model=model_name or os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
-        api_key=os.environ.get("OPENROUTER_API_KEY")
-        or os.environ.get("OPENAI_API_KEY"),
-        base_url=os.environ.get("OPENAI_API_BASE", "https://openrouter.ai/api/v1"),
-    )
+    # When OrcaRouter is configured, its smart-routing model is used
+    # regardless of the explicit OpenRouter model id passed by the caller.
+    llm = build_orcarouter_llm(model=None if orcarouter_configured() else model_name)
     llm_with_tools = llm.bind_tools(tools)
 
     def chatbot(state: State):

--- a/examples/langgraph-memanto/custom_memory_saver/agent.py
+++ b/examples/langgraph-memanto/custom_memory_saver/agent.py
@@ -44,7 +44,6 @@ import os
 from typing import Literal
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
-from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph_memanto import create_memanto_tools
@@ -128,13 +127,9 @@ def get_memanto_client_and_tools():
 
 def create_llm():
     """Create the LLM with Memanto tools bound."""
-    llm = ChatOpenAI(
-        model=os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
-        temperature=0,
-        api_key=os.environ.get("OPENROUTER_API_KEY")
-        or os.environ.get("OPENAI_API_KEY"),
-        base_url=os.environ.get("OPENAI_API_BASE", "https://openrouter.ai/api/v1"),
-    )
+    from orcarouter_llm import build_orcarouter_llm
+
+    llm = build_orcarouter_llm(temperature=0)
     _, tools = get_memanto_client_and_tools()
     return llm.bind_tools(tools)
 

--- a/examples/langgraph-memanto/custom_memory_saver/langgraph_agent.py
+++ b/examples/langgraph-memanto/custom_memory_saver/langgraph_agent.py
@@ -71,6 +71,17 @@ def _get_llm():
     model = os.getenv("LLM_MODEL", "openrouter/openai/gpt-4o-mini")
     provider, _, model_name = model.partition("/")
 
+    # ---- OrcaRouter ----
+    if os.getenv("ORCAROUTER_API_KEY") or provider == "orcarouter":
+        # When the OrcaRouter key is set, route through OrcaRouter. The model
+        # is the user's explicit ``orcarouter/...`` id, a bare name, or the
+        # smart-routing default. OpenRouter-format LLM_MODEL values are
+        # ignored because they are not routable through the gateway.
+        if provider == "orcarouter":
+            return _OrcaRouterLLM(model)
+        if "/" in model and model_name:
+            return _OrcaRouterLLM("orcarouter/auto")
+        return _OrcaRouterLLM(model)
     # ---- OpenRouter (default) ----
     if provider == "openrouter":
         return _OpenRouterLLM(model_name)
@@ -83,6 +94,47 @@ def _get_llm():
 
     # Fallback: raw HTTP with OpenRouter-style API
     return _OpenRouterLLM(model_name)
+
+
+class _OrcaRouterLLM:
+    """Minimal LLM wrapper using OrcaRouter's OpenAI-compatible API.
+
+    Requires ``ORCAROUTER_API_KEY``. Routes through OrcaRouter's smart
+    routing gateway (``orcarouter/auto``) by default.
+    """
+
+    def __init__(self, model: str = "orcarouter/auto"):
+        model = (model or "orcarouter/auto").strip()
+        # Ensure the OrcaRouter namespace prefix is present: bare model ids
+        # (e.g. ``fusion``) are not routable through the gateway. A model id
+        # carrying some other provider's prefix (e.g. ``openai/gpt-4o-mini``)
+        # is not routable either, so fall back to smart routing.
+        if "/" in model and not model.startswith("orcarouter/"):
+            model = "orcarouter/auto"
+        elif not model.startswith("orcarouter/"):
+            model = f"orcarouter/{model}"
+        self.model = model
+        self.api_key = os.getenv("ORCAROUTER_API_KEY", "")
+
+    def invoke(self, messages: list[dict]) -> str:
+        import httpx
+
+        r = httpx.post(
+            os.getenv("ORCAROUTER_API_BASE", "https://api.orcarouter.ai/v1")
+            + "/chat/completions",
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": self.model,
+                "messages": messages,
+                "temperature": 0.3,
+            },
+            timeout=60,
+        )
+        r.raise_for_status()
+        return r.json()["choices"][0]["message"]["content"]
 
 
 class _OpenRouterLLM:

--- a/examples/langgraph-memanto/custom_memory_saver/run_demo.py
+++ b/examples/langgraph-memanto/custom_memory_saver/run_demo.py
@@ -38,7 +38,8 @@ def check_env():
     if not os.getenv("MOORCHEH_API_KEY"):
         missing.append("MOORCHEH_API_KEY")
     if not os.getenv("OPENROUTER_API_KEY") and not os.getenv("OPENAI_API_KEY"):
-        missing.append("OPENROUTER_API_KEY or OPENAI_API_KEY")
+        if not os.getenv("ORCAROUTER_API_KEY"):
+            missing.append("OPENROUTER_API_KEY, OPENAI_API_KEY, or ORCAROUTER_API_KEY")
     if missing:
         print("❌ Missing environment variables: " + ", ".join(missing))
         print("   Copy .env.example to .env and add your keys.")

--- a/examples/langgraph-memanto/memanto_base_store/README.md
+++ b/examples/langgraph-memanto/memanto_base_store/README.md
@@ -176,7 +176,7 @@ These are documented up-front rather than papered over.
 ## Troubleshooting
 
 * **`MOORCHEH_API_KEY not set`**: copy `.env.example` to `.env` and fill it in.
-* **`OPENROUTER_API_KEY not set`**: the graph routes `langchain-openai` through OpenRouter. Set the env var or override the model via `LANGGRAPH_LLM` (e.g. `LANGGRAPH_LLM=openai/gpt-4o-mini`).
+* **`OPENROUTER_API_KEY not set`**: the graph routes `langchain-openai` through OpenRouter. Set the env var, or set `ORCAROUTER_API_KEY` to route through [OrcaRouter](https://www.orcarouter.ai) (smart-routing `orcarouter/auto`), or override the model via `LANGGRAPH_LLM` (e.g. `LANGGRAPH_LLM=openai/gpt-4o-mini`).
 * **`429 RateLimitError` from OpenRouter**: the default `openai/gpt-oss-120b:free` is the fastest free option (~3 s per extraction) but shares rate limits across all OpenRouter free-tier users. The graph's `RetryPolicy` retries up to 5× with 32 s back-off. If retries are exhausted, switch to another free model via `LANGGRAPH_LLM=openai/gpt-oss-20b:free` (slower but less contested) or a paid model like `openai/gpt-4o-mini`.
 * **`Namespace limit reached (Community plan)`**: the free tier allows 5 agents. List your agents with `client.list_agents()` and delete unused ones with `client.delete_agent(agent_id)`, or reuse an existing agent id.
 * **`Agent already exists`**: fine. `MemantoSetup.setup` catches `AgentAlreadyExistsError` and reuses the existing agent; no action needed.

--- a/examples/langgraph-memanto/memanto_base_store/app.py
+++ b/examples/langgraph-memanto/memanto_base_store/app.py
@@ -154,8 +154,12 @@ st.set_page_config(
 # ── API key guard ─────────────────────────────────────────────────────────────
 
 missing = [k for k in ("MOORCHEH_API_KEY",) if not os.environ.get(k)]
-if not os.environ.get("OPENROUTER_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-    missing.append("OPENROUTER_API_KEY or OPENAI_API_KEY")
+if (
+    not os.environ.get("OPENROUTER_API_KEY")
+    and not os.environ.get("OPENAI_API_KEY")
+    and not os.environ.get("ORCAROUTER_API_KEY")
+):
+    missing.append("OPENROUTER_API_KEY, OPENAI_API_KEY, or ORCAROUTER_API_KEY")
 
 if missing:
     st.error(

--- a/examples/langgraph-memanto/memanto_base_store/graph.py
+++ b/examples/langgraph-memanto/memanto_base_store/graph.py
@@ -250,9 +250,10 @@ def _try_load_memories(text: str) -> ExtractedMemories | None:
 
 
 def _make_llm(temperature: float = 0.2, max_tokens: int | None = None) -> ChatOpenAI:
-    """Build a ChatOpenAI instance routed through OpenRouter.
+    """Build a ChatOpenAI instance routed through OpenRouter (or OrcaRouter).
 
-    Requires ``OPENROUTER_API_KEY``. Override the model via ``LANGGRAPH_LLM``.
+    Requires ``OPENROUTER_API_KEY`` (or ``ORCAROUTER_API_KEY``). Override the
+    model via ``LANGGRAPH_LLM``.
     Called twice inside build_support_graph: once at temperature=0.2 for the
     conversational responder, once at temperature=0.1 for the extractor.
     Two separate instances are used because chaining .bind(temperature=0) onto
@@ -263,8 +264,16 @@ def _make_llm(temperature: float = 0.2, max_tokens: int | None = None) -> ChatOp
     that consume tokens for an internal thinking phase before emitting visible
     output. Without an explicit cap, OpenRouter reserves the model's full
     context budget (65k+) and rejects the call when the API key's credit
-    limit can't cover that reservation.
+    limit can't cover that reservation. OrcaRouter's ``orcarouter/auto``
+    smart-routing model also lands on reasoning upstreams, so the same cap
+    applies there.
     """
+    from orcarouter_llm import build_orcarouter_llm
+
+    # When OrcaRouter is configured, use its smart-routing gateway.
+    if os.environ.get("ORCAROUTER_API_KEY"):
+        return build_orcarouter_llm(temperature=temperature, max_tokens=max_tokens)
+
     # Default: openai/gpt-oss-120b:free - fastest free model on OpenRouter
     # for KIND::CONTENT line extraction. Benchmarked at ~3s for 5 facts.
     # Free, no credits required. Subject to OpenRouter's shared free-tier

--- a/examples/langgraph-memanto/memanto_base_store/run_full_demo.py
+++ b/examples/langgraph-memanto/memanto_base_store/run_full_demo.py
@@ -49,11 +49,14 @@ async def main() -> None:
     if not api_key:
         print("Error: MOORCHEH_API_KEY not set. Copy .env.example to .env.")
         sys.exit(1)
-    if not os.environ.get("OPENROUTER_API_KEY") and not os.environ.get(
-        "OPENAI_API_KEY"
+    if (
+        not os.environ.get("OPENROUTER_API_KEY")
+        and not os.environ.get("OPENAI_API_KEY")
+        and not os.environ.get("ORCAROUTER_API_KEY")
     ):
         print(
-            "Error: OPENROUTER_API_KEY or OPENAI_API_KEY not set. Get one at https://openrouter.ai/keys."
+            "Error: OPENROUTER_API_KEY, OPENAI_API_KEY, or ORCAROUTER_API_KEY not set. "
+            "Get one at https://openrouter.ai/keys or https://www.orcarouter.ai."
         )
         sys.exit(1)
 

--- a/examples/langgraph-memanto/memanto_base_store/run_session_1.py
+++ b/examples/langgraph-memanto/memanto_base_store/run_session_1.py
@@ -39,11 +39,14 @@ async def main() -> None:
             "Error: MOORCHEH_API_KEY not set. Copy .env.example to .env and fill it in."
         )
         sys.exit(1)
-    if not os.environ.get("OPENROUTER_API_KEY") and not os.environ.get(
-        "OPENAI_API_KEY"
+    if (
+        not os.environ.get("OPENROUTER_API_KEY")
+        and not os.environ.get("OPENAI_API_KEY")
+        and not os.environ.get("ORCAROUTER_API_KEY")
     ):
         print(
-            "Error: OPENROUTER_API_KEY or OPENAI_API_KEY not set. Get one at https://openrouter.ai/keys."
+            "Error: OPENROUTER_API_KEY, OPENAI_API_KEY, or ORCAROUTER_API_KEY not set. "
+            "Get one at https://openrouter.ai/keys or https://www.orcarouter.ai."
         )
         sys.exit(1)
 

--- a/examples/langgraph-memanto/memanto_base_store/run_session_2.py
+++ b/examples/langgraph-memanto/memanto_base_store/run_session_2.py
@@ -36,11 +36,14 @@ async def main() -> None:
             "Error: MOORCHEH_API_KEY not set. Copy .env.example to .env and fill it in."
         )
         sys.exit(1)
-    if not os.environ.get("OPENROUTER_API_KEY") and not os.environ.get(
-        "OPENAI_API_KEY"
+    if (
+        not os.environ.get("OPENROUTER_API_KEY")
+        and not os.environ.get("OPENAI_API_KEY")
+        and not os.environ.get("ORCAROUTER_API_KEY")
     ):
         print(
-            "Error: OPENROUTER_API_KEY or OPENAI_API_KEY not set. Get one at https://openrouter.ai/keys."
+            "Error: OPENROUTER_API_KEY, OPENAI_API_KEY, or ORCAROUTER_API_KEY not set. "
+            "Get one at https://openrouter.ai/keys or https://www.orcarouter.ai."
         )
         sys.exit(1)
 

--- a/examples/langgraph-memanto/orcarouter_llm.py
+++ b/examples/langgraph-memanto/orcarouter_llm.py
@@ -1,0 +1,92 @@
+"""
+OrcaRouter LLM factory for the Memanto + LangGraph examples.
+
+This module lets any example opt into [OrcaRouter](https://www.orcarouter.ai)
+as a **named** OpenAI-compatible provider, without losing the existing
+OpenRouter / OpenAI fallbacks.
+
+How it works
+------------
+- If ``ORCAROUTER_API_KEY`` is set, every ``build_orcarouter_llm()`` call
+  returns a ``ChatOpenAI`` pointed at OrcaRouter's OpenAI-compatible gateway
+  (``https://api.orcarouter.ai/v1``), with the smart-routing model
+  ``orcarouter/auto`` by default.
+- Otherwise it falls back to the exact behaviour the examples had before:
+  OpenRouter (default) or OpenAI, overridable via ``LLM_MODEL`` /
+  ``OPENAI_API_BASE``.
+
+OrcaRouter routes ``orcarouter/auto`` to the best available upstream model
+for the request (smart routing), so the model id must keep the
+``orcarouter/`` prefix — it is sent to the gateway verbatim.
+"""
+
+from __future__ import annotations
+
+import os
+
+from langchain_openai import ChatOpenAI
+
+# Named OrcaRouter gateway constants.
+ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1"
+ORCAROUTER_MODEL = "orcarouter/auto"
+
+# Gateway models offered through OrcaRouter's smart routing.
+ORCAROUTER_MODELS = (
+    "orcarouter/auto",
+    "orcarouter/fusion",
+    "orcarouter/fusion-flash",
+    "orcarouter/fusion-mini",
+)
+
+
+def orcarouter_configured() -> bool:
+    """Return True when the user has opted into OrcaRouter."""
+    return bool(os.environ.get("ORCAROUTER_API_KEY"))
+
+
+def build_orcarouter_llm(
+    *,
+    model: str | None = None,
+    temperature: float = 0.0,
+    max_tokens: int | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> ChatOpenAI:
+    """Build a ``ChatOpenAI`` preferring OrcaRouter when configured.
+
+    When ``ORCAROUTER_API_KEY`` is set the model defaults to
+    ``orcarouter/auto`` (smart routing) and the base URL to OrcaRouter's
+    OpenAI-compatible endpoint. Otherwise the legacy OpenRouter/OpenAI
+    resolution is used so existing demos keep working unchanged.
+
+    Args:
+        model: Model override. When OrcaRouter is active this should be a
+            full ``orcarouter/...`` id; default ``orcarouter/auto``.
+        temperature: Sampling temperature.
+        max_tokens: Optional max output tokens (reasoning upstreams need a cap).
+        api_key: Explicit key override (defaults to env resolution).
+        base_url: Explicit base URL override (defaults to env resolution).
+    """
+    if api_key is None:
+        api_key = os.environ.get("ORCAROUTER_API_KEY")
+    if base_url is None:
+        base_url = os.environ.get("ORCAROUTER_API_BASE", ORCAROUTER_API_BASE)
+
+    if api_key:
+        return ChatOpenAI(
+            model=model or os.environ.get("ORCAROUTER_MODEL", ORCAROUTER_MODEL),
+            temperature=temperature,
+            api_key=api_key,
+            base_url=base_url,
+            max_tokens=max_tokens,
+        )
+
+    # Legacy fallback: OpenRouter (default) or OpenAI, as before.
+    return ChatOpenAI(
+        model=model or os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
+        temperature=temperature,
+        api_key=os.environ.get("OPENROUTER_API_KEY")
+        or os.environ.get("OPENAI_API_KEY"),
+        base_url=os.environ.get("OPENAI_API_BASE", "https://openrouter.ai/api/v1"),
+        max_tokens=max_tokens,
+    )

--- a/examples/langgraph-memanto/research_pipeline/langgraph_memanto/nodes.py
+++ b/examples/langgraph-memanto/research_pipeline/langgraph_memanto/nodes.py
@@ -12,7 +12,7 @@ from typing import Any, Literal
 
 from dotenv import load_dotenv
 from langchain_core.tools import tool
-from langchain_openai import ChatOpenAI
+from orcarouter_llm import build_orcarouter_llm
 
 from langgraph_memanto import create_memanto_tools
 from memanto.cli.client.sdk_client import SdkClient
@@ -44,15 +44,8 @@ def _get_moorcheh_api_key() -> str:
 
 
 def _get_llm():
-    """Build a flexible ChatOpenAI model."""
-    return ChatOpenAI(
-        model=os.getenv("LLM_MODEL", "openai/gpt-4o-mini"),
-        api_key=os.getenv("OPENROUTER_API_KEY")
-        or os.getenv("OPENAI_API_KEY")
-        or OPENROUTER_API_KEY,
-        base_url=os.getenv("OPENAI_API_BASE", "https://openrouter.ai/api/v1"),
-        temperature=0.7,
-    )
+    """Build a flexible ChatOpenAI model (prefers OrcaRouter when configured)."""
+    return build_orcarouter_llm(temperature=0.7)
 
 
 # ---------------------------------------------------------------------------

--- a/examples/langgraph-memanto/research_pipeline/pipeline/nodes.py
+++ b/examples/langgraph-memanto/research_pipeline/pipeline/nodes.py
@@ -12,8 +12,8 @@ from typing import Any, Literal
 
 from dotenv import load_dotenv
 from langchain_core.tools import tool
-from langchain_openai import ChatOpenAI
 from langgraph_memanto import create_memanto_tools
+from orcarouter_llm import build_orcarouter_llm
 
 from memanto.cli.client.sdk_client import SdkClient
 
@@ -44,15 +44,8 @@ def _get_moorcheh_api_key() -> str:
 
 
 def _get_llm():
-    """Build a flexible ChatOpenAI model."""
-    return ChatOpenAI(
-        model=os.getenv("LLM_MODEL", "openai/gpt-4o-mini"),
-        api_key=os.getenv("OPENROUTER_API_KEY")
-        or os.getenv("OPENAI_API_KEY")
-        or OPENROUTER_API_KEY,
-        base_url=os.getenv("OPENAI_API_BASE", "https://openrouter.ai/api/v1"),
-        temperature=0.7,
-    )
+    """Build a flexible ChatOpenAI model (prefers OrcaRouter when configured)."""
+    return build_orcarouter_llm(temperature=0.7)
 
 
 # ---------------------------------------------------------------------------

--- a/examples/langgraph-memanto/research_pipeline/run_research.py
+++ b/examples/langgraph-memanto/research_pipeline/run_research.py
@@ -21,15 +21,17 @@ load_dotenv()
 
 MOORCHEH_API_KEY = os.getenv("MOORCHEH_API_KEY", "")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
+ORCAROUTER_API_KEY = os.getenv("ORCAROUTER_API_KEY", "")
 AGENT_ID = os.getenv("MEMANTO_AGENT_ID", "langgraph-research-team")
 TOPIC = os.getenv("RESEARCH_TOPIC", "AI agent framework market size and trends 2024")
 
 
 def main():
-    if not MOORCHEH_API_KEY or not OPENROUTER_API_KEY:
+    if not MOORCHEH_API_KEY or (not OPENROUTER_API_KEY and not ORCAROUTER_API_KEY):
         print("ERROR: Missing API keys.")
         print(
-            "Copy .env.example to .env and fill in MOORCHEH_API_KEY and OPENROUTER_API_KEY"
+            "Copy .env.example to .env and fill in MOORCHEH_API_KEY and "
+            "OPENROUTER_API_KEY (or ORCAROUTER_API_KEY)"
         )
         sys.exit(1)
 

--- a/examples/langgraph-memanto/research_pipeline/run_writer.py
+++ b/examples/langgraph-memanto/research_pipeline/run_writer.py
@@ -13,8 +13,8 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from dotenv import load_dotenv
-from langchain_openai import ChatOpenAI
 from langgraph_memanto import create_memanto_tools
+from orcarouter_llm import build_orcarouter_llm
 
 from memanto.cli.client.sdk_client import SdkClient
 
@@ -32,19 +32,17 @@ TOPIC = os.getenv("RESEARCH_TOPIC", "AI agent framework market size and trends 2
 
 
 def main():
-    if not MOORCHEH_API_KEY or not OPENROUTER_API_KEY:
+    if not MOORCHEH_API_KEY or (
+        not OPENROUTER_API_KEY and not os.getenv("ORCAROUTER_API_KEY")
+    ):
         print("ERROR: Missing API keys.")
         print(
-            "Copy .env.example to .env and fill in MOORCHEH_API_KEY and OPENROUTER_API_KEY"
+            "Copy .env.example to .env and fill in MOORCHEH_API_KEY and "
+            "OPENROUTER_API_KEY (or ORCAROUTER_API_KEY)"
         )
         sys.exit(1)
 
-    llm = ChatOpenAI(
-        api_key=OPENROUTER_API_KEY,
-        base_url="https://openrouter.ai/api/v1",
-        model=os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
-        temperature=0.7,
-    )
+    llm = build_orcarouter_llm(temperature=0.7)
 
     print(f"Writer Agent retrieving memories for: {TOPIC}")
     print("---")


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named OpenAI-compatible
provider for the LangGraph examples in `examples/langgraph-memanto/`. OrcaRouter
is a smart model-routing gateway that exposes models from OpenAI, Anthropic,
Google, DeepSeek, Qwen, MiniMax and others behind a single endpoint and API key.
It also runs gateway-level, zero-trust security for AI agents on the same
endpoint — screening every prompt/response and governing every tool call on a
default-deny basis, with no application code changes.

Disclosure: I'm an engineer on the OrcaRouter team.

## What this changes

The LangGraph examples previously hard-coded OpenRouter as their OpenAI-compatible
LLM route (`ChatOpenAI(base_url="https://openrouter.ai/api/v1")`). This PR makes
every example prefer a **named OrcaRouter provider** whenever `ORCAROUTER_API_KEY`
is set, while keeping the existing OpenRouter/OpenAI behaviour as the fallback so
nothing breaks for current users.

- `examples/langgraph-memanto/orcarouter_llm.py` (new): shared `build_orcarouter_llm()`
  factory. When `ORCAROUTER_API_KEY` is set it returns a `ChatOpenAI` pointed at
  `https://api.orcarouter.ai/v1` with the smart-routing model `orcarouter/auto`;
  otherwise it falls back to the exact OpenRouter/OpenAI resolution used before.
- `basic_integration/agent.py`, `custom_memory_saver/agent.py`,
  `cross_session_recall/graph.py`: route through the OrcaRouter-aware factory.
- `custom_memory_saver/langgraph_agent.py`: new `_OrcaRouterLLM` HTTP wrapper with
  provider dispatch (`LLM_MODEL=orcarouter/...` or `ORCAROUTER_API_KEY`).
- `research_pipeline/{pipeline,langgraph_memanto}/nodes.py`, `run_research.py`,
  `run_writer.py`: use the factory and accept `ORCAROUTER_API_KEY` in the env checks.
- `memanto_base_store/graph.py`: `_make_llm` prefers OrcaRouter when configured
  (same `max_tokens` cap semantics for reasoning upstreams), OpenRouter otherwise.
- `memanto_base_store/{run_full_demo,run_session_1,run_session_2}.py`, `app.py`:
  accept `ORCAROUTER_API_KEY` in the env guards.
- `.env.example`, `README.md`, `memanto_base_store/README.md`: document the
  OrcaRouter option (`ORCAROUTER_API_KEY`, optional `ORCAROUTER_MODEL` /
  `ORCAROUTER_API_BASE`).

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how the examples already wire OpenRouter as a named provider, so the
model picker, env vars and docs stay consistent for users. Setting
`ORCAROUTER_API_KEY` is a one-line switch to OrcaRouter's smart routing and its
gateway-level security controls, with no code changes in the agent graph itself.

## How to use it

1. Get an OrcaRouter key at https://www.orcarouter.ai (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY` in `.env`.
3. Optional: set `ORCAROUTER_MODEL` (default `orcarouter/auto`, smart routing).

## Verification

- `ruff check examples/langgraph-memanto/` — all checks passed.
- `ruff format --check` — clean for every touched Python file (the only
  unformatted file, `memanto_base_store/README.md:112`, is pre-existing on main).
- `python3 -m py_compile` on every changed file — all pass.
- Provider resolution exercised with a stub `ChatOpenAI`: OrcaRouter active
  (`orcarouter/auto` + `https://api.orcarouter.ai/v1`), env overrides, and
  OpenRouter fallback all resolve correctly. `_get_llm()` in
  `custom_memory_saver/langgraph_agent.py` dispatches to `_OrcaRouterLLM` /
  `_OpenRouterLLM` for all 6 combinations.
- Live API: `POST https://api.orcarouter.ai/v1/chat/completions` with model
  `orcarouter/auto` returned HTTP 200 (`ORCA-LIVE-OK`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter support across LangGraph memory and research examples.
  * Added automatic routing, configurable models, and optional base URL settings.
  * Existing OpenRouter and OpenAI configurations remain supported as fallbacks.

* **Documentation**
  * Updated setup instructions, environment examples, provider guidance, and troubleshooting information.
  * Improved startup messages to explain accepted provider credentials and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->