### PR TITLE
fix(security): enforce client session authorization across policy, conflict, and sync operations (#1852)

### DIFF
--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -46,7 +46,9 @@ class MemantoSetup:
     """
 
     def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
         self.client = SdkClient(api_key=api_key)
+        self._clients: dict[str, SdkClient] = {}
 
     def setup(
         self,
@@ -56,8 +58,9 @@ class MemantoSetup:
         duration_hours: int = 6,
     ) -> SdkClient:
         """Create agent (if needed) and activate a session."""
+        client = SdkClient(api_key=self.api_key)
         try:
-            self.client.create_agent(
+            client.create_agent(
                 agent_id=agent_id,
                 pattern=pattern,
                 description=description,
@@ -69,14 +72,18 @@ class MemantoSetup:
             logger.error("Failed to create agent '%s': %s", agent_id, e)
             raise
 
-        self.client.activate_agent(agent_id, duration_hours=duration_hours)
+        client.activate_agent(agent_id, duration_hours=duration_hours)
+        self._clients[agent_id] = client
+        self.client = client
         logger.info("Activated session for agent '%s'", agent_id)
-        return self.client
+        return client
 
     def teardown(self, agent_id: str) -> None:
         """Deactivate the agent session."""
         try:
-            self.client.deactivate_agent(agent_id)
+            client = self._clients.get(agent_id, self.client)
+            client.deactivate_agent(agent_id)
+            self._clients.pop(agent_id, None)
             logger.info("Deactivated session for agent '%s'", agent_id)
         except Exception as e:
             logger.warning("Failed to deactivate agent '%s': %s", agent_id, e)

--- a/integrations/crewai/crewai_memanto/tools.py
+++ b/integrations/crewai/crewai_memanto/tools.py
@@ -46,6 +46,7 @@ class MemantoSetup:
     """
 
     def __init__(self, api_key: str) -> None:
+        """Initialize MemantoSetup with the provided API key."""
         self.api_key = api_key
         self.client = SdkClient(api_key=api_key)
         self._clients: dict[str, SdkClient] = {}
@@ -57,7 +58,17 @@ class MemantoSetup:
         description: str | None = None,
         duration_hours: int = 6,
     ) -> SdkClient:
-        """Create agent (if needed) and activate a session."""
+        """Create agent (if needed) and activate an isolated session.
+
+        Args:
+            agent_id: Identifier of the agent to create and activate.
+            pattern: Agent architecture pattern (e.g. 'tool', 'support', 'project').
+            description: Optional human-readable description for the agent.
+            duration_hours: Session token validity lifetime in hours.
+
+        Returns:
+            SdkClient instance bound to the newly activated agent session.
+        """
         client = SdkClient(api_key=self.api_key)
         try:
             client.create_agent(
@@ -79,11 +90,22 @@ class MemantoSetup:
         return client
 
     def teardown(self, agent_id: str) -> None:
-        """Deactivate the agent session."""
+        """Deactivate the agent session for *agent_id*.
+
+        Args:
+            agent_id: Identifier of the agent to deactivate.
+        """
         try:
-            client = self._clients.get(agent_id, self.client)
+            client = self._clients.pop(agent_id, None)
+            if client is None:
+                if self.client and getattr(self.client, "agent_id", None) == agent_id:
+                    client = self.client
+                else:
+                    logger.warning("No tracked client for agent '%s' to deactivate", agent_id)
+                    return
             client.deactivate_agent(agent_id)
-            self._clients.pop(agent_id, None)
+            if self.client is client:
+                self.client = next(iter(self._clients.values()), None)
             logger.info("Deactivated session for agent '%s'", agent_id)
         except Exception as e:
             logger.warning("Failed to deactivate agent '%s': %s", agent_id, e)

--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -384,6 +384,15 @@ def enforce_session_scope(session: Session, agent_id: str) -> None:
         )
 
 
+def _direct_client_for_session(session: Session, agent_id: str) -> DirectClient:
+    """Instantiate a DirectClient bound to the authenticated session."""
+    client = DirectClient(settings.MOORCHEH_API_KEY)
+    client.agent_id = agent_id
+    client.session_token = session.session_token
+    client._cached_session = session
+    return client
+
+
 def resolve_recall_limit(request_limit: int | None) -> int:
     """Resolve and validate the effective recall result limit."""
 
@@ -1125,8 +1134,9 @@ async def generate_daily_summary(
     resolved_date = request.date or utc_date_str()
     _validate_summary_key(agent_id, resolved_date)
     try:
+        client = _direct_client_for_session(session, agent_id)
         result = await asyncio.to_thread(
-            DirectClient(settings.MOORCHEH_API_KEY).generate_daily_summary,
+            client.generate_daily_summary,
             agent_id,
             resolved_date,
             None,
@@ -1157,8 +1167,9 @@ async def generate_conflict_report(
     resolved_date = request.date or utc_date_str()
     _validate_summary_key(agent_id, resolved_date)
     try:
+        client = _direct_client_for_session(session, agent_id)
         result = await asyncio.to_thread(
-            DirectClient(settings.MOORCHEH_API_KEY).generate_conflict_report,
+            client.generate_conflict_report,
             agent_id,
             resolved_date,
         )
@@ -1192,8 +1203,9 @@ async def list_conflicts(
     resolved_date = date or utc_date_str()
     _validate_summary_key(agent_id, resolved_date)
     try:
+        client = _direct_client_for_session(session, agent_id)
         conflicts = await asyncio.to_thread(
-            DirectClient(settings.MOORCHEH_API_KEY).list_conflicts,
+            client.list_conflicts,
             agent_id,
             resolved_date,
         )
@@ -1224,8 +1236,9 @@ async def resolve_conflict(
     resolved_date = request.date or utc_date_str()
     _validate_summary_key(agent_id, resolved_date)
     try:
+        client = _direct_client_for_session(session, agent_id)
         result = await asyncio.to_thread(
-            DirectClient(settings.MOORCHEH_API_KEY).resolve_conflict,
+            client.resolve_conflict,
             agent_id,
             resolved_date,
             request.conflict_index,

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -393,11 +393,23 @@ class DirectClient:
             # Surface the same specific session errors as the service
             raise
 
+        if token_payload.agent_id != agent_id:
+            raise SessionError(
+                f"Session token is for agent '{token_payload.agent_id}', "
+                f"cannot access '{agent_id}'"
+            )
+
         # Load the persisted session record
         session = session_service.get_session(token_payload.agent_id)
         if not session:
             raise SessionNotFoundError(
                 f"Session for agent {token_payload.agent_id} not found"
+            )
+
+        if session.agent_id != agent_id:
+            raise SessionError(
+                f"Session record is for agent '{session.agent_id}', "
+                f"cannot access '{agent_id}'"
             )
 
         # Check and auto-renew if near expiry. SessionService.renew_session

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -1064,6 +1064,7 @@ class DirectClient:
 
     def get_policy(self, agent_id: str) -> dict[str, Any]:
         """Return the agent's expiry policy as a plain dict."""
+        self._get_validated_session_for_agent(agent_id)
         policy = self._get_policy_service().load_policy(agent_id)
         return {
             "agent_id": agent_id,
@@ -1076,6 +1077,7 @@ class DirectClient:
 
         Saving does not expire anything; run :meth:`apply_policy` afterwards.
         """
+        self._get_validated_session_for_agent(agent_id)
         from memanto.app.services.memory_policy_service import MemoryPolicy
 
         parsed = MemoryPolicy(**policy)
@@ -1109,6 +1111,7 @@ class DirectClient:
 
     def apply_policy_preset(self, agent_id: str, name: str) -> dict[str, Any]:
         """Adopt a predefined policy bundle as the agent's policy."""
+        self._get_validated_session_for_agent(agent_id)
         from memanto.app.services.policy_presets import load_preset
 
         policy = load_preset(name)
@@ -1440,6 +1443,7 @@ class DirectClient:
         Returns:
             Dict with ``summary`` and ``export`` sub-results.
         """
+        self._get_validated_session_for_agent(agent_id)
         # Ensure agent exists
         self.get_agent(agent_id)
 
@@ -1483,6 +1487,7 @@ class DirectClient:
         Returns:
             Dict with ``conflicts`` sub-result.
         """
+        self._get_validated_session_for_agent(agent_id)
         # Ensure agent exists
         self.get_agent(agent_id)
 
@@ -1512,7 +1517,7 @@ class DirectClient:
             List of unresolved conflict dicts, each with a stable ``index``
             into the full conflict report.
         """
-
+        self._get_validated_session_for_agent(agent_id)
         if not date:
             date = utc_date_str()
 
@@ -1560,7 +1565,7 @@ class DirectClient:
         Returns:
             Dict with resolution result.
         """
-
+        self._get_validated_session_for_agent(agent_id)
         valid_actions = {
             "keep_old",
             "keep_new",
@@ -1796,6 +1801,7 @@ class DirectClient:
             previous export was reused instead).
         """
         validate_safe_id(agent_id, "agent_id")
+        self._get_validated_session_for_agent(agent_id)
         cache_path = get_data_dir() / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1917,6 +1923,8 @@ class DirectClient:
         project. Falls back to the previous cached bundle when the backend is
         unreachable (``source="stale-cache"``).
         """
+        validate_safe_id(agent_id, "agent_id")
+        self._get_validated_session_for_agent(agent_id)
         target = Path(project_dir) / "okf"
         cache = Path.home() / ".memanto" / "exports" / f"{agent_id}_okf"
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -225,11 +225,23 @@ class SdkClient:
             # Surface the same specific session errors as the service
             raise
 
+        if token_payload.agent_id != agent_id:
+            raise SessionError(
+                f"Session token is for agent '{token_payload.agent_id}', "
+                f"cannot access '{agent_id}'"
+            )
+
         # Load the persisted session record
         session = session_service.get_session(token_payload.agent_id)
         if not session:
             raise SessionNotFoundError(
                 f"Session for agent {token_payload.agent_id} not found"
+            )
+
+        if session.agent_id != agent_id:
+            raise SessionError(
+                f"Session record is for agent '{session.agent_id}', "
+                f"cannot access '{agent_id}'"
             )
 
         # Check and auto-renew if near expiry. SessionService.renew_session

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -890,6 +890,7 @@ class SdkClient:
 
     def get_policy(self, agent_id: str) -> dict[str, Any]:
         """Return the agent's expiry policy as a plain dict."""
+        self._get_validated_session_for_agent(agent_id)
         policy = self._get_policy_service().load_policy(agent_id)
         return {
             "agent_id": agent_id,
@@ -902,6 +903,7 @@ class SdkClient:
 
         Saving does not expire anything; run :meth:`apply_policy` afterwards.
         """
+        self._get_validated_session_for_agent(agent_id)
         from memanto.app.services.memory_policy_service import MemoryPolicy
 
         parsed = MemoryPolicy(**policy)
@@ -935,6 +937,7 @@ class SdkClient:
 
     def apply_policy_preset(self, agent_id: str, name: str) -> dict[str, Any]:
         """Adopt a predefined policy bundle as the agent's policy."""
+        self._get_validated_session_for_agent(agent_id)
         from memanto.app.services.policy_presets import load_preset
 
         policy = load_preset(name)
@@ -1316,6 +1319,7 @@ class SdkClient:
         Returns:
             Dict with ``summary`` and ``export`` sub-results.
         """
+        self._get_validated_session_for_agent(agent_id)
         # Ensure agent exists
         self.get_agent(agent_id)
 
@@ -1359,6 +1363,7 @@ class SdkClient:
         Returns:
             Dict with ``conflicts`` sub-result.
         """
+        self._get_validated_session_for_agent(agent_id)
         # Ensure agent exists
         self.get_agent(agent_id)
 
@@ -1388,6 +1393,7 @@ class SdkClient:
             List of unresolved conflict dicts, each with a stable ``index``
             into the full conflict report.
         """
+        self._get_validated_session_for_agent(agent_id)
         if not date:
             date = utc_date_str()
 
@@ -1435,6 +1441,7 @@ class SdkClient:
         Returns:
             Dict with resolution result.
         """
+        self._get_validated_session_for_agent(agent_id)
         valid_actions = {
             "keep_old",
             "keep_new",
@@ -1661,6 +1668,7 @@ class SdkClient:
             previous export was reused instead).
         """
         validate_safe_id(agent_id, "agent_id")
+        self._get_validated_session_for_agent(agent_id)
         cache_path = get_data_dir() / "exports" / f"{agent_id}_memory.md"
         target_path = Path(project_dir) / "MEMORY.md"
         target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1781,6 +1789,8 @@ class SdkClient:
         project. Falls back to the previous cached bundle when the backend is
         unreachable (``source="stale-cache"``).
         """
+        validate_safe_id(agent_id, "agent_id")
+        self._get_validated_session_for_agent(agent_id)
         target = Path(project_dir) / "okf"
         cache = Path.home() / ".memanto" / "exports" / f"{agent_id}_okf"
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -388,6 +388,9 @@ class TestExportDataDirRouting:
 
         for client_cls in (DirectClient, SdkClient):
             client = client_cls(api_key="dummy-key")
+            monkeypatch.setattr(
+                client, "_get_validated_session_for_agent", lambda agent_id: None
+            )
             export_calls = []
 
             def failing_export(export_calls=export_calls, **kwargs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,6 +152,9 @@ def _make_direct_client(tmp_path, monkeypatch):
         direct_client_module.Path, "home", classmethod(lambda cls: tmp_path)
     )
     client = DirectClient(api_key="test-key")
+    monkeypatch.setattr(
+        client, "_get_validated_session_for_agent", lambda agent_id: None
+    )
     mock_write = MagicMock()
     mock_write.delete_memory.return_value = True
     mock_write.store_memory.return_value = {"id": "manual_new"}

--- a/tests/test_client_session_authorization.py
+++ b/tests/test_client_session_authorization.py
@@ -3,13 +3,15 @@ Tests for client-level session authorization enforcement.
 
 Verifies that SdkClient and DirectClient enforce session validation across all
 memory lifecycle operations, policy management, conflict resolution, daily
-summaries, and project sync methods. Calls without an active session or targeting
-a different agent must raise SessionError.
+summaries, and project sync methods. Calls without an active session, with a
+mismatched agent ID, or with a token issued for another agent must raise
+SessionError.
 """
 
 from unittest.mock import MagicMock
 import pytest
 
+from memanto.app.services.session_service import SessionService
 from memanto.app.utils.errors import SessionError
 from memanto.cli.client.direct_client import DirectClient
 from memanto.cli.client.sdk_client import SdkClient
@@ -19,47 +21,56 @@ from memanto.cli.client.sdk_client import SdkClient
 class TestClientSessionAuthorizationUnauthenticated:
     """Ensure all critical client methods require active agent session validation."""
 
-    def test_get_policy_unauthorized_raises(self, client_cls):
+    def test_get_policy_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify get_policy raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.get_policy(agent_id="victim-agent")
 
-    def test_set_policy_unauthorized_raises(self, client_cls):
+    def test_set_policy_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify set_policy raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.set_policy(agent_id="victim-agent", policy={"rules": []})
 
-    def test_apply_policy_preset_unauthorized_raises(self, client_cls):
+    def test_apply_policy_preset_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify apply_policy_preset raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.apply_policy_preset(agent_id="victim-agent", name="assistant")
 
-    def test_apply_policy_unauthorized_raises(self, client_cls):
+    def test_apply_policy_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify apply_policy raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.apply_policy(agent_id="victim-agent")
 
-    def test_purge_expired_unauthorized_raises(self, client_cls):
+    def test_purge_expired_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify purge_expired raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.purge_expired(agent_id="victim-agent")
 
-    def test_generate_daily_summary_unauthorized_raises(self, client_cls):
+    def test_generate_daily_summary_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify generate_daily_summary raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.generate_daily_summary(agent_id="victim-agent", date="2026-08-25")
 
-    def test_generate_conflict_report_unauthorized_raises(self, client_cls):
+    def test_generate_conflict_report_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify generate_conflict_report raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.generate_conflict_report(agent_id="victim-agent", date="2026-08-25")
 
-    def test_list_conflicts_unauthorized_raises(self, client_cls):
+    def test_list_conflicts_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify list_conflicts raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.list_conflicts(agent_id="victim-agent")
 
-    def test_resolve_conflict_unauthorized_raises(self, client_cls):
+    def test_resolve_conflict_unauthorized_raises(self, client_cls: type) -> None:
+        """Verify resolve_conflict raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.resolve_conflict(
@@ -69,7 +80,8 @@ class TestClientSessionAuthorizationUnauthenticated:
                 action="keep_newer",
             )
 
-    def test_sync_memory_to_project_unauthorized_raises(self, client_cls, tmp_path):
+    def test_sync_memory_to_project_unauthorized_raises(self, client_cls: type, tmp_path) -> None:
+        """Verify sync_memory_to_project raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.sync_memory_to_project(
@@ -77,7 +89,8 @@ class TestClientSessionAuthorizationUnauthenticated:
                 project_dir=str(tmp_path),
             )
 
-    def test_sync_okf_to_project_unauthorized_raises(self, client_cls, tmp_path):
+    def test_sync_okf_to_project_unauthorized_raises(self, client_cls: type, tmp_path) -> None:
+        """Verify sync_okf_to_project raises SessionError when called without active session."""
         client = client_cls(api_key="test-api-key")
         with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
             client.sync_okf_to_project(
@@ -90,7 +103,8 @@ class TestClientSessionAuthorizationUnauthenticated:
 class TestClientSessionAuthorizationCrossAgentMismatch:
     """Ensure an active session for Agent A cannot be used to operate on Agent B."""
 
-    def test_cross_agent_operations_rejected(self, client_cls, monkeypatch, tmp_path):
+    def test_cross_agent_operations_rejected(self, client_cls: type, monkeypatch, tmp_path) -> None:
+        """Verify client rejects all operations targeting agent-b when authenticated as agent-a."""
         client = client_cls(api_key="test-api-key")
         client.agent_id = "agent-a"
         client.session_token = "token-for-agent-a"
@@ -147,3 +161,54 @@ class TestClientSessionAuthorizationCrossAgentMismatch:
                 agent_id="agent-b",
                 project_dir=str(tmp_path),
             )
+
+
+@pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+class TestColdValidatorCrossAgentTokenSpoofing:
+    """Exercise the real cold session validator against token spoofing attempts."""
+
+    def test_token_issued_for_agent_a_rejected_when_spoofing_agent_b(
+        self, client_cls: type, tmp_path, monkeypatch
+    ) -> None:
+        """Verify real JWT validator rejects token issued for agent-a when accessing agent-b."""
+        sessions_dir = tmp_path / "sessions"
+        service = SessionService(
+            secret_key="test-secret-key-32-bytes-long-secure!!", sessions_dir=sessions_dir
+        )
+        session_a = service.create_session(agent_id="agent-a", duration_hours=1)
+
+        client = client_cls(api_key="test-api-key")
+        monkeypatch.setattr(client, "_get_session_service", lambda: service)
+
+        # Attacker sets client.agent_id to 'agent-b' but provides agent-a's token
+        client.agent_id = "agent-b"
+        client.session_token = session_a.session_token
+
+        with pytest.raises(SessionError, match="Session token is for agent 'agent-a', cannot access 'agent-b'"):
+            client._get_validated_session_for_agent("agent-b")
+
+    def test_cached_session_mismatch_invalidates_cache_and_rejects(
+        self, client_cls: type, tmp_path, monkeypatch
+    ) -> None:
+        """Verify cached session for agent-a cannot be reused for agent-b."""
+        sessions_dir = tmp_path / "sessions"
+        service = SessionService(
+            secret_key="test-secret-key-32-bytes-long-secure!!", sessions_dir=sessions_dir
+        )
+        session_a = service.create_session(agent_id="agent-a", duration_hours=1)
+
+        client = client_cls(api_key="test-api-key")
+        monkeypatch.setattr(client, "_get_session_service", lambda: service)
+
+        client.agent_id = "agent-a"
+        client.session_token = session_a.session_token
+        # Populate cached session for agent-a
+        valid_a = client._get_validated_session_for_agent("agent-a")
+        assert valid_a.agent_id == "agent-a"
+        assert client._cached_session is not None
+
+        # Attempt to access agent-b
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', cannot access 'agent-b'"):
+            client._get_validated_session_for_agent("agent-b")
+        # Cache must have been cleared
+        assert client._cached_session is None

--- a/tests/test_client_session_authorization.py
+++ b/tests/test_client_session_authorization.py
@@ -212,3 +212,58 @@ class TestColdValidatorCrossAgentTokenSpoofing:
             client._get_validated_session_for_agent("agent-b")
         # Cache must have been cleared
         assert client._cached_session is None
+
+    def test_session_record_mismatch_rejected_even_when_token_matches(
+        self, client_cls: type, tmp_path, monkeypatch
+    ) -> None:
+        """Verify the session-record check rejects a mismatched stored record.
+
+        This guards the second, defence-in-depth check in
+        `_get_validated_session_for_agent`:
+
+            session = session_service.get_session(token_payload.agent_id)
+            if session.agent_id != agent_id:      # <- this one
+                raise SessionError(...)
+
+        It cannot be reached through the ordinary spoofing path, because the
+        token check above it already rejects a token whose subject differs from
+        the requested agent, and the record is then loaded by that same subject.
+        The check only fires when the session store hands back a record for a
+        different agent than the one asked for -- a corrupted or tampered
+        `~/.memanto/sessions/{agent}.json`, or a store-level bug.
+
+        A mutation run showed this was necessary: replacing the condition with
+        `if False` left the whole suite green, so the guard was shipped
+        unprotected. The token-payload checks at direct_client.py:396 and
+        sdk_client.py:228 were each caught by an existing test; these two
+        record-level checks were not.
+        """
+        sessions_dir = tmp_path / "sessions"
+        service = SessionService(
+            secret_key="test-secret-key-32-bytes-long-secure!!", sessions_dir=sessions_dir
+        )
+        session_b = service.create_session(agent_id="agent-b", duration_hours=1)
+
+        client = client_cls(api_key="test-api-key")
+        monkeypatch.setattr(client, "_get_session_service", lambda: service)
+
+        # Token really is for agent-b, so the token-payload check passes.
+        client.agent_id = "agent-b"
+        client.session_token = session_b.session_token
+
+        # Simulate the store returning a record belonging to someone else.
+        real_get_session = service.get_session
+
+        def _tampered_get_session(agent_id: str):
+            record = real_get_session(agent_id)
+            if record is not None:
+                record.agent_id = "attacker-agent"
+            return record
+
+        monkeypatch.setattr(service, "get_session", _tampered_get_session)
+
+        with pytest.raises(
+            SessionError,
+            match="Session record is for agent 'attacker-agent', cannot access 'agent-b'",
+        ):
+            client._get_validated_session_for_agent("agent-b")

--- a/tests/test_client_session_authorization.py
+++ b/tests/test_client_session_authorization.py
@@ -1,0 +1,149 @@
+"""
+Tests for client-level session authorization enforcement.
+
+Verifies that SdkClient and DirectClient enforce session validation across all
+memory lifecycle operations, policy management, conflict resolution, daily
+summaries, and project sync methods. Calls without an active session or targeting
+a different agent must raise SessionError.
+"""
+
+from unittest.mock import MagicMock
+import pytest
+
+from memanto.app.utils.errors import SessionError
+from memanto.cli.client.direct_client import DirectClient
+from memanto.cli.client.sdk_client import SdkClient
+
+
+@pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+class TestClientSessionAuthorizationUnauthenticated:
+    """Ensure all critical client methods require active agent session validation."""
+
+    def test_get_policy_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.get_policy(agent_id="victim-agent")
+
+    def test_set_policy_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.set_policy(agent_id="victim-agent", policy={"rules": []})
+
+    def test_apply_policy_preset_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.apply_policy_preset(agent_id="victim-agent", name="assistant")
+
+    def test_apply_policy_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.apply_policy(agent_id="victim-agent")
+
+    def test_purge_expired_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.purge_expired(agent_id="victim-agent")
+
+    def test_generate_daily_summary_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.generate_daily_summary(agent_id="victim-agent", date="2026-08-25")
+
+    def test_generate_conflict_report_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.generate_conflict_report(agent_id="victim-agent", date="2026-08-25")
+
+    def test_list_conflicts_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.list_conflicts(agent_id="victim-agent")
+
+    def test_resolve_conflict_unauthorized_raises(self, client_cls):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.resolve_conflict(
+                agent_id="victim-agent",
+                date="2026-08-25",
+                conflict_index=0,
+                action="keep_newer",
+            )
+
+    def test_sync_memory_to_project_unauthorized_raises(self, client_cls, tmp_path):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.sync_memory_to_project(
+                agent_id="victim-agent",
+                project_dir=str(tmp_path),
+            )
+
+    def test_sync_okf_to_project_unauthorized_raises(self, client_cls, tmp_path):
+        client = client_cls(api_key="test-api-key")
+        with pytest.raises(SessionError, match="No active session|Session.*expired|activate_agent"):
+            client.sync_okf_to_project(
+                agent_id="victim-agent",
+                project_dir=str(tmp_path),
+            )
+
+
+@pytest.mark.parametrize("client_cls", [SdkClient, DirectClient])
+class TestClientSessionAuthorizationCrossAgentMismatch:
+    """Ensure an active session for Agent A cannot be used to operate on Agent B."""
+
+    def test_cross_agent_operations_rejected(self, client_cls, monkeypatch, tmp_path):
+        client = client_cls(api_key="test-api-key")
+        client.agent_id = "agent-a"
+        client.session_token = "token-for-agent-a"
+
+        def mock_validate(target_agent_id):
+            if target_agent_id != client.agent_id:
+                raise SessionError(
+                    f"Active session is for agent '{client.agent_id}', not '{target_agent_id}'"
+                )
+            return MagicMock()
+
+        monkeypatch.setattr(client, "_get_validated_session_for_agent", mock_validate)
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.get_policy(agent_id="agent-b")
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.set_policy(agent_id="agent-b", policy={"rules": []})
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.apply_policy_preset(agent_id="agent-b", name="assistant")
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.apply_policy(agent_id="agent-b")
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.purge_expired(agent_id="agent-b")
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.generate_daily_summary(agent_id="agent-b", date="2026-08-25")
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.generate_conflict_report(agent_id="agent-b", date="2026-08-25")
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.list_conflicts(agent_id="agent-b")
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.resolve_conflict(
+                agent_id="agent-b",
+                date="2026-08-25",
+                conflict_index=0,
+                action="keep_newer",
+            )
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.sync_memory_to_project(
+                agent_id="agent-b",
+                project_dir=str(tmp_path),
+            )
+
+        with pytest.raises(SessionError, match="Active session is for agent 'agent-a', not 'agent-b'"):
+            client.sync_okf_to_project(
+                agent_id="agent-b",
+                project_dir=str(tmp_path),
+            )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2485,6 +2485,9 @@ def test_direct_sync_exports_fresh_before_copying(tmp_path, monkeypatch):
     cache_path.write_text("# MEMORY\n\n### stale memory\n", encoding="utf-8")
 
     client = DirectClient.__new__(DirectClient)
+    monkeypatch.setattr(
+        client, "_get_validated_session_for_agent", lambda agent_id: None
+    )
     export_calls = []
 
     def fresh_export(*, agent_id, limit_per_type):


### PR DESCRIPTION
### Security: Enforce Client Session Validation across Policy, Conflict, and Sync Operations

Fixes #1852

#### Summary
Resolves Broken Object-Level Authorization (BOLA) and IDOR risks across client interfaces by enforcing `_get_validated_session_for_agent(agent_id)` on administrative, conflict resolution, retention policy management, and project export synchronization methods.

#### Changes
1. **Client Authorization Guards (`memanto/cli/client/sdk_client.py`, `memanto/cli/client/direct_client.py`)**:
   - Added mandatory session validation checks to `get_policy`, `set_policy`, `apply_policy_preset`, `generate_daily_summary`, `generate_conflict_report`, `list_conflicts`, `resolve_conflict`, `sync_memory_to_project`, and `sync_okf_to_project`.
2. **Threadpool Session Propagation (`memanto/app/routes/memory.py`)**:
   - Added `_direct_client_for_session` to bind authenticated FastAPI session tokens into worker thread client instances.
3. **CrewAI Client Isolation (`integrations/crewai/crewai_memanto/tools.py`)**:
   - Updated `MemantoSetup` with a per-agent client pool (`_clients`) to prevent multi-agent session token overwriting.
4. **Regression Tests (`tests/test_client_session_authorization.py`)**:
   - Added 24 dedicated test cases covering unauthenticated access rejection and cross-agent session mismatch rejections. All 903 tests pass.

*Note: Sensitive vulnerability details and full proof-of-concept steps have been disclosed directly to `support@moorcheh.ai` in accordance with the security challenge guidelines.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added session validation for policy management, memory operations, summaries, conflict handling, and project synchronization.
  - Restricted operations to authenticated, active sessions for the specified agent.
  - Prevented access when session tokens or stored credentials belong to a different agent.

- **Bug Fixes**
  - Ensured agent-specific clients and session credentials are consistently used.
  - Improved client cleanup when agent sessions are deactivated.

- **Tests**
  - Added coverage for unauthenticated, cross-agent, spoofed-token, and mismatched-session access attempts.
  - Updated export and conflict-resolution tests for session-aware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->