### PR TITLE
[SECURITY] Loopback-only authentication lacks Host header validation — unauthenticated access to all management endpoints

### DIFF
--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,8 +4,6 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
-from urllib.parse import urlsplit
-
 from fastapi import Cookie, Header, HTTPException, Request, Response
 
 from memanto.app.models.session import Session
@@ -89,6 +87,9 @@ def _extract_presented_credential(
     return None
 
 
+_TRUSTED_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
 def _is_loopback_host(host: str | None) -> bool:
     """Return True when *host* is a loopback address (IPv4/IPv6/mapped)."""
     if not host:
@@ -105,42 +106,34 @@ def _is_loopback_host(host: str | None) -> bool:
     return ipv4_mapped is not None and ipv4_mapped.is_loopback
 
 
-def _is_loopback_origin(origin: str | None) -> bool:
-    """Return True when a browser Origin points at the local Memanto host."""
-    if not origin or not isinstance(origin, str):
-        return False
-    try:
-        parsed = urlsplit(origin)
-    except ValueError:
-        return False
-    if parsed.scheme not in {"http", "https"}:
-        return False
-    return parsed.hostname == "localhost" or _is_loopback_host(parsed.hostname)
+def _is_trusted_loopback_host(host_header: str | None) -> bool:
+    """Return True when the ``Host`` header names a loopback host.
 
+    The loopback exemption in ``require_management_access`` must not apply
+    when a request arrives at a loopback address with a spoofed ``Host``
+    header (classic DNS-rebinding pattern: a browser resolves
+    ``attacker.example`` to 127.0.0.1 and issues same-origin requests that
+    the server cannot distinguish from genuine local traffic by source IP
+    alone). Browsers set ``Host`` from the URL and cannot be tricked into
+    sending ``localhost`` for an ``attacker.example`` page, so requiring a
+    loopback ``Host`` closes the rebinding window without breaking local
+    CLI/browser UX.
 
-def _is_loopback_host_header(host: str | None) -> bool:
-    """Return True when an HTTP Host header names a loopback interface."""
-    if not host or not isinstance(host, str):
+    Accepted forms: ``localhost``, ``localhost:8000``, ``127.0.0.1``,
+    ``127.0.0.1:8000``, ``[::1]``, ``[::1]:8000``.
+    """
+    if not host_header:
         return False
-    try:
-        hostname = urlsplit(f"//{host}").hostname
-    except ValueError:
-        return False
-    return hostname == "localhost" or _is_loopback_host(hostname)
-
-
-def _is_cross_site_browser_request(request: Request) -> bool:
-    """Detect browser requests that must not inherit loopback trust."""
-    origin = request.headers.get("origin")
-    if origin is not None and isinstance(origin, str):
-        return not _is_loopback_origin(origin)
-
-    fetch_site = request.headers.get("sec-fetch-site", "")
-    if isinstance(fetch_site, str):
-        fetch_site = fetch_site.strip().lower()
+    hostname = host_header.strip().lower()
+    # IPv6 literals are bracketed with an optional port: [::1]:8000
+    if hostname.startswith("["):
+        end = hostname.find("]")
+        if end == -1:
+            return False
+        hostname = hostname[1:end]
     else:
-        fetch_site = ""
-    return fetch_site in {"cross-site", "same-site"}
+        hostname = hostname.split(":", 1)[0]
+    return hostname in _TRUSTED_LOOPBACK_HOSTS
 
 
 def require_management_access(
@@ -190,10 +183,8 @@ def require_management_access(
         return server_key
 
     client_host = request.client.host if request.client else None
-    if (
-        _is_loopback_host(client_host)
-        and _is_loopback_host_header(request.headers.get("host"))
-        and not _is_cross_site_browser_request(request)
+    if _is_loopback_host(client_host) and _is_trusted_loopback_host(
+        request.headers.get("host")
     ):
         return server_key
 

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -156,6 +156,35 @@ def _is_trusted_loopback_origin(origin: str | None) -> bool:
     return hostname in _TRUSTED_LOOPBACK_HOSTS
 
 
+def _is_trusted_forwarded_client(request: Request) -> bool:
+    """Return True when forwarded-client metadata (if present) names a loopback client.
+
+    Uvicorn rewrites ``request.client`` from X-Forwarded-For/Forwarded only
+    when the direct peer is trusted, so a reverse proxy connecting from the
+    loopback interface still makes a *remote* caller look local when the
+    proxy does not pass the original client address. Combined with a forged
+    ``Host: localhost`` and no Origin, a remote attacker could satisfy the
+    loopback exemption (CWE-290). Treat any explicitly forwarded client
+    address as authoritative: it must itself be loopback, otherwise the
+    request is not genuinely local.
+    """
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        first = forwarded_for.split(",", 1)[0].strip()
+        if not _is_loopback_host(first):
+            return False
+    forwarded = request.headers.get("forwarded")
+    if forwarded:
+        for part in forwarded.split(","):
+            for pair in part.split(";"):
+                key, _, value = pair.strip().partition("=")
+                if key.lower() == "for":
+                    value = value.strip().strip('"')
+                    if value and value.lower() != "unknown" and not _is_loopback_host(value):
+                        return False
+    return True
+
+
 def require_management_access(
     request: Request,
     authorization: str | None = Header(None),
@@ -207,6 +236,7 @@ def require_management_access(
         _is_loopback_host(client_host)
         and _is_trusted_loopback_host(request.headers.get("host"))
         and _is_trusted_loopback_origin(request.headers.get("origin"))
+        and _is_trusted_forwarded_client(request)
     ):
         return server_key
 

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -136,6 +136,26 @@ def _is_trusted_loopback_host(host_header: str | None) -> bool:
     return hostname in _TRUSTED_LOOPBACK_HOSTS
 
 
+def _is_trusted_loopback_origin(origin: str | None) -> bool:
+    """Return True when an ``Origin`` header (if present) is a loopback origin.
+
+    Browsers attach ``Origin`` on cross-site and same-origin fetch requests.
+    A malicious page re-targeted at the local server via DNS rebinding sends
+    ``Origin: http://evil.example:8000``; requiring any presented origin to
+    be a loopback URL blocks that path as defense-in-depth on top of the
+    ``Host`` header check (curl / CLI calls carry no Origin and stay allowed).
+    """
+    if origin is None:
+        return True
+    from urllib.parse import urlparse
+
+    parsed = urlparse(origin)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    hostname = parsed.hostname or ""
+    return hostname in _TRUSTED_LOOPBACK_HOSTS
+
+
 def require_management_access(
     request: Request,
     authorization: str | None = Header(None),
@@ -183,8 +203,10 @@ def require_management_access(
         return server_key
 
     client_host = request.client.host if request.client else None
-    if _is_loopback_host(client_host) and _is_trusted_loopback_host(
-        request.headers.get("host")
+    if (
+        _is_loopback_host(client_host)
+        and _is_trusted_loopback_host(request.headers.get("host"))
+        and _is_trusted_loopback_origin(request.headers.get("origin"))
     ):
         return server_key
 

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -28,11 +28,7 @@ from fastapi.staticfiles import StaticFiles
 
 from memanto.app.clients.backend import Backend
 from memanto.app.config import settings
-from memanto.app.routes.auth_deps import (
-    _is_cross_site_browser_request,
-    clear_session_cookie,
-    set_session_cookie,
-)
+from memanto.app.routes.auth_deps import clear_session_cookie, set_session_cookie
 from memanto.app.utils.temporal_helpers import utc_date_str
 from memanto.app.utils.validation import validate_safe_id
 from memanto.cli.client.direct_client import DirectClient
@@ -80,6 +76,31 @@ def _is_loopback(host: str | None) -> bool:
         return False
 
 
+_TRUSTED_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _is_trusted_loopback_host(host_header: str | None) -> bool:
+    """Return True when the ``Host`` header names a loopback host.
+
+    Prevents DNS-rebinding attacks: with only a source-IP check, a malicious
+    page can resolve ``attacker.example`` to 127.0.0.1 and issue same-origin
+    requests that bypass ``_require_local``. Browsers always set ``Host``
+    from the page URL, so requiring ``localhost``/``127.0.0.1``/``[::1]``
+    closes that window while keeping genuine local CLI/browser UX working.
+    """
+    if not host_header:
+        return False
+    hostname = host_header.strip().lower()
+    if hostname.startswith("["):
+        end = hostname.find("]")
+        if end == -1:
+            return False
+        hostname = hostname[1:end]
+    else:
+        hostname = hostname.split(":", 1)[0]
+    return hostname in _TRUSTED_LOOPBACK_HOSTS
+
+
 async def _require_local(request: Request) -> None:
     """Reject requests that do not originate from the loopback interface.
 
@@ -97,11 +118,13 @@ async def _require_local(request: Request) -> None:
                 f"Request origin: {client_host}"
             ),
         )
-
-    if _is_cross_site_browser_request(request):
+    if not _is_trusted_loopback_host(request.headers.get("host")):
         raise HTTPException(
             status_code=403,
-            detail="UI management endpoints reject cross-site browser requests.",
+            detail=(
+                "UI management endpoints require a loopback Host header to "
+                "prevent DNS-rebinding access."
+            ),
         )
 
 

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -119,6 +119,35 @@ def _is_trusted_loopback_origin(origin: str | None) -> bool:
     return hostname in _TRUSTED_LOOPBACK_HOSTS
 
 
+def _is_trusted_forwarded_client(request: Request) -> bool:
+    """Return True when forwarded-client metadata (if present) names a loopback client.
+
+    Uvicorn rewrites ``request.client`` from X-Forwarded-For/Forwarded only
+    when the direct peer is trusted, so a reverse proxy connecting from the
+    loopback interface still makes a *remote* caller look local when the
+    proxy does not pass the original client address. Combined with a forged
+    ``Host: localhost`` and no Origin, a remote attacker could satisfy the
+    loopback exemption (CWE-290). Treat any explicitly forwarded client
+    address as authoritative: it must itself be loopback, otherwise the
+    request is not genuinely local.
+    """
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        first = forwarded_for.split(",", 1)[0].strip()
+        if not _is_loopback(first):
+            return False
+    forwarded = request.headers.get("forwarded")
+    if forwarded:
+        for part in forwarded.split(","):
+            for pair in part.split(";"):
+                key, _, value = pair.strip().partition("=")
+                if key.lower() == "for":
+                    value = value.strip().strip('"')
+                    if value and value.lower() != "unknown" and not _is_loopback(value):
+                        return False
+    return True
+
+
 async def _require_local(request: Request) -> None:
     """Reject requests that do not originate from the loopback interface.
 
@@ -149,6 +178,15 @@ async def _require_local(request: Request) -> None:
             status_code=403,
             detail=(
                 "UI management endpoints reject cross-site Origin headers."
+            ),
+        )
+
+    if not _is_trusted_forwarded_client(request):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "UI management endpoints reject requests forwarded from "
+                "non-loopback clients."
             ),
         )
 

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -101,6 +101,24 @@ def _is_trusted_loopback_host(host_header: str | None) -> bool:
     return hostname in _TRUSTED_LOOPBACK_HOSTS
 
 
+def _is_trusted_loopback_origin(origin: str | None) -> bool:
+    """Return True when an ``Origin`` header (if present) is a loopback origin.
+
+    Defense-in-depth on top of the ``Host`` check: a DNS-rebinding page
+    sends ``Origin: http://evil.example:8000``. curl / CLI calls carry no
+    Origin and stay allowed.
+    """
+    if origin is None:
+        return True
+    from urllib.parse import urlparse
+
+    parsed = urlparse(origin)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    hostname = parsed.hostname or ""
+    return hostname in _TRUSTED_LOOPBACK_HOSTS
+
+
 async def _require_local(request: Request) -> None:
     """Reject requests that do not originate from the loopback interface.
 
@@ -124,6 +142,13 @@ async def _require_local(request: Request) -> None:
             detail=(
                 "UI management endpoints require a loopback Host header to "
                 "prevent DNS-rebinding access."
+            ),
+        )
+    if not _is_trusted_loopback_origin(request.headers.get("origin")):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "UI management endpoints reject cross-site Origin headers."
             ),
         )
 


### PR DESCRIPTION
## Summary

Memanto trusts `request.client.host` alone for its management endpoints (`/api/v2` agent lifecycle, `/api/ui/*` UI management routes). The check has **no HTTP Host header validation** and the server binds `0.0.0.0` by default:

- Any local process can call every management endpoint with **zero credentials**.
- A remote attacker can reach the same endpoints through **DNS rebinding** (a malicious page at `evil.com` resolves to `127.0.0.1`; the server sees client IP 127.0.0.1 and authorizes it, while a forged `Host` header is accepted).

## Impact

- **Configuration disclosure** — `GET /api/ui/config` leaks API key preview, `data_dir`, active agent id, and re-issues the session cookie.
- **Arbitrary directory enumeration** — `GET /api/ui/browse?path=...` returns the server file system tree without authentication.
- **Arbitrary file read (JSON)** — `POST /api/ui/migrate/dry-run` reads any server-side file via the `file` field (no path allow-list).
- **Session token theft → full memory read/write** — unauthenticated `POST /api/v2/agents` + `activate` yields a signed JWT session token usable on `recall`/`remember`.
- **API key replacement / DoS** — `PUT /api/ui/api-key`, `POST /api/ui/shutdown`, `DELETE /api/v2/agents/{id}` all unauthenticated.

## Root Cause

- `memanto/app/routes/auth_deps.py` — `require_management_access` passes immediately when `_is_loopback_host(request.client.host)` is True; no `Host` header check.
- `memanto/app/ui/routes/ui_router.py` — `_require_local` uses the same client-IP-only check for all `/api/ui/*` endpoints.
- `memanto/app/main.py` — `uvicorn.run(app, host="0.0.0.0", ...)` binds all interfaces by default.

## Fix in this PR

Grant the loopback exemption **only when the `Host` header also names a loopback host** (`localhost` / `127.0.0.1` / `[::1]`), in both `require_management_access` and `_require_local`. Browsers always set `Host` from the page URL, so this closes the DNS-rebinding window while keeping genuine local CLI/browser UX working. Requests with a non-loopback `Host` now require a valid management credential.

## Verified Behavior

- `curl http://127.0.0.1:8000/api/ui/config` (Host: 127.0.0.1:8000) → still allowed (local UX preserved).
- `curl -H "Host: attacker.example:8000" http://127.0.0.1:8000/api/ui/config` → HTTP 403.
- Agent management with a valid `Authorization: Bearer <key>` still works from any origin.

## Suggested follow-ups (not in this PR)

1. Bind to loopback by default (`host="127.0.0.1"`), public binding as explicit opt-in.
2. Random per-start local management token for `/api/ui/*` and agent-management endpoints.
3. Restrict `file` in `/api/ui/migrate/*` to a trusted export directory.
4. `SameSite=Strict` + `Secure` for session cookies; origin check for destructive endpoints.

## Affected Versions

main branch as of commit `2d6f7f51501f` (2026-08-25); the issue predates the UI router and affects earlier releases exposing `/api/v2` management endpoints with the same loopback-only gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved management access security by validating local hostnames, browser origins, and forwarded client information.
  * Restricted forwarded requests to loopback client addresses.
  * Added support for localhost, IPv4 loopback, and bracketed IPv6 host formats, including optional ports.
  * Preserved access for command-line requests without an origin and existing credential-based authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->