### PR TITLE
fix: update OKF export to conform to v0.2 spec

### DIFF
--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -285,7 +285,13 @@ class OkfExportService:
         for src, destination_name in planned:
             text = src.read_text(encoding="utf-8")
             if not text.startswith("---"):
-                front = f"---\ntype: Context Document\ntitle: {src.stem}\n---\n\n"
+                frontmatter = yaml.safe_dump(
+                    {"type": "Context Document", "title": src.stem},
+                    sort_keys=False,
+                    allow_unicode=True,
+                    default_flow_style=False,
+                ).strip()
+                front = f"---\n{frontmatter}\n---\n\n"
                 (section_dir / destination_name).write_text(
                     front + text, encoding="utf-8"
                 )

--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -1,7 +1,7 @@
 """
 OKF (Open Knowledge Format) Export Service
 
-Serializes an agent's memories into an OKF v0.1 bundle — a directory of
+Serializes an agent's memories into an OKF v0.2 bundle — a directory of
 markdown files with YAML frontmatter, one concept per file, grouped into a
 folder per Memanto memory type.
 
@@ -283,7 +283,14 @@ class OkfExportService:
         section_dir.mkdir(parents=True, exist_ok=True)
         links: list[tuple[str, str]] = []
         for src, destination_name in planned:
-            shutil.copy2(str(src), str(section_dir / destination_name))
+            text = src.read_text(encoding="utf-8")
+            if not text.startswith("---"):
+                front = f"---\ntype: Context Document\ntitle: {src.stem}\n---\n\n"
+                (section_dir / destination_name).write_text(
+                    front + text, encoding="utf-8"
+                )
+            else:
+                shutil.copy2(str(src), str(section_dir / destination_name))
             links.append((destination_name, destination_name))
 
         self._write_index(section_dir, title, f"{title} ({len(links)})", links)
@@ -318,7 +325,13 @@ class OkfExportService:
             return False
 
         metrics_dir.mkdir(parents=True, exist_ok=True)
-        body = f"# Metrics — aggregate\n\n> {len(records)} memories\n{viz}\n"
+        body = (
+            "---\n"
+            "type: Metrics Overview\n"
+            "title: Aggregate Metrics\n"
+            "---\n\n"
+            f"# Metrics — aggregate\n\n> {len(records)} memories\n{viz}\n"
+        )
         (metrics_dir / "overview.md").write_text(body, encoding="utf-8")
         self._write_index(
             metrics_dir, "metrics", "Metrics", [("overview", "overview.md")]
@@ -376,7 +389,14 @@ class OkfExportService:
 
         created_at = mem.get("created_at")
         if created_at:
-            frontmatter["timestamp"] = str(created_at)
+            source = mem.get("source") or "process:unknown"
+            if not (
+                source.startswith("human:")
+                or source.startswith("process:")
+                or "/" in source
+            ):
+                source = f"process:{source}"
+            frontmatter["generated"] = {"by": source, "at": str(created_at)}
 
         source_ref = mem.get("source_ref")
         if source_ref:
@@ -435,14 +455,7 @@ class OkfExportService:
         self, directory: Path, title: str, heading: str, links: list[tuple[str, str]]
     ) -> None:
         """Write a navigational ``index.md`` (skipped on import)."""
-        now = datetime.now().isoformat(timespec="seconds")
         lines = [
-            "---",
-            "type: index",
-            f"title: {title}",
-            f"timestamp: {now}",
-            "---",
-            "",
             f"# {heading}",
             "",
         ]
@@ -453,12 +466,9 @@ class OkfExportService:
     def _write_root_index(
         self, base: Path, agent_id: str, sections: dict[str, str]
     ) -> None:
-        now = datetime.now().isoformat(timespec="seconds")
         lines = [
             "---",
-            "type: index",
-            f"title: {agent_id} knowledge bundle",
-            f"timestamp: {now}",
+            'okf_version: "0.2"',
             "---",
             "",
             f"# {agent_id} — OKF bundle",

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -521,7 +521,7 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
         extra = entry.get("extra") or {}
         generated = extra.get("generated", {})
         gen_at = generated.get("at") if isinstance(generated, dict) else None
-        created_at = _parse_dt(gen_at)
+        created_at = _parse_dt(gen_at) or _parse_dt(entry.get("timestamp"))
 
         updated_at = _parse_dt(x_memanto.get("updated_at")) or migrated_at
         expires_at = _parse_dt(x_memanto.get("expires_at"))

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -517,7 +517,12 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
 
         source = x_memanto.get("source") or "okf"
         provenance = _coerce_provenance(x_memanto.get("provenance"))
-        created_at = _parse_dt(entry.get("timestamp"))
+
+        extra = entry.get("extra") or {}
+        generated = extra.get("generated", {})
+        gen_at = generated.get("at") if isinstance(generated, dict) else None
+        created_at = _parse_dt(gen_at)
+
         updated_at = _parse_dt(x_memanto.get("updated_at")) or migrated_at
         expires_at = _parse_dt(x_memanto.get("expires_at"))
         ttl_seconds = _parse_positive_int(x_memanto.get("ttl_seconds"))

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -197,7 +197,7 @@ def test_foreign_okf_bundle_is_lossless(tmp_path):
         "description: One row per completed customer order.\n"
         "resource: https://console.cloud.google.com/bigquery?t=orders\n"
         "tags: [sales, revenue]\n"
-        "timestamp: 2026-05-28T14:30:00Z\n"
+        "generated: { by: reference_agent, at: 2026-05-28T14:30:00Z }\n"
         "owner: data-team\n"
         "---\n\n"
         "# Schema\nJoined with [customers](/tables/customers.md).\n",

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -197,7 +197,7 @@ def test_foreign_okf_bundle_is_lossless(tmp_path):
         "description: One row per completed customer order.\n"
         "resource: https://console.cloud.google.com/bigquery?t=orders\n"
         "tags: [sales, revenue]\n"
-        "generated: { by: reference_agent, at: 2026-05-28T14:30:00Z }\n"
+        "timestamp: 2026-05-28T14:30:00Z\n"
         "owner: data-team\n"
         "---\n\n"
         "# Schema\nJoined with [customers](/tables/customers.md).\n",


### PR DESCRIPTION
Made following changes to conform to OKF v0.2 spec:
- Removed frontmatter from index files
- Added okf_version declaration in index.md
- Migrated to generated schema over timestamp
- Add context document frontmatter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated OKF exports to version 0.2.
  * Added generated metadata for context documents and metrics overviews.
  * Exported memory timestamps using standardized generated-at metadata.

* **Bug Fixes**
  * Improved migration handling for nested generated timestamps.
  * Added fallback support for legacy timestamp data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->