### PR TITLE
fix: stop UnicodeEncodeError when CLI output is redirected on Windows

### DIFF
--- a/memanto/cli/__init__.py
+++ b/memanto/cli/__init__.py
@@ -3,3 +3,37 @@ MEMANTO CLI Package
 
 Command-line interface for MEMANTO V2 API
 """
+
+import sys
+
+
+def _ensure_utf8_streams() -> None:
+    """Make redirected output UTF-8 so Rich glyphs cannot crash the CLI.
+
+    Rich emits box-drawing characters, bullets, em-dashes and braille spinner
+    frames. When stdout is redirected on Windows, Python encodes it with the
+    locale code page (cp1252 on most installs), which cannot represent any of
+    them, so the command dies mid-run with UnicodeEncodeError. That hits every
+    caller which captures the CLI: shell pipelines, CI logs, `> file`, and agent
+    harnesses such as Claude Code.
+
+    The encoding is the only thing worth testing. `isatty()` is not a usable
+    discriminator here: on Windows, `NUL` reports itself as a character device,
+    so `command > NUL` is a tty by that measure while still encoding as cp1252.
+    A console that already reports UTF-8 is left untouched.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            encoding = (stream.encoding or "").lower().replace("-", "").replace("_", "")
+            if encoding == "utf8":
+                continue
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            # Stream setup must never stop the CLI from starting.
+            pass
+
+
+_ensure_utf8_streams()

--- a/tests/test_cli_stream_encoding.py
+++ b/tests/test_cli_stream_encoding.py
@@ -19,26 +19,26 @@ from memanto.cli import _ensure_utf8_streams
 RICH_GLYPHS = "⠹⠦ ┌─┐ ● —"
 
 
-class FakeStream(io.StringIO):
-    """Text stream with a settable encoding that records reconfigure() calls."""
+class FakeStream:
+    """Stand-in for sys.stdout that records reconfigure() calls.
+
+    Deliberately not an io.StringIO subclass: StringIO.encoding is a writable
+    attribute, so overriding it with a property is a typing error. The helper
+    only needs the three members _ensure_utf8_streams touches.
+    """
 
     def __init__(self, encoding: str, isatty: bool = False):
-        super().__init__()
-        self._encoding = encoding
+        self.encoding = encoding
         self._isatty = isatty
         self.reconfigured: list[dict] = []
-
-    @property
-    def encoding(self) -> str:
-        return self._encoding
 
     def isatty(self) -> bool:
         return self._isatty
 
-    def reconfigure(self, **kwargs):
+    def reconfigure(self, **kwargs) -> None:
         self.reconfigured.append(kwargs)
         if "encoding" in kwargs:
-            self._encoding = kwargs["encoding"]
+            self.encoding = kwargs["encoding"]
 
 
 def _run(monkeypatch, stdout, stderr):

--- a/tests/test_cli_stream_encoding.py
+++ b/tests/test_cli_stream_encoding.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Regression tests for CLI stream encoding.
+
+Rich emits box-drawing characters, bullets and braille spinner frames. When the
+CLI's output is captured on Windows, Python encodes it with the locale code page
+(cp1252), which cannot represent any of them, and every affected command dies
+with UnicodeEncodeError before printing a result.
+
+See memanto.cli._ensure_utf8_streams.
+"""
+
+import io
+
+from memanto.cli import _ensure_utf8_streams
+
+# One frame of Rich's braille spinner, a box-drawing corner, and a bullet: the
+# exact characters that crashed `memanto recall` under cp1252.
+RICH_GLYPHS = "⠹⠦ ┌─┐ ● —"
+
+
+class FakeStream(io.StringIO):
+    """Text stream with a settable encoding that records reconfigure() calls."""
+
+    def __init__(self, encoding: str, isatty: bool = False):
+        super().__init__()
+        self._encoding = encoding
+        self._isatty = isatty
+        self.reconfigured: list[dict] = []
+
+    @property
+    def encoding(self) -> str:
+        return self._encoding
+
+    def isatty(self) -> bool:
+        return self._isatty
+
+    def reconfigure(self, **kwargs):
+        self.reconfigured.append(kwargs)
+        if "encoding" in kwargs:
+            self._encoding = kwargs["encoding"]
+
+
+def _run(monkeypatch, stdout, stderr):
+    monkeypatch.setattr("sys.stdout", stdout)
+    monkeypatch.setattr("sys.stderr", stderr)
+    _ensure_utf8_streams()
+
+
+def test_legacy_codepage_streams_are_switched_to_utf8(monkeypatch):
+    out, err = FakeStream("cp1252"), FakeStream("cp1252")
+    _run(monkeypatch, out, err)
+
+    for stream in (out, err):
+        assert stream.reconfigured == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_nul_device_is_fixed_even_though_it_claims_to_be_a_tty(monkeypatch):
+    """`command > NUL` on Windows reports isatty() True while encoding cp1252.
+
+    isatty() is therefore not a usable signal here; only the encoding is.
+    """
+    out = FakeStream("cp1252", isatty=True)
+    _run(monkeypatch, out, FakeStream("utf-8"))
+
+    assert out.reconfigured == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_utf8_streams_are_left_alone(monkeypatch):
+    out, err = FakeStream("utf-8"), FakeStream("UTF-8")
+    _run(monkeypatch, out, err)
+
+    assert out.reconfigured == []
+    assert err.reconfigured == []
+
+
+def test_utf8_alias_spellings_are_left_alone(monkeypatch):
+    out, err = FakeStream("utf8"), FakeStream("UTF_8")
+    _run(monkeypatch, out, err)
+
+    assert out.reconfigured == []
+    assert err.reconfigured == []
+
+
+def test_streams_without_reconfigure_are_skipped(monkeypatch):
+    """Captured stdout under pytest/CI may be a plain object with no reconfigure."""
+
+    class Bare:
+        encoding = "cp1252"
+
+        def isatty(self):
+            return False
+
+    _run(monkeypatch, Bare(), Bare())  # must not raise
+
+
+def test_reconfigure_failure_never_stops_the_cli(monkeypatch):
+    class Hostile(FakeStream):
+        def reconfigure(self, **kwargs):
+            raise OSError("stream is closed")
+
+    _run(monkeypatch, Hostile("cp1252"), Hostile("cp1252"))  # must not raise
+
+
+def test_rich_glyphs_survive_a_cp1252_stream_after_the_fix():
+    """End to end: the glyphs that used to crash now encode cleanly."""
+    buffer = io.BytesIO()
+    stream = io.TextIOWrapper(buffer, encoding="cp1252", errors="strict")
+
+    try:
+        stream.write(RICH_GLYPHS)
+        stream.flush()
+        raise AssertionError("cp1252 unexpectedly encoded Rich's glyphs")
+    except UnicodeEncodeError:
+        pass  # the bug this module guards against
+
+    stream.reconfigure(encoding="utf-8", errors="replace")
+    stream.write(RICH_GLYPHS)
+    stream.flush()
+
+    assert RICH_GLYPHS.encode("utf-8") in buffer.getvalue()


### PR DESCRIPTION
Rich emits box-drawing characters, bullets and braille spinner frames. When stdout is captured on Windows, Python encodes it with the locale code page (cp1252), which cannot represent any of them, so commands died mid-run:

    UnicodeEncodeError: 'charmap' codec can't encode character '⠹'

This hit every caller that captures output — shell pipelines, `> file`, CI logs, and agent harnesses such as Claude Code, which always pipe stdout. `recall`, `status`, `forget` and the other 23 console.status() sites were all affected.

Switch redirected streams to UTF-8 once, at CLI package import, before any Rich Console is built. Fixing the stream covers every call site; patching spinners would not have covered the box-drawing and bullet glyphs.

isatty() is deliberately not used to detect this: on Windows NUL reports itself as a character device, so `command > NUL` looks like a tty while still encoding as cp1252. The encoding is the only reliable signal, and streams already reporting UTF-8 are left untouched.

tests/test_cli_stream_encoding.py covers the cp1252 switch, the NUL-as-tty case, UTF-8 spellings being left alone, and failure paths never breaking startup.

Verified on Windows: recall/status/session/agent/config now exit 0 under pipe,
> /dev/null, > file, and 2>&1. tests/test_cli.py is unchanged at 9 failed /
100 passed before and after (those 9 are pre-existing ANSI assertions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line output compatibility by automatically using UTF-8 encoding when supported.
  * Prevented special characters and Rich-formatted output from failing on legacy code-page streams.
  * CLI startup now continues safely when stream reconfiguration is unavailable or unsuccessful.
  * Preserved existing UTF-8 stream behavior while improving output reliability across supported environments.
* **Tests**
  * Added coverage for legacy encodings, UTF-8 variants, unsupported streams, reconfiguration failures, and special-character output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->