### PR TITLE
fix(mcp): require inbound auth for network transports

### DIFF
--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -144,6 +144,7 @@ All config is via environment variables (load order: process env →
 | `MEMANTO_MCP_TRANSPORT` | no | `stdio` | `stdio`, `sse`, or `streamable-http`. |
 | `MEMANTO_MCP_HOST` | no | `127.0.0.1` | Bind host for sse/http transports. |
 | `MEMANTO_MCP_PORT` | no | `8765` | Bind port for sse/http transports. |
+| `MEMANTO_MCP_AUTH_TOKEN` | required for non-loopback HTTP/SSE | _none_ | Bearer token checked on every inbound HTTP request. Keep it separate from `MOORCHEH_API_KEY`. |
 | `MEMANTO_MCP_LOG_LEVEL` | no | `INFO` | Log level (logs are always sent to stderr). |
 
 CLI flags (`memanto-mcp --transport sse --port 9000`) override env vars.
@@ -155,6 +156,7 @@ transport:
 
 ```bash
 # Streamable HTTP (recommended modern transport)
+export MEMANTO_MCP_AUTH_TOKEN='replace-with-a-long-random-token'
 memanto-mcp --transport streamable-http --host 0.0.0.0 --port 8765
 
 # Server-Sent Events (older, still widely supported)
@@ -162,10 +164,12 @@ memanto-mcp --transport sse --host 0.0.0.0 --port 8765
 ```
 
 Then point your client at `http://your-host:8765/mcp` (or whatever path the
-chosen transport advertises). Pair with a reverse proxy + auth for
-production deployments — the server itself authenticates upstream to
-Moorcheh using your API key but does **not** authenticate inbound MCP
-clients.
+chosen transport advertises) and send `Authorization: Bearer
+<MEMANTO_MCP_AUTH_TOKEN>`. Non-loopback HTTP/SSE binds fail closed at startup
+unless `MEMANTO_MCP_AUTH_TOKEN` is set; the token is checked before any MCP
+route or tool handler runs. The server authenticates upstream to Moorcheh
+using `MOORCHEH_API_KEY`, which is a separate credential. Use TLS and a
+reverse proxy for production deployments.
 
 ## How it works
 

--- a/integrations/mcp/memanto_mcp/auth.py
+++ b/integrations/mcp/memanto_mcp/auth.py
@@ -1,0 +1,86 @@
+"""Inbound authentication for network MCP transports.
+
+The Moorcheh API key authenticates Memanto *to* Moorcheh. It must not be
+treated as authentication for clients connecting *to* this MCP server. The
+network transports therefore use a separate bearer token, while the default
+loopback-only mode remains convenient for local MCP clients.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from hmac import compare_digest
+
+from starlette.types import Receive, Scope, Send
+
+from memanto_mcp.config import is_loopback_host
+
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+
+_UNAUTHORIZED_BODY = b'{"detail":"Unauthorized"}'
+_FORBIDDEN_BODY = b'{"detail":"Loopback access required"}'
+
+
+def _bearer_token(scope: Scope) -> str | None:
+    """Extract one well-formed bearer token from an ASGI HTTP scope."""
+    authorization_headers = [
+        value
+        for name, value in scope.get("headers", [])
+        if name.lower() == b"authorization"
+    ]
+    if len(authorization_headers) != 1:
+        return None
+
+    parts = authorization_headers[0].split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != b"bearer":
+        return None
+    token = parts[1].strip()
+    return token.decode("latin-1") if token else None
+
+
+def _peer_is_loopback(scope: Scope) -> bool:
+    client = scope.get("client")
+    return bool(client and is_loopback_host(str(client[0])))
+
+
+async def _send_error(send: Send, status: int, body: bytes) -> None:
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode("ascii")),
+    ]
+    if status == 401:
+        headers.append((b"www-authenticate", b"Bearer"))
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": body})
+
+
+class MCPInboundAuthMiddleware:
+    """Protect every HTTP request before it reaches an MCP transport app.
+
+    A configured token is required for every HTTP request. Without a token,
+    only loopback peers are accepted; configuration validation prevents that
+    mode from being used with a non-loopback bind address.
+    """
+
+    def __init__(self, app: ASGIApp, auth_token: str | None) -> None:
+        self.app = app
+        self.auth_token = auth_token
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if self.auth_token is None:
+            if not _peer_is_loopback(scope):
+                await _send_error(send, 403, _FORBIDDEN_BODY)
+                return
+        else:
+            supplied_token = _bearer_token(scope)
+            if supplied_token is None or not compare_digest(
+                supplied_token, self.auth_token
+            ):
+                await _send_error(send, 401, _UNAUTHORIZED_BODY)
+                return
+
+        await self.app(scope, receive, send)

--- a/integrations/mcp/memanto_mcp/config.py
+++ b/integrations/mcp/memanto_mcp/config.py
@@ -7,9 +7,10 @@ surfaces immediately at startup rather than on the first tool call.
 
 from __future__ import annotations
 
+import ipaddress
 from enum import Enum
 
-from pydantic import Field, SecretStr, field_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -24,6 +25,23 @@ class TransportType(str, Enum):
 # Patterns recognized by Memanto's agent service. Kept in sync with
 # `memanto.app.constants.VALID_PATTERNS`.
 _VALID_AGENT_PATTERNS = {"support", "project", "tool"}
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return whether *host* is an explicitly local bind address.
+
+    Unknown hostnames are treated as non-loopback so a typo cannot silently
+    disable the network-auth requirement.
+    """
+    normalized = host.strip().lower().rstrip(".")
+    if normalized == "localhost":
+        return True
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 class MCPServerSettings(BaseSettings):
@@ -46,6 +64,8 @@ class MCPServerSettings(BaseSettings):
             ``get_agent``, and ``delete_agent`` tools. Off by default to keep
             the surface focused on memory operations.
         transport / host / port: How the server is reached.
+        mcp_auth_token: Bearer token required by network transports. It is
+            mandatory whenever a network transport binds outside loopback.
         log_level: Logging verbosity (logs go to stderr).
     """
 
@@ -112,6 +132,14 @@ class MCPServerSettings(BaseSettings):
         validation_alias="MEMANTO_MCP_PORT",
         description="Bind port for sse / streamable-http.",
     )
+    mcp_auth_token: SecretStr | None = Field(
+        default=None,
+        validation_alias="MEMANTO_MCP_AUTH_TOKEN",
+        description=(
+            "Bearer token for inbound sse / streamable-http requests. "
+            "Required for non-loopback binds."
+        ),
+    )
 
     # ---- Logging ----
     log_level: str = Field(
@@ -149,6 +177,30 @@ class MCPServerSettings(BaseSettings):
             )
         return v
 
+    @field_validator("mcp_auth_token")
+    @classmethod
+    def _validate_mcp_auth_token(cls, v: SecretStr | None) -> SecretStr | None:
+        if v is not None and not v.get_secret_value().strip():
+            raise ValueError("MEMANTO_MCP_AUTH_TOKEN must not be empty")
+        return v
+
+    @model_validator(mode="after")
+    def _require_network_auth_for_remote_bind(self) -> MCPServerSettings:
+        network_transport = self.transport in {
+            TransportType.SSE,
+            TransportType.STREAMABLE_HTTP,
+        }
+        if network_transport and not is_loopback_host(self.host) and not self.mcp_auth_token:
+            raise ValueError(
+                "MEMANTO_MCP_AUTH_TOKEN is required when an HTTP/SSE transport "
+                "binds to a non-loopback host"
+            )
+        return self
+
     # Convenience accessor — never logged.
     def api_key_value(self) -> str:
         return self.moorcheh_api_key.get_secret_value()
+
+    def auth_token_value(self) -> str | None:
+        """Return the inbound token without ever including it in settings text."""
+        return self.mcp_auth_token.get_secret_value() if self.mcp_auth_token else None

--- a/integrations/mcp/memanto_mcp/server.py
+++ b/integrations/mcp/memanto_mcp/server.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 import logging
 import sys
 
+import anyio
+from starlette.types import ASGIApp
+
 try:
     from mcp.server.fastmcp import FastMCP
 except ImportError as exc:  # pragma: no cover - install-time message
@@ -19,6 +22,7 @@ except ImportError as exc:  # pragma: no cover - install-time message
         "memanto-mcp requires the `mcp` package. Install with: pip install 'mcp[cli]>=1.2'"
     ) from exc
 
+from memanto_mcp.auth import MCPInboundAuthMiddleware
 from memanto_mcp.config import MCPServerSettings, TransportType
 from memanto_mcp.lifecycle import MemantoLifecycle
 from memanto_mcp.tools import register_tools
@@ -113,10 +117,44 @@ def run_server(settings: MCPServerSettings | None = None) -> None:
             # FastMCP.run() defaults to stdio when called with no transport.
             mcp.run(transport="stdio")
         elif transport is TransportType.SSE:
-            mcp.run(transport="sse")
+            anyio.run(_serve_network_transport, mcp, settings)
         elif transport is TransportType.STREAMABLE_HTTP:
-            mcp.run(transport="streamable-http")
+            anyio.run(_serve_network_transport, mcp, settings)
         else:  # pragma: no cover - exhausted by enum
             raise ValueError(f"Unsupported transport: {transport}")
     finally:
         lifecycle.shutdown()
+
+
+def _build_network_app(mcp: FastMCP, settings: MCPServerSettings) -> ASGIApp:
+    """Build and guard the Starlette app used by an HTTP transport."""
+    if settings.transport is TransportType.SSE:
+        transport_app = mcp.sse_app()
+    elif settings.transport is TransportType.STREAMABLE_HTTP:
+        transport_app = mcp.streamable_http_app()
+    else:  # pragma: no cover - called only for network transports
+        raise ValueError(f"Unsupported network transport: {settings.transport}")
+
+    return MCPInboundAuthMiddleware(transport_app, settings.auth_token_value())
+
+
+async def _serve_network_transport(
+    mcp: FastMCP, settings: MCPServerSettings
+) -> None:  # pragma: no cover - waits for a real server lifecycle
+    """Serve a guarded FastMCP app with Uvicorn.
+
+    FastMCP.run() constructs the Starlette app internally, so it cannot be
+    wrapped with the inbound-auth middleware. Building the public transport
+    app first keeps the guard on the actual serving path.
+    """
+    import uvicorn
+
+    app = _build_network_app(mcp, settings)
+    config = uvicorn.Config(
+        app,
+        host=settings.host,
+        port=settings.port,
+        log_level=settings.log_level.lower(),
+    )
+    server = uvicorn.Server(config)
+    await server.serve()

--- a/integrations/mcp/tests/test_auth.py
+++ b/integrations/mcp/tests/test_auth.py
@@ -1,0 +1,112 @@
+"""Unit tests for the MCP server's inbound network-auth boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from memanto_mcp.auth import MCPInboundAuthMiddleware
+
+
+async def _run_request(
+    app: MCPInboundAuthMiddleware,
+    *,
+    headers: list[tuple[bytes, bytes]] | None = None,
+    client: tuple[str, int] | None = ("127.0.0.1", 43210),
+    scope_type: str = "http",
+) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+
+    scope: dict[str, Any] = {
+        "type": scope_type,
+        "headers": headers or [],
+        "client": client,
+    }
+    await app(scope, receive, send)
+    return messages
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "headers",
+    [
+        [],
+        [(b"authorization", b"Basic secret")],
+        [(b"authorization", b"Bearer wrong")],
+        [(b"authorization", b"Bearer secret"), (b"authorization", b"Bearer secret")],
+    ],
+)
+async def test_configured_token_rejects_missing_or_invalid_credentials(
+    headers: list[tuple[bytes, bytes]],
+) -> None:
+    called = False
+
+    async def downstream(scope: Any, receive: Any, send: Any) -> None:
+        nonlocal called
+        called = True
+
+    app = MCPInboundAuthMiddleware(downstream, "secret")
+    messages = await _run_request(app, headers=headers, client=("203.0.113.10", 1))
+
+    assert messages[0]["status"] == 401
+    assert messages[0]["headers"][-1] == (b"www-authenticate", b"Bearer")
+    assert b"secret" not in messages[1]["body"]
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_configured_token_allows_valid_bearer_credentials() -> None:
+    called = False
+
+    async def downstream(scope: Any, receive: Any, send: Any) -> None:
+        nonlocal called
+        called = True
+
+    app = MCPInboundAuthMiddleware(downstream, "secret")
+    messages = await _run_request(
+        app,
+        headers=[(b"Authorization", b"bearer secret")],
+        client=("203.0.113.10", 1),
+    )
+
+    assert messages == []
+    assert called
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_token_only_allows_loopback_peers() -> None:
+    called = False
+
+    async def downstream(scope: Any, receive: Any, send: Any) -> None:
+        nonlocal called
+        called = True
+
+    app = MCPInboundAuthMiddleware(downstream, None)
+    local_messages = await _run_request(app, client=("127.0.0.1", 1))
+    assert local_messages == []
+    assert called
+
+    called = False
+    remote_messages = await _run_request(app, client=("203.0.113.10", 1))
+    assert remote_messages[0]["status"] == 403
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_non_http_scopes_bypass_http_auth() -> None:
+    called = False
+
+    async def downstream(scope: Any, receive: Any, send: Any) -> None:
+        nonlocal called
+        called = True
+
+    app = MCPInboundAuthMiddleware(downstream, "secret")
+    await _run_request(app, scope_type="lifespan", client=None)
+    assert called

--- a/integrations/mcp/tests/test_config.py
+++ b/integrations/mcp/tests/test_config.py
@@ -98,3 +98,36 @@ def test_transport_enum_from_env(
 ) -> None:
     monkeypatch.setenv("MEMANTO_MCP_TRANSPORT", "sse")
     assert MCPServerSettings().transport is TransportType.SSE  # type: ignore[call-arg]
+
+
+def test_remote_http_bind_requires_inbound_auth_token(
+    fake_api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MEMANTO_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.setenv("MEMANTO_MCP_HOST", "0.0.0.0")
+
+    with pytest.raises(ValidationError, match="MEMANTO_MCP_AUTH_TOKEN"):
+        MCPServerSettings()  # type: ignore[call-arg]
+
+
+def test_remote_http_bind_accepts_inbound_auth_token(
+    fake_api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token = "local-test-token"
+    monkeypatch.setenv("MEMANTO_MCP_TRANSPORT", "sse")
+    monkeypatch.setenv("MEMANTO_MCP_HOST", "0.0.0.0")
+    monkeypatch.setenv("MEMANTO_MCP_AUTH_TOKEN", token)
+
+    settings = MCPServerSettings()  # type: ignore[call-arg]
+    assert settings.auth_token_value() == token
+    assert token not in repr(settings)
+    assert token not in str(settings)
+
+
+def test_empty_inbound_auth_token_rejected(
+    fake_api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MEMANTO_MCP_AUTH_TOKEN", "   ")
+
+    with pytest.raises(ValidationError, match="MEMANTO_MCP_AUTH_TOKEN"):
+        MCPServerSettings()  # type: ignore[call-arg]

--- a/integrations/mcp/tests/test_server.py
+++ b/integrations/mcp/tests/test_server.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from mcp.shared.memory import create_connected_server_and_client_session
 from mcp.types import Implementation
@@ -17,8 +18,8 @@ from memanto.app.constants import (
 )
 from memanto.app.core import SOURCE_MAX_LENGTH, SOURCE_PATTERN
 
-from memanto_mcp.config import MCPServerSettings
-from memanto_mcp.server import build_server
+from memanto_mcp.config import MCPServerSettings, TransportType
+from memanto_mcp.server import _build_network_app, build_server
 
 MAIN_TOOL_NAMES = {
     "remember",
@@ -166,3 +167,34 @@ async def test_tool_descriptions_non_empty(fake_api_key: str) -> None:
         assert tool.description and tool.description.strip(), (
             f"Tool {tool.name!r} has an empty description"
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("transport", "path"),
+    [
+        (TransportType.SSE, "/sse"),
+        (TransportType.STREAMABLE_HTTP, "/mcp"),
+    ],
+)
+async def test_network_transport_app_is_guarded_before_mcp_routes(
+    fake_api_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+    transport: TransportType,
+    path: str,
+) -> None:
+    """The auth boundary must wrap the real FastMCP transport app."""
+    monkeypatch.setenv("MEMANTO_MCP_TRANSPORT", transport.value)
+    monkeypatch.setenv("MEMANTO_MCP_AUTH_TOKEN", "network-test-token")
+
+    settings = MCPServerSettings()  # type: ignore[call-arg]
+    mcp = build_server(settings)
+    app = _build_network_app(mcp, settings)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://127.0.0.1",
+    ) as client:
+        response = await client.get(path)
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

The MCP package exposed SSE and Streamable HTTP transports without authenticating inbound clients, while the documentation showed how to bind them to `0.0.0.0`. `MOORCHEH_API_KEY` authenticates Memanto to Moorcheh; it is not an inbound client credential.

This change adds a separate bearer token for network MCP clients, fails closed for non-loopback binds without that token, and wraps both supported HTTP transport apps before Uvicorn serves them.

Related bounty: #1852

## Security impact

With the original configuration, any client able to reach the configured MCP port could send MCP requests and use the memory operations available to the configured API key and agent. If administrative tools were enabled, agent-management operations were exposed through the same unauthenticated surface.

The patch prevents unauthenticated network clients from reaching the MCP routes when a remote bind is configured. It keeps the Moorcheh API key upstream-only and never accepts it as the inbound token.

## Reproduction basis

On the base branch:

```text
MEMANTO_MCP_TRANSPORT=streamable-http
MEMANTO_MCP_HOST=0.0.0.0
memanto-mcp --transport streamable-http --host 0.0.0.0 --port 8765
```

`run_server()` dispatched directly to `mcp.run(transport="streamable-http")` or `mcp.run(transport="sse")`, and no inbound bearer-token check existed. The README explicitly stated that inbound MCP clients were not authenticated.

This is a code/configuration reproduction. No real API key, tenant, or Moorcheh request was used.

## Changes

- Add `MEMANTO_MCP_AUTH_TOKEN` as a `SecretStr` setting.
- Require the token for HTTP/SSE transports bound to a non-loopback host.
- Wrap the real FastMCP SSE and Streamable HTTP ASGI apps before Uvicorn.
- Require `Authorization: Bearer <token>` when configured and compare with `hmac.compare_digest`.
- Keep loopback-only HTTP/SSE usage available without a token, while rejecting non-loopback peers in that mode.
- Leave stdio transport unchanged.
- Document the separate inbound token and add tests for invalid, duplicate, valid, loopback, and remote credentials.

## Verification

- `python -m pytest integrations/mcp/tests -q` — 86 passed
- `python -m ruff check integrations/mcp/memanto_mcp integrations/mcp/tests` — passed
- `python -m mypy integrations/mcp/memanto_mcp/*.py` — no issues
- Repository test suite — exit 0; live Moorcheh E2E cases were skipped because no real API key was configured, and two POSIX-permission tests were skipped on Windows

No real credentials or tenant data are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bearer-token authentication for HTTP and SSE connections.
  * Remote network bindings now require `MEMANTO_MCP_AUTH_TOKEN`.
  * Requests without valid credentials are rejected before accessing MCP routes or tools.
  * Loopback connections remain available without a token; remote unauthenticated access is blocked.

* **Documentation**
  * Updated setup instructions with token configuration and authorization header requirements.
  * Documented startup behavior and authentication responses for network transports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->