### PR TITLE
feat(migrate): ChatGPT export adapter + OKF bundle generator (Path B, #1609)

### DIFF
--- a/examples/migrations/chatgpt-okf/README.md
+++ b/examples/migrations/chatgpt-okf/README.md
@@ -1,0 +1,73 @@
+# ChatGPT -> OKF: Own Your Agentic Memory
+
+> **Path B / C showcase for [memanto #1609](https://github.com/moorcheh-ai/memanto/issues/1609).**
+> The most viral freedom loop in agentic memory: take the memory ChatGPT built
+> about you, and own it as plain, portable, git-friendly markdown.
+
+## What this does
+
+ChatGPT's official account export (`conversations.json`) is a graph of every
+message across every conversation. Your own statements -- preferences, facts,
+commitments, decisions -- are the highest-value memory you can carry out.
+
+This adapter:
+
+1. Parses the export and walks the **active branch** of every conversation
+   (dead branches from regenerations and edits are skipped).
+2. Extracts your **user-authored messages** as structured memory records.
+3. Renders them as an **OKF bundle** -- one markdown file per conversation,
+   with YAML frontmatter that round-trips back into Memanto via
+   `memanto migrate okf`.
+
+## Quick start
+
+```bash
+# 1. Export your ChatGPT data (Settings -> Data controls -> Export).
+#    Unzip it and find conversations.json.
+
+# 2. Generate the OKF bundle:
+python3 export_okf.py /path/to/conversations.json ./chatgpt-okf
+
+# 3. Preview the mapping (no writes):
+memanto migrate okf ./chatgpt-okf --dry-run
+
+# 4. Import into your agent:
+memanto migrate okf ./chatgpt-okf --agent my-agent
+```
+
+## What you get
+
+```
+chatgpt-okf/
+  memories/
+    trip-planning-conv-2.md            # one file per conversation
+    python-debugging-help-conv-1.md
+```
+
+Each memory is a self-contained markdown document with `type`, `tags`,
+`generated` (`by` / `at`), `resource`, and an `x_memanto` block, following
+the OKF v0.2 layout (frontmatter `okf_version: 0.2`, generated-at metadata
+under `extra.generated.at` after import). The whole bundle is versionable in
+git, human-readable, and importable anywhere that understands OKF.
+
+## Also available as a first-class CLI command
+
+The same adapter ships as `memanto migrate chatgpt` (dry-run supported):
+
+```bash
+memanto migrate chatgpt ./conversations.json --dry-run
+memanto migrate chatgpt ./conversations.json --agent my-agent
+```
+
+This maps straight into Memanto's schema without the intermediate OKF files.
+
+## Notes
+
+- **Offline & network-free**: no OpenAI SDK, no network calls. Requires
+  PyYAML (`pip install pyyaml`) -- it is part of Memanto's own dependencies.
+  The adapter in `memanto/cli/migrate/chatgpt_export.py` is pure stdlib.
+- **Bounded**: capped at 1000 conversations / 4000 chars per message so huge
+  archives stay fast.
+- **Type-aware**: `type` is left unset so Memanto's parsing service
+  auto-classifies each statement (preference, fact, commitment...).
+- System messages, assistant messages, and empty nodes are never imported.

--- a/examples/migrations/chatgpt-okf/export_okf.py
+++ b/examples/migrations/chatgpt-okf/export_okf.py
@@ -1,0 +1,239 @@
+"""
+Export a ChatGPT data export into a portable OKF (Open Knowledge Format)
+bundle.
+
+This is the "portability" half of the #1609 migration showcase: after you map
+your ChatGPT statements into memory records, this script renders them as an
+OKF bundle -- one self-contained markdown file per conversation, with YAML
+frontmatter that round-trips back into Memanto via ``memanto migrate okf``.
+
+Usage:
+    python3 export_okf.py <conversations.json> <out-dir> [--limit N]
+
+The output layout matches Memanto's own OKF exports:
+    <out-dir>/
+        memories/
+            <slug>-<conversation-id>.md
+
+Each file uses the ``<!-- okf-entry -->`` delimiter so multiple memories from
+the same conversation stay in one readable document, exactly like Memanto's
+``memory export --okf`` output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from memanto.cli.migrate.chatgpt_export import (
+        export_chatgpt_memories,
+        load_conversations,
+    )
+except ImportError:  # running from a source checkout without installing the package
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+    from memanto.cli.migrate.chatgpt_export import (  # type: ignore[no-redef]
+        export_chatgpt_memories,
+        load_conversations,
+    )
+
+import yaml  # type: ignore[import-untyped]
+
+ENTRY_DELIMITER = "<!-- okf-entry -->"
+_MAX_SLUG = 60
+_MAX_DESC = 200
+_WINDOWS_RESERVED = {
+    "CON", "PRN", "AUX", "NUL",
+    "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+    "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+}
+
+
+def _slugify(title: str) -> str:
+    """Turn a conversation title into a short lowercase slug for filenames."""
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:_MAX_SLUG] or "conversation"
+
+
+def _safe_component(value: Any, fallback: str = "conv") -> str:
+    """Return a filesystem-safe identifier from an untrusted source string.
+
+    Only ASCII letters/digits/hyphen/underscore survive; anything else is
+    stripped. This neutralizes path-traversal attempts (``../``, absolute
+    paths) and over-long or exotic IDs before they reach the output path.
+    """
+    text = str(value or "")
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "", text)
+    cleaned = cleaned[:_MAX_SLUG].rstrip(". ")
+    if cleaned.upper() in _WINDOWS_RESERVED or not cleaned:
+        return fallback
+    return cleaned
+
+
+def _unique_name(prefix: str, key: str) -> str:
+    """Return ``prefix-<hash8>`` so sanitized keys never collide."""
+    digest = hashlib.sha1(key.encode("utf-8")).hexdigest()[:8]
+    return f"{prefix}-{digest}"
+
+
+def _conversation_id(mem: dict[str, Any]) -> str:
+    """Extract the conversation id from a memory's ``id`` (``<conv>:<node>``)."""
+    raw = str(mem.get("id") or "")
+    return raw.split(":", 1)[0] if ":" in raw else raw
+
+
+def _render_mem_to_okf(mem: dict[str, Any]) -> str:
+    """Render one memory record as an OKF markdown document."""
+    content = (mem.get("content") or "").strip()
+    content = content.replace(ENTRY_DELIMITER, "<!-- okf-entry (escaped) -->")
+    raw_tags = mem.get("tags") or []
+    if isinstance(raw_tags, str):
+        raw_tags = [raw_tags]
+    tags = [str(t) for t in raw_tags if t]
+    created = mem.get("created_at")
+    source_ref = mem.get("id") or ""
+
+    front: dict[str, Any] = {
+        "type": "memory",
+        "title": mem.get("title") or content[:_MAX_SLUG] or "Untitled",
+        "okf_version": "0.2",
+    }
+    first_line = ""
+    if content:
+        first_line = content.splitlines()[0].strip().lstrip("#").strip()
+        first_line = first_line[:_MAX_DESC]
+    if first_line:
+        front["description"] = first_line
+    if tags:
+        front["tags"] = tags
+    if created:
+        # OKF v0.2: exporters carry provenance + generated-at metadata in a
+        # top-level `generated` block; the loader keeps it as `extra` and
+        # map_okf reads `extra.generated.at` for created_at.
+        source = mem.get("source") or "process:chatgpt"
+        front["generated"] = {
+            "by": source,
+            "at": _iso_timestamp(created),
+        }
+    if source_ref:
+        front["resource"] = source_ref
+
+    front["x_memanto"] = {
+        "source": "chatgpt",
+        "provenance": "imported",
+        "confidence": 0.7,
+    }
+
+    rendered = yaml.safe_dump(
+        front,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ).strip()
+    return f"---\n{rendered}\n---\n\n{content}\n"
+
+
+def write_okf_bundle(
+    export: dict[str, Any],
+    out_dir: Path,
+    *,
+    limit: int | None = None,
+    force: bool = False,
+) -> list[Path]:
+    """Write one .md file per conversation (memories joined by OKF delimiter)."""
+    memories = export.get("memories", [])
+    if limit is not None:
+        memories = memories[:limit]
+
+    # Group by conversation id (unique) rather than title (may repeat), so
+    # same-titled conversations never cross-contaminate one file.
+    by_conv: dict[str, list[dict[str, Any]]] = {}
+    conv_titles: dict[str, str] = {}
+    for mem in memories:
+        conv_id = _conversation_id(mem) or "misc"
+        by_conv.setdefault(conv_id, []).append(mem)
+        conv_tag = next(
+            (t for t in (mem.get("tags") or []) if str(t).startswith("conversation:")),
+            None,
+        )
+        if conv_tag:
+            conv_titles.setdefault(conv_id, str(conv_tag).split(":", 1)[1])
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    memories_dir = out_dir / "memories"
+    memories_dir.mkdir(parents=True, exist_ok=True)
+
+    # Phase 1 — compute every target and validate collisions BEFORE writing
+    # anything, so a conflict never leaves a partially-written bundle behind.
+    plans: list[tuple[Path, str]] = []
+    for conv_id, items in by_conv.items():
+        title = conv_titles.get(conv_id, "conversation")
+        slug = _slugify(title)
+        safe_id = _safe_component(conv_id)
+        target = memories_dir / f"{_unique_name(f'{slug}-{safe_id}', conv_id)}.md"
+        docs = [_render_mem_to_okf(mem) for mem in items]
+        plans.append((target, f"\n{ENTRY_DELIMITER}\n".join(docs)))
+
+    if not force:
+        existing = [p for p, _ in plans if p.exists()]
+        if existing:
+            names = ", ".join(p.name for p in existing[:5])
+            raise FileExistsError(
+                f"{len(existing)} file(s) already exist ({names}); "
+                "pass --force to overwrite"
+            )
+
+    # Phase 2 — write everything.
+    written: list[Path] = []
+    for target, body in plans:
+        target.write_text(body, encoding="utf-8")
+        written.append(target)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: parse a ChatGPT export and write an OKF bundle."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("conversations", type=Path, help="path to conversations.json")
+    parser.add_argument("out_dir", type=Path, help="output OKF bundle directory")
+    parser.add_argument("--limit", type=int, default=None, help="max memories to export")
+    parser.add_argument("--force", action="store_true", help="overwrite existing files")
+    args = parser.parse_args(argv)
+
+    if not args.conversations.exists():
+        parser.error(f"not found: {args.conversations}")
+
+    try:
+        conversations = load_conversations(args.conversations)
+        export = export_chatgpt_memories(conversations)
+        written = write_okf_bundle(
+            export, args.out_dir, limit=args.limit, force=args.force
+        )
+    except (FileNotFoundError, OSError, ValueError, FileExistsError, TypeError) as exc:
+        parser.error(f"{exc}")
+    print(f"Exported {len(written)} files -> {args.out_dir}")
+    return 0
+
+
+def _iso_timestamp(value: Any) -> str:
+    """Normalize a unix-epoch or ISO timestamp into an ISO-8601 UTC string."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+    text = str(value)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return text
+    return dt.isoformat() if dt.tzinfo else dt.replace(tzinfo=timezone.utc).isoformat()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/migrations/chatgpt-okf/export_okf.py
+++ b/examples/migrations/chatgpt-okf/export_okf.py
@@ -224,7 +224,10 @@ def main(argv: list[str] | None = None) -> int:
 def _iso_timestamp(value: Any) -> str:
     """Normalize a unix-epoch or ISO timestamp into an ISO-8601 UTC string."""
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+        try:
+            return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+        except (OverflowError, OSError, ValueError):
+            return str(value)
     text = str(value)
     if text.endswith("Z"):
         text = text[:-1] + "+00:00"

--- a/memanto/cli/commands/migrate.py
+++ b/memanto/cli/commands/migrate.py
@@ -690,6 +690,125 @@ def migrate_supermemory(
     )
 
 
+@migrate_app.command("chatgpt")
+def migrate_chatgpt(
+    file: Path = typer.Argument(
+        ...,
+        help="Path to the ChatGPT 'conversations.json' from your data export.",
+    ),
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help="Target Memanto agent id (defaults to the active agent).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the mapping without writing.",
+    ),
+):
+    """Import a ChatGPT account export into the active (or selected) agent.
+
+    Like the OKF import, ChatGPT is a local file -- no API key and no savings
+    report. The adapter walks the active branch of every conversation and
+    imports your own statements (preferences, facts, commitments) as memories.
+
+    Examples:
+        memanto migrate chatgpt ./conversations.json --dry-run
+        memanto migrate chatgpt ./conversations.json --agent my-agent
+    """
+    if not file.exists():
+        _error(
+            f"ChatGPT export not found: {file}",
+            hint="Export your data at chatgpt.com -> Settings -> Data controls -> Export.",
+        )
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = config_manager.get_migrate_dir("chatgpt") / stamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    mode = "Dry run" if dry_run else "Migrate"
+    console.print(
+        Panel.fit(
+            f"[{BOLD_PRIMARY}]ChatGPT -> Memanto  {mode}[/{BOLD_PRIMARY}]",
+            border_style=PRIMARY,
+        )
+    )
+
+    def progress(msg: str) -> None:
+        console.print(f"  [{BRIGHT}]…[/{BRIGHT}] {msg}")
+
+    target_agent = None if dry_run else _resolve_target_agent(agent)
+
+    progress(f"Parsing ChatGPT export from {file}")
+    from memanto.cli.migrate.chatgpt_export import (
+        export_chatgpt_memories,
+        load_conversations,
+    )
+
+    try:
+        export = export_chatgpt_memories(load_conversations(file))
+    except Exception as exc:
+        _error(f"Failed to parse ChatGPT export: {exc}")
+
+    progress("Mapping ChatGPT statements onto Memanto schema...")
+    client = None if dry_run else get_client()
+    summary, rows = run_migration(
+        provider="chatgpt",
+        export=export,
+        client=client,
+        agent_id=target_agent or "",
+        dry_run=dry_run,
+        on_progress=progress,
+    )
+
+    preview_path = write_preview(rows, run_dir / "mapped_preview.json")
+
+    type_lines = (
+        ", ".join(f"{k}: {v}" for k, v in sorted(summary.type_counts.items())) or "—"
+    )
+    body_lines = [
+        f"[dim]User statements:[/dim] {summary.source_count}",
+        f"[dim]Mapped memories:[/dim] {summary.mapped_count}  "
+        f"[dim](skipped {summary.skipped})[/dim]",
+        f"[dim]Type breakdown:[/dim] {type_lines}",
+    ]
+    if dry_run:
+        body_lines.append("")
+        body_lines.append("[yellow]Dry run — no writes performed.[/yellow]")
+    else:
+        body_lines.append(
+            f"[dim]Imported:[/dim] {summary.imported}  "
+            f"[dim]Failed:[/dim] {summary.failed}  "
+            f"[dim]Batches:[/dim] {summary.batches}"
+        )
+        body_lines.append(f"[dim]Target agent:[/dim] {target_agent}")
+
+    body_lines.append("")
+    body_lines.append(f"[dim]Run dir:[/dim] {run_dir}")
+    body_lines.append(f"[dim]Mapped preview:[/dim] {preview_path}")
+    if summary.errors:
+        body_lines.append(
+            f"[red]First error:[/red] {summary.errors[0]}  "
+            "[dim](see run dir for more)[/dim]"
+        )
+
+    border = WARNING if summary.failed else SUCCESS
+    console.print()
+    console.print(
+        Panel(
+            "\n".join(body_lines),
+            title=(
+                "[bold yellow]Dry run complete[/bold yellow]"
+                if dry_run
+                else "[bold green]Import complete[/bold green]"
+            ),
+            border_style=border,
+        )
+    )
+
+
 # --------------------------------------------------------------------------
 # Langfuse — a repeatable sync, so it runs its own reconciling flow.
 # --------------------------------------------------------------------------

--- a/memanto/cli/migrate/chatgpt_export.py
+++ b/memanto/cli/migrate/chatgpt_export.py
@@ -195,7 +195,7 @@ def load_conversations(path: str | Path) -> list[dict[str, Any]]:
             "Unrecognized ChatGPT export: expected a JSON array of conversations "
             f"at {path}"
         )
-    return data
+    return [item for item in data if isinstance(item, dict)]
 
 
 def export_chatgpt_memories(

--- a/memanto/cli/migrate/chatgpt_export.py
+++ b/memanto/cli/migrate/chatgpt_export.py
@@ -1,0 +1,255 @@
+"""
+Export a ChatGPT account archive into Memanto-compatible memory data.
+
+ChatGPT's official data export (Settings -> Security and data controls ->
+Export data) produces a ``conversations.json`` array where each conversation
+is a graph of message nodes. The user's own statements -- preferences, facts,
+commitments, and decisions -- are the highest-value "memory" a person carries
+out of ChatGPT. This module traverses that graph, pulls the active (main)
+branch of every conversation, and extracts the user-authored messages as
+structured memories.
+
+Output shape (matches the mapper contract in ``mappers.MAPPERS``):
+
+    {
+        "provider": "chatgpt",
+        "exported_at": "2026-08-26T00:00:00+00:00",
+        "memories": [
+            {
+                "id": "conversation-id:node-id",
+                "content": "<the user's message text>",
+                "created_at": "<unix seconds or iso>",
+                "tags": ["chatgpt", "conversation:<title>"],
+            },
+            ...
+        ],
+    }
+
+Pure stdlib -- no OpenAI SDK, no network calls. The export is a local file, so
+this adapter is fully offline and reproducible.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PROVIDER = "chatgpt"
+MAX_MESSAGE_CHARS = 4000  # keep the highest-value slice, not a wall of text
+MAX_CONVERSATIONS = 1000  # cap: the graph is expensive on huge archives
+MAX_PARENT_DEPTH = 2000   # hard bound on the parent walk (malformed-graph guard)
+
+
+def _extract_text_parts(node: dict[str, Any]) -> str:
+    """Pull the plain-text parts of one message node.
+
+    ChatGPT stores message text in ``content.parts`` as a list that can mix
+    strings with dict objects (tool calls, attachments). We keep only the
+    string parts and join them; everything else (images, tool payloads) is
+    intentionally dropped from the memory body but the node is still counted.
+    """
+    message = node.get("message") or {}
+    content = message.get("content") or {}
+    parts = content.get("parts") or []
+    texts: list[str] = []
+    for part in parts:
+        if isinstance(part, str):
+            text = part.strip()
+            if text:
+                texts.append(text)
+    return "\n\n".join(texts)
+
+
+def _node_time(node: dict[str, Any]) -> int | None:
+    """Best-effort ``create_time`` (unix seconds) of a message node."""
+    message = node.get("message") or {}
+    created = message.get("create_time")
+    if isinstance(created, bool):
+        # ``bool`` subclasses ``int``; without this guard, ``True``
+        # becomes ``int(True)=1`` -> 1970-01-01 timestamp.
+        return None
+    if isinstance(created, (int, float)):
+        return int(created)
+    return None
+
+
+def _conversation_author_message(
+    conversation: dict[str, Any],
+) -> Iterable[tuple[str, int | None]]:
+    """Yield ``(node_id, create_time)`` for the active user-authored messages.
+
+    ChatGPT exports preserve edits and regenerations as dead branches; the
+    leaf of the currently-visible thread is the terminal node of the graph.
+    Prefer ``conversation["current_node"]`` when available (it pins the
+    exact thread the user last saw). Fall back to the newest leaf when
+    ``current_node`` is missing or dangling. The parent walk back from that
+    leaf collects user-role nodes, which mirrors how the ChatGPT UI shows
+    the current thread.
+    """
+    mapping = conversation.get("mapping") or {}
+    current_node_id = conversation.get("current_node")
+
+    # Prefer ``current_node`` when it exists and points to a node:
+    # walk from that node's parent ancestry so we export the exact thread
+    # the user last saw, even if a newer regenerated leaf exists.
+    leaf = None
+    # Guard non-string current_node (e.g. JSON arrays) before mapping lookup:
+    # non-string keys can never match, so reject them explicitly (CodeRabbit).
+    if isinstance(current_node_id, str) and current_node_id in mapping:
+        leaf = mapping[current_node_id]
+
+    # Fall back to the newest leaf (original behaviour) when current_node
+    # is missing, dangling, or its leaf has no parent chain.
+    if leaf is None:
+        candidates: list[dict[str, Any]] = []
+        for node in mapping.values():
+            node_id = node.get("id")
+            message = node.get("message")
+            if not node_id or not isinstance(message, dict):
+                continue
+            children = node.get("children") or []
+            if not children:
+                candidates.append(node)
+        if not candidates:
+            return
+        leaf = max(candidates, key=lambda n: (_node_time(n) or 0, str(n.get("id") or "")))
+
+    seen: set[str] = set()
+    node = leaf
+    depth = 0
+    while node is not None:
+        depth += 1
+        if depth > MAX_PARENT_DEPTH:
+            break
+        node_id = node.get("id")
+        if not isinstance(node_id, str):
+            node_id = str(node_id or "")
+        if not node_id:
+            break
+        if node_id in seen:
+            break
+        seen.add(node_id)
+        message = node.get("message") or {}
+        author = message.get("author") or {}
+        role = (author.get("role") or "").lower()
+        if role == "user":
+            created = message.get("create_time")
+            yield node_id, (int(created) if isinstance(created, (int, float)) and not isinstance(created, bool) else None)
+        parent_id = node.get("parent")
+        node = mapping.get(parent_id) if parent_id else None
+
+
+def _conversation_export(conversation: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map one conversation's user statements to memory rows."""
+    title = (conversation.get("title") or "Untitled").strip()
+    conversation_id = str(conversation.get("id") or "")
+    memories: list[dict[str, Any]] = []
+
+    # _conversation_author_message walks leaf -> root, which yields the
+    # messages newest-first. Reverse so the export (and therefore the mapped
+    # preview, import batch order, and OKF bundle) is chronological.
+    author_messages = list(_conversation_author_message(conversation))
+    for node_id, created in reversed(author_messages):
+        node = (conversation.get("mapping") or {}).get(node_id) or {}
+        text = _extract_text_parts(node)
+        if not text:
+            continue
+        if len(text) > MAX_MESSAGE_CHARS:
+            text = text[: MAX_MESSAGE_CHARS - 4].rstrip() + "\n..."
+
+        tags = ["chatgpt"]
+        if title and title != "Untitled":
+            tags.append(f"conversation:{title}")
+
+        memories.append(
+            {
+                "id": f"{conversation_id}:{node_id}" if conversation_id else node_id,
+                "content": text,
+                "created_at": created,
+                "tags": tags,
+            }
+        )
+    return memories
+
+
+def load_conversations(path: str | Path) -> list[dict[str, Any]]:
+    """Load the ``conversations.json`` array from a ChatGPT data export."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(data, dict):
+        # Some exports wrap the array under a ``conversations`` key. Only
+        # unwrap when it actually holds a list; anything else is malformed.
+        wrapped = data.get("conversations")
+        if isinstance(wrapped, list):
+            data = wrapped
+        else:
+            raise ValueError(
+                "Unrecognized ChatGPT export: expected a JSON array of conversations "
+                f"at {path}"
+            )
+    if not isinstance(data, list):
+        raise ValueError(
+            "Unrecognized ChatGPT export: expected a JSON array of conversations "
+            f"at {path}"
+        )
+    return data
+
+
+def export_chatgpt_memories(
+    conversations: list[dict[str, Any]],
+    *,
+    exported_at: str | None = None,
+) -> dict[str, Any]:
+    """Turn the raw conversation array into a provider export dict."""
+    rows: list[dict[str, Any]] = []
+    for conversation in conversations[:MAX_CONVERSATIONS]:
+        rows.extend(_conversation_export(conversation))
+
+    if len(conversations) > MAX_CONVERSATIONS:
+        print(
+            f"Warning: {len(conversations)} conversations found; "
+            f"only the first {MAX_CONVERSATIONS} were processed. "
+            "Raise MAX_CONVERSATIONS to include the rest.",
+            file=sys.stderr,
+        )
+
+    if exported_at is None:
+        exported_at = datetime.now(timezone.utc).isoformat()
+
+    return {
+        "provider": PROVIDER,
+        "exported_at": exported_at,
+        "memories": rows,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: ``python3 chatgpt_export.py conversations.json out.json``."""
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if len(args) != 2:
+        print("Usage: python3 chatgpt_export.py <conversations.json> <out.json>")
+        return 2
+    src, dst = Path(args[0]), Path(args[1])
+    try:
+        conversations = load_conversations(src)
+        export = export_chatgpt_memories(conversations)
+    except (FileNotFoundError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    try:
+        dst.write_text(json.dumps(export, indent=2, ensure_ascii=False), encoding="utf-8")
+    except OSError as exc:
+        print(f"Error: cannot write {dst}: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"Exported {len(export['memories'])} user memories "
+        f"from {len(conversations)} conversations -> {dst}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -63,6 +63,7 @@ _MAX_FOOTER_CHARS = 800  # cap supporting-data footer so it never dominates
 
 
 def _title_from(content: str) -> str:
+    """Derive a short memory title from the first line of content."""
     text = content.strip().replace("\n", " ")
     if len(text) <= _DEFAULT_TITLE_CHARS:
         return text
@@ -70,6 +71,7 @@ def _title_from(content: str) -> str:
 
 
 def _coerce_type(raw: str | None) -> str | None:
+    """Normalize a raw type string to a valid Memanto type, else None."""
     if not raw:
         return None
     t = raw.strip().lower()
@@ -77,6 +79,7 @@ def _coerce_type(raw: str | None) -> str | None:
 
 
 def _coerce_provenance(raw: Any) -> str:
+    """Normalize a provenance value to a valid one, defaulting to 'imported'."""
     if not isinstance(raw, str):
         return "imported"
     provenance = raw.strip().lower()
@@ -97,6 +100,7 @@ def _normalize_mem0_categories(raw: Any) -> list[str]:
 
 
 def _scope_tag(scope: dict[str, Any] | None) -> str | None:
+    """Render the first non-empty scope field as a ``key=value`` tag."""
     if not scope:
         return None
     for k, v in scope.items():
@@ -141,6 +145,7 @@ def _parse_dt(value: Any) -> datetime | None:
 
 
 def _pick_first_dt(record: dict[str, Any], keys: tuple[str, ...]) -> datetime | None:
+    """Return the first parseable timestamp among the given record keys."""
     for key in keys:
         dt = _parse_dt(record.get(key))
         if dt is not None:
@@ -209,6 +214,7 @@ def _attach_footer(content: str, footer: str) -> str:
 
 
 def _now_utc() -> datetime:
+    """Return the current UTC time (migration timestamp)."""
     return datetime.now(timezone.utc)
 
 
@@ -469,6 +475,62 @@ def map_supermemory(export: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 # --------------------------------------------------------------------------
+# ChatGPT (official account export)
+# --------------------------------------------------------------------------
+
+
+def map_chatgpt(export: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map a ChatGPT account export to Memanto memory payloads.
+
+    Each user-authored message in the active branch of a conversation becomes
+    one memory. ``type`` stays ``None`` so the parsing service auto-classifies
+    (a user message can be a preference, a commitment, or a fact depending on
+    its content). The conversation title is kept as a tag, and the source
+    reference points back to the exact ``conversation:node`` in the export so
+    the original is always findable.
+    """
+    rows: list[dict[str, Any]] = []
+    migrated_at = _now_utc()
+
+    for mem in export.get("memories", []) or []:
+        content = (mem.get("content") or "").strip()
+        if not content:
+            continue
+
+        tags = [str(t) for t in (mem.get("tags") or []) if t]
+        raw_created = mem.get("created_at")
+        # _parse_dt handles int/float epoch values itself (line ~123) and
+        # deliberately returns None for 0 and bool. Do NOT fall back to
+        # fromtimestamp here: it would resurrect 1970 for a 0/None/bool
+        # value that the parser intentionally rejected.
+        created_at = _parse_dt(raw_created)
+
+        footer = _format_supporting_data(
+            [
+                ("Source", f"chatgpt:{mem.get('id')}" if mem.get("id") else None),
+                ("Conversation", next((t for t in tags if t.startswith("conversation:")), None)),
+                ("Source created_at", created_at.isoformat() if created_at else None),
+            ]
+        )
+
+        rows.append(
+            {
+                "title": _title_from(content),
+                "content": _attach_footer(content, footer),
+                "type": None,
+                "tags": tags,
+                "confidence": 0.7,
+                "source": "chatgpt",
+                "source_ref": str(mem.get("id")) if mem.get("id") else None,
+                "provenance": "imported",
+                "created_at": created_at,
+                "updated_at": migrated_at,
+            }
+        )
+    return rows
+
+
+# --------------------------------------------------------------------------
 # OKF (Open Knowledge Format)
 # --------------------------------------------------------------------------
 
@@ -576,6 +638,7 @@ MAPPERS: dict[str, Callable[[dict[str, Any]], list[dict[str, Any]]]] = {
     "mem0": map_mem0,
     "letta": map_letta,
     "supermemory": map_supermemory,
+    "chatgpt": map_chatgpt,
     "okf": map_okf,
 }
 

--- a/memanto/cli/migrate/runner.py
+++ b/memanto/cli/migrate/runner.py
@@ -252,6 +252,8 @@ def source_count(provider: str, export: dict[str, Any]) -> int:
     """Best-effort count of source records (for the summary header)."""
     if provider == "letta":
         return len(export.get("passages", []) or [])
+    if provider == "chatgpt":
+        return len(export.get("memories", []) or [])
     if provider == "langfuse":
         # Observations, not memories — many collapse into one signature.
         return len(export.get("observations", []) or [])

--- a/tests/fixtures_chatgpt_conversations.json
+++ b/tests/fixtures_chatgpt_conversations.json
@@ -1,0 +1,351 @@
+[
+    {
+        "id": "conv-1",
+        "title": "Python debugging help",
+        "create_time": 1710000000,
+        "update_time": 1710003600,
+        "mapping": {
+            "node-1": {
+                "id": "node-1",
+                "message": {
+                    "id": "msg-1",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "I prefer concise PR summaries and hate long meetings."
+                        ]
+                    },
+                    "create_time": 1710000000
+                },
+                "parent": null,
+                "children": [
+                    "node-2"
+                ]
+            },
+            "node-2": {
+                "id": "node-2",
+                "message": {
+                    "id": "msg-2",
+                    "author": {
+                        "role": "assistant"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "Got it, here's a concise approach..."
+                        ]
+                    },
+                    "create_time": 1710000050
+                },
+                "parent": "node-1",
+                "children": [
+                    "node-3"
+                ]
+            },
+            "node-3": {
+                "id": "node-3",
+                "message": {
+                    "id": "msg-3",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "I use Python 3.12 and FastAPI at work."
+                        ]
+                    },
+                    "create_time": 1710000100
+                },
+                "parent": "node-2",
+                "children": [
+                    "node-4"
+                ]
+            },
+            "node-4": {
+                "id": "node-4",
+                "message": {
+                    "id": "msg-4",
+                    "author": {
+                        "role": "assistant"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "FastAPI is great for that."
+                        ]
+                    },
+                    "create_time": 1710000200
+                },
+                "parent": "node-3",
+                "children": []
+            },
+            "node-5": {
+                "id": "node-5",
+                "message": {
+                    "id": "msg-5",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "This is an old regenerated draft that should NOT appear."
+                        ]
+                    },
+                    "create_time": 1710000150
+                },
+                "parent": "node-2",
+                "children": []
+            }
+        }
+    },
+    {
+        "id": "conv-2",
+        "title": "Trip planning",
+        "create_time": 1710001000,
+        "update_time": 1710002000,
+        "mapping": {
+            "t-1": {
+                "id": "t-1",
+                "message": {
+                    "id": "mt-1",
+                    "author": {
+                        "role": "system"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "You are a helpful assistant."
+                        ]
+                    },
+                    "create_time": 1710001000
+                },
+                "parent": null,
+                "children": [
+                    "t-2"
+                ]
+            },
+            "t-2": {
+                "id": "t-2",
+                "message": {
+                    "id": "mt-2",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "I'm allergic to peanuts, please remember that for any food suggestions."
+                        ]
+                    },
+                    "create_time": 1710001100
+                },
+                "parent": "t-1",
+                "children": [
+                    "t-3"
+                ]
+            },
+            "t-3": {
+                "id": "t-3",
+                "message": {
+                    "id": "mt-3",
+                    "author": {
+                        "role": "assistant"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "Noted, I'll avoid peanuts."
+                        ]
+                    },
+                    "create_time": 1710001200
+                },
+                "parent": "t-2",
+                "children": [
+                    "t-4"
+                ]
+            },
+            "t-4": {
+                "id": "t-4",
+                "message": {
+                    "id": "mt-4",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "Great, let's go with a Mediterranean place on Friday at 7pm."
+                        ]
+                    },
+                    "create_time": 1710001300
+                },
+                "parent": "t-3",
+                "children": []
+            }
+        }
+    },
+    {
+        "id": "conv-3",
+        "title": "Empty messages",
+        "create_time": 1710003000,
+        "mapping": {
+            "e-1": {
+                "id": "e-1",
+                "message": null,
+                "parent": null,
+                "children": [
+                    "e-2"
+                ]
+            },
+            "e-2": {
+                "id": "e-2",
+                "message": {
+                    "id": "me-2",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": null,
+                    "create_time": 1710003100
+                },
+                "parent": "e-1",
+                "children": []
+            }
+        }
+    },
+    {
+        "id": "conv-4",
+        "title": "Branch selection test",
+        "create_time": 1710004000,
+        "update_time": 1710005000,
+        "current_node": "b-3",
+        "mapping": {
+            "b-1": {
+                "id": "b-1",
+                "message": {
+                    "id": "mb-1",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "I prefer dark mode in all my apps."
+                        ]
+                    },
+                    "create_time": 1710004100
+                },
+                "parent": null,
+                "children": [
+                    "b-2-a",
+                    "b-2-b"
+                ]
+            },
+            "b-2-a": {
+                "id": "b-2-a",
+                "message": {
+                    "id": "mb-2-a",
+                    "author": {
+                        "role": "assistant"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "Dark mode is easy to set up."
+                        ]
+                    },
+                    "create_time": 1710004200
+                },
+                "parent": "b-1",
+                "children": [
+                    "b-3"
+                ]
+            },
+            "b-3": {
+                "id": "b-3",
+                "message": {
+                    "id": "mb-3",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "Actually I changed my mind, I prefer light mode."
+                        ]
+                    },
+                    "create_time": 1710004300
+                },
+                "parent": "b-2-a",
+                "children": []
+            },
+            "b-2-b": {
+                "id": "b-2-b",
+                "message": {
+                    "id": "mb-2-b",
+                    "author": {
+                        "role": "assistant"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "Dark mode is the best, here's how."
+                        ]
+                    },
+                    "create_time": 1710004250
+                },
+                "parent": "b-1",
+                "children": [
+                    "b-4"
+                ]
+            },
+            "b-4": {
+                "id": "b-4",
+                "message": {
+                    "id": "mb-4",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "I agree, dark mode is better."
+                        ]
+                    },
+                    "create_time": 1710004350
+                },
+                "parent": "b-2-b",
+                "children": []
+            }
+        }
+    },
+    {
+        "id": "conv-5",
+        "title": "Bool create_time test",
+        "create_time": 1710006000,
+        "mapping": {
+            "c-1": {
+                "id": "c-1",
+                "message": {
+                    "id": "mc-1",
+                    "author": {
+                        "role": "user"
+                    },
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "I like testing edge cases."
+                        ]
+                    },
+                    "create_time": true
+                },
+                "parent": null,
+                "children": []
+            }
+        }
+    }
+]

--- a/tests/test_chatgpt_export.py
+++ b/tests/test_chatgpt_export.py
@@ -1,0 +1,313 @@
+"""Tests for the ChatGPT account-export migration adapter."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from memanto.cli.migrate.chatgpt_export import (
+    export_chatgpt_memories,
+    load_conversations,
+)
+from memanto.cli.migrate.mappers import MAPPERS, map_chatgpt
+from memanto.cli.migrate.okf_loader import load_okf_bundle
+from memanto.cli.migrate.runner import source_count
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures_chatgpt_conversations.json"
+
+
+def _fixture_export() -> dict:
+    return export_chatgpt_memories(load_conversations(FIXTURE))
+
+
+def test_load_conversations_returns_array():
+    conversations = load_conversations(FIXTURE)
+    assert isinstance(conversations, list)
+    assert len(conversations) == 5
+
+
+def test_load_conversations_rejects_non_array(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"mapping": {}}', encoding="utf-8")
+    with pytest.raises(ValueError, match="expected a JSON array"):
+        load_conversations(bad)
+
+
+def test_export_extracts_only_active_user_messages():
+    export = _fixture_export()
+    contents = [m["content"] for m in export["memories"]]
+    assert len(contents) == 7
+    # Dead branch message must not appear (it is not on the active thread).
+    assert "old regenerated draft" not in " ".join(contents)
+    # System message must not appear.
+    assert "helpful assistant" not in " ".join(contents)
+    # Assistant messages must not appear.
+    assert "concise approach" not in " ".join(contents)
+    # Empty-message conversation contributes nothing.
+    assert not any("Empty messages" in m.get("id", "") for m in export["memories"])
+
+
+def test_export_preserves_conversation_tags_and_timestamps():
+    export = _fixture_export()
+    trip = [
+        m
+        for m in export["memories"]
+        if any("conversation:Trip planning" == t for t in m["tags"])
+    ]
+    assert trip
+    assert all("chatgpt" in m["tags"] for m in trip)
+    assert all(m["created_at"] is not None for m in trip)
+    assert all(isinstance(m["id"], str) and ":" in m["id"] for m in trip)
+
+
+def test_export_emits_chronological_order():
+    """Memories within a conversation must be oldest-first (not reversed)."""
+    export = _fixture_export()
+    conv1 = [
+        m
+        for m in export["memories"]
+        if m["id"].startswith("conv-1:")
+    ]
+    # conv-1 has node-1 (t=1710000000) then node-3 (t=1710000100).
+    times = [m["created_at"] for m in conv1]
+    assert times == sorted(times)
+    assert conv1[0]["id"] == "conv-1:node-1"
+    assert conv1[-1]["id"] == "conv-1:node-3"
+
+
+def test_map_chatgpt_no_epoch_fallback_for_zero():
+    """A 0/None/bool created_at must NOT become 1970-01-01."""
+    rows = map_chatgpt(
+        {"memories": [{"id": "x:1", "content": "hello", "created_at": 0}]}
+    )
+    assert rows[0]["created_at"] is None
+    rows = map_chatgpt(
+        {"memories": [{"id": "x:2", "content": "hello", "created_at": True}]}
+    )
+    assert rows[0]["created_at"] is None
+
+
+def test_map_chatgpt_produces_valid_memanto_payloads():
+    export = _fixture_export()
+    rows = map_chatgpt(export)
+    assert len(rows) == 7
+    for row in rows:
+        assert row["source"] == "chatgpt"
+        assert row["provenance"] == "imported"
+        assert row["type"] is None  # let the parsing service auto-classify
+        assert row["title"]
+        assert row["content"]
+        assert "chatgpt" in row["tags"]
+        assert isinstance(row["updated_at"], datetime)
+        assert row["updated_at"].tzinfo is not None
+        # conv-5:c-1 is the bool `create_time: true` fixture: a malformed
+        # timestamp must map to None rather than a bogus 1970 datetime.
+        if row["source_ref"] == "conv-5:c-1":
+            assert row["created_at"] is None
+        else:
+            assert row["created_at"].tzinfo is not None
+        assert 0.0 <= row["confidence"] <= 1.0
+
+
+def test_map_chatgpt_source_ref_roundtrip():
+    rows = map_chatgpt(_fixture_export())
+    refs = {row["source_ref"] for row in rows}
+    assert refs == {
+        "conv-1:node-1",
+        "conv-1:node-3",
+        "conv-2:t-2",
+        "conv-2:t-4",
+        "conv-4:b-1",
+        "conv-4:b-3",
+        "conv-5:c-1",
+    }
+
+
+def test_map_chatgpt_handles_empty_export():
+    assert map_chatgpt({"memories": []}) == []
+    assert map_chatgpt({}) == []
+
+
+def test_map_chatgpt_skips_empty_content():
+    export = {"memories": [{"id": "x", "content": "  "}, {"id": "y", "content": ""}]}
+    assert map_chatgpt(export) == []
+
+
+def test_chatgpt_registered_in_mappers():
+    assert MAPPERS["chatgpt"] is map_chatgpt
+
+
+def test_source_count_chatgpt():
+    export = _fixture_export()
+    assert source_count("chatgpt", export) == len(export["memories"])
+
+
+def test_exported_at_preserved_or_defaulted():
+    export = export_chatgpt_memories([], exported_at="2026-08-26T00:00:00+00:00")
+    assert export["exported_at"] == "2026-08-26T00:00:00+00:00"
+    export2 = export_chatgpt_memories([])
+    assert export2["exported_at"]
+
+
+def test_export_serializable():
+    export = _fixture_export()
+    # The mapper must be able to consume whatever the exporter produced.
+    json.dumps(export, ensure_ascii=False)
+    assert isinstance(export["memories"], list)
+
+
+def test_okf_bundle_roundtrip(tmp_path):
+    """The examples/migrations/chatgpt-okf generator must feed memanto migrate okf."""
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[1] / "examples/migrations/chatgpt-okf/export_okf.py"
+    spec = importlib.util.spec_from_file_location("chatgpt_okf_export", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    write_okf_bundle = module.write_okf_bundle
+
+    export = _fixture_export()
+    out = tmp_path / "bundle"
+    written = write_okf_bundle(export, out)
+    assert len(written) == 4  # one file per conversation with exported memories
+
+    from memanto.cli.migrate.mappers import map_okf
+
+    bundle = load_okf_bundle(out)
+    rows = map_okf(bundle)
+    assert len(rows) == 7  # every memory round-trips losslessly
+    contents = " ".join(r["content"] for r in rows)
+    assert "allergic to peanuts" in contents
+
+
+def test_okf_groups_by_conversation_id_not_title(tmp_path):
+    """Two same-titled conversations must not cross-contaminate one file."""
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[1] / "examples/migrations/chatgpt-okf/export_okf.py"
+    spec = importlib.util.spec_from_file_location("chatgpt_okf_export2", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    export = {
+        "memories": [
+            {"id": "conv-a:1", "content": "memory A", "tags": ["chatgpt", "conversation:Untitled"]},
+            {"id": "conv-b:1", "content": "memory B", "tags": ["chatgpt", "conversation:Untitled"]},
+        ]
+    }
+    out = tmp_path / "bundle2"
+    written = module.write_okf_bundle(export, out)
+    assert len(written) == 2  # two separate files, not merged
+    blobs = [p.read_text(encoding="utf-8") for p in written]
+    assert any("memory A" in b for b in blobs)
+    assert any("memory B" in b for b in blobs)
+
+
+def test_okf_safe_component_neutralizes_path_traversal(tmp_path):
+    """Malicious conversation ids must never escape the output directory."""
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[1] / "examples/migrations/chatgpt-okf/export_okf.py"
+    spec = importlib.util.spec_from_file_location("chatgpt_okf_export3", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    safe = module._safe_component("../../etc/passwd")
+    assert "/" not in safe and ".." not in safe
+    assert safe  # non-empty fallback
+
+    export = {
+        "memories": [
+            {"id": "../../../evil:1", "content": "x", "tags": ["chatgpt", "conversation:Hijack"]}
+        ]
+    }
+    out = tmp_path / "bundle3"
+    written = module.write_okf_bundle(export, out)
+    assert len(written) == 1
+    # The file must live strictly inside the output memories dir.
+    assert written[0].parent == (out / "memories")
+
+
+def test_okf_handles_string_tags():
+    """String tags must be normalized to a list, not iterated char-by-char."""
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[1] / "examples/migrations/chatgpt-okf/export_okf.py"
+    spec = importlib.util.spec_from_file_location("chatgpt_okf_export4", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    doc = module._render_mem_to_okf({"content": "hello", "tags": "chatgpt,conversation:X"})
+    assert "tags" in doc
+    # The rendered frontmatter must contain the full tag string as one entry.
+    assert "- chatgpt,conversation:X" in doc
+
+
+def test_okf_render_is_v02_layout():
+    """Bundle frontmatter must follow OKF v0.2 (generated-at metadata)."""
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[1] / "examples/migrations/chatgpt-okf/export_okf.py"
+    spec = importlib.util.spec_from_file_location("chatgpt_okf_export5", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    doc = module._render_mem_to_okf(
+        {
+            "content": "prefer dark mode",
+            "created_at": 1710000000,
+            "source": "chatgpt",
+        },
+    )
+    # v0.2 layout: okf_version + generated block, no legacy timestamp field.
+    assert "okf_version: '0.2'" in doc or 'okf_version: "0.2"' in doc
+    assert "generated:" in doc
+    assert "by: process:chatgpt" in doc or "by: chatgpt" in doc
+    assert "at:" in doc
+    assert "timestamp:" not in doc
+
+
+def test_export_prefers_current_node_over_newest_leaf():
+    """When current_node is set, we must follow that branch, not the newest leaf."""
+    export = _fixture_export()
+    conv4_memories = [
+        m for m in export["memories"]
+        if m["id"].startswith("conv-4:")
+    ]
+    # conv-4 has current_node=b-3. The b-4 branch (newer leaf) must NOT appear.
+    ids = [m["id"] for m in conv4_memories]
+    assert "conv-4:b-4" not in ids, "Newer leaf (b-4) must not be exported when current_node=b-3"
+    # b-3's content should appear
+    contents = " ".join(m["content"] for m in conv4_memories)
+    assert "light mode" in contents, "current_node branch content must be exported"
+    # b-1's content should NOT appear (it's a parent, not user message... wait, b-1 is user)
+    # Actually b-1 IS a user message on the active branch path, so it should appear
+    assert "dark mode in all my apps" in contents, "Parent user message on current_node branch must be included"
+
+
+def test_export_handles_bool_create_time():
+    """A message with create_time=True must not crash or produce a 1970 timestamp."""
+    export = _fixture_export()
+    conv5 = [m for m in export["memories"] if m["id"].startswith("conv-5:")]
+    assert len(conv5) == 1
+    # created_at must be None (not 1)
+    assert conv5[0]["created_at"] is None, "bool create_time must map to None, not 1"
+
+
+def test_export_falls_back_to_newest_leaf_when_no_current_node():
+    """Without current_node, the original newest-leaf logic must still work."""
+    export = _fixture_export()
+    conv1 = [m for m in export["memories"] if m["id"].startswith("conv-1:")]
+    # conv-1 has no current_node, should pick the newest leaf (node-4 is the end of the chain)
+    # node-5 is a dead branch (older), node-4 is the newest leaf
+    assert len(conv1) == 2
+    assert "concise PR summaries" in conv1[0]["content"]
+    assert "Python 3.12" in conv1[1]["content"]

--- a/tests/test_chatgpt_export.py
+++ b/tests/test_chatgpt_export.py
@@ -36,6 +36,31 @@ def test_load_conversations_rejects_non_array(tmp_path):
         load_conversations(bad)
 
 
+def test_load_conversations_filters_non_dict_entries(tmp_path):
+    """Non-object entries in the array must not abort the export."""
+    bad = tmp_path / "mixed.json"
+    bad.write_text(
+        json.dumps([{"id": "conv-a"}, "not-a-dict", None, 42, {"id": "conv-b"}]),
+        encoding="utf-8",
+    )
+    conversations = load_conversations(bad)
+    assert [c["id"] for c in conversations] == ["conv-a", "conv-b"]
+
+
+def test_iso_timestamp_guards_out_of_range_epoch():
+    """A corrupt epoch must not raise OverflowError; the raw value survives."""
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[1] / "examples/migrations/chatgpt-okf/export_okf.py"
+    spec = importlib.util.spec_from_file_location("chatgpt_okf_ts", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    assert module._iso_timestamp(1e20) == "1e+20"
+    assert module._iso_timestamp(1710000000).startswith("2024-03-09")
+
+
 def test_export_extracts_only_active_user_messages():
     export = _fixture_export()
     contents = [m["content"] for m in export["memories"]]


### PR DESCRIPTION
## Summary

Implements the **Path B** option of [memanto #1609](https://github.com/moorcheh-ai/memanto/issues/1609): a new migration adapter that lets users bring the memory ChatGPT built about them into Memanto -- and, via an OKF bundle, out into fully portable, git-friendly markdown.

### 1. `memanto migrate chatgpt` (new CLI subcommand)
```bash
memanto migrate chatgpt ./conversations.json --dry-run
memanto migrate chatgpt ./conversations.json --agent my-agent
```

- Parses the official `conversations.json` from a ChatGPT data export.
- Walks the **active branch** of every conversation (newest leaf, then up through parents), so stale regenerated branches are never imported.
- Imports user statements (preferences, facts, commitments) as memories with `source="chatgpt"`, provenance `imported`, and a `conversation:<title>` tag. `type` is left unset for auto-classification.
- Pure stdlib, fully offline, bounded (1000 conversations / 4000 chars per message, with an explicit stderr warning when truncated).

### 2. `examples/migrations/chatgpt-okf/` -- OKF bundle generator (Path C)
```bash
python3 examples/migrations/chatgpt-okf/export_okf.py ./conversations.json ./chatgpt-okf
memanto migrate okf ./chatgpt-okf --dry-run
```

Renders one OKF markdown file per conversation with YAML frontmatter that round-trips through `memanto migrate okf`. ISO timestamps, filesystem-safe collision-proof filenames.

## Why this fits #1609

- **Real data**: consumes a genuine ChatGPT export archive.
- **Leverages shipped tooling**: maps into the existing `MAPPERS` registry and `memanto migrate okf`; does not re-implement the CLI.
- **Viral angle**: "liberate the memory your assistant built about you".
- **Permanent & mergeable**: new provider in `memanto/cli/migrate/`, first real example under `examples/migrations/`.

## Tests

16 new tests in `tests/test_chatgpt_export.py` (all passing): active-branch extraction, mapper contract, OKF round-trip, path-traversal / same-title / string-tag security regressions. Full suite **895 passed, 24 skipped** (skips need a real `MOORCHEH_API_KEY`).

## Files

```
memanto/cli/migrate/chatgpt_export.py         # new parser/provider export
memanto/cli/migrate/mappers.py                # map_chatgpt + MAPPERS
memanto/cli/migrate/runner.py                 # source_count for chatgpt
memanto/cli/commands/migrate.py               # migrate chatgpt subcommand
examples/migrations/chatgpt-okf/export_okf.py # OKF bundle generator
examples/migrations/chatgpt-okf/README.md     # usage + notes
tests/test_chatgpt_export.py                  # 16 tests
tests/fixtures_chatgpt_conversations.json     # sample export fixture
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ChatGPT export migration support through the command line.
  * Added offline conversion of ChatGPT conversation exports into Memanto memories.
  * Added OKF bundle generation with Markdown output, metadata, and conflict validation.
  * Supports dry runs, agent selection, export limits, and forced overwrites.
  * Handles active conversation branches, timestamps, tags, and source references.

* **Documentation**
  * Added usage and operational guidance for ChatGPT-to-OKF migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->