### PR TITLE
fix: remove reintroduced ttl_seconds logic

### DIFF
--- a/memanto/app/core.py
+++ b/memanto/app/core.py
@@ -4,7 +4,7 @@ MEMANTO Core Architecture - Namespace Strategy & Memory Records
 
 import re
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, StringConstraints, field_validator
@@ -129,10 +129,6 @@ class MemoryRecord(BaseModel):
     # ``manual``, or ``conflict-resolution``.
     expired_at: datetime | None = None
     expired_by: BoundedExpiredBy | None = None
-
-    def set_ttl(self, ttl_seconds: int) -> None:
-        """Set expiration time based on a TTL in seconds."""
-        self.expired_at = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
 
     def to_moorcheh_document(self) -> dict[str, Any]:
         """

--- a/memanto/app/models/__init__.py
+++ b/memanto/app/models/__init__.py
@@ -53,11 +53,6 @@ class BatchRememberItem(BaseModel):
         "explicit_statement",
         description="How memory was obtained (explicit_statement, inferred, observed, etc.)",
     )
-    ttl_seconds: int | None = Field(
-        None,
-        ge=1,
-        description="Time-to-live in seconds. Memory expires after this duration.",
-    )
 
     @field_validator("content")
     @classmethod

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -462,9 +462,6 @@ async def remember(
             provenance=cast(ProvenanceType, request.provenance),
         )
 
-        if request.ttl_seconds:
-            memory.set_ttl(request.ttl_seconds)
-
         # Store memory in agent's namespace.
         result = await asyncio.to_thread(write_service.store_memory, memory)
         status = str(result.get("status", "unknown"))
@@ -544,8 +541,6 @@ async def batch_remember(
                 source=item.source,
                 provenance=cast(ProvenanceType, item.provenance),
             )
-            if item.ttl_seconds:
-                memory.set_ttl(item.ttl_seconds)
             memory_records.append(memory)
 
         # Store in batch

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -761,8 +761,6 @@ class DirectClient:
                 "source_ref",
                 "created_at",
                 "updated_at",
-                "expires_at",
-                "ttl_seconds",
             ):
                 val = item.get(opt_key)
                 if val is not None:

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -590,8 +590,6 @@ class SdkClient:
                 "source_ref",
                 "created_at",
                 "updated_at",
-                "expires_at",
-                "ttl_seconds",
             ):
                 val = item.get(opt_key)
                 if val is not None:

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -4038,19 +4038,6 @@
             "title": "Provenance",
             "description": "How memory was obtained (explicit_statement, inferred, observed, etc.)",
             "default": "explicit_statement"
-          },
-          "ttl_seconds": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ttl Seconds",
-            "description": "Time-to-live in seconds. Memory expires after this duration."
           }
         },
         "type": "object",
@@ -5383,19 +5370,6 @@
             "title": "Provenance",
             "description": "How memory was obtained (explicit_statement, inferred, observed, etc.)",
             "default": "explicit_statement"
-          },
-          "ttl_seconds": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ttl Seconds",
-            "description": "Time-to-live in seconds. Memory expires after this duration."
           }
         },
         "type": "object",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -579,7 +579,6 @@ class TestMEMANTOCLI:
         mock_session = MagicMock()
         mock_session.namespace = "memanto_agent_test-agent"
         updated_at = datetime(2026, 6, 1, 9, 15, tzinfo=timezone.utc)
-        expires_at = datetime(2026, 8, 1, 9, 15, tzinfo=timezone.utc)
 
         with (
             patch.object(Client, "_get_write_service", return_value=mock_write_service),
@@ -598,16 +597,12 @@ class TestMEMANTOCLI:
                     {
                         "content": "Temporary operational context",
                         "updated_at": updated_at,
-                        "expires_at": expires_at,
-                        "ttl_seconds": 5_529_600,
                     }
                 ],
             )
 
         record = mock_write_service.batch_store_memories.call_args.args[0][0]
         assert record.updated_at == updated_at
-        assert record.expires_at == expires_at
-        assert record.ttl_seconds == 5_529_600
 
     def test_edit_sdk_normalizes_confidence_and_accepts_valid_payload(
         self, mock_all_clients


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Removed expiration settings from newly created memories.
  - Memory creation and batch imports no longer accept or apply time-to-live values or explicit expiration timestamps.
  - Updated request models and SDK interfaces to remove expiration-related options.
  - Memory records no longer expose TTL-based expiration assignment.
  - Temporal metadata now retains update timestamps without expiration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->