### PR TITLE
Feat/harden skills

### DIFF
--- a/memanto/app/clients/onprem.py
+++ b/memanto/app/clients/onprem.py
@@ -24,7 +24,9 @@ _DEFAULT_URL = "http://localhost:8080"
 def _import_raw_client() -> Any:
     """Lazy import so the cloud path doesn't require ``moorcheh-client``."""
     try:
-        from moorcheh import MoorchehClient  # type: ignore[import-not-found,import-untyped]
+        from moorcheh import (
+            MoorchehClient,  # type: ignore[import-not-found,import-untyped]
+        )
     except ImportError as e:  # pragma: no cover - exercised at runtime only
         raise RuntimeError(
             "moorcheh-client is not installed. Run: pip install moorcheh-client"

--- a/memanto/app/clients/onprem.py
+++ b/memanto/app/clients/onprem.py
@@ -24,7 +24,7 @@ _DEFAULT_URL = "http://localhost:8080"
 def _import_raw_client() -> Any:
     """Lazy import so the cloud path doesn't require ``moorcheh-client``."""
     try:
-        from moorcheh import MoorchehClient  # type: ignore[import-not-found]
+        from moorcheh import MoorchehClient  # type: ignore[import-not-found,import-untyped]
     except ImportError as e:  # pragma: no cover - exercised at runtime only
         raise RuntimeError(
             "moorcheh-client is not installed. Run: pip install moorcheh-client"
@@ -35,7 +35,7 @@ def _import_raw_client() -> Any:
 def _import_docker_runtime_helpers() -> tuple[Any, Any]:
     """Lazy import of upload-dir helpers; only needed for ``upload_file``."""
     try:
-        from moorcheh.docker_runtime import (  # type: ignore[import-not-found]
+        from moorcheh.docker_runtime import (  # type: ignore[import-not-found,import-untyped]
             ensure_upload_dir,
             host_path_to_container_upload_path,
         )

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -758,7 +758,8 @@ async def get_connections(_: None = Depends(_require_local)):
             {
                 "name": agent.name,
                 "display_name": agent.display_name,
-                "instruction_file": agent.instruction_file,
+                "instruction_local_file": agent.instruction_local_file,
+                "instruction_global_file": agent.instruction_global_file,
                 "skill_local_template": (
                     f"{agent.skill_local_dir}/memanto"
                     if agent.skill_local_dir

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -314,14 +314,14 @@ def _update_onprem_answer(ans: dict) -> None:
         # moorcheh-client 0.1.5 moved user_config into the cli subpackage;
         # try the new path first and fall back so 0.1.3-0.1.5 all work.
         try:
-            from moorcheh.cli.user_config import (  # type: ignore[import-not-found]
+            from moorcheh.cli.user_config import (  # type: ignore[import-not-found,import-untyped]
                 EmbeddingConfig,
                 LlmConfig,
                 default_base_url,
                 save_runtime_config,
             )
         except ImportError:
-            from moorcheh.user_config import (  # type: ignore[import-not-found]
+            from moorcheh.user_config import (  # type: ignore[import-not-found,import-untyped]
                 EmbeddingConfig,
                 LlmConfig,
                 default_base_url,

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -840,6 +840,65 @@ async def browse_path(
     }
 
 
+@router.get("/api/ui/template-status")
+async def get_template_status(_: None = Depends(_require_local)):
+    """Check if agent instruction templates are outdated."""
+    from memanto.cli.connect.templates import TEMPLATE_VERSION
+    from memanto.cli.connect.updater import check_for_updates
+
+    try:
+        # Check both local and global installations
+        status = check_for_updates(project_dir=".")
+        return status
+    except Exception as e:
+        return {"outdated": False, "error": str(e), "latest_version": TEMPLATE_VERSION}
+
+
+@router.get("/api/ui/template-status/dismissed")
+async def get_template_status_dismissed(_: None = Depends(_require_local)):
+    """Get the currently dismissed template version."""
+    dismissed = _config_manager.get("cli.dismissed_template_version", "")
+    return {"version": dismissed}
+
+
+@router.post("/api/ui/template-status/dismiss")
+async def dismiss_template_status(_: None = Depends(_require_local)):
+    """Dismiss the template update warning for the current version."""
+    from memanto.cli.connect.templates import TEMPLATE_VERSION
+
+    _config_manager.set("cli.dismissed_template_version", TEMPLATE_VERSION)
+    return {"status": "success", "dismissed_version": TEMPLATE_VERSION}
+
+
+@router.post("/api/ui/template-status/update")
+async def apply_template_update(_: None = Depends(_require_local)):
+    """Update all active Memanto templates in the workspace and globally."""
+    from memanto.cli.connect.updater import update_all_agents
+
+    try:
+        messages = update_all_agents(
+            project_dir=".", update_global=True, update_local=True
+        )
+
+        has_success = any("Successfully updated" in m for m in messages)
+        if has_success:
+            messages = [
+                m for m in messages if "No active Memanto integrations found" not in m
+            ]
+
+        # Deduplicate while preserving order
+        seen = set()
+        deduped = []
+        for m in messages:
+            if m not in seen:
+                seen.add(m)
+                deduped.append(m)
+
+        return {"status": "success", "messages": deduped}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.post("/api/ui/connections/install")
 async def connections_install(body: dict, _: None = Depends(_require_local)):
     """Install MEMANTO integration for one or more agents at a given location.

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -842,7 +842,7 @@ async def browse_path(
 
 @router.get("/api/ui/template-status")
 async def get_template_status(_: None = Depends(_require_local)):
-    """Check if agent instruction templates are outdated."""
+    """Check if agent instructions are outdated."""
     from memanto.cli.connect.templates import TEMPLATE_VERSION
     from memanto.cli.connect.updater import check_for_updates
 
@@ -856,14 +856,14 @@ async def get_template_status(_: None = Depends(_require_local)):
 
 @router.get("/api/ui/template-status/dismissed")
 async def get_template_status_dismissed(_: None = Depends(_require_local)):
-    """Get the currently dismissed template version."""
+    """Get the currently dismissed instruction version."""
     dismissed = _config_manager.get("cli.dismissed_template_version", "")
     return {"version": dismissed}
 
 
 @router.post("/api/ui/template-status/dismiss")
 async def dismiss_template_status(_: None = Depends(_require_local)):
-    """Dismiss the template update warning for the current version."""
+    """Dismiss the instruction update warning for the current version."""
     from memanto.cli.connect.templates import TEMPLATE_VERSION
 
     _config_manager.set("cli.dismissed_template_version", TEMPLATE_VERSION)
@@ -872,7 +872,7 @@ async def dismiss_template_status(_: None = Depends(_require_local)):
 
 @router.post("/api/ui/template-status/update")
 async def apply_template_update(_: None = Depends(_require_local)):
-    """Update all active Memanto templates in the workspace and globally."""
+    """Update all active Memanto agent instructions in the workspace and globally."""
     from memanto.cli.connect.updater import update_all_agents
 
     try:

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -5995,7 +5995,7 @@
                 projectsHtml = projects.map(p => {
                     const missingTag = p.exists ? '' : ' <span class="badge badge-warning" style="margin-left:8px">missing</span>';
                     const btnLabel = p.exists ? 'Disconnect' : 'Untrack';
-                    const safePath = escHtml(p.path).replace(/'/g, "&#39;");
+                    const safePath = escHtml(p.path).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
                     return `<div class="conn-project-row${p.exists ? '' : ' missing'}" id="proj-row-${btoa(unescape(encodeURIComponent(p.path))).replace(/=/g, '')}">
                         <div>
                             <div class="conn-project-path">${escHtml(p.path)}${missingTag}</div>

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -5254,6 +5254,7 @@
         const AGENT_LOGOS = {
             'claude-code':    { src: 'https://cdn.simpleicons.org/claude/d97757',          fallback: 'https://icons.duckduckgo.com/ip3/claude.ai.ico',           bg: '#1a0f0a', letter: 'C' },
             'codex':          { src: 'https://icons.duckduckgo.com/ip3/chatgpt.com.ico',   fallback: 'https://icons.duckduckgo.com/ip3/openai.com.ico',         bg: '#FFFFFF', letter: 'C' },
+            'pi':             { src: 'https://cdn.simpleicons.org/pi/ffffff',              fallback: 'https://pi.dev/favicon.svg',                              bg: '#09090b', letter: 'P' },
             'cursor':         { src: 'https://cdn.simpleicons.org/cursor/ffffff',          fallback: 'https://icons.duckduckgo.com/ip3/cursor.com.ico',         bg: '#0a0a0a', letter: 'C' },
             'windsurf':       { src: 'https://cdn.simpleicons.org/windsurf/24a5da',        fallback: 'https://icons.duckduckgo.com/ip3/codeium.com.ico',        bg: '#0a1218', letter: 'W' },
             'antigravity':    { src: 'https://icons.duckduckgo.com/ip3/google.com.ico',    fallback: null,                                                      bg: '#1a2230', letter: 'A' },

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2904,24 +2904,24 @@
             try {
                 await api('POST', '/api/ui/template-status/dismiss');
                 document.getElementById('templateUpdateBanner').style.display = 'none';
-                showToast("Update dismissed for this version");
+                toast("Update dismissed for this version");
             } catch (err) {
-                showToast("Failed to dismiss update", "error");
+                toast("Failed to dismiss update", "error");
             }
         }
 
         async function updateTemplates() {
             try {
-                showToast("Updating templates...");
+                toast("Updating templates...");
                 const res = await api('POST', '/api/ui/template-status/update');
                 if (res && res.status === "success") {
                     document.getElementById('templateUpdateBanner').style.display = 'none';
-                    showToast("Templates updated successfully!");
+                    toast("Templates updated successfully!");
                 } else {
-                    showToast("Failed to update templates", "error");
+                    toast("Failed to update templates", "error");
                 }
             } catch (err) {
-                showToast("Error updating templates", "error");
+                toast("Error updating templates", "error");
             }
         }
 

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2362,6 +2362,18 @@
         <main class="main">
             <!-- DASHBOARD -->
             <section class="page active" id="page-dashboard">
+                <!-- Update Banner (Hidden by default) -->
+                <div id="templateUpdateBanner" style="display: none; background: #fff3cd; color: #856404; padding: 12px 20px; border-radius: 6px; margin: 0 0 20px 0; border: 1px solid #ffeeba; align-items: center; justify-content: space-between;">
+                    <div>
+                        <span style="margin-right: 8px;">⚠️</span>
+                        <strong style="margin-right: 4px;">Template Update Available</strong>
+                        <span id="templateUpdateMsg">Your workspace is using an outdated instruction template.</span>
+                    </div>
+                    <div style="display: flex; gap: 10px;">
+                        <button onclick="dismissTemplateUpdate()" style="background: transparent; border: 1px solid #856404; color: #856404; padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 13px;">Dismiss</button>
+                        <button onclick="updateTemplates()" style="background: #856404; border: none; color: white; padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 13px;">Update Now</button>
+                    </div>
+                </div>
                 <div class="page-header">
                     <h2>Dashboard</h2>
                     <p>System overview at a glance</p>
@@ -2861,6 +2873,56 @@
             loadDashboard();
             // Load conflict count for badge
             loadConflictBadge();
+            // Check for template updates
+            checkTemplateStatus();
+        }
+
+        async function checkTemplateStatus() {
+            try {
+                const ts = new Date().getTime();
+                const status = await api('GET', `/api/ui/template-status?_t=${ts}`);
+                if (!status) return;
+
+                const banner = document.getElementById('templateUpdateBanner');
+                if (status.outdated && status.installed_version) {
+                    const dismissed = await api('GET', `/api/ui/template-status/dismissed?_t=${ts}`);
+                    if (dismissed && dismissed.version !== status.latest_version) {
+                        document.getElementById('templateUpdateMsg').innerText = `Your workspace is using an outdated instruction template (v${status.installed_version}). Version ${status.latest_version} is now available.`;
+                        banner.style.display = 'flex';
+                    } else {
+                        banner.style.display = 'none';
+                    }
+                } else {
+                    banner.style.display = 'none';
+                }
+            } catch (err) {
+                console.warn("Failed to check template status", err);
+            }
+        }
+
+        async function dismissTemplateUpdate() {
+            try {
+                await api('POST', '/api/ui/template-status/dismiss');
+                document.getElementById('templateUpdateBanner').style.display = 'none';
+                showToast("Update dismissed for this version");
+            } catch (err) {
+                showToast("Failed to dismiss update", "error");
+            }
+        }
+
+        async function updateTemplates() {
+            try {
+                showToast("Updating templates...");
+                const res = await api('POST', '/api/ui/template-status/update');
+                if (res && res.status === "success") {
+                    document.getElementById('templateUpdateBanner').style.display = 'none';
+                    showToast("Templates updated successfully!");
+                } else {
+                    showToast("Failed to update templates", "error");
+                }
+            } catch (err) {
+                showToast("Error updating templates", "error");
+            }
         }
 
         function isOnPrem() {

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -2363,15 +2363,15 @@
             <!-- DASHBOARD -->
             <section class="page active" id="page-dashboard">
                 <!-- Update Banner (Hidden by default) -->
-                <div id="templateUpdateBanner" style="display: none; background: #fff3cd; color: #856404; padding: 12px 20px; border-radius: 6px; margin: 0 0 20px 0; border: 1px solid #ffeeba; align-items: center; justify-content: space-between;">
+                <div id="templateUpdateBanner" style="display: none; background: #fff3cd; color: #856404; padding: 8px 16px; border-radius: 4px; margin: 0 0 16px 0; border: 1px solid #ffeeba; align-items: center; justify-content: space-between; font-size: 14px;">
                     <div>
-                        <span style="margin-right: 8px;">⚠️</span>
-                        <strong style="margin-right: 4px;">Template Update Available</strong>
-                        <span id="templateUpdateMsg">Your workspace is using an outdated instruction template.</span>
+                        <span style="margin-right: 6px;">⚠️</span>
+                        <strong style="margin-right: 4px;">Agent Instruction Update Available</strong>
+                        <span id="templateUpdateMsg">Your workspace is using outdated agent instructions.</span>
                     </div>
-                    <div style="display: flex; gap: 10px;">
-                        <button onclick="dismissTemplateUpdate()" style="background: transparent; border: 1px solid #856404; color: #856404; padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 13px;">Dismiss</button>
-                        <button onclick="updateTemplates()" style="background: #856404; border: none; color: white; padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 13px;">Update Now</button>
+                    <div style="display: flex; gap: 8px;">
+                        <button onclick="dismissTemplateUpdate()" style="background: transparent; border: 1px solid #856404; color: #856404; padding: 3px 10px; border-radius: 4px; cursor: pointer; font-size: 12px;">Dismiss</button>
+                        <button onclick="updateTemplates()" style="background: #856404; border: none; color: white; padding: 3px 10px; border-radius: 4px; cursor: pointer; font-size: 12px;">Update Now</button>
                     </div>
                 </div>
                 <div class="page-header">
@@ -2887,7 +2887,7 @@
                 if (status.outdated && status.installed_version) {
                     const dismissed = await api('GET', `/api/ui/template-status/dismissed?_t=${ts}`);
                     if (dismissed && dismissed.version !== status.latest_version) {
-                        document.getElementById('templateUpdateMsg').innerText = `Your workspace is using an outdated instruction template (v${status.installed_version}). Version ${status.latest_version} is now available.`;
+                        document.getElementById('templateUpdateMsg').innerText = `Your workspace is using outdated agent instructions (v${status.installed_version}). Version ${status.latest_version} is now available.`;
                         banner.style.display = 'flex';
                     } else {
                         banner.style.display = 'none';

--- a/memanto/cli/commands/connect.py
+++ b/memanto/cli/commands/connect.py
@@ -167,6 +167,28 @@ def connect_codex(
     _run_connect_for_agent("codex", project_dir, is_global)
 
 
+@connect_app.command("pi")
+def connect_pi(
+    project_dir: str = typer.Option(
+        ".", "--project-dir", "-p", help="Target project directory"
+    ),
+    is_global: bool = typer.Option(
+        False, "--global", "-g", help="Install globally to ~/.pi/agent/"
+    ),
+):
+    """Connect MEMANTO to Pi (coding agent).
+
+    Adds MEMANTO instructions to AGENTS.md, deploys the skill, and installs a
+    Pi extension that auto-syncs MEMORY.md on each fresh session start.
+
+    Examples:
+        memanto connect pi
+        memanto connect pi --project-dir ./my-project
+        memanto connect pi --global
+    """
+    _run_connect_for_agent("pi", project_dir, is_global)
+
+
 @connect_app.command("cursor")
 def connect_cursor(
     project_dir: str = typer.Option(

--- a/memanto/cli/commands/connect.py
+++ b/memanto/cli/commands/connect.py
@@ -429,7 +429,7 @@ def connect_list(
             det_icon,
             local_icon,
             global_icon,
-            agent.instruction_file or "[dim]skills only[/dim]",
+            agent.instruction_local_file or agent.instruction_global_file or "[dim]skills only[/dim]",
         )
 
     console.print(table)

--- a/memanto/cli/commands/connect.py
+++ b/memanto/cli/commands/connect.py
@@ -429,7 +429,9 @@ def connect_list(
             det_icon,
             local_icon,
             global_icon,
-            agent.instruction_local_file or agent.instruction_global_file or "[dim]skills only[/dim]",
+            agent.instruction_local_file
+            or agent.instruction_global_file
+            or "[dim]skills only[/dim]",
         )
 
     console.print(table)

--- a/memanto/cli/commands/connect.py
+++ b/memanto/cli/commands/connect.py
@@ -105,7 +105,7 @@ def update_templates(
         ".", "--project-dir", "-p", help="Target project directory"
     ),
 ):
-    """Update all active Memanto templates (both local and global) to the latest version."""
+    """Update all active Memanto agent instructions (both local and global) to the latest version."""
     from memanto.cli.connect.updater import update_all_agents
 
     messages = update_all_agents(project_dir, update_global=True, update_local=True)

--- a/memanto/cli/commands/connect.py
+++ b/memanto/cli/commands/connect.py
@@ -99,6 +99,36 @@ def _run_connect_for_agent(agent_name: str, project_dir: str, is_global: bool) -
 # Individual agent connect commands
 
 
+@connect_app.command("update")
+def update_templates(
+    project_dir: str = typer.Option(
+        ".", "--project-dir", "-p", help="Target project directory"
+    ),
+):
+    """Update all active Memanto templates (both local and global) to the latest version."""
+    from memanto.cli.connect.updater import update_all_agents
+
+    messages = update_all_agents(project_dir, update_global=True, update_local=True)
+
+    # Filter out empty state messages if we successfully updated at least one thing
+    has_success = any("Successfully updated" in m for m in messages)
+    if has_success:
+        messages = [
+            m for m in messages if "No active Memanto integrations found" not in m
+        ]
+
+    # Deduplicate messages while preserving order
+    seen = set()
+    deduped = []
+    for m in messages:
+        if m not in seen:
+            seen.add(m)
+            deduped.append(m)
+
+    for msg in deduped:
+        console.print(msg)
+
+
 @connect_app.command("claude-code")
 def connect_claude_code(
     project_dir: str = typer.Option(

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -343,14 +343,14 @@ def _import_user_config() -> tuple:
     0.1.3 through 0.1.5 all work.
     """
     try:
-        from moorcheh.cli.user_config import (  # type: ignore[import-not-found]
+        from moorcheh.cli.user_config import (  # type: ignore[import-not-found,import-untyped]
             EmbeddingConfig,
             LlmConfig,
             default_base_url,
             save_runtime_config,
         )
     except ImportError:
-        from moorcheh.user_config import (  # type: ignore[import-not-found]
+        from moorcheh.user_config import (  # type: ignore[import-not-found,import-untyped]
             EmbeddingConfig,
             LlmConfig,
             default_base_url,
@@ -506,7 +506,7 @@ def _pull_ollama_model(model: str) -> None:
     ``docker exec`` for a bundled container we can't reach over HTTP.
     """
     try:
-        from moorcheh.ollama_setup import ollama_is_reachable, pull_ollama_model_http
+        from moorcheh.ollama_setup import ollama_is_reachable, pull_ollama_model_http  # type: ignore[import-untyped]
     except ImportError:
         ollama_is_reachable = None
 

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -506,7 +506,10 @@ def _pull_ollama_model(model: str) -> None:
     ``docker exec`` for a bundled container we can't reach over HTTP.
     """
     try:
-        from moorcheh.ollama_setup import ollama_is_reachable, pull_ollama_model_http  # type: ignore[import-untyped]
+        from moorcheh.ollama_setup import (  # type: ignore[import-untyped]
+            ollama_is_reachable,
+            pull_ollama_model_http,
+        )
     except ImportError:
         ollama_is_reachable = None
 

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -912,6 +912,27 @@ def status():
     except Exception:
         console.print("[dim]Could not fetch agent list.[/dim]")
 
+    # Check for template updates
+    try:
+        from memanto.cli.connect.templates import TEMPLATE_VERSION
+        from memanto.cli.connect.updater import check_for_updates
+
+        status = check_for_updates(project_dir=".")
+
+        is_outdated = status.get("outdated")
+        installed_version = status.get("installed_version")
+
+        if is_outdated:
+            console.print(f"\n[{BOLD_PRIMARY}]Template Status[/{BOLD_PRIMARY}]")
+            console.print(
+                f"[yellow]⚠️ Outdated (v{installed_version} installed, v{TEMPLATE_VERSION} available)[/yellow]"
+            )
+            console.print(
+                "[yellow]   Run `memanto connect update` to apply the latest instruction hardening.[/yellow]"
+            )
+    except Exception:
+        pass
+
     console.print()
 
 

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -930,8 +930,8 @@ def status():
             console.print(
                 "[yellow]   Run `memanto connect update` to apply the latest instruction hardening.[/yellow]"
             )
-    except Exception:
-        pass
+    except Exception as e:
+        console.print(f"[dim]Failed to check template update status: {e}[/dim]")
 
     console.print()
 

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -923,7 +923,9 @@ def status():
         installed_version = status.get("installed_version")
 
         if is_outdated:
-            console.print(f"\n[{BOLD_PRIMARY}]Agent Instruction Status[/{BOLD_PRIMARY}]")
+            console.print(
+                f"\n[{BOLD_PRIMARY}]Agent Instruction Status[/{BOLD_PRIMARY}]"
+            )
             console.print(
                 f"[yellow]⚠️ Outdated (v{installed_version} installed, v{TEMPLATE_VERSION} available)[/yellow]"
             )

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -912,7 +912,7 @@ def status():
     except Exception:
         console.print("[dim]Could not fetch agent list.[/dim]")
 
-    # Check for template updates
+    # Check for instruction updates
     try:
         from memanto.cli.connect.templates import TEMPLATE_VERSION
         from memanto.cli.connect.updater import check_for_updates
@@ -923,7 +923,7 @@ def status():
         installed_version = status.get("installed_version")
 
         if is_outdated:
-            console.print(f"\n[{BOLD_PRIMARY}]Template Status[/{BOLD_PRIMARY}]")
+            console.print(f"\n[{BOLD_PRIMARY}]Agent Instruction Status[/{BOLD_PRIMARY}]")
             console.print(
                 f"[yellow]⚠️ Outdated (v{installed_version} installed, v{TEMPLATE_VERSION} available)[/yellow]"
             )
@@ -931,7 +931,7 @@ def status():
                 "[yellow]   Run `memanto connect update` to apply the latest instruction hardening.[/yellow]"
             )
     except Exception as e:
-        console.print(f"[dim]Failed to check template update status: {e}[/dim]")
+        console.print(f"[dim]Failed to check instruction update status: {e}[/dim]")
 
     console.print()
 

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -176,6 +176,29 @@ def memory_export(
     console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")
 
 
+def _check_template_updates(project_dir: str):
+    """Silently check for outdated templates and print a warning if needed."""
+    try:
+        from memanto.cli.commands._shared import console
+        from memanto.cli.connect.templates import TEMPLATE_VERSION
+        from memanto.cli.connect.updater import check_for_updates
+
+        status = check_for_updates(project_dir=project_dir)
+
+        is_outdated = status.get("outdated")
+        installed_version = status.get("installed_version")
+
+        if is_outdated:
+            console.print(
+                f"\n[yellow]⚠️ Notice: Your Memanto agent templates are out of date (v{installed_version} installed, v{TEMPLATE_VERSION} available).[/yellow]"
+            )
+            console.print(
+                "[yellow]   Run `memanto connect update` to apply the latest instruction hardening.[/yellow]"
+            )
+    except Exception:
+        pass
+
+
 @memory_app.command("sync")
 def memory_sync(
     project_dir: str = typer.Option(
@@ -272,6 +295,7 @@ def memory_sync(
             )
 
         console.print(f"[dim]Output: {out_path}[/dim]")
+        _check_template_updates(project_dir)
         console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")
         return
 
@@ -318,4 +342,5 @@ def memory_sync(
         )
 
     console.print(f"[dim]Output: {out_path}[/dim]")
+    _check_template_updates(project_dir)
     console.print(f"[dim]Completed in {elapsed:.2f}s[/dim]")

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -195,8 +195,8 @@ def _check_template_updates(project_dir: str):
             console.print(
                 "[yellow]   Run `memanto connect update` to apply the latest instruction hardening.[/yellow]"
             )
-    except Exception:
-        pass
+    except Exception as e:
+        console.print(f"[dim]Failed to check template update status: {e}[/dim]")
 
 
 @memory_app.command("sync")

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -177,7 +177,7 @@ def memory_export(
 
 
 def _check_template_updates(project_dir: str):
-    """Silently check for outdated templates and print a warning if needed."""
+    """Silently check for outdated agent instructions and print a warning if needed."""
     try:
         from memanto.cli.commands._shared import console
         from memanto.cli.connect.templates import TEMPLATE_VERSION
@@ -190,7 +190,7 @@ def _check_template_updates(project_dir: str):
 
         if is_outdated:
             console.print(
-                f"\n[yellow]⚠️ Notice: Your Memanto agent templates are out of date (v{installed_version} installed, v{TEMPLATE_VERSION} available).[/yellow]"
+                f"\n[yellow]⚠️ Notice: Your Memanto agent instructions are out of date (v{installed_version} installed, v{TEMPLATE_VERSION} available).[/yellow]"
             )
             console.print(
                 "[yellow]   Run `memanto connect update` to apply the latest instruction hardening.[/yellow]"
@@ -198,9 +198,9 @@ def _check_template_updates(project_dir: str):
     except Exception as e:
         try:
             from memanto.cli.commands._shared import console
-            console.print(f"[dim]Failed to check template update status: {e}[/dim]")
+            console.print(f"[dim]Failed to check instruction update status: {e}[/dim]")
         except Exception:
-            print(f"Failed to check template update status: {e}")
+            print(f"Failed to check instruction update status: {e}")
 
 
 @memory_app.command("sync")

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -196,7 +196,11 @@ def _check_template_updates(project_dir: str):
                 "[yellow]   Run `memanto connect update` to apply the latest instruction hardening.[/yellow]"
             )
     except Exception as e:
-        console.print(f"[dim]Failed to check template update status: {e}[/dim]")
+        try:
+            from memanto.cli.commands._shared import console
+            console.print(f"[dim]Failed to check template update status: {e}[/dim]")
+        except Exception:
+            print(f"Failed to check template update status: {e}")
 
 
 @memory_app.command("sync")

--- a/memanto/cli/commands/memory_mgmt.py
+++ b/memanto/cli/commands/memory_mgmt.py
@@ -198,6 +198,7 @@ def _check_template_updates(project_dir: str):
     except Exception as e:
         try:
             from memanto.cli.commands._shared import console
+
             console.print(f"[dim]Failed to check instruction update status: {e}[/dim]")
         except Exception:
             print(f"Failed to check instruction update status: {e}")

--- a/memanto/cli/connect/agent_registry.py
+++ b/memanto/cli/connect/agent_registry.py
@@ -119,20 +119,6 @@ class AgentDef:
             base = project_dir / self.extension_local_dir
         return base / self.extension_file
 
-    def resolve_extension_file(self, project_dir: Path, is_global: bool) -> Path | None:
-        """Resolve code extension file path (for agents that support one)."""
-        if not self.extension_file:
-            return None
-        if is_global:
-            if not self.extension_global_dir:
-                return None
-            base = Path.home() / self.extension_global_dir.lstrip("~/")
-        else:
-            if not self.extension_local_dir:
-                return None
-            base = project_dir / self.extension_local_dir
-        return base / self.extension_file
-
 
 # Agent Definitions
 
@@ -265,20 +251,6 @@ PI = AgentDef(
     display_name="Pi (coding agent)",
     instruction_local_file="AGENTS.md",
     instruction_global_file="~/.pi/agent/AGENTS.md",
-    instruction_format="markdown",
-    skill_local_dir=".pi/skills",
-    skill_global_dir="~/.pi/agent/skills",
-    config_local_dir=".pi",
-    config_global_dir="~/.pi/agent",
-    extension_file="memanto-sync.ts",
-    extension_global_dir="~/.pi/agent/extensions",
-    extension_local_dir=".pi/extensions",
-)
-
-PI = AgentDef(
-    name="pi",
-    display_name="Pi (coding agent)",
-    instruction_file="AGENTS.md",
     instruction_format="markdown",
     skill_local_dir=".pi/skills",
     skill_global_dir="~/.pi/agent/skills",

--- a/memanto/cli/connect/agent_registry.py
+++ b/memanto/cli/connect/agent_registry.py
@@ -29,6 +29,9 @@ class AgentHookConfig:
     settings_file: str  # e.g. "settings.json"
     hook_key: str  # e.g. "hooks.SessionStart"
     hook_payload: dict = field(default_factory=dict)
+    asset_file: str | None = (
+        None  # e.g. "hooks.json", "cursor-hooks.json", "codex-hooks.json"
+    )
 
 
 @dataclass
@@ -114,15 +117,64 @@ CLAUDE_CODE = AgentDef(
     hook_config=AgentHookConfig(
         settings_file="settings.json",
         hook_key="hooks.SessionStart",
+        asset_file="hooks.json",
         hook_payload={
-            "matcher": "startup",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": "memanto memory sync --project-dir .",
-                    "timeout": 30,
-                }
-            ],
+            "description": "MEMANTO: persistent memory for Claude Code. SessionStart refreshes MEMORY.md and installs the status line once. PreCompact re-syncs before compaction, so context about to be summarized away survives. PostToolUse replaces the raw 'Bash(memanto ...)' line in chat with a readable summary of what the memory operation actually did; it is gated by an if-filter so it never spawns for unrelated commands. Each Python hook is registered under both 'python' and 'python3' because neither spelling exists on every platform; whichever is missing fails harmlessly and every script is idempotent.",
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "hooks": [
+                            {
+                                "command": 'python "${CLAUDE_PLUGIN_ROOT}/hooks/notify.py"',
+                                "if": "Bash(memanto *)",
+                                "timeout": 10,
+                                "type": "command",
+                            },
+                            {
+                                "command": 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/notify.py"',
+                                "if": "Bash(memanto *)",
+                                "timeout": 10,
+                                "type": "command",
+                            },
+                        ],
+                        "matcher": "Bash",
+                    }
+                ],
+                "PreCompact": [
+                    {
+                        "hooks": [
+                            {
+                                "args": [
+                                    "memory",
+                                    "sync",
+                                    "--project-dir",
+                                    "${CLAUDE_PROJECT_DIR}",
+                                ],
+                                "command": "memanto",
+                                "timeout": 30,
+                                "type": "command",
+                            }
+                        ]
+                    }
+                ],
+                "SessionStart": [
+                    {
+                        "hooks": [
+                            {
+                                "command": 'python "${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"',
+                                "timeout": 30,
+                                "type": "command",
+                            },
+                            {
+                                "command": 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py"',
+                                "timeout": 30,
+                                "type": "command",
+                            },
+                        ],
+                        "matcher": "startup|resume",
+                    }
+                ],
+            },
         },
     ),
     permissions_file="settings.local.json",
@@ -139,6 +191,40 @@ CODEX = AgentDef(
     skill_global_dir="~/.codex/skills",
     config_local_dir=".agents",
     config_global_dir="~/.codex",
+    supports_hooks=True,
+    hook_config=AgentHookConfig(
+        settings_file="hooks.json",
+        hook_key="hooks.SessionStart",
+        asset_file="codex-hooks.json",
+        hook_payload={
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "memanto memory sync --project-dir .",
+                                "timeout": 30,
+                                "statusMessage": "Loading MEMANTO memory...",
+                            }
+                        ]
+                    }
+                ],
+                "PreCompact": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "memanto memory sync --project-dir .",
+                                "timeout": 30,
+                                "statusMessage": "Saving MEMANTO memory...",
+                            }
+                        ]
+                    }
+                ],
+            }
+        },
+    ),
 )
 
 CURSOR = AgentDef(
@@ -151,6 +237,26 @@ CURSOR = AgentDef(
     skill_global_dir="~/.cursor/skills",
     config_local_dir=".cursor",
     config_global_dir="~/.cursor",
+    supports_hooks=True,
+    hook_config=AgentHookConfig(
+        settings_file="hooks.json",
+        hook_key="hooks.sessionStart",
+        asset_file="cursor-hooks.json",
+        hook_payload={
+            "hooks": {
+                "sessionStart": [
+                    {
+                        "command": 'python "${PLUGIN_ROOT}/hooks/session_start.py" --host cursor'
+                    }
+                ],
+                "preCompact": [
+                    {
+                        "command": 'python "${PLUGIN_ROOT}/hooks/session_start.py" --host cursor'
+                    }
+                ],
+            }
+        },
+    ),
 )
 
 WINDSURF = AgentDef(

--- a/memanto/cli/connect/agent_registry.py
+++ b/memanto/cli/connect/agent_registry.py
@@ -69,6 +69,11 @@ class AgentDef:
     permissions_file: str | None = None  # e.g. "settings.local.json"
     permissions_payload: dict | None = None
 
+    # Code extension file (for agents that load native extensions, e.g. Pi .ts)
+    extension_file: str | None = None  # e.g. "memanto-sync.ts"
+    extension_global_dir: str | None = None  # e.g. "~/.pi/agent/extensions"
+    extension_local_dir: str | None = None  # e.g. ".pi/extensions"
+
     def resolve_skill_local(self, project_dir: Path) -> Path:
         """Resolve local skill directory path."""
         if self.skill_local_dir:
@@ -99,6 +104,20 @@ class AgentDef:
             if not self.instruction_local_file:
                 return None
             return project_dir / self.instruction_local_file
+
+    def resolve_extension_file(self, project_dir: Path, is_global: bool) -> Path | None:
+        """Resolve code extension file path (for agents that support one)."""
+        if not self.extension_file:
+            return None
+        if is_global:
+            if not self.extension_global_dir:
+                return None
+            base = Path.home() / self.extension_global_dir.lstrip("~/")
+        else:
+            if not self.extension_local_dir:
+                return None
+            base = project_dir / self.extension_local_dir
+        return base / self.extension_file
 
 
 # Agent Definitions
@@ -225,6 +244,21 @@ CODEX = AgentDef(
             }
         },
     ),
+)
+
+PI = AgentDef(
+    name="pi",
+    display_name="Pi (coding agent)",
+    instruction_local_file="AGENTS.md",
+    instruction_global_file="~/.pi/agent/AGENTS.md",
+    instruction_format="markdown",
+    skill_local_dir=".pi/skills",
+    skill_global_dir="~/.pi/agent/skills",
+    config_local_dir=".pi",
+    config_global_dir="~/.pi/agent",
+    extension_file="memanto-sync.ts",
+    extension_global_dir="~/.pi/agent/extensions",
+    extension_local_dir=".pi/extensions",
 )
 
 CURSOR = AgentDef(
@@ -386,6 +420,7 @@ AGENT_REGISTRY: dict[str, AgentDef] = {
     for a in [
         CLAUDE_CODE,
         CODEX,
+        PI,
         CURSOR,
         WINDSURF,
         ANTIGRAVITY,

--- a/memanto/cli/connect/agent_registry.py
+++ b/memanto/cli/connect/agent_registry.py
@@ -5,8 +5,21 @@ Defines all supported AI coding agents with their instruction file paths,
 skill directories, and integration capabilities.
 """
 
+import os
+import platform
 from dataclasses import dataclass, field
 from pathlib import Path
+
+
+def _get_vscode_prompts_dir() -> str:
+    system = platform.system()
+    if system == "Windows":
+        base = os.environ.get("APPDATA", os.path.expanduser("~\\AppData\\Roaming"))
+        return os.path.join(base, "Code", "User", "prompts", "memanto.instructions.md")
+    elif system == "Darwin":
+        return "~/Library/Application Support/Code/User/prompts/memanto.instructions.md"
+    else:
+        return "~/.config/Code/User/prompts/memanto.instructions.md"
 
 
 @dataclass
@@ -26,7 +39,8 @@ class AgentDef:
     display_name: str  # Human name, e.g. "Claude Code"
 
     # Instruction file (the main file where agent reads instructions)
-    instruction_file: str | None = None  # e.g. "CLAUDE.md"
+    instruction_local_file: str | None = None  # e.g. "CLAUDE.md"
+    instruction_global_file: str | None = None  # e.g. "~/.claude/CLAUDE.md"
     instruction_format: str = "markdown"  # "markdown" | "mdc" | "append"
 
     # Skill directory paths (relative)
@@ -68,24 +82,20 @@ class AgentDef:
         self, project_dir: Path, is_global: bool
     ) -> Path | None:
         """Resolve instruction file path."""
-        if not self.instruction_file:
-            return None
         if is_global:
-            if self.config_global_dir:
-                base = Path.home() / self.config_global_dir.lstrip("~/")
-                instruction_path = Path(self.instruction_file)
-                if self.config_local_dir:
-                    try:
-                        instruction_path = instruction_path.relative_to(
-                            self.config_local_dir
-                        )
-                    except ValueError:
-                        pass
+            if not self.instruction_global_file:
+                return None
+            p = Path(self.instruction_global_file)
+            if p.is_absolute():
+                return p
+            elif self.instruction_global_file.startswith("~/"):
+                return Path.home() / self.instruction_global_file[2:]
             else:
-                base = Path.home()
-                instruction_path = Path(self.instruction_file)
-            return base / instruction_path
-        return project_dir / self.instruction_file
+                return Path.home() / self.instruction_global_file
+        else:
+            if not self.instruction_local_file:
+                return None
+            return project_dir / self.instruction_local_file
 
 
 # Agent Definitions
@@ -93,7 +103,8 @@ class AgentDef:
 CLAUDE_CODE = AgentDef(
     name="claude-code",
     display_name="Claude Code",
-    instruction_file="CLAUDE.md",
+    instruction_local_file="CLAUDE.md",
+    instruction_global_file="~/.claude/CLAUDE.md",
     instruction_format="markdown",
     skill_local_dir=".claude/skills",
     skill_global_dir="~/.claude/skills",
@@ -121,7 +132,8 @@ CLAUDE_CODE = AgentDef(
 CODEX = AgentDef(
     name="codex",
     display_name="Codex CLI",
-    instruction_file="AGENTS.md",
+    instruction_local_file="AGENTS.md",
+    instruction_global_file="~/.codex/AGENTS.md",
     instruction_format="markdown",
     skill_local_dir=".agents/skills",
     skill_global_dir="~/.codex/skills",
@@ -132,7 +144,8 @@ CODEX = AgentDef(
 CURSOR = AgentDef(
     name="cursor",
     display_name="Cursor",
-    instruction_file=".cursor/rules/memanto.mdc",
+    instruction_local_file=".cursor/rules/memanto.mdc",
+    instruction_global_file="~/.cursor/rules/memanto.mdc",
     instruction_format="mdc",
     skill_local_dir=".cursor/skills",
     skill_global_dir="~/.cursor/skills",
@@ -143,7 +156,8 @@ CURSOR = AgentDef(
 WINDSURF = AgentDef(
     name="windsurf",
     display_name="Windsurf",
-    instruction_file=".windsurfrules",
+    instruction_local_file=".windsurfrules",
+    instruction_global_file="~/.codeium/windsurf/.windsurfrules",
     instruction_format="append",
     skill_local_dir=".windsurf/skills",
     skill_global_dir="~/.codeium/windsurf/skills",
@@ -154,7 +168,8 @@ WINDSURF = AgentDef(
 ANTIGRAVITY = AgentDef(
     name="antigravity",
     display_name="Antigravity (Google)",
-    instruction_file=None,  # Antigravity uses skills only
+    instruction_local_file=None,  # Antigravity uses skills only
+    instruction_global_file=None,
     skill_local_dir=".agent/skills",
     skill_global_dir="~/.gemini/antigravity/skills",
     config_local_dir=".agent",
@@ -164,7 +179,8 @@ ANTIGRAVITY = AgentDef(
 GEMINI_CLI = AgentDef(
     name="gemini-cli",
     display_name="Gemini CLI",
-    instruction_file="GEMINI.md",
+    instruction_local_file="GEMINI.md",
+    instruction_global_file="~/.gemini/GEMINI.md",
     instruction_format="markdown",
     skill_local_dir=".gemini/skills",
     skill_global_dir="~/.gemini/skills",
@@ -175,7 +191,8 @@ GEMINI_CLI = AgentDef(
 CLINE = AgentDef(
     name="cline",
     display_name="Cline",
-    instruction_file=".clinerules/memanto.md",
+    instruction_local_file=".clinerules/memanto.md",
+    instruction_global_file="~/.clinerules/memanto.md",
     instruction_format="markdown",
     instruction_is_dir=True,
     skill_local_dir=".agents/skills",
@@ -186,7 +203,8 @@ CLINE = AgentDef(
 CONTINUE = AgentDef(
     name="continue",
     display_name="Continue",
-    instruction_file=".continue/rules/memanto.md",
+    instruction_local_file=".continue/rules/memanto.md",
+    instruction_global_file="~/.continue/rules/memanto.md",
     instruction_format="markdown",
     instruction_is_dir=True,
     skill_local_dir=".continue/skills",
@@ -198,7 +216,8 @@ CONTINUE = AgentDef(
 OPENCODE = AgentDef(
     name="opencode",
     display_name="OpenCode",
-    instruction_file="AGENTS.md",
+    instruction_local_file="AGENTS.md",
+    instruction_global_file="~/.config/opencode/AGENTS.md",
     instruction_format="markdown",
     skill_local_dir=".agents/skills",
     skill_global_dir="~/.config/opencode/skills",
@@ -208,7 +227,8 @@ OPENCODE = AgentDef(
 GOOSE = AgentDef(
     name="goose",
     display_name="Goose",
-    instruction_file=None,  # Goose uses config.yaml + MCP, not an instruction file
+    instruction_local_file=None,
+    instruction_global_file=None,
     skill_local_dir=".goose/skills",
     skill_global_dir="~/.config/goose/skills",
     config_local_dir=".goose",
@@ -218,7 +238,8 @@ GOOSE = AgentDef(
 ROO = AgentDef(
     name="roo",
     display_name="Roo Code",
-    instruction_file=".roo/rules/memanto.md",
+    instruction_local_file=".roo/rules/memanto.md",
+    instruction_global_file="~/.roo/rules/memanto.md",
     instruction_format="markdown",
     instruction_is_dir=True,
     skill_local_dir=".roo/skills",
@@ -230,7 +251,8 @@ ROO = AgentDef(
 GITHUB_COPILOT = AgentDef(
     name="github-copilot",
     display_name="GitHub Copilot",
-    instruction_file=".github/copilot-instructions.md",
+    instruction_local_file=".github/copilot-instructions.md",
+    instruction_global_file=_get_vscode_prompts_dir(),
     instruction_format="markdown",
     skill_local_dir=".agents/skills",
     skill_global_dir="~/.copilot/skills",
@@ -240,7 +262,8 @@ GITHUB_COPILOT = AgentDef(
 AUGMENT = AgentDef(
     name="augment",
     display_name="Augment Code",
-    instruction_file=".augment/rules/memanto.md",
+    instruction_local_file=".augment/rules/memanto.md",
+    instruction_global_file="~/.augment/rules/memanto.md",
     instruction_format="markdown",
     instruction_is_dir=True,
     skill_local_dir=".augment/skills",
@@ -296,8 +319,8 @@ def detect_agents_in_project(project_dir: Path) -> list[AgentDef]:
                 detected.append(agent)
                 continue
         # Check for instruction file
-        if agent.instruction_file:
-            instr_path = project_dir / agent.instruction_file
+        if agent.instruction_local_file:
+            instr_path = project_dir / agent.instruction_local_file
             # For directory-based instruction files, check parent dir
             if agent.instruction_is_dir:
                 parent = instr_path.parent
@@ -315,7 +338,7 @@ def detect_memanto_installed(project_dir: Path) -> list[AgentDef]:
     installed = []
     for agent in AGENT_REGISTRY.values():
         if _has_memanto_skill(agent, project_dir, is_global=False) and (
-            not agent.instruction_file
+            not agent.instruction_local_file
             or _has_memanto_instruction(agent, project_dir, is_global=False)
         ):
             installed.append(agent)
@@ -327,7 +350,7 @@ def detect_memanto_installed_global() -> list[AgentDef]:
     installed = []
     for agent in AGENT_REGISTRY.values():
         if _has_memanto_skill(agent, Path.home(), is_global=True) and (
-            not agent.instruction_file
+            not agent.instruction_global_file
             or _has_memanto_instruction(agent, Path.home(), is_global=True)
         ):
             installed.append(agent)

--- a/memanto/cli/connect/assets/hooks/codex-hooks.json
+++ b/memanto/cli/connect/assets/hooks/codex-hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memanto memory sync --project-dir .",
+            "timeout": 30,
+            "statusMessage": "Loading MEMANTO memory..."
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memanto memory sync --project-dir .",
+            "timeout": 30,
+            "statusMessage": "Saving MEMANTO memory..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/memanto/cli/connect/assets/hooks/cursor-hooks.json
+++ b/memanto/cli/connect/assets/hooks/cursor-hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "python \"${PLUGIN_ROOT}/hooks/session_start.py\" --host cursor"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "python \"${PLUGIN_ROOT}/hooks/session_start.py\" --host cursor"
+      }
+    ]
+  }
+}

--- a/memanto/cli/connect/assets/hooks/hooks.json
+++ b/memanto/cli/connect/assets/hooks/hooks.json
@@ -1,0 +1,58 @@
+{
+  "description": "MEMANTO: persistent memory for Claude Code. SessionStart refreshes MEMORY.md and installs the status line once. PreCompact re-syncs before compaction, so context about to be summarized away survives. PostToolUse replaces the raw 'Bash(memanto ...)' line in chat with a readable summary of what the memory operation actually did; it is gated by an if-filter so it never spawns for unrelated commands. Each Python hook is registered under both 'python' and 'python3' because neither spelling exists on every platform; whichever is missing fails harmlessly and every script is idempotent.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py\"",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memanto",
+            "args": [
+              "memory",
+              "sync",
+              "--project-dir",
+              "${CLAUDE_PROJECT_DIR}"
+            ],
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(memanto *)",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/notify.py\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "if": "Bash(memanto *)",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/notify.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/memanto/cli/connect/assets/hooks/notify.py
+++ b/memanto/cli/connect/assets/hooks/notify.py
@@ -68,7 +68,8 @@ def _emit(message: str | None) -> None:
         return
     payload = {"systemMessage": f"{MARK} · {message}"}
     try:
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined,union-attr]
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
     except Exception:
         pass
     try:
@@ -83,8 +84,9 @@ def _plain(value) -> str:
         return value
     if isinstance(value, dict):
         for key in ("stdout", "output", "content", "text"):
-            if isinstance(value.get(key), str):
-                return value[key]
+            val = value.get(key)
+            if isinstance(val, str):
+                return val
         return json.dumps(value)
     if isinstance(value, list):
         return " ".join(_plain(item) for item in value)

--- a/memanto/cli/connect/assets/hooks/notify.py
+++ b/memanto/cli/connect/assets/hooks/notify.py
@@ -57,6 +57,7 @@ def _claim(key: str, ttl: float = 10.0) -> bool:
                 os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
                 return True
         except Exception:
+            # Ignore errors checking or unlinking lock file
             pass
         return False
     except Exception:
@@ -71,10 +72,12 @@ def _emit(message: str | None) -> None:
         if hasattr(sys.stdout, "reconfigure"):
             sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
     except Exception:
+        # Ignore if stdout reconfigure fails or is unsupported
         pass
     try:
         sys.stdout.write(json.dumps(payload, ensure_ascii=False))
     except Exception:
+        # Ignore stdout writing errors in hook
         pass
 
 

--- a/memanto/cli/connect/assets/hooks/notify.py
+++ b/memanto/cli/connect/assets/hooks/notify.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""MEMANTO PostToolUse hook — turn raw CLI calls into a readable line.
+
+Without this, every memory operation shows up in chat as the bare shell command:
+
+    Bash(memanto remember "Chose PostgreSQL over SQLite..." --type decision ...)
+
+With it, the user sees what actually happened:
+
+    👾 Memanto · stored a decision (confidence 0.95)
+    👾 Memanto · recalled 7 memories
+    👾 Memanto · MEMORY.md synced — 42 memories
+
+Emits `systemMessage`, which is a universal hook output field shown to the user.
+PostToolUse plain stdout only reaches the debug log, so the JSON field is the
+only way to surface anything here.
+
+Registered with `if: "Bash(memanto *)"` so the process is not spawned for
+unrelated shell commands. Silent on anything it cannot confidently describe:
+a wrong summary is worse than none.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import sys
+
+MARK = "👾 Memanto"
+
+
+def _claim(key: str, ttl: float = 10.0) -> bool:
+    """First invocation for `key` wins; a duplicate stays silent.
+
+    hooks.json registers each Python hook twice — once as `python`, once as
+    `python3` — because neither spelling exists on every platform. On a machine
+    where both resolve, both processes run, so the work must be claimed exactly
+    once or the user sees every notice twice.
+    """
+    import hashlib
+    import os
+    import tempfile
+    import time
+
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"memanto-hook-{hashlib.sha256(key.encode('utf-8')).hexdigest()[:24]}.lock",
+    )
+    try:
+        os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+        return True
+    except FileExistsError:
+        try:
+            if time.time() - os.stat(path).st_mtime > ttl:
+                os.unlink(path)
+                os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+                return True
+        except Exception:
+            pass
+        return False
+    except Exception:
+        return True  # never suppress the hook over an unexpected filesystem error
+
+
+def _emit(message: str | None) -> None:
+    if not message:
+        return
+    payload = {"systemMessage": f"{MARK} · {message}"}
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined,union-attr]
+    except Exception:
+        pass
+    try:
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+    except Exception:
+        pass
+
+
+def _plain(value) -> str:
+    """Flatten tool_response into searchable text; it may be str or blocks."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("stdout", "output", "content", "text"):
+            if isinstance(value.get(key), str):
+                return value[key]
+        return json.dumps(value)
+    if isinstance(value, list):
+        return " ".join(_plain(item) for item in value)
+    return ""
+
+
+def _flag(tokens: list[str], name: str) -> str | None:
+    for i, token in enumerate(tokens):
+        if token == name and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if token.startswith(name + "="):
+            return token.split("=", 1)[1]
+    return None
+
+
+def _int_after(pattern: str, text: str) -> int | None:
+    match = re.search(pattern, text, re.I)
+    return int(match.group(1)) if match else None
+
+
+def describe(command: str, output: str) -> str | None:
+    try:
+        tokens = shlex.split(command)
+    except Exception:
+        tokens = command.split()
+    if not tokens:
+        return None
+
+    # Strip anything before the memanto invocation (env prefixes, cd && ...).
+    while tokens and not tokens[0].endswith("memanto"):
+        tokens.pop(0)
+    if len(tokens) < 2:
+        return None
+
+    verb = tokens[1]
+    sub = tokens[2] if len(tokens) > 2 else ""
+
+    if verb == "remember":
+        stored = _int_after(r"Stored\s+(\d+)\s*/", output)
+        if stored is not None:
+            total = _int_after(r"Stored\s+\d+\s*/\s*(\d+)", output)
+            noun = "memory" if stored == 1 else "memories"
+            return f"stored {stored} {noun}" + (
+                f" of {total}" if total and total != stored else ""
+            )
+        if "stored successfully" not in output.lower():
+            return None
+        kind = _flag(tokens, "--type") or _flag(tokens, "-t") or "memory"
+        confidence = _flag(tokens, "--confidence") or _flag(tokens, "-c")
+        article = "an" if kind[:1].lower() in "aeiou" else "a"
+        tail = f" (confidence {confidence})" if confidence else ""
+        return f"stored {article} {kind}{tail}"
+
+    if verb == "recall":
+        found = _int_after(r"Found\s+(\d+)\s+memor", output)
+        if found is not None:
+            return f"recalled {found} " + ("memory" if found == 1 else "memories")
+        if "no memories found" in output.lower():
+            return "searched memory — no matches"
+        return None
+
+    if verb == "answer":
+        return "answered from memory" if output.strip() else None
+
+    if verb == "upload":
+        if "successful" in output.lower() or "uploaded" in output.lower():
+            name = (
+                tokens[2].replace("\\", "/").rsplit("/", 1)[-1]
+                if len(tokens) > 2
+                else "file"
+            )
+            return f"ingested {name}"
+        return None
+
+    if verb == "forget":
+        return "permanently deleted a memory" if "deleted" in output.lower() else None
+
+    if verb == "edit":
+        return (
+            "updated a memory"
+            if "updated" in output.lower() or "OK" in output
+            else None
+        )
+
+    if verb == "memory":
+        if sub == "sync":
+            count = _int_after(r"Synced\s+(\d+)\s+memor", output)
+            return (
+                f"MEMORY.md synced — {count} "
+                + ("memory" if count == 1 else "memories")
+                if count is not None
+                else None
+            )
+        if sub == "export":
+            return (
+                "exported memory snapshot"
+                if "OK" in output or "export" in output.lower()
+                else None
+            )
+        if sub == "expire":
+            return (
+                "expired a memory (reversible)" if "expired" in output.lower() else None
+            )
+        if sub == "restore":
+            return "restored an expired memory" if "restor" in output.lower() else None
+        return None
+
+    if verb == "detect-conflicts":
+        count = _int_after(r"(\d+)\s+conflict", output)
+        if count is not None:
+            return f"found {count} " + ("conflict" if count == 1 else "conflicts")
+        return "checked for conflicts"
+
+    if verb == "daily-summary":
+        return "generated a daily summary" if output.strip() else None
+
+    if verb == "agent" and sub == "create":
+        return f"created agent {tokens[3]}" if len(tokens) > 3 else "created an agent"
+
+    if verb == "agent" and sub == "activate":
+        return (
+            f"activated agent {tokens[3]}" if len(tokens) > 3 else "activated an agent"
+        )
+
+    return None
+
+
+def main() -> None:
+    try:
+        payload = json.loads(sys.stdin.read().strip() or "{}")
+        if not isinstance(payload, dict):
+            return
+        command = (payload.get("tool_input") or {}).get("command") or ""
+        if "memanto" not in command:
+            return
+        response = _plain(payload.get("tool_response"))
+        if not _claim("posttooluse:" + command + ":" + response[:200]):
+            return
+        _emit(describe(command, response))
+    except Exception:
+        # Never disrupt the session over a cosmetic notice.
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/memanto/cli/connect/assets/hooks/session_start.py
+++ b/memanto/cli/connect/assets/hooks/session_start.py
@@ -57,6 +57,7 @@ def _claim(key: str, ttl: float = 10.0) -> bool:
                 os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
                 return True
         except Exception:
+            # Ignore errors checking or unlinking lock file
             pass
         return False
     except Exception:
@@ -69,6 +70,7 @@ def _out(text: str) -> None:
         if hasattr(sys.stdout, "reconfigure"):
             sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
     except Exception:
+        # Ignore if stdout reconfigure fails or is unsupported
         pass
     try:
         sys.stdout.write(text + "\n")
@@ -76,6 +78,7 @@ def _out(text: str) -> None:
         try:
             sys.stdout.write(text.encode("ascii", "ignore").decode("ascii") + "\n")
         except Exception:
+            # Ignore stdout writing errors in hook
             pass
 
 
@@ -214,6 +217,7 @@ def _touch(marker: Path) -> None:
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.write_text("1", encoding="utf-8")
     except Exception:
+        # Ignore errors writing statusline installation marker
         pass
 
 
@@ -232,6 +236,7 @@ def main() -> None:
                 f"{MARK} {summary} Read MEMORY.md before acting; it carries standing instructions, decisions, and open commitments from previous sessions."
             )
     except Exception:
+        # Ignore errors syncing memory in session start hook
         pass
 
     try:
@@ -239,6 +244,7 @@ def main() -> None:
         if notice:
             lines.append(notice)
     except Exception:
+        # Ignore errors installing statusline in session start hook
         pass
 
     if lines:

--- a/memanto/cli/connect/assets/hooks/session_start.py
+++ b/memanto/cli/connect/assets/hooks/session_start.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""MEMANTO SessionStart hook.
+
+Three jobs, in order of importance:
+
+1. Refresh MEMORY.md so the agent has full context before the first message.
+2. Print a short notice — SessionStart stdout is added to the session context.
+3. Install the MEMANTO status line into ~/.claude/settings.json, once.
+
+A plugin cannot ship a `statusLine`: plugin settings.json only honors `agent`
+and `subagentStatusLine`, so the entry has to be written into the user's own
+settings. This hook resolves the interpreter with sys.executable — the Python
+actually running right now — which sidesteps `python` vs `python3` entirely.
+
+Must never crash the session. Every step is independently guarded, and the
+script is idempotent so running it twice is harmless (hooks.json intentionally
+registers two interpreter spellings so at least one resolves on any platform).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+MARK = "👾"
+SYNC_TIMEOUT = 25
+STATUSLINE_REFRESH = 5
+
+
+def _claim(key: str, ttl: float = 10.0) -> bool:
+    """First invocation for `key` wins; a duplicate stays silent.
+
+    hooks.json registers each Python hook twice — once as `python`, once as
+    `python3` — because neither spelling exists on every platform. On a machine
+    where both resolve, both processes run, so the work must be claimed exactly
+    once or the user sees every notice twice.
+    """
+    import hashlib
+    import os
+    import tempfile
+    import time
+
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"memanto-hook-{hashlib.sha256(key.encode('utf-8')).hexdigest()[:24]}.lock",
+    )
+    try:
+        os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+        return True
+    except FileExistsError:
+        try:
+            if time.time() - os.stat(path).st_mtime > ttl:
+                os.unlink(path)
+                os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+                return True
+        except Exception:
+            pass
+        return False
+    except Exception:
+        return True  # never suppress the hook over an unexpected filesystem error
+
+
+def _out(text: str) -> None:
+    """Write UTF-8 regardless of the console code page (Windows cp1252)."""
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined,union-attr]
+    except Exception:
+        pass
+    try:
+        sys.stdout.write(text + "\n")
+    except Exception:
+        try:
+            sys.stdout.write(text.encode("ascii", "ignore").decode("ascii") + "\n")
+        except Exception:
+            pass
+
+
+def _read_stdin() -> dict:
+    try:
+        if sys.stdin is None or sys.stdin.isatty():
+            return {}
+        payload = json.loads(sys.stdin.read().strip() or "{}")
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _project_dir(payload: dict) -> str:
+    workspace = payload.get("workspace") or {}
+    for value in (
+        workspace.get("project_dir"),
+        workspace.get("current_dir"),
+        payload.get("cwd"),
+    ):
+        if value:
+            return str(value)
+    return os.getcwd()
+
+
+def sync_memory(project_dir: str) -> str | None:
+    """Refresh MEMORY.md. Returns a one-line summary, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["memanto", "memory", "sync", "--project-dir", project_dir],
+            capture_output=True,
+            text=True,
+            timeout=SYNC_TIMEOUT,
+        )
+    except FileNotFoundError:
+        return None  # memanto not installed; stay quiet rather than nag every session
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    memory_file = Path(project_dir) / "MEMORY.md"
+    if not memory_file.exists():
+        return None
+
+    try:
+        import re
+
+        text = memory_file.read_text(encoding="utf-8", errors="replace")
+        match = re.search(r"Total memories:\s*\*{0,2}\s*(\d+)", text)
+        count = int(match.group(1)) if match else None
+    except Exception:
+        count = None
+
+    if count is None:
+        return "MEMORY.md refreshed."
+    if count == 0:
+        return "MEMORY.md refreshed — no memories stored yet."
+    return (
+        f"MEMORY.md refreshed — {count} "
+        + ("memory" if count == 1 else "memories")
+        + " loaded."
+    )
+
+
+def _settings_path() -> Path:
+    return Path(os.path.expanduser("~")) / ".claude" / "settings.json"
+
+
+def _statusline_script() -> Path:
+    return (Path(__file__).resolve().parent.parent / "statusline.py").resolve()
+
+
+def install_statusline() -> str | None:
+    """Add our statusLine to the user's settings once. Never overwrite theirs."""
+    marker = (
+        Path(os.path.expanduser("~")) / ".memanto" / ".claude-statusline" / "installed"
+    )
+    if marker.exists():
+        return None
+
+    script = _statusline_script()
+    if not script.exists():
+        return None
+
+    settings_file = _settings_path()
+    try:
+        settings = (
+            json.loads(settings_file.read_text(encoding="utf-8"))
+            if settings_file.exists()
+            else {}
+        )
+        if not isinstance(settings, dict):
+            return None
+    except Exception:
+        return None  # unreadable or malformed: never risk clobbering it
+
+    existing = settings.get("statusLine")
+    if isinstance(existing, dict) and "statusline.py" in json.dumps(existing):
+        _touch(marker)
+        return None
+
+    command = f'"{sys.executable}" "{script}"'
+
+    if existing:
+        _touch(marker)
+        return (
+            f"{MARK} MEMANTO status line available, but you already have a "
+            f'"statusLine" in ~/.claude/settings.json — run /memanto:statusline to switch.'
+        )
+
+    settings["statusLine"] = {
+        "type": "command",
+        "command": command,
+        "refreshInterval": STATUSLINE_REFRESH,
+    }
+
+    try:
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp = settings_file.with_suffix(".json.memanto.tmp")
+        tmp.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, settings_file)
+    except Exception:
+        return None
+
+    _touch(marker)
+    return (
+        f"{MARK} MEMANTO status line installed — it appears next time Claude Code starts. "
+        f"Turn it off with /memanto:statusline remove."
+    )
+
+
+def _touch(marker: Path) -> None:
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("1", encoding="utf-8")
+    except Exception:
+        pass
+
+
+def main() -> None:
+    payload = _read_stdin()
+    project_dir = _project_dir(payload)
+
+    if not _claim("sessionstart:" + str(payload.get("session_id") or project_dir)):
+        return
+
+    lines = []
+    try:
+        summary = sync_memory(project_dir)
+        if summary:
+            lines.append(
+                f"{MARK} {summary} Read MEMORY.md before acting; it carries standing instructions, decisions, and open commitments from previous sessions."
+            )
+    except Exception:
+        pass
+
+    try:
+        notice = install_statusline()
+        if notice:
+            lines.append(notice)
+    except Exception:
+        pass
+
+    if lines:
+        _out("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/memanto/cli/connect/assets/hooks/session_start.py
+++ b/memanto/cli/connect/assets/hooks/session_start.py
@@ -66,7 +66,8 @@ def _claim(key: str, ttl: float = 10.0) -> bool:
 def _out(text: str) -> None:
     """Write UTF-8 regardless of the console code page (Windows cp1252)."""
     try:
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined,union-attr]
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
     except Exception:
         pass
     try:

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -308,6 +308,7 @@ def _remove_instructions(
             if parent.exists() and not any(parent.iterdir()):
                 parent.rmdir()
         except Exception:
+            # Ignore errors if directory is not empty or non-deletable
             pass
         return f"Removed {instr_path.name}"
 
@@ -378,6 +379,7 @@ def _remove_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str |
             if skill_dir.exists() and not any(skill_dir.iterdir()):
                 skill_dir.rmdir()
         except Exception:
+            # Ignore errors if directory is not empty or non-deletable
             pass
         return f"Removed skill from {_display_path(skill_dir, is_global)}"
     return None
@@ -420,6 +422,7 @@ def _remove_extension(
         if ext_path.parent.exists() and not any(ext_path.parent.iterdir()):
             ext_path.parent.rmdir()
     except Exception:
+        # Ignore errors if directory is not empty or non-deletable
         pass
     return f"Removed extension from {_display_path(ext_path.parent, is_global)}"
 
@@ -588,11 +591,13 @@ def _remove_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str |
                 try:
                     script_path.unlink()
                 except Exception:
+                    # Ignore errors if script file cannot be unlinked
                     pass
         # Try to remove dir if empty
         try:
             target_hooks_dir.rmdir()
         except Exception:
+            # Ignore errors if directory is not empty or non-deletable
             pass
 
     if changed:

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -371,15 +371,18 @@ def _is_memanto_hook(hook_group: dict) -> bool:
     """Helper to detect if a hook group belongs to memanto."""
     if not isinstance(hook_group, dict):
         return False
+    # Handle single hook dicts (e.g. Cursor: {"command": "python ..."})
+    cmd = hook_group.get("command", "")
+    if "memanto" in cmd or "notify.py" in cmd or "session_start.py" in cmd:
+        return True
     hooks = hook_group.get("hooks", [])
-    if not isinstance(hooks, list):
-        return False
-    for h in hooks:
-        if not isinstance(h, dict):
-            continue
-        cmd = h.get("command", "")
-        if "memanto" in cmd or "notify.py" in cmd or "session_start.py" in cmd:
-            return True
+    if isinstance(hooks, list):
+        for h in hooks:
+            if not isinstance(h, dict):
+                continue
+            c = h.get("command", "")
+            if "memanto" in c or "notify.py" in c or "session_start.py" in c:
+                return True
     return False
 
 
@@ -412,7 +415,10 @@ def _install_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str 
 
     # 1. Try to load hooks from assets
     assets_hooks_dir = Path(__file__).parent / "assets" / "hooks"
-    if assets_hooks_dir.exists() and (assets_hooks_dir / "hooks.json").exists():
+    asset_file_name = agent.hook_config.asset_file or f"{agent.name}-hooks.json"
+    asset_file_path = assets_hooks_dir / asset_file_name
+
+    if assets_hooks_dir.exists() and asset_file_path.exists():
         target_hooks_dir = config_dir / "hooks"
         target_hooks_dir.mkdir(parents=True, exist_ok=True)
 
@@ -423,9 +429,12 @@ def _install_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str 
             shutil.copy2(py_file, target_hooks_dir / py_file.name)
 
         # Parse and inject JSON
-        raw_json = (assets_hooks_dir / "hooks.json").read_text(encoding="utf-8")
+        raw_json = asset_file_path.read_text(encoding="utf-8")
         raw_json = raw_json.replace(
             "${CLAUDE_PLUGIN_ROOT}", str(config_dir).replace("\\", "/")
+        )
+        raw_json = raw_json.replace(
+            "${PLUGIN_ROOT}", str(config_dir).replace("\\", "/")
         )
         raw_json = raw_json.replace(
             "${CLAUDE_PROJECT_DIR}", str(project_path.absolute()).replace("\\", "/")

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -17,6 +17,7 @@ from memanto.cli.connect.templates import (
     MEMANTO_DYNAMIC_SENTINEL_END,
     MEMANTO_SENTINEL,
     MEMANTO_SENTINEL_END,
+    get_extension_content,
     get_instruction_content,
     get_skill_content,
 )
@@ -77,6 +78,15 @@ def install_agent(
                 steps.append(perm_result)
         except Exception as e:
             errors.append(f"Permissions: {e}")
+
+    # Code extension (Pi .ts extension that runs memanto memory sync on startup)
+    if agent.extension_file:
+        try:
+            ext_result = _install_extension(agent, project_path, is_global)
+            if ext_result:
+                steps.append(ext_result)
+        except Exception as e:
+            errors.append(f"Extension: {e}")
 
     if steps:
         try:
@@ -140,6 +150,15 @@ def remove_agent(
                 steps.append(perm_result)
         except Exception as e:
             errors.append(f"Permission removal: {e}")
+
+    # Remove code extension (agent-specific)
+    if agent.extension_file:
+        try:
+            ext_result = _remove_extension(agent, project_path, is_global)
+            if ext_result:
+                steps.append(ext_result)
+        except Exception as e:
+            errors.append(f"Extension removal: {e}")
 
     try:
         ConfigManager().remove_connection(
@@ -362,6 +381,47 @@ def _remove_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str |
             pass
         return f"Removed skill from {_display_path(skill_dir, is_global)}"
     return None
+
+
+# Internal: Code extension deployment (Pi)
+
+
+def _install_extension(
+    agent: AgentDef, project_path: Path, is_global: bool
+) -> str | None:
+    """Deploy the agent's code extension file (e.g. the Pi .ts extension)."""
+    if not agent.extension_file:
+        return None
+
+    ext_path = agent.resolve_extension_file(project_path, is_global)
+    if not ext_path:
+        return None
+
+    ext_path.parent.mkdir(parents=True, exist_ok=True)
+    ext_path.write_text(get_extension_content(), encoding="utf-8")
+
+    return f"Deployed extension to {_display_path(ext_path, is_global)}"
+
+
+def _remove_extension(
+    agent: AgentDef, project_path: Path, is_global: bool
+) -> str | None:
+    """Remove the agent's code extension file."""
+    if not agent.extension_file:
+        return None
+
+    ext_path = agent.resolve_extension_file(project_path, is_global)
+    if not ext_path or not ext_path.exists():
+        return None
+
+    ext_path.unlink()
+    # Clean up empty parent dirs
+    try:
+        if ext_path.parent.exists() and not any(ext_path.parent.iterdir()):
+            ext_path.parent.rmdir()
+    except Exception:
+        pass
+    return f"Removed extension from {_display_path(ext_path.parent, is_global)}"
 
 
 # Internal: Hook configuration (Claude Code)

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -367,6 +367,22 @@ def _remove_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str |
 # Internal: Hook configuration (Claude Code)
 
 
+def _is_memanto_hook(hook_group: dict) -> bool:
+    """Helper to detect if a hook group belongs to memanto."""
+    if not isinstance(hook_group, dict):
+        return False
+    hooks = hook_group.get("hooks", [])
+    if not isinstance(hooks, list):
+        return False
+    for h in hooks:
+        if not isinstance(h, dict):
+            continue
+        cmd = h.get("command", "")
+        if "memanto" in cmd or "notify.py" in cmd or "session_start.py" in cmd:
+            return True
+    return False
+
+
 def _install_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str | None:
     """Configure auto-sync hooks for agents that support them."""
     if not agent.hook_config:
@@ -391,28 +407,60 @@ def _install_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str 
     else:
         settings = {}
 
-    # Navigate to hook location
-    hooks = settings.setdefault("hooks", {})
-    session_start = hooks.setdefault("SessionStart", [])
+    hooks_section = settings.setdefault("hooks", {})
+    changed = False
 
-    # Check if memanto hook already exists
-    memanto_exists = any(
-        isinstance(group, dict)
-        and any(
-            isinstance(h, dict) and "memanto" in h.get("command", "")
-            for h in group.get("hooks", [])
+    # 1. Try to load hooks from assets
+    assets_hooks_dir = Path(__file__).parent / "assets" / "hooks"
+    if assets_hooks_dir.exists() and (assets_hooks_dir / "hooks.json").exists():
+        target_hooks_dir = config_dir / "hooks"
+        target_hooks_dir.mkdir(parents=True, exist_ok=True)
+
+        # Copy python scripts
+        import shutil
+
+        for py_file in assets_hooks_dir.glob("*.py"):
+            shutil.copy2(py_file, target_hooks_dir / py_file.name)
+
+        # Parse and inject JSON
+        raw_json = (assets_hooks_dir / "hooks.json").read_text(encoding="utf-8")
+        raw_json = raw_json.replace(
+            "${CLAUDE_PLUGIN_ROOT}", str(config_dir).replace("\\", "/")
         )
-        for group in session_start
-    )
+        raw_json = raw_json.replace(
+            "${CLAUDE_PROJECT_DIR}", str(project_path.absolute()).replace("\\", "/")
+        )
 
-    if not memanto_exists:
+        asset_hooks_data = json.loads(raw_json)
+        asset_hooks = asset_hooks_data.get("hooks", {})
+
+        for event_name, event_payloads in asset_hooks.items():
+            target_event = hooks_section.setdefault(event_name, [])
+            if not isinstance(target_event, list):
+                continue
+
+            for payload in event_payloads:
+                if not any(_is_memanto_hook(existing) for existing in target_event):
+                    target_event.append(payload)
+                    changed = True
+
+        if changed:
+            settings_path.write_text(
+                json.dumps(settings, indent=2) + "\n", encoding="utf-8"
+            )
+            return "Installed Memanto hooks and scripts"
+        return None
+
+    # 2. Fallback to hardcoded agent payload
+    session_start = hooks_section.setdefault("SessionStart", [])
+    if not any(_is_memanto_hook(group) for group in session_start):
         session_start.append(agent.hook_config.hook_payload)
         settings_path.write_text(
             json.dumps(settings, indent=2) + "\n", encoding="utf-8"
         )
         return "Added SessionStart hook"
 
-    return None  # Already configured
+    return None
 
 
 def _remove_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str | None:
@@ -436,60 +484,53 @@ def _remove_hooks(agent: AgentDef, project_path: Path, is_global: bool) -> str |
         return None
 
     settings = json.loads(settings_path.read_text(encoding="utf-8"))
-    hooks = settings.get("hooks")
-    session_start = hooks.get("SessionStart") if isinstance(hooks, dict) else None
-    if not isinstance(session_start, list):
-        return None
-
-    expected_payload = agent.hook_config.hook_payload
-    expected_matcher = expected_payload.get("matcher")
-    expected_hooks = [
-        hook for hook in expected_payload.get("hooks", []) if isinstance(hook, dict)
-    ]
-    expected_commands = {
-        hook.get("command") for hook in expected_hooks if hook.get("command")
-    }
-    if not expected_commands:
+    hooks_section = settings.get("hooks")
+    if not isinstance(hooks_section, dict):
         return None
 
     changed = False
-    next_session_start = []
-    for group in session_start:
-        if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
-            next_session_start.append(group)
+
+    # 1. Remove from all hook events
+    empty_events = []
+    for event_name, event_payloads in hooks_section.items():
+        if not isinstance(event_payloads, list):
             continue
 
-        remaining_hooks = []
-        for hook in group["hooks"]:
-            if (
-                group.get("matcher") == expected_matcher
-                and isinstance(hook, dict)
-                and hook.get("command") in expected_commands
-                and any(hook == expected_hook for expected_hook in expected_hooks)
-            ):
-                changed = True
-                continue
-            remaining_hooks.append(hook)
-
-        if remaining_hooks:
-            updated_group = dict(group)
-            updated_group["hooks"] = remaining_hooks
-            next_session_start.append(updated_group)
-        else:
+        remaining = [group for group in event_payloads if not _is_memanto_hook(group)]
+        if len(remaining) != len(event_payloads):
+            hooks_section[event_name] = remaining
             changed = True
 
-    if not changed:
-        return None
+        if not remaining:
+            empty_events.append(event_name)
 
-    if next_session_start:
-        hooks["SessionStart"] = next_session_start
-    else:
-        hooks.pop("SessionStart", None)
-    if not hooks:
+    for event_name in empty_events:
+        hooks_section.pop(event_name, None)
+
+    if not hooks_section:
         settings.pop("hooks", None)
 
-    _write_or_remove_json(settings_path, settings)
-    return "Removed SessionStart hook"
+    # 2. Remove copied script files
+    target_hooks_dir = config_dir / "hooks"
+    if target_hooks_dir.exists():
+        for f in ["notify.py", "session_start.py"]:
+            script_path = target_hooks_dir / f
+            if script_path.exists():
+                try:
+                    script_path.unlink()
+                except Exception:
+                    pass
+        # Try to remove dir if empty
+        try:
+            target_hooks_dir.rmdir()
+        except Exception:
+            pass
+
+    if changed:
+        _write_or_remove_json(settings_path, settings)
+        return "Removed Memanto hooks and scripts"
+
+    return None
 
 
 # Internal: Permission configuration

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -336,7 +336,7 @@ def _install_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str:
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_path = skill_dir / "SKILL.md"
 
-    content = get_skill_content()
+    content = get_skill_content(agent.name)
 
     skill_path.write_text(content, encoding="utf-8")
 

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -158,8 +158,10 @@ def _install_instructions(
     agent: AgentDef, project_path: Path, is_global: bool
 ) -> str | None:
     """Install MEMANTO instructions into the agent's instruction file."""
-    if not agent.instruction_file:
-        return None  # Agent doesn't use instruction files (skills-only)
+    if is_global and not agent.instruction_global_file:
+        return None
+    if not is_global and not agent.instruction_local_file:
+        return None
 
     instr_path = agent.resolve_instruction_file(project_path, is_global)
     if not instr_path:
@@ -268,9 +270,6 @@ def _remove_instructions(
     agent: AgentDef, project_path: Path, is_global: bool
 ) -> str | None:
     """Remove MEMANTO instructions from the agent's instruction file."""
-    if not agent.instruction_file:
-        return None
-
     instr_path = agent.resolve_instruction_file(project_path, is_global)
     if not instr_path or not instr_path.exists():
         return None

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -13,10 +13,10 @@ from typing import Any
 from memanto.cli.config.manager import ConfigManager
 from memanto.cli.connect.agent_registry import AGENT_REGISTRY, AgentDef
 from memanto.cli.connect.templates import (
-    MEMANTO_SENTINEL,
-    MEMANTO_SENTINEL_END,
     MEMANTO_DYNAMIC_SENTINEL,
     MEMANTO_DYNAMIC_SENTINEL_END,
+    MEMANTO_SENTINEL,
+    MEMANTO_SENTINEL_END,
     get_instruction_content,
     get_skill_content,
 )
@@ -186,10 +186,12 @@ def _install_instructions(
 def _strip_dynamic_block(text: str) -> str:
     """Remove the dynamic memory block from the text."""
     return re.sub(
-        re.escape(MEMANTO_DYNAMIC_SENTINEL) + r".*?" + re.escape(MEMANTO_DYNAMIC_SENTINEL_END),
+        re.escape(MEMANTO_DYNAMIC_SENTINEL)
+        + r".*?"
+        + re.escape(MEMANTO_DYNAMIC_SENTINEL_END),
         "",
         text,
-        flags=re.DOTALL
+        flags=re.DOTALL,
     ).strip()
 
 
@@ -301,7 +303,11 @@ def _remove_instructions(
         modified = True
 
     if MEMANTO_DYNAMIC_SENTINEL in existing:
-        pattern2 = re.escape(MEMANTO_DYNAMIC_SENTINEL) + r".*?" + re.escape(MEMANTO_DYNAMIC_SENTINEL_END)
+        pattern2 = (
+            re.escape(MEMANTO_DYNAMIC_SENTINEL)
+            + r".*?"
+            + re.escape(MEMANTO_DYNAMIC_SENTINEL_END)
+        )
         existing = re.sub(pattern2, "", existing, flags=re.DOTALL)
         modified = True
 

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -181,6 +181,20 @@ def _install_instructions(
     return _inject_into_file(instr_path, content, create_if_missing=True)
 
 
+def _preserve_dynamic_memories(existing: str, new_content: str) -> str:
+    """Extract dynamic memories from existing content and inject them into new content."""
+    from memanto.cli.connect.templates import MEMANTO_DYNAMIC_SENTINEL, MEMANTO_DYNAMIC_SENTINEL_END
+    
+    pattern = re.escape(MEMANTO_DYNAMIC_SENTINEL) + r"(.*?)" + re.escape(MEMANTO_DYNAMIC_SENTINEL_END)
+    match = re.search(pattern, existing, flags=re.DOTALL)
+    if match:
+        dynamic_content = match.group(1)
+        # Avoid backslash issues with replace instead of sub if the content has backslashes
+        replacement = MEMANTO_DYNAMIC_SENTINEL + dynamic_content + MEMANTO_DYNAMIC_SENTINEL_END
+        new_content = re.sub(pattern, replacement.replace("\\", "\\\\"), new_content, flags=re.DOTALL)
+    return new_content
+
+
 def _write_dedicated_file(file_path: Path, content: str) -> str:
     """Write content to a dedicated file (creates parent dirs)."""
     file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -188,11 +202,12 @@ def _write_dedicated_file(file_path: Path, content: str) -> str:
     if file_path.exists():
         existing = file_path.read_text(encoding="utf-8")
         if MEMANTO_SENTINEL in existing:
+            content = _preserve_dynamic_memories(existing, content)
             # Replace existing section
             pattern = (
                 re.escape(MEMANTO_SENTINEL) + r".*?" + re.escape(MEMANTO_SENTINEL_END)
             )
-            updated = re.sub(pattern, content.strip(), existing, flags=re.DOTALL)
+            updated = re.sub(pattern, content.strip().replace("\\", "\\\\"), existing, flags=re.DOTALL)
             file_path.write_text(updated, encoding="utf-8")
             return f"Updated {file_path.name}"
 
@@ -207,11 +222,12 @@ def _inject_into_file(
     if file_path.exists():
         existing = file_path.read_text(encoding="utf-8")
         if MEMANTO_SENTINEL in existing:
+            section = _preserve_dynamic_memories(existing, section)
             # Replace existing section
             pattern = (
                 re.escape(MEMANTO_SENTINEL) + r".*?" + re.escape(MEMANTO_SENTINEL_END)
             )
-            updated = re.sub(pattern, section.strip(), existing, flags=re.DOTALL)
+            updated = re.sub(pattern, section.strip().replace("\\", "\\\\"), existing, flags=re.DOTALL)
             file_path.write_text(updated, encoding="utf-8")
             return f"Updated MEMANTO section in {file_path.name}"
         else:

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -183,15 +183,26 @@ def _install_instructions(
 
 def _preserve_dynamic_memories(existing: str, new_content: str) -> str:
     """Extract dynamic memories from existing content and inject them into new content."""
-    from memanto.cli.connect.templates import MEMANTO_DYNAMIC_SENTINEL, MEMANTO_DYNAMIC_SENTINEL_END
-    
-    pattern = re.escape(MEMANTO_DYNAMIC_SENTINEL) + r"(.*?)" + re.escape(MEMANTO_DYNAMIC_SENTINEL_END)
+    from memanto.cli.connect.templates import (
+        MEMANTO_DYNAMIC_SENTINEL,
+        MEMANTO_DYNAMIC_SENTINEL_END,
+    )
+
+    pattern = (
+        re.escape(MEMANTO_DYNAMIC_SENTINEL)
+        + r"(.*?)"
+        + re.escape(MEMANTO_DYNAMIC_SENTINEL_END)
+    )
     match = re.search(pattern, existing, flags=re.DOTALL)
     if match:
         dynamic_content = match.group(1)
         # Avoid backslash issues with replace instead of sub if the content has backslashes
-        replacement = MEMANTO_DYNAMIC_SENTINEL + dynamic_content + MEMANTO_DYNAMIC_SENTINEL_END
-        new_content = re.sub(pattern, replacement.replace("\\", "\\\\"), new_content, flags=re.DOTALL)
+        replacement = (
+            MEMANTO_DYNAMIC_SENTINEL + dynamic_content + MEMANTO_DYNAMIC_SENTINEL_END
+        )
+        new_content = re.sub(
+            pattern, replacement.replace("\\", "\\\\"), new_content, flags=re.DOTALL
+        )
     return new_content
 
 
@@ -207,7 +218,12 @@ def _write_dedicated_file(file_path: Path, content: str) -> str:
             pattern = (
                 re.escape(MEMANTO_SENTINEL) + r".*?" + re.escape(MEMANTO_SENTINEL_END)
             )
-            updated = re.sub(pattern, content.strip().replace("\\", "\\\\"), existing, flags=re.DOTALL)
+            updated = re.sub(
+                pattern,
+                content.strip().replace("\\", "\\\\"),
+                existing,
+                flags=re.DOTALL,
+            )
             file_path.write_text(updated, encoding="utf-8")
             return f"Updated {file_path.name}"
 
@@ -227,7 +243,12 @@ def _inject_into_file(
             pattern = (
                 re.escape(MEMANTO_SENTINEL) + r".*?" + re.escape(MEMANTO_SENTINEL_END)
             )
-            updated = re.sub(pattern, section.strip().replace("\\", "\\\\"), existing, flags=re.DOTALL)
+            updated = re.sub(
+                pattern,
+                section.strip().replace("\\", "\\\\"),
+                existing,
+                flags=re.DOTALL,
+            )
             file_path.write_text(updated, encoding="utf-8")
             return f"Updated MEMANTO section in {file_path.name}"
         else:
@@ -312,7 +333,13 @@ def _install_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str:
 
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_path = skill_dir / "SKILL.md"
-    skill_path.write_text(get_skill_content(), encoding="utf-8")
+
+    content = get_skill_content()
+    if skill_path.exists():
+        existing = skill_path.read_text(encoding="utf-8")
+        content = _preserve_dynamic_memories(existing, content)
+
+    skill_path.write_text(content, encoding="utf-8")
 
     rel = _display_path(skill_path, is_global)
     return f"Deployed skill to {rel}"

--- a/memanto/cli/connect/engine.py
+++ b/memanto/cli/connect/engine.py
@@ -15,6 +15,8 @@ from memanto.cli.connect.agent_registry import AGENT_REGISTRY, AgentDef
 from memanto.cli.connect.templates import (
     MEMANTO_SENTINEL,
     MEMANTO_SENTINEL_END,
+    MEMANTO_DYNAMIC_SENTINEL,
+    MEMANTO_DYNAMIC_SENTINEL_END,
     get_instruction_content,
     get_skill_content,
 )
@@ -181,29 +183,14 @@ def _install_instructions(
     return _inject_into_file(instr_path, content, create_if_missing=True)
 
 
-def _preserve_dynamic_memories(existing: str, new_content: str) -> str:
-    """Extract dynamic memories from existing content and inject them into new content."""
-    from memanto.cli.connect.templates import (
-        MEMANTO_DYNAMIC_SENTINEL,
-        MEMANTO_DYNAMIC_SENTINEL_END,
-    )
-
-    pattern = (
-        re.escape(MEMANTO_DYNAMIC_SENTINEL)
-        + r"(.*?)"
-        + re.escape(MEMANTO_DYNAMIC_SENTINEL_END)
-    )
-    match = re.search(pattern, existing, flags=re.DOTALL)
-    if match:
-        dynamic_content = match.group(1)
-        # Avoid backslash issues with replace instead of sub if the content has backslashes
-        replacement = (
-            MEMANTO_DYNAMIC_SENTINEL + dynamic_content + MEMANTO_DYNAMIC_SENTINEL_END
-        )
-        new_content = re.sub(
-            pattern, replacement.replace("\\", "\\\\"), new_content, flags=re.DOTALL
-        )
-    return new_content
+def _strip_dynamic_block(text: str) -> str:
+    """Remove the dynamic memory block from the text."""
+    return re.sub(
+        re.escape(MEMANTO_DYNAMIC_SENTINEL) + r".*?" + re.escape(MEMANTO_DYNAMIC_SENTINEL_END),
+        "",
+        text,
+        flags=re.DOTALL
+    ).strip()
 
 
 def _write_dedicated_file(file_path: Path, content: str) -> str:
@@ -213,14 +200,14 @@ def _write_dedicated_file(file_path: Path, content: str) -> str:
     if file_path.exists():
         existing = file_path.read_text(encoding="utf-8")
         if MEMANTO_SENTINEL in existing:
-            content = _preserve_dynamic_memories(existing, content)
             # Replace existing section
             pattern = (
                 re.escape(MEMANTO_SENTINEL) + r".*?" + re.escape(MEMANTO_SENTINEL_END)
             )
+            static_content = _strip_dynamic_block(content)
             updated = re.sub(
                 pattern,
-                content.strip().replace("\\", "\\\\"),
+                static_content.replace("\\", "\\\\"),
                 existing,
                 flags=re.DOTALL,
             )
@@ -238,14 +225,14 @@ def _inject_into_file(
     if file_path.exists():
         existing = file_path.read_text(encoding="utf-8")
         if MEMANTO_SENTINEL in existing:
-            section = _preserve_dynamic_memories(existing, section)
             # Replace existing section
             pattern = (
                 re.escape(MEMANTO_SENTINEL) + r".*?" + re.escape(MEMANTO_SENTINEL_END)
             )
+            static_section = _strip_dynamic_block(section)
             updated = re.sub(
                 pattern,
-                section.strip().replace("\\", "\\\\"),
+                static_section.replace("\\", "\\\\"),
                 existing,
                 flags=re.DOTALL,
             )
@@ -306,14 +293,24 @@ def _remove_instructions(
 
     # For shared files (CLAUDE.md, AGENTS.md, etc.), remove the section
     existing = instr_path.read_text(encoding="utf-8")
+    modified = False
+
     if MEMANTO_SENTINEL in existing:
         pattern = re.escape(MEMANTO_SENTINEL) + r".*?" + re.escape(MEMANTO_SENTINEL_END)
-        updated = re.sub(pattern, "", existing, flags=re.DOTALL)
+        existing = re.sub(pattern, "", existing, flags=re.DOTALL)
+        modified = True
+
+    if MEMANTO_DYNAMIC_SENTINEL in existing:
+        pattern2 = re.escape(MEMANTO_DYNAMIC_SENTINEL) + r".*?" + re.escape(MEMANTO_DYNAMIC_SENTINEL_END)
+        existing = re.sub(pattern2, "", existing, flags=re.DOTALL)
+        modified = True
+
+    if modified:
         # Clean up extra whitespace
-        updated = re.sub(r"\n{3,}", "\n\n", updated).strip() + "\n"
+        updated = re.sub(r"\n{3,}", "\n\n", existing).strip() + "\n"
         if updated.strip():
             instr_path.write_text(updated, encoding="utf-8")
-            return f"Removed MEMANTO section from {instr_path.name}"
+            return f"Removed MEMANTO sections from {instr_path.name}"
         else:
             instr_path.unlink()
             return f"Removed {instr_path.name} (was empty)"
@@ -335,9 +332,6 @@ def _install_skill(agent: AgentDef, project_path: Path, is_global: bool) -> str:
     skill_path = skill_dir / "SKILL.md"
 
     content = get_skill_content()
-    if skill_path.exists():
-        existing = skill_path.read_text(encoding="utf-8")
-        content = _preserve_dynamic_memories(existing, content)
 
     skill_path.write_text(content, encoding="utf-8")
 

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -282,11 +282,7 @@ def get_instruction_content(agent_name: str) -> str:
             tool_phrase="the terminal",
             note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions.",
         ),
-        "github-copilot": _base_instruction_content(
-            agent_id="github-copilot",
-            tool_phrase="the terminal",
-            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions. DO NOT write project-specific rules to the global `User/prompts/` directory to avoid context dilution—rely exclusively on Memanto.",
-        ),
+        "github-copilot": _get_copilot_content(),
         "augment": _base_instruction_content(
             agent_id="augment",
             tool_phrase="the terminal",
@@ -304,6 +300,20 @@ alwaysApply: true
 ---
 
 {_base_instruction_content(agent_id=agent_id, tool_phrase="the terminal")}"""
+
+
+def _get_copilot_content() -> str:
+    """Get frontmatter-formatted rules content for GitHub Copilot."""
+    base_content = _base_instruction_content(
+        agent_id="github-copilot",
+        tool_phrase="the terminal",
+        note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions.",
+    )
+    return f"""---
+applyTo: "**/*"
+---
+
+{base_content}"""
 
 
 def get_skill_content(agent_name: str = "<agent_name>") -> str:

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -336,56 +336,6 @@ def get_skill_content(agent_name: str = "<agent_name>") -> str:
 
 
 # Pi .ts extension content (auto-syncs MEMORY.md on each fresh session start).
-# Installed by `memanto connect pi`. Remove with `memanto connect remove pi`.
-
-EXTENSION_TS_CONTENT = """/**
- * MEMANTO auto-sync extension for Pi.
- *
- * On a fresh process start, runs `memanto memory sync` in the background so the
- * project's MEMORY.md is up to date before you begin working. It is
- * fire-and-forget: it never blocks startup, and errors are swallowed (e.g. when
- * memanto is not installed, not on PATH, or no agent is active).
- *
- * Installed by `memanto connect pi`. Remove with `memanto connect remove pi`.
- */
-import { spawn } from "node:child_process";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-
-export default function (pi: ExtensionAPI) {
-  pi.on("session_start", (event, ctx) => {
-    // Only on a fresh process start — not on /resume, /fork, or /reload.
-    if (event.reason !== "startup") return;
-
-    const child = spawn(
-      "memanto",
-      ["memory", "sync", "--project-dir", ctx.cwd],
-      { stdio: "ignore", detached: true },
-    );
-    child.unref();
-
-    child.on("error", () => {
-      /* memanto CLI not installed / not on PATH — ignore. */
-    });
-    child.on("close", (code) => {
-      if (code === 0 && ctx.hasUI) {
-        try {
-          ctx.ui.notify("Memanto: memory synced", "info");
-        } catch {
-          /* notification unavailable in this mode — ignore. */
-        }
-      }
-    });
-  });
-}
-"""
-
-
-def get_skill_content() -> str:
-    """Get the SKILL.md content (shared across all agents)."""
-    return SKILL_MD_CONTENT.strip() + "\n"
-
-
-# Pi .ts extension content (auto-syncs MEMORY.md on each fresh session start).
 # Installed by `memanto connect pi` into ~/.pi/agent/extensions/ (or .pi/extensions/).
 
 EXTENSION_TS_CONTENT = """/**

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -204,12 +204,13 @@ You must actively evaluate:
 5. ENVIRONMENT: Was a key [ENVIRONMENT FACT] verified? (e.g., OS behavior, path layout, or tool version requirement)
 
 **How to Execute the Evaluation:**
-- **If you are operating in Claude Code / Anthropic Web UI:** You MUST perform this evaluation inside a `<thinking>` block at the very start of your turn.
-- **For all other tool-capable agents (VS Code Copilot, Cursor, Aider, etc.):**
-  [CRITICAL CONSTRAINT]: You MUST use the "Tool Explanation Trick" to secure your scratchpad. Before generating ANY normal chat text, you MUST immediately invoke the terminal/bash tool and use the `explanation`, `reason`, or `thought` parameter to silently write out your step-by-step evaluation. If no memory triggers apply, you MUST execute a dummy command (like `echo "memory check complete"`) solely to populate the explanation parameter.
-
-If any trigger applies, your FIRST action must be to execute the `memanto remember` command via the terminal.
-
+- **If you are operating in Claude Code, Cursor, Cline, Roo, Windsurf, Aider, or Anthropic Web UI:**
+  You MUST perform this evaluation inside a `<thinking>` block at the very start of your turn.
+- **If you are operating in VS Code Copilot:**
+  [CRITICAL SEQUENCE]: You MUST execute the following three steps in exact order ONCE at the very beginning of your turn (immediately after the user's prompt). Do NOT repeat this check before subsequent tool calls in the same turn.
+  - **Step 1:** You MUST invoke the terminal tool with the dummy command `echo "memory check"`. You will use this tool call's `explanation` parameter to silently write out your step-by-step evaluation WRAPPED inside a `<thinking>` XML tag.
+  - **Step 2:** If your evaluation in Step 1 found a matching trigger, your next immediate tool call MUST be `memanto remember`.
+  - **Step 3:** Only AFTER Step 1 (and Step 2 if applicable) are complete, you may proceed to execute productive tools or output normal chat text.
 ### 2. THE ABSTRACTION RULE (HOW TO THINK ABOUT MEMORY)
 Users speak naturally and implicitly. When you store a memory, **ELEVATE IT TO A PRINCIPLE**.
 - **WRONG (Activity Log)**: "User told me to use functional components."

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -305,9 +305,10 @@ alwaysApply: true
 {_base_instruction_content(agent_id=agent_id, tool_phrase="the terminal")}"""
 
 
-def get_skill_content() -> str:
+def get_skill_content(agent_name: str = "<agent_name>") -> str:
     """Get the SKILL.md content (shared across all agents)."""
     content = SKILL_MD_CONTENT.strip()
+    content = content.replace("<agent_name>", agent_name)
     # Inject the version tag right after the frontmatter
     if "---\n\n# MEMANTO Memory Skill" in content:
         content = content.replace(

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -252,6 +252,11 @@ def get_instruction_content(agent_name: str) -> str:
             tool_phrase="the terminal",
             note_suffix="The `memanto-memory` skill in `.agents/skills/memanto/` contains detailed reference guidelines (best practices, confidence levels, tagging).",
         ),
+        "pi": _base_instruction_content(
+            agent_id="pi",
+            tool_phrase="the terminal",
+            note_suffix="A Pi extension auto-syncs MEMORY.md on each fresh session start; the `memanto-memory` skill in `.pi/skills/memanto/` (or `~/.pi/agent/skills/memanto/`) contains detailed reference guidelines.",
+        ),
         "cursor": _get_mdc_content(agent_id="cursor"),
         "windsurf": _base_instruction_content(
             agent_id="windsurf",
@@ -328,3 +333,53 @@ def get_skill_content(agent_name: str = "<agent_name>") -> str:
             f"---\n\n{MEMANTO_VERSION_TAG}\n\n# MEMANTO Memory Skill",
         )
     return content + "\n"
+
+
+# Pi .ts extension content (auto-syncs MEMORY.md on each fresh session start).
+# Installed by `memanto connect pi`. Remove with `memanto connect remove pi`.
+
+EXTENSION_TS_CONTENT = """/**
+ * MEMANTO auto-sync extension for Pi.
+ *
+ * On a fresh process start, runs `memanto memory sync` in the background so the
+ * project's MEMORY.md is up to date before you begin working. It is
+ * fire-and-forget: it never blocks startup, and errors are swallowed (e.g. when
+ * memanto is not installed, not on PATH, or no agent is active).
+ *
+ * Installed by `memanto connect pi`. Remove with `memanto connect remove pi`.
+ */
+import { spawn } from "node:child_process";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", (event, ctx) => {
+    // Only on a fresh process start — not on /resume, /fork, or /reload.
+    if (event.reason !== "startup") return;
+
+    const child = spawn(
+      "memanto",
+      ["memory", "sync", "--project-dir", ctx.cwd],
+      { stdio: "ignore", detached: true },
+    );
+    child.unref();
+
+    child.on("error", () => {
+      /* memanto CLI not installed / not on PATH — ignore. */
+    });
+    child.on("close", (code) => {
+      if (code === 0 && ctx.hasUI) {
+        try {
+          ctx.ui.notify("Memanto: memory synced", "info");
+        } catch {
+          /* notification unavailable in this mode — ignore. */
+        }
+      }
+    });
+  });
+}
+"""
+
+
+def get_extension_content() -> str:
+    """Get the Pi .ts extension content (memanto auto-sync on session start)."""
+    return EXTENSION_TS_CONTENT.strip() + "\n"

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -204,9 +204,9 @@ You must actively evaluate:
 5. ENVIRONMENT: Was a key [ENVIRONMENT FACT] verified? (e.g., OS behavior, path layout, or tool version requirement)
 
 **How to Execute the Evaluation:**
-- **If you are operating in Claude Code, Cursor, Cline, Roo, Windsurf, Aider, or Anthropic Web UI:**
+- **If you are operating in Native CLI & Integrated IDE Environments (Claude Code, Cursor, Windsurf, Gemini CLI, Cline, Roo, Continue, OpenCode, Codex, Aider, or Anthropic Web UI):**
   You MUST perform this evaluation inside a `<thinking>` block at the very start of your turn.
-- **If you are operating in VS Code Copilot:**
+- **If you are operating in VS Code Agent Environments (VS Code Copilot or VS Code Extension Agent Mode):**
   [CRITICAL SEQUENCE]: You MUST execute the following three steps in exact order ONCE at the very beginning of your turn (immediately after the user's prompt). Do NOT repeat this check before subsequent tool calls in the same turn.
   - **Step 1:** You MUST invoke the terminal tool with the dummy command `echo "memory check"`. You will use this tool call's `explanation` parameter to silently write out your step-by-step evaluation WRAPPED inside a `<thinking>` XML tag.
   - **Step 2:** If your evaluation in Step 1 found a matching trigger, your next immediate tool call MUST be `memanto remember`.

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -205,7 +205,8 @@ You must actively evaluate:
 
 **How to Execute the Evaluation:**
 - **If you are operating in Claude Code / Anthropic Web UI:** You MUST perform this evaluation inside a `<thinking>` block at the very start of your turn.
-- **For all other environments:** Evaluate SILENTLY. Do NOT output `<thinking>` blocks or internal monologue.
+- **For all other tool-capable agents (VS Code Copilot, Cursor, Aider, etc.):**
+  [CRITICAL CONSTRAINT]: You MUST use the "Tool Explanation Trick" to secure your scratchpad. Before generating ANY normal chat text, you MUST immediately invoke the terminal/bash tool and use the `explanation`, `reason`, or `thought` parameter to silently write out your step-by-step evaluation. If no memory triggers apply, you MUST execute a dummy command (like `echo "memory check complete"`) solely to populate the explanation parameter.
 
 If any trigger applies, your FIRST action must be to execute the `memanto remember` command via the terminal.
 

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -222,9 +222,10 @@ Do not guess or write code blindly. Run `memanto recall` (or `memanto answer`) u
 ### 5. HOW TO EXECUTE
 For all command syntax, required flags, memory types, tagging best practices, and CLI options, refer to the `memanto-memory` SKILL.md. You MUST read this skill before running any memory operations if you do not know the exact command schema.
 
+{MEMANTO_SENTINEL_END}
+
 {MEMANTO_DYNAMIC_SENTINEL}
-{MEMANTO_DYNAMIC_SENTINEL_END}
-{MEMANTO_SENTINEL_END}"""
+{MEMANTO_DYNAMIC_SENTINEL_END}"""
 
 
 def get_instruction_content(agent_name: str) -> str:

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -13,6 +13,8 @@ MEMANTO_SENTINEL_END = "<!-- /MEMANTO-MANAGED-SECTION -->"
 MEMANTO_DYNAMIC_SENTINEL = "<!-- MEMANTO-DYNAMIC-MEMORIES -->"
 MEMANTO_DYNAMIC_SENTINEL_END = "<!-- /MEMANTO-DYNAMIC-MEMORIES -->"
 
+TEMPLATE_VERSION = "1.0.0"
+MEMANTO_VERSION_TAG = f"<!-- memanto-template-version: {TEMPLATE_VERSION} -->"
 
 
 # Shared SKILL.md content (same across all agents)
@@ -174,7 +176,9 @@ memanto remember "Use UUID v4 for all primary keys across all PostgreSQL tables"
 
 
 def _base_instruction_content(
-    agent_id: str = "<agent_name>", tool_phrase: str = "the terminal", note_suffix: str = ""
+    agent_id: str = "<agent_name>",
+    tool_phrase: str = "the terminal",
+    note_suffix: str = "",
 ) -> str:
     """Generate base MEMANTO instruction content, adapted per agent."""
     note_line = ""
@@ -182,6 +186,7 @@ def _base_instruction_content(
         note_line = f"\n> **Note**: {note_suffix}"
 
     return f"""{MEMANTO_SENTINEL}
+{MEMANTO_VERSION_TAG}
 ## MEMANTO - Your Active Memory Companion
 
 > **CRITICAL DIRECTIVE**: You are an agent equipped with Memanto. Without it, you are amnesiac. You have zero memory between chat sessions. Your ability to learn and adapt depends ENTIRELY on you actively writing to Memanto.
@@ -189,7 +194,7 @@ def _base_instruction_content(
 Every memory operation in this session goes through MEMANTO. There is no exception. All memanto commands are **shell commands**. Always run them using {tool_phrase}. Never simulate, describe, or "pretend to call" them.{note_line}
 
 ### 1. THE ABSTRACTION RULE (HOW TO THINK ABOUT MEMORY)
-Users speak naturally and implicitly. When you store a memory, **ELEVATE IT TO A PRINCIPLE**. 
+Users speak naturally and implicitly. When you store a memory, **ELEVATE IT TO A PRINCIPLE**.
 - **WRONG (Activity Log)**: "User told me to use functional components."
 - **RIGHT (Universal Principle)**: "Exclusively use functional components for React UI."
 Do not record the conversation. Record the universal rule.
@@ -220,6 +225,7 @@ For all command syntax, required flags, memory types, tagging best practices, an
 {MEMANTO_DYNAMIC_SENTINEL}
 {MEMANTO_DYNAMIC_SENTINEL_END}
 {MEMANTO_SENTINEL_END}"""
+
 
 def get_instruction_content(agent_name: str) -> str:
     """Get MEMANTO instruction section content for a specific agent."""
@@ -291,4 +297,11 @@ alwaysApply: true
 
 def get_skill_content() -> str:
     """Get the SKILL.md content (shared across all agents)."""
-    return SKILL_MD_CONTENT.strip() + "\n"
+    content = SKILL_MD_CONTENT.strip()
+    # Inject the version tag right after the frontmatter
+    if "---\n\n# MEMANTO Memory Skill" in content:
+        content = content.replace(
+            "---\n\n# MEMANTO Memory Skill",
+            f"---\n\n{MEMANTO_VERSION_TAG}\n\n# MEMANTO Memory Skill",
+        )
+    return content + "\n"

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -193,19 +193,27 @@ def _base_instruction_content(
 
 Every memory operation in this session goes through MEMANTO. There is no exception. All memanto commands are **shell commands**. Always run them using {tool_phrase}. Never simulate, describe, or "pretend to call" them.{note_line}
 
-### 1. THE ABSTRACTION RULE (HOW TO THINK ABOUT MEMORY)
+### 1. ENVIRONMENT-AWARE EXECUTION PROTOCOL
+Before you write any code or provide a final answer, you MUST evaluate if the current context contains new memory triggers.
+
+You must actively evaluate:
+1. PREFERENCE: Did the user state a [USER PREFERENCE / RULE]? (e.g., code formatting style, choice of library, or tool preference)
+2. GOAL: Did we establish or reach a [GOAL / MILESTONE]? (e.g., target feature completion, roadmap deliverable, or sprint objective)
+3. FAILURE: Did we learn a [CORRECTION / FAILURE LESSON] from an error, tool, or test? (e.g., a bug fix workaround, error post-mortem, or test failure insight)
+4. SYSTEM: Did we uncover a [DOMAIN INVARIANT / SYSTEM QUIRK]? (e.g., a technical constraint, API quirk, or dependency behavior)
+5. ENVIRONMENT: Was a key [ENVIRONMENT FACT] verified? (e.g., OS behavior, path layout, or tool version requirement)
+
+**How to Execute the Evaluation:**
+- **If you are operating in Claude Code / Anthropic Web UI:** You MUST perform this evaluation inside a `<thinking>` block at the very start of your turn.
+- **For all other environments:** Evaluate SILENTLY. Do NOT output `<thinking>` blocks or internal monologue.
+
+If any trigger applies, your FIRST action must be to execute the `memanto remember` command via the terminal.
+
+### 2. THE ABSTRACTION RULE (HOW TO THINK ABOUT MEMORY)
 Users speak naturally and implicitly. When you store a memory, **ELEVATE IT TO A PRINCIPLE**.
 - **WRONG (Activity Log)**: "User told me to use functional components."
 - **RIGHT (Universal Principle)**: "Exclusively use functional components for React UI."
 Do not record the conversation. Record the universal rule.
-
-### 2. THE TRIGGER MATRIX (WHEN TO STORE)
-Do not wait to be asked. If any of the following occur, your VERY FIRST ACTION must be to use {tool_phrase} to run `memanto remember`. Do not answer the user first.
-- **[USER PREFERENCE / RULE]** The user explicitly or implicitly states a convention, tool preference, or coding rule (e.g., "Use Tailwind v4", "Never use lodash", "Prefer async/await").
-- **[ARCHITECTURAL DECISION]** A decision is made regarding project structure, stack choice, DB schema, or API design (e.g., "Selected PostgreSQL with Prisma ORM").
-- **[CORRECTION / FAILURE LESSON]** You attempt an approach that fails and find a workaround, or the user corrects your code or mistake (e.g., "Must pass --no-cache when running build script").
-- **[GOAL / MILESTONE]** A milestone is reached, or a project roadmap/commitment is confirmed (e.g., "Phase 1 API complete, starting UI next").
-- **[ENVIRONMENT FACT]** A key technical fact about the user's workspace, OS, or toolchain is verified (e.g., "Runs on Windows PowerShell 5.1 with Python 3.11").
 
 ### 3. THE DURABILITY TEST (WHAT NOT TO STORE)
 Before storing, ask yourself: *"Will this generalized principle fundamentally change how I generate code for this user 3 months from now?"*
@@ -230,6 +238,7 @@ For all command syntax, required flags, memory types, tagging best practices, an
 
 def get_instruction_content(agent_name: str) -> str:
     """Get MEMANTO instruction section content for a specific agent."""
+
     templates = {
         "claude-code": _base_instruction_content(
             agent_id="claude-code",
@@ -275,7 +284,7 @@ def get_instruction_content(agent_name: str) -> str:
         "github-copilot": _base_instruction_content(
             agent_id="github-copilot",
             tool_phrase="the terminal",
-            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions. DO NOT write project-specific rules to the global `User/prompts/` directory to avoid context dilution—rely exclusively on Memanto and the `CLAUDE.md` Hot Cache.",
+            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions. DO NOT write project-specific rules to the global `User/prompts/` directory to avoid context dilution—rely exclusively on Memanto.",
         ),
         "augment": _base_instruction_content(
             agent_id="augment",

--- a/memanto/cli/connect/templates.py
+++ b/memanto/cli/connect/templates.py
@@ -10,161 +10,162 @@ Per-agent instruction content and skill templates for MEMANTO integration.
 MEMANTO_SENTINEL = "<!-- MEMANTO-MANAGED-SECTION -->"
 MEMANTO_SENTINEL_END = "<!-- /MEMANTO-MANAGED-SECTION -->"
 
+MEMANTO_DYNAMIC_SENTINEL = "<!-- MEMANTO-DYNAMIC-MEMORIES -->"
+MEMANTO_DYNAMIC_SENTINEL_END = "<!-- /MEMANTO-DYNAMIC-MEMORIES -->"
+
+
 
 # Shared SKILL.md content (same across all agents)
 
 SKILL_MD_CONTENT = """---
 name: memanto-memory
-description: Use this skill when you need to store or search MEMANTO persistent memories. It defines mandatory guidelines for best practices, memory types, confidence levels, tagging, and patterns for effective agent memory usage.
+description: Use this skill when you need to store, search, edit, or manage MEMANTO persistent memories. It defines mandatory guidelines for CLI command syntax, memory types, confidence levels, provenance, tagging rules, and patterns for effective agent memory usage.
 ---
 
 # MEMANTO Memory Skill
 
-Detailed reference for using MEMANTO persistent memory effectively.
+Detailed reference guide for using MEMANTO persistent memory effectively across sessions.
 
-## Memory Types: Decision Matrix
+## Quick Command Reference
 
-| Type | When to Use | Confidence | Example |
-|------|-------------|------------|---------|
-| `fact` | Verified information, project status | 0.9-1.0 | "MEMANTO uses PostgreSQL for metadata" |
-| `decision` | Architecture choices, approach selections | 0.9-1.0 | "Chose React over Vue for frontend" |
-| `instruction` | Standing rules, preferences, guidelines | 0.9-1.0 | "Always use type hints in Python" |
-| `commitment` | Promises, TODOs, obligations | 1.0 | "Will deploy monitoring by Friday" |
-| `preference` | User/team preferences | 0.8-1.0 | "User prefers dark mode" |
-| `goal` | Objectives, targets, milestones | 0.8-1.0 | "Launch CLI by end of March" |
-| `artifact` | Tool outputs, reports, file locations | 0.9-1.0 | "Report saved at ./reports/q1.md" |
-| `learning` | Knowledge acquired from experience | 0.7-0.9 | "Batch operations 100x faster" |
-| `event` | Important conversations, milestones | 0.8-0.95 | "Completed Phase 1 features" |
-| `relationship` | Team context, collaboration patterns | 0.85-0.95 | "Alice is lead backend engineer" |
-| `observation` | Patterns noticed, behaviors | 0.6-0.85 | "User prefers short responses" |
-| `error` | Failures, bugs, lessons learned | 0.95-1.0 | "Namespace format bug - use underscores" |
-| `context` | Session summaries, status updates | 0.9-1.0 | "Project 70% done, API complete" |
+All Memanto operations are performed via shell commands. Never simulate commands or keep internal mental notes.
 
-## Confidence Levels
+```bash
+# Store memory (ALWAYS pass full metadata flags)
+memanto remember "Generalized principle or rule" --type TYPE --tags "tag1,tag2" --confidence <0.0-1.0> --provenance PROVENANCE --source <agent_name>
 
-- **1.0** — Explicit user statement, verified fact, standing instruction
-- **0.9-0.95** — Strong consensus, well-tested approach, clear team preference
-- **0.8-0.85** — Observed pattern (3+ times), indirect but supported preference
-- **0.7-0.75** — Emerging pattern (2 times), reasonable inference
-- **0.6-0.65** — Single observation, uncertain interpretation
-- **< 0.6** — Don't store. Too uncertain.
+# Search memories (Semantic recall for context building)
+memanto recall "query string" --limit 10 --type TYPE --min-similarity 0.8
+
+# Temporal search variants (no query needed)
+memanto recall --recent --limit 10                 # newest memories first
+memanto recall --as-of "YYYY-MM-DD"                # memory state at a past point in time
+memanto recall --changed-since "last 7 days"       # memories created or updated recently
+
+# Grounded RAG answer (Synthesizes memory into a direct answer)
+memanto answer "Question about past decisions or commitments"
+
+# Edit existing memory
+memanto edit MEMORY_ID --content "Updated content" --type TYPE --confidence 0.95
+
+# Delete memory
+memanto forget MEMORY_ID
+
+# Sync dynamic memories to local project instructions
+memanto memory sync --project-dir .
+```
+
+## Memory Types: Complete Decision Matrix
+
+Select the exact memory type that best categorizes the information being persisted. Elevate every memory to a clean, declarative principle—never write chat logs or activity narratives (e.g., "User told me...", "Chose X...", "Agreed to...").
+
+| Type | When to Use | Default Confidence | Default Provenance | Example |
+|------|-------------|--------------------|--------------------|---------|
+| `fact` | Verified technical facts, environment details, project state | 0.9 - 1.0 | `validated` / `observed` | "Database stack is PostgreSQL 15 with Prisma ORM." |
+| `decision` | Architecture choices, stack selection, design patterns | 0.9 - 1.0 | `inferred` / `explicit_statement` | "Use Next.js App Router exclusively; Pages Router is deprecated." |
+| `instruction` | Standing rules, guidelines, enforced constraints | 0.9 - 1.0 | `explicit_statement` | "Enforce strict TypeScript typing; explicit 'any' is disallowed." |
+| `preference` | User style, tooling choices, formatting rules | 0.8 - 1.0 | `explicit_statement` / `observed` | "Use pnpm for dependency management and workspace scripts." |
+| `learning` | Workarounds, discovered fixes, post-error insights | 0.8 - 0.95 | `observed` / `corrected` | "Windows build script requires --max-workers=2 to prevent worker process crashes." |
+| `goal` | Objectives, roadmap items, target milestones | 0.8 - 1.0 | `explicit_statement` | "Complete OAuth2 authentication workflow integration." |
+| `commitment` | Promises, agreed deliverables, explicitly accepted tasks | 1.0 | `explicit_statement` | "Refactor API route handlers before merging PR." |
+| `artifact` | Output locations, build targets, file paths | 0.9 - 1.0 | `observed` | "Generated OpenAPI schema lives at ./docs/openapi.json." |
+| `event` | Significant milestones, releases, major architectural shifts | 0.8 - 0.95 | `observed` | "Database successfully migrated to v2 schema." |
+| `relationship` | Team structure, component ownership, API integrations | 0.85 - 0.95 | `explicit_statement` | "Auth service integrates with Keycloak cluster at auth.example.com." |
+| `observation` | Behavioral patterns observed across multiple interactions | 0.6 - 0.85 | `observed` | "Provide concise code blocks without conversational preamble." |
+| `error` | Failure post-mortems, bug root causes, regression notes | 0.95 - 1.0 | `observed` / `corrected` | "Parser memory leak was caused by unclosed file handle in logger.py." |
+| `context` | Session state summaries, high-level project milestones | 0.9 - 1.0 | `observed` | "Phase 1 backend complete; database models fully migrated." |
+
+## Confidence Levels Guide
+
+Assign a confidence score between `0.0` and `1.0` based on source certainty:
+
+- **1.0** — Explicit user statement, verified codebase fact, standing user instruction.
+- **0.9 - 0.95** — Strong technical consensus, verified working code, well-tested pattern.
+- **0.8 - 0.85** — Observed pattern (seen 3+ times), indirect user preference with strong evidence.
+- **0.7 - 0.75** — Emerging pattern (seen 2 times), reasonable inference from context.
+- **0.6 - 0.65** — Single observation, plausible hypothesis needing future confirmation.
+- **< 0.6** — **DO NOT STORE.** Too uncertain.
 
 ## Provenance Types
 
-Always categorize the source of the memory. Valid options:
-- `explicit_statement` — Directly stated by user
-- `inferred` — Derived from behavior/context
-- `observed` — Seen in action
-- `corrected` — Updated after contradiction
-- `validated` — Confirmed/verified
-- `imported` — Brought in from an external source (file upload, sync, migration)
+Provenance identifies *how* the memory originated. You MUST specify one of the following:
 
-## Source Types
-
-Always specify the tool or agent creating the memory.
-- For AI agents: Use the agent name (e.g., `--source claude_code` or `--source cursor`)
-- Generic fallbacks when no specific writer applies: `user`, `agent`, `tool`, `system`
-- Any label works, up to 64 letters, digits, `.`, `_`, or `-` (no spaces)
+- `explicit_statement` — User directly stated this fact, rule, or preference in conversation.
+- `inferred` — Derived logically from user actions, codebase structure, or context.
+- `observed` — Witnessed directly during execution, test run, or terminal output.
+- `corrected` — Formulated after a previous mistake was corrected by the user or an error.
+- `validated` — Verified against code, tests, or official documentation.
+- `imported` — Ingested from an external source, config file, or migration.
 
 ## Tagging Best Practices
 
-Use 2-5 tags per memory. Tags make memories findable.
+Always pass `--tags` with 2 to 5 specific, lowercase, hyphenated tags. Tags make memories searchable and clusterable.
 
-Good: `--tags "authentication,oauth,security"`
-Good: `--tags "bug-fix,namespace,commit-3f39351"`
-Bad: `--tags "important"` (too generic)
-Bad: `--tags "thing"` (not descriptive)
+### Tag Formatting Rules
+- **Lowercase & Hyphenated**: Use `bug-fix`, `auth-oauth`, `next-js` (never camelCase or spaces).
+- **Be Specific**: Use `prisma-schema` instead of `db`, `jwt-auth` instead of `security`.
+- **Include Context & Refs**: Add commit hashes, component names, or issue IDs when relevant (e.g., `commit-a1b2c3d`, `user-router`).
 
-Conventions:
-- Lowercase with hyphens: `bug-fix` not `BugFix`
-- Be specific: `authentication-oauth` not `auth`
-- Include refs: `commit-abc123` for git references
+### Good vs Bad Examples
+- **GOOD**: `--tags "auth,oauth2,jwt,security"`
+- **GOOD**: `--tags "docker,windows,wsl2,networking"`
+- **BAD**: `--tags "important,stuff,code"` (Too generic, useless for retrieval)
 
-## Patterns
+## Choosing Between `recall` and `answer`
 
-### Session Start
+`recall` and `answer` serve distinct, complementary purposes. Choose based on what you need next:
+
+| Criteria | `memanto recall` | `memanto answer` |
+|----------|------------------|------------------|
+| **Output Type** | Raw memory chunks with IDs, types, and metadata | Synthesized, grounded textual answer |
+| **Primary Goal** | Build context for multi-step coding tasks | Answer a direct question or check a decision |
+| **When to Use** | Before starting complex work, reviewing options | User asks "What did we decide about X?" |
+| **Next Action** | Read memories, extract details, write code | Output answer directly to user or verify a fact |
+
+**Rule of Thumb**:
+- Need context to guide your work? Use `memanto recall`.
+- Need a synthesized answer to a specific question? Use `memanto answer`.
+
+## Pitfalls & Anti-Patterns to Avoid
+
+1. **Activity Logging (The Chat-Log Anti-Pattern)**
+   - **BAD**: `memanto remember "User told me to rename button component"`
+   - **GOOD**: `memanto remember "UI components must use PascalCase naming convention"`
+
+2. **Memory Hoarding**
+   - Ask: *"Will this principle matter to a fresh agent session 3 months from now?"* If no, do not store.
+
+3. **Vague Content**
+   - **BAD**: `memanto remember "Improved API speed"`
+   - **GOOD**: `memanto remember "API response time must remain under 200ms using Redis caching"`
+
+4. **Missing Metadata Flags**
+   - Never omit `--type`, `--confidence`, `--provenance`, or `--source`. Untyped memories pollute retrieval quality.
+
+5. **Expecting Invisible Context Injection**
+   - Do not expect hooks or background tools to automatically inject dynamic memories into chat UI. If context is needed, run `memanto recall` explicitly.
+
+6. **Storing Duplicate Memories**
+   - Before storing a major architectural decision or rule, run `memanto recall` to check if a similar rule already exists. Update it with `memanto edit` if necessary.
+
+## Execution Workflows
+
+### Workflow 1: Session Start / Task Initiation
 ```bash
-# recall — load raw context (instructions, decisions, goals) to guide this session
-memanto recall "instructions decisions goals" --limit 20
-
-# answer — get a direct synthesized summary of pending commitments
-memanto answer "What are my pending commitments?"
+# Check for existing architectural decisions and instructions relevant to the task
+memanto recall "authentication setup guidelines" --limit 10
 ```
 
-### After Important Work
+### Workflow 2: Learning from Error / Correction
 ```bash
-memanto remember "Implemented X using approach Y because Z. Commit abc123." --type decision --tags "feature-x" --confidence 0.95 --provenance "inferred" --source "claude_code"
-memanto remember "Learned that batch ops reduce API calls 100x." --type learning --tags "performance" --confidence 0.85 --provenance "observed" --source "claude_code"
+# Store lesson immediately after fixing a tricky bug or receiving user correction
+memanto remember "Next.js standalone build requires output: 'standalone' in next.config.js" --type learning --tags "nextjs,build,deployment" --confidence 1.0 --provenance corrected --source <agent_name>
 ```
 
-### When User Corrects You
+### Workflow 3: User Sets Architectural Constraint
 ```bash
-memanto remember "User corrected: prefer pytest over unittest." --type learning --tags "correction,testing" --confidence 1.0 --provenance "corrected" --source "claude_code"
-```
-
-### Choosing Between recall and answer
-
-These are **equal-priority tools**. Pick the right one — do NOT always default to `recall`.
-
-| Situation | Use |
-|-----------|-----|
-| Need raw memory chunks to read and apply as context | `recall` |
-| Need a direct synthesized answer to give (or act on) | `answer` |
-| Building context before a complex multi-step task | `recall` |
-| User asks "what did we decide / prefer / commit to?" | `answer` |
-| Comparing multiple matching memories | `recall` |
-| Need one grounded yes/no or summary response | `answer` |
-
-**Decision rule**: If your next step is *"read these memories and act"* → `recall`. If your next step is *"answer this question directly"* → `answer`. Both save tokens equally — `answer` synthesizes so you don't have to.
-
-```bash
-# Use recall — need raw context to work from
-memanto recall "authentication approach" --limit 10
-
-# Use answer — need a direct synthesized answer
-memanto answer "What auth approach did we decide on and why?"
-```
-
-## Pitfalls to Avoid
-
-1. **Memory hoarding** — Ask "Will this matter in a week?" before storing
-2. **Vague content** — Bad: "better performance" → Good: "API response < 200ms"
-3. **No context** — Bad: "fixed bug" → Good: "Fixed OAuth expiry bug. Commit abc123."
-4. **Duplicates** — Search first (`memanto recall`), then store if not found
-5. **Missing tags** — Always include tags for retrieval
-
-## recall vs answer: Choose the Right Tool
-
-**Equal priority** — do NOT always default to `recall`. Pick based on what you need next:
-
-| Use `recall` when... | Use `answer` when... |
-|---------------------|---------------------|
-| You need raw memory chunks as context | You need one direct synthesized response |
-| Building context before a complex task | User asks "what did we decide / prefer?" |
-| Comparing or reviewing multiple memories | Getting a grounded summary or yes/no |
-| Next step: *read these and act on them* | Next step: *deliver this as the answer* |
-
-**Short rule**: need context to work from → `recall`. Need a ready answer → `answer`. Both save the agent tokens and time — `answer` synthesizes so you don't have to read and merge manually.
-
-## Command Reference
-
-```bash
-# Store memory
-memanto remember "content" --type TYPE --tags "tag1,tag2" --confidence 0.9 --provenance "inferred" --source "claude_code"
-
-# Raw memory search (use for context-building, multi-step tasks)
-memanto recall "query" --limit 10 --type TYPE --min-similarity 0.8
-
-# Temporal recall variants (no query needed)
-memanto recall --recent --limit 10                 # newest first
-memanto recall --as-of "2026-01-15"                # state at a point in time
-memanto recall --changed-since "last 7 days"       # what changed since
-
-# Synthesized answer (use for direct questions, "what did we decide about X?")
-memanto answer "question"
-
-# Sync memories to project
-memanto memory sync --project-dir .
+# Store user-defined rule immediately
+memanto remember "Use UUID v4 for all primary keys across all PostgreSQL tables" --type instruction --tags "database,postgresql,schema" --confidence 1.0 --provenance explicit_statement --source <agent_name>
 ```
 """
 
@@ -173,7 +174,7 @@ memanto memory sync --project-dir .
 
 
 def _base_instruction_content(
-    tool_phrase: str = "the terminal", note_suffix: str = ""
+    agent_id: str = "<agent_name>", tool_phrase: str = "the terminal", note_suffix: str = ""
 ) -> str:
     """Generate base MEMANTO instruction content, adapted per agent."""
     note_line = ""
@@ -183,211 +184,109 @@ def _base_instruction_content(
     return f"""{MEMANTO_SENTINEL}
 ## MEMANTO - Your Active Memory Companion
 
-**MEMANTO is not a passive store. It is an active companion agent that works alongside you.**
-Don't treat MEMANTO like a static blob you query once and forget. It's a teammate you keep
-talking to, every preference, decision, and correction flows through it. MEMANTO remembers,
-recalls, and answers so you hold context across sessions, honor prior decisions, and avoid
-repeating mistakes the user already corrected.
+> **CRITICAL DIRECTIVE**: You are an agent equipped with Memanto. Without it, you are amnesiac. You have zero memory between chat sessions. Your ability to learn and adapt depends ENTIRELY on you actively writing to Memanto.
 
-Every memory operation in this session goes through MEMANTO. There is no exception.
+Every memory operation in this session goes through MEMANTO. There is no exception. All memanto commands are **shell commands**. Always run them using {tool_phrase}. Never simulate, describe, or "pretend to call" them.{note_line}
 
-> **CRITICAL**: All `memanto` commands are **shell commands**. Always run them using {tool_phrase}.
-> Never simulate, describe, or "pretend to call" them. If you cannot run the shell, say so explicitly instead of inventing memory state.
+### 1. THE ABSTRACTION RULE (HOW TO THINK ABOUT MEMORY)
+Users speak naturally and implicitly. When you store a memory, **ELEVATE IT TO A PRINCIPLE**. 
+- **WRONG (Activity Log)**: "User told me to use functional components."
+- **RIGHT (Universal Principle)**: "Exclusively use functional components for React UI."
+Do not record the conversation. Record the universal rule.
 
-### NON-NEGOTIABLE RULES
+### 2. THE TRIGGER MATRIX (WHEN TO STORE)
+Do not wait to be asked. If any of the following occur, your VERY FIRST ACTION must be to use {tool_phrase} to run `memanto remember`. Do not answer the user first.
+- **[USER PREFERENCE / RULE]** The user explicitly or implicitly states a convention, tool preference, or coding rule (e.g., "Use Tailwind v4", "Never use lodash", "Prefer async/await").
+- **[ARCHITECTURAL DECISION]** A decision is made regarding project structure, stack choice, DB schema, or API design (e.g., "Selected PostgreSQL with Prisma ORM").
+- **[CORRECTION / FAILURE LESSON]** You attempt an approach that fails and find a workaround, or the user corrects your code or mistake (e.g., "Must pass --no-cache when running build script").
+- **[GOAL / MILESTONE]** A milestone is reached, or a project roadmap/commitment is confirmed (e.g., "Phase 1 API complete, starting UI next").
+- **[ENVIRONMENT FACT]** A key technical fact about the user's workspace, OS, or toolchain is verified (e.g., "Runs on Windows PowerShell 5.1 with Python 3.11").
 
-These are not suggestions. Follow each one on every turn.
+### 3. THE DURABILITY TEST (WHAT NOT TO STORE)
+Before storing, ask yourself: *"Will this generalized principle fundamentally change how I generate code for this user 3 months from now?"*
+- **DO NOT STORE**: Step-by-step progress, routine bug fixes, UI tweaks, temporary code snippets, or literal chat summaries.
 
-1. **Read `MEMORY.md` before doing anything.** It is auto-synced at session start and holds
-   the user's preferences, facts, goals, instructions, decisions, and commitments from every
-   prior session. You MUST honor what is written there. If you act against it, you are
-   breaking continuity the user is paying for.
-2. **Search memory before saying you don't know.** If the user asks about past context, an
-   earlier decision, a preference, or anything you are unsure about, you MUST run `recall`
-   or `answer` first. Saying "I don't have context" without searching is a failure.
-3. **Store proactively. Do not wait to be asked.** The moment a memory-worthy event happens
-   — a preference stated, a decision made, a fact learned, an instruction given, a goal set,
-   a mistake corrected — run `memanto remember` immediately, in the same turn.
-4. **Always pass full metadata to `remember`.** Every `memanto remember` call MUST include
-   `--type`, `--confidence`, `--provenance`, and `--source <your_agent_name>`. Never let
-   these default. Untyped, unsourced memories pollute the agent's recall quality.
-5. **One memory operation goes through MEMANTO. All of them do.** Do not keep mental notes,
-   in-context scratch pads, or "I'll remember this for next time" promises. If it matters
-   beyond this turn, it goes into MEMANTO. If it doesn't, drop it.
+### 4. RECALL TRIGGER MATRIX (WHEN TO SEARCH MEMORY)
+Do not guess or write code blindly. Run `memanto recall` (or `memanto answer`) using {tool_phrase} before acting if any of the following occur:
+- **[TASK INITIATION]** Before starting a complex feature, refactor, or multi-file architecture task, search for relevant stack constraints, rules, and prior decisions.
+- **[AMBIGUOUS REPAIR / ERROR]** When facing a cryptic build failure, test failure, or environment bug, search memory for past workarounds and error post-mortems.
+- **[UNSTATED PREFERENCE]** When about to choose a library, pattern, or naming convention that isn't specified in the prompt, search memory to see if a preference was established in an earlier session.
+- **[EXPLICIT USER QUESTION]** When the user asks "What did we decide about X?", "Check memory", or "Recall context", run `memanto recall` (or `memanto answer`) immediately.
+- **[FRESH SESSION / CONTEXT REFRESH]** At session start or after switching tasks, run `memanto recall --recent` to retrieve active task state and recent commitments.
 
-### Memory Operations — Use the Right One
+### 5. HOW TO EXECUTE
+For all command syntax, required flags, memory types, tagging best practices, and CLI options, refer to the `memanto-memory` SKILL.md. You MUST read this skill before running any memory operations if you do not know the exact command schema.
 
-MEMANTO gives you three primitives. They are equal-priority. Pick by intent, not by habit.
-
-| You want to... | Use | Why |
-|---|---|---|
-| Read raw memory chunks and apply them as context | `memanto recall "query"` | Best for context-building, multi-step work, comparing options |
-| Get one synthesized, grounded answer to a direct question | `memanto answer "question"` | Best for "what did we decide / prefer / commit to?" — saves you reading and merging |
-| Persist something memory-worthy | `memanto remember "content" --type ... --confidence ... --provenance ... --source ...` | Every preference, decision, fact, instruction, goal, lesson |
-| See what changed since last time | `memanto recall --changed-since "last 7 days"` | Catching up after a break |
-| See the most recent memories | `memanto recall --recent` | Fast context refresh |
-
-Do NOT always default to `recall`. If the user asked a direct question, `answer` is usually
-the right tool — it returns a grounded synthesis so you don't burn tokens re-reading raw
-chunks.
-
-### When to Call `remember` (Examples — Run Immediately)
-
-- User says *"I prefer tabs over spaces"*:
-  `memanto remember "User prefers tabs over spaces for indentation" --type preference --confidence 1.0 --provenance explicit_statement --source <your_agent_name>`
-- You decide to use Library X for reason Y:
-  `memanto remember "Chose Library X for reason Y; commit abc123" --type decision --confidence 0.95 --provenance inferred --source <your_agent_name>`
-- User corrects an approach:
-  `memanto remember "User corrected: use pytest, not unittest" --type learning --confidence 1.0 --provenance corrected --source <your_agent_name>`
-- A failed approach taught you something:
-  `memanto remember "Batch size > 100 fails with TimeoutError" --type error --confidence 0.95 --provenance observed --source <your_agent_name>`
-
-### Command Reference
-
-```bash
-# Store — ALWAYS pass full metadata
-memanto remember "content" --type <type> --confidence <0.0-1.0> --provenance <provenance> --source <agent_name>
-
-# Recall raw context
-memanto recall "query"                              # semantic search
-memanto recall "query" --type <type> --limit 10     # filtered search
-memanto recall --recent --limit 10                  # newest first, no query
-memanto recall --as-of "2026-01-15"                 # state at a point in time
-memanto recall --changed-since "last 7 days"        # what changed since
-
-# Synthesized answer (grounded RAG over memories)
-memanto answer "question"
-
-# Re-sync MEMORY.md (project-local cache)
-memanto memory sync --project-dir .
-```
-
-**Memory types** (use the closest fit, do not invent new ones):
-`fact`, `preference`, `instruction`, `decision`, `event`, `goal`, `commitment`,
-`observation`, `learning`, `relationship`, `context`, `artifact`, `error`.
-
-**Provenance values**: `explicit_statement`, `inferred`, `observed`, `corrected`,
-`validated`, `imported`.
-
-**Confidence**: `1.0` for explicit user statements; `0.9-0.95` for strong consensus;
-`0.8-0.85` for observed patterns (3+ times); `0.6-0.75` for emerging patterns.
-{note_line}
+{MEMANTO_DYNAMIC_SENTINEL}
+{MEMANTO_DYNAMIC_SENTINEL_END}
 {MEMANTO_SENTINEL_END}"""
-
 
 def get_instruction_content(agent_name: str) -> str:
     """Get MEMANTO instruction section content for a specific agent."""
     templates = {
         "claude-code": _base_instruction_content(
+            agent_id="claude-code",
             tool_phrase="the Bash tool",
             note_suffix="The `memanto-memory` skill contains reference guidelines only (best practices, confidence levels, tagging). It is NOT executable — always use Bash for memanto commands.",
         ),
         "codex": _base_instruction_content(
+            agent_id="codex",
             tool_phrase="the terminal",
             note_suffix="The `memanto-memory` skill in `.agents/skills/memanto/` contains detailed reference guidelines (best practices, confidence levels, tagging).",
         ),
-        "cursor": _get_mdc_content(),
+        "cursor": _get_mdc_content(agent_id="cursor"),
         "windsurf": _base_instruction_content(
+            agent_id="windsurf",
             tool_phrase="the terminal",
             note_suffix="The `memanto-memory` skill in `.windsurf/skills/memanto/` contains detailed reference guidelines.",
         ),
         "gemini-cli": _base_instruction_content(
+            agent_id="gemini-cli",
             tool_phrase="the terminal",
             note_suffix="The `memanto-memory` skill in `.gemini/skills/memanto/` contains detailed reference guidelines.",
         ),
         "cline": _base_instruction_content(
+            agent_id="cline",
             tool_phrase="the terminal",
-            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to populate MEMORY.md.",
+            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions.",
         ),
         "continue": _base_instruction_content(
+            agent_id="continue",
             tool_phrase="the terminal",
-            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to populate MEMORY.md.",
+            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions.",
         ),
         "opencode": _base_instruction_content(
+            agent_id="opencode",
             tool_phrase="the terminal",
             note_suffix="The `memanto-memory` skill in `.agents/skills/memanto/` contains detailed reference guidelines.",
         ),
         "roo": _base_instruction_content(
+            agent_id="roo",
             tool_phrase="the terminal",
-            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to populate MEMORY.md.",
+            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions.",
         ),
         "github-copilot": _base_instruction_content(
+            agent_id="github-copilot",
             tool_phrase="the terminal",
-            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to populate MEMORY.md.",
+            note_suffix="Run `memanto memory sync --project-dir .` at the start of each session to inject the latest dynamic memories into your system instructions. DO NOT write project-specific rules to the global `User/prompts/` directory to avoid context dilution—rely exclusively on Memanto and the `CLAUDE.md` Hot Cache.",
         ),
         "augment": _base_instruction_content(
+            agent_id="augment",
             tool_phrase="the terminal",
             note_suffix="The `memanto-memory` skill in `.augment/skills/memanto/` contains detailed reference guidelines.",
         ),
     }
-    return templates.get(agent_name, _base_instruction_content())
+    return templates.get(agent_name, _base_instruction_content(agent_id=agent_name))
 
 
-def _get_mdc_content() -> str:
+def _get_mdc_content(agent_id: str = "cursor") -> str:
     """Get MDC-formatted rules content for Cursor."""
     return f"""---
 description: MEMANTO — active memory companion. Mandatory rules for storing, recalling, and answering from persistent memory.
 alwaysApply: true
 ---
 
-{MEMANTO_SENTINEL}
-
-# MEMANTO — Your Active Memory Companion
-
-**MEMANTO is not a passive store. It is an active companion agent that works alongside you.**
-Don't treat MEMANTO like a static blob you query once and forget. It's a teammate you keep
-talking to — every preference, decision, and correction flows through it. MEMANTO remembers,
-recalls, and answers so you hold context across sessions, honor prior decisions, and avoid
-repeating mistakes the user already corrected. Every memory operation in this session goes
-through MEMANTO.
-
-> **CRITICAL**: All `memanto` commands are **shell commands**. Always run them in the terminal.
-> Never simulate or "pretend to call" them. If you cannot run the shell, say so explicitly
-> instead of inventing memory state.
-
-## NON-NEGOTIABLE RULES
-
-1. **Sync and read `MEMORY.md` at session start.** Run `memanto memory sync --project-dir .`
-   then read `MEMORY.md` in the project root. It holds the user's preferences, facts,
-   goals, instructions, decisions, and commitments from every prior session. You MUST
-   honor what is written there.
-2. **Search memory before saying you don't know.** If the user asks about past context,
-   an earlier decision, a preference, or anything you are unsure about, you MUST run
-   `recall` or `answer` first.
-3. **Store proactively. Do not wait to be asked.** The moment a memory-worthy event
-   happens — a preference stated, a decision made, a fact learned, an instruction given,
-   a goal set, a mistake corrected — run `memanto remember` immediately, in the same turn.
-4. **Always pass full metadata to `remember`.** Every call MUST include `--type`,
-   `--confidence`, `--provenance`, and `--source <your_agent_name>`. Never let these
-   default.
-5. **All memory operations go through MEMANTO.** No mental scratch pads, no "I'll
-   remember this next time." If it matters beyond this turn, it goes into MEMANTO.
-
-## Memory Operations — Use the Right One
-
-```bash
-memanto recall "query"      # raw memory chunks — for context-building, multi-step work
-memanto answer "question"   # one synthesized, grounded answer — for direct questions
-memanto recall --recent     # newest first, no query needed
-memanto recall --changed-since "last 7 days"
-memanto remember "content" --type <type> --confidence <0.0-1.0> --provenance <provenance> --source <agent_name>
-memanto memory sync --project-dir .
-```
-
-Do NOT always default to `recall`. `recall` returns raw chunks (best for context-building);
-`answer` returns one grounded synthesis (best for "what did we decide / prefer / commit
-to?"). Equal priority — pick by intent.
-
-**Memory types**: `fact`, `preference`, `instruction`, `decision`, `event`, `goal`,
-`commitment`, `observation`, `learning`, `relationship`, `context`, `artifact`, `error`.
-
-**Provenance**: `explicit_statement`, `inferred`, `observed`, `corrected`, `validated`,
-`imported`.
-
-**Confidence**: `1.0` for explicit user statements; `0.9-0.95` strong consensus;
-`0.8-0.85` for patterns seen 3+ times; below `0.6` — do not store.
-
-{MEMANTO_SENTINEL_END}"""
+{_base_instruction_content(agent_id=agent_id, tool_phrase="the terminal")}"""
 
 
 def get_skill_content() -> str:

--- a/memanto/cli/connect/updater.py
+++ b/memanto/cli/connect/updater.py
@@ -22,6 +22,7 @@ def _extract_version(file_path: Path) -> str | None:
                 [int(x) for x in v_str.split(".")]
                 return v_str
             except ValueError:
+                # Ignore version string if parts are not valid integers
                 pass
 
         if "<!-- MEMANTO-MANAGED-SECTION -->" in content:

--- a/memanto/cli/connect/updater.py
+++ b/memanto/cli/connect/updater.py
@@ -1,0 +1,145 @@
+import re
+from pathlib import Path
+from typing import Any
+
+from memanto.cli.connect.agent_registry import list_agents
+from memanto.cli.connect.engine import install_agent
+from memanto.cli.connect.templates import TEMPLATE_VERSION
+
+
+def _extract_version(file_path: Path) -> str | None:
+    """Extracts the memanto template version from a file."""
+    if not file_path.exists():
+        return None
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        match = re.search(r"<!-- memanto-template-version: ([\d\.]+) -->", content)
+        if match:
+            return match.group(1)
+        if "<!-- MEMANTO-MANAGED-SECTION -->" in content:
+            return "0.0.0"
+        return None
+    except Exception:
+        return None
+
+
+def _is_version_lower(v1: str, v2: str) -> bool:
+    """Simple semver comparison."""
+    try:
+        return [int(x) for x in v1.split(".")] < [int(x) for x in v2.split(".")]
+    except ValueError:
+        return False
+
+
+def check_for_updates(
+    project_dir: str = ".",
+) -> dict[str, Any]:
+    """
+    Scans the workspace and globally for active integrations and checks if their templates are outdated.
+
+    Returns:
+        dict: {
+            "outdated": bool,
+            "installed_version": str | None,
+            "latest_version": str,
+            "active_agents": list[str],
+            "active_local": list[str],
+            "active_global": list[str]
+        }
+    """
+    project_path = Path(project_dir).expanduser().resolve()
+    lowest_version = None
+    active_local = []
+    active_global = []
+
+    for agent in list_agents():
+        # Check Local
+        local_has_files = False
+        inst_path_local = agent.resolve_instruction_file(project_path, False)
+        if inst_path_local and inst_path_local.exists():
+            local_has_files = True
+            v = _extract_version(inst_path_local)
+            if v and (lowest_version is None or _is_version_lower(v, lowest_version)):
+                lowest_version = v
+
+        skill_dir_local = agent.resolve_skill_local(project_path)
+        skill_path_local = skill_dir_local / "SKILL.md"
+        if skill_path_local.exists():
+            local_has_files = True
+            v = _extract_version(skill_path_local)
+            if v and (lowest_version is None or _is_version_lower(v, lowest_version)):
+                lowest_version = v
+
+        if local_has_files:
+            active_local.append(agent.name)
+
+        # Check Global
+        global_has_files = False
+        inst_path_global = agent.resolve_instruction_file(project_path, True)
+        if inst_path_global and inst_path_global.exists():
+            global_has_files = True
+            v = _extract_version(inst_path_global)
+            if v and (lowest_version is None or _is_version_lower(v, lowest_version)):
+                lowest_version = v
+
+        skill_dir_global = agent.resolve_skill_global()
+        skill_path_global = skill_dir_global / "SKILL.md"
+        if skill_path_global.exists():
+            global_has_files = True
+            v = _extract_version(skill_path_global)
+            if v and (lowest_version is None or _is_version_lower(v, lowest_version)):
+                lowest_version = v
+
+        if global_has_files:
+            active_global.append(agent.name)
+
+    is_outdated = False
+    if lowest_version and _is_version_lower(lowest_version, TEMPLATE_VERSION):
+        is_outdated = True
+
+    return {
+        "outdated": is_outdated,
+        "installed_version": lowest_version,
+        "latest_version": TEMPLATE_VERSION,
+        "active_agents": list(set(active_local + active_global)),
+        "active_local": active_local,
+        "active_global": active_global,
+    }
+
+
+def update_all_agents(
+    project_dir: str = ".", update_global: bool = True, update_local: bool = True
+) -> list[str]:
+    """
+    Updates all currently installed agents to the latest template version.
+    Returns a list of messages.
+    """
+    status = check_for_updates(project_dir)
+    messages = []
+
+    if not status.get("active_local") and not status.get("active_global"):
+        return ["No active Memanto integrations found to update."]
+
+    if update_local:
+        for agent_name in status.get("active_local", []):
+            res = install_agent(agent_name, project_dir, is_global=False)
+            messages.extend(res.get("steps", []))
+            if res.get("errors"):
+                messages.extend(
+                    [f"Error updating local {agent_name}: {e}" for e in res["errors"]]
+                )
+
+    if update_global:
+        for agent_name in status.get("active_global", []):
+            res = install_agent(agent_name, project_dir, is_global=True)
+            messages.extend(res.get("steps", []))
+            if res.get("errors"):
+                messages.extend(
+                    [f"Error updating global {agent_name}: {e}" for e in res["errors"]]
+                )
+
+    messages.append(
+        f"\n🎉 Successfully updated all active templates to v{TEMPLATE_VERSION}!"
+    )
+    return messages

--- a/memanto/cli/connect/updater.py
+++ b/memanto/cli/connect/updater.py
@@ -162,11 +162,11 @@ def update_all_agents(
 
     if not has_errors:
         messages.append(
-            f"\n🎉 Successfully updated all active templates to v{TEMPLATE_VERSION}!"
+            f"\n🎉 Successfully updated all active agent instructions to v{TEMPLATE_VERSION}!"
         )
     else:
         messages.append(
-            "\n⚠️ Update completed with errors. Some templates may not have been updated."
+            "\n⚠️ Update completed with errors. Some instructions may not have been updated."
         )
 
     return messages

--- a/memanto/cli/connect/updater.py
+++ b/memanto/cli/connect/updater.py
@@ -16,7 +16,14 @@ def _extract_version(file_path: Path) -> str | None:
         content = file_path.read_text(encoding="utf-8")
         match = re.search(r"<!-- memanto-template-version: ([\d\.]+) -->", content)
         if match:
-            return match.group(1)
+            v_str = match.group(1)
+            try:
+                # Validate all components are integers to prevent malformed versions like 1..2
+                [int(x) for x in v_str.split(".")]
+                return v_str
+            except ValueError:
+                pass
+
         if "<!-- MEMANTO-MANAGED-SECTION -->" in content:
             return "0.0.0"
         return None
@@ -126,9 +133,11 @@ def update_all_agents(
         return ["No active Memanto integrations found to update."]
 
     has_errors = False
+    ran_updates = False
 
     if update_local:
         for agent_name in status.get("active_local", []):
+            ran_updates = True
             res = install_agent(agent_name, project_dir, is_global=False)
             messages.extend(res.get("steps", []))
             if res.get("errors"):
@@ -139,6 +148,7 @@ def update_all_agents(
 
     if update_global:
         for agent_name in status.get("active_global", []):
+            ran_updates = True
             res = install_agent(agent_name, project_dir, is_global=True)
             messages.extend(res.get("steps", []))
             if res.get("errors"):
@@ -146,6 +156,9 @@ def update_all_agents(
                 messages.extend(
                     [f"Error updating global {agent_name}: {e}" for e in res["errors"]]
                 )
+
+    if not ran_updates:
+        return ["No active Memanto integrations found in the selected scope."]
 
     if not has_errors:
         messages.append(

--- a/memanto/cli/connect/updater.py
+++ b/memanto/cli/connect/updater.py
@@ -58,18 +58,20 @@ def check_for_updates(
         local_has_files = False
         inst_path_local = agent.resolve_instruction_file(project_path, False)
         if inst_path_local and inst_path_local.exists():
-            local_has_files = True
             v = _extract_version(inst_path_local)
-            if v and (lowest_version is None or _is_version_lower(v, lowest_version)):
-                lowest_version = v
+            if v is not None:
+                local_has_files = True
+                if lowest_version is None or _is_version_lower(v, lowest_version):
+                    lowest_version = v
 
         skill_dir_local = agent.resolve_skill_local(project_path)
         skill_path_local = skill_dir_local / "SKILL.md"
         if skill_path_local.exists():
-            local_has_files = True
             v = _extract_version(skill_path_local)
-            if v and (lowest_version is None or _is_version_lower(v, lowest_version)):
-                lowest_version = v
+            if v is not None:
+                local_has_files = True
+                if lowest_version is None or _is_version_lower(v, lowest_version):
+                    lowest_version = v
 
         if local_has_files:
             active_local.append(agent.name)
@@ -78,18 +80,20 @@ def check_for_updates(
         global_has_files = False
         inst_path_global = agent.resolve_instruction_file(project_path, True)
         if inst_path_global and inst_path_global.exists():
-            global_has_files = True
             v = _extract_version(inst_path_global)
-            if v and (lowest_version is None or _is_version_lower(v, lowest_version)):
-                lowest_version = v
+            if v is not None:
+                global_has_files = True
+                if lowest_version is None or _is_version_lower(v, lowest_version):
+                    lowest_version = v
 
         skill_dir_global = agent.resolve_skill_global()
         skill_path_global = skill_dir_global / "SKILL.md"
         if skill_path_global.exists():
-            global_has_files = True
             v = _extract_version(skill_path_global)
-            if v and (lowest_version is None or _is_version_lower(v, lowest_version)):
-                lowest_version = v
+            if v is not None:
+                global_has_files = True
+                if lowest_version is None or _is_version_lower(v, lowest_version):
+                    lowest_version = v
 
         if global_has_files:
             active_global.append(agent.name)
@@ -121,11 +125,14 @@ def update_all_agents(
     if not status.get("active_local") and not status.get("active_global"):
         return ["No active Memanto integrations found to update."]
 
+    has_errors = False
+
     if update_local:
         for agent_name in status.get("active_local", []):
             res = install_agent(agent_name, project_dir, is_global=False)
             messages.extend(res.get("steps", []))
             if res.get("errors"):
+                has_errors = True
                 messages.extend(
                     [f"Error updating local {agent_name}: {e}" for e in res["errors"]]
                 )
@@ -135,11 +142,18 @@ def update_all_agents(
             res = install_agent(agent_name, project_dir, is_global=True)
             messages.extend(res.get("steps", []))
             if res.get("errors"):
+                has_errors = True
                 messages.extend(
                     [f"Error updating global {agent_name}: {e}" for e in res["errors"]]
                 )
 
-    messages.append(
-        f"\n🎉 Successfully updated all active templates to v{TEMPLATE_VERSION}!"
-    )
+    if not has_errors:
+        messages.append(
+            f"\n🎉 Successfully updated all active templates to v{TEMPLATE_VERSION}!"
+        )
+    else:
+        messages.append(
+            "\n⚠️ Update completed with errors. Some templates may not have been updated."
+        )
+
     return messages

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -3413,7 +3413,7 @@
           "Web UI"
         ],
         "summary": "Get Template Status",
-        "description": "Check if agent instruction templates are outdated.",
+        "description": "Check if agent instructions are outdated.",
         "operationId": "get_template_status_api_ui_template_status_get",
         "responses": {
           "200": {
@@ -3433,7 +3433,7 @@
           "Web UI"
         ],
         "summary": "Get Template Status Dismissed",
-        "description": "Get the currently dismissed template version.",
+        "description": "Get the currently dismissed instruction version.",
         "operationId": "get_template_status_dismissed_api_ui_template_status_dismissed_get",
         "responses": {
           "200": {
@@ -3453,7 +3453,7 @@
           "Web UI"
         ],
         "summary": "Dismiss Template Status",
-        "description": "Dismiss the template update warning for the current version.",
+        "description": "Dismiss the instruction update warning for the current version.",
         "operationId": "dismiss_template_status_api_ui_template_status_dismiss_post",
         "responses": {
           "200": {
@@ -3473,7 +3473,7 @@
           "Web UI"
         ],
         "summary": "Apply Template Update",
-        "description": "Update all active Memanto templates in the workspace and globally.",
+        "description": "Update all active Memanto agent instructions in the workspace and globally.",
         "operationId": "apply_template_update_api_ui_template_status_update_post",
         "responses": {
           "200": {

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -3407,6 +3407,86 @@
         }
       }
     },
+    "/api/ui/template-status": {
+      "get": {
+        "tags": [
+          "Web UI"
+        ],
+        "summary": "Get Template Status",
+        "description": "Check if agent instruction templates are outdated.",
+        "operationId": "get_template_status_api_ui_template_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ui/template-status/dismissed": {
+      "get": {
+        "tags": [
+          "Web UI"
+        ],
+        "summary": "Get Template Status Dismissed",
+        "description": "Get the currently dismissed template version.",
+        "operationId": "get_template_status_dismissed_api_ui_template_status_dismissed_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ui/template-status/dismiss": {
+      "post": {
+        "tags": [
+          "Web UI"
+        ],
+        "summary": "Dismiss Template Status",
+        "description": "Dismiss the template update warning for the current version.",
+        "operationId": "dismiss_template_status_api_ui_template_status_dismiss_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ui/template-status/update": {
+      "post": {
+        "tags": [
+          "Web UI"
+        ],
+        "summary": "Apply Template Update",
+        "description": "Update all active Memanto templates in the workspace and globally.",
+        "operationId": "apply_template_update_api_ui_template_status_update_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/ui/connections/install": {
       "post": {
         "tags": [

--- a/tests/test_connect_detection.py
+++ b/tests/test_connect_detection.py
@@ -49,7 +49,7 @@ def test_cline_install_detection_requires_cline_rule_file(tmp_path):
 def test_skills_only_agent_detected_from_skill_file_alone(tmp_path):
     """Agents without an instruction file are detected from SKILL.md alone."""
     skills_only_agent = AGENT_REGISTRY["antigravity"]
-    assert skills_only_agent.instruction_file is None
+    assert skills_only_agent.instruction_local_file is None
     _write_agent_skill(tmp_path, skills_only_agent.name)
 
     installed = {agent.name for agent in detect_memanto_installed(tmp_path)}

--- a/tests/test_connect_detection.py
+++ b/tests/test_connect_detection.py
@@ -55,3 +55,24 @@ def test_skills_only_agent_detected_from_skill_file_alone(tmp_path):
     installed = {agent.name for agent in detect_memanto_installed(tmp_path)}
 
     assert skills_only_agent.name in installed
+
+
+def test_pi_install_detection_requires_pi_skill_dir(tmp_path):
+    """Pi shares AGENTS.md with codex/opencode, so its own skill dir decides."""
+    agents_md = tmp_path / "AGENTS.md"
+    agents_md.write_text(
+        f"{MEMANTO_SENTINEL}\n## MEMANTO\n{MEMANTO_SENTINEL_END}\n",
+        encoding="utf-8",
+    )
+    _write_shared_agents_skill(tmp_path)
+
+    installed = {agent.name for agent in detect_memanto_installed(tmp_path)}
+
+    assert "codex" in installed
+    assert "pi" not in installed
+
+    _write_agent_skill(tmp_path, "pi")
+
+    installed = {agent.name for agent in detect_memanto_installed(tmp_path)}
+
+    assert "pi" in installed

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -1,9 +1,14 @@
 import json
+from pathlib import Path
 
 from memanto.cli.connect import engine
 from memanto.cli.connect.agent_registry import AGENT_REGISTRY
 from memanto.cli.connect.engine import _remove_instructions
-from memanto.cli.connect.templates import get_instruction_content
+from memanto.cli.connect.templates import (
+    MEMANTO_SENTINEL,
+    MEMANTO_SENTINEL_END,
+    get_instruction_content,
+)
 
 
 def test_remove_dedicated_instruction_preserves_unmanaged_file(tmp_path):
@@ -152,3 +157,85 @@ def test_remove_claude_code_preserves_unrelated_hooks_and_permissions(
         "permissions": {"allow": ["Bash(git status)"]},
         "env": {"KEEP": "1"},
     }
+
+
+def test_pi_install_deploys_instructions_skill_and_extension(tmp_path, monkeypatch):
+    stub_config_manager(monkeypatch)
+
+    result = engine.install_agent("pi", str(tmp_path))
+
+    assert result["errors"] == []
+    assert (tmp_path / "AGENTS.md").exists()
+    assert (tmp_path / ".pi" / "skills" / "memanto" / "SKILL.md").exists()
+    extension_path = tmp_path / ".pi" / "extensions" / "memanto-sync.ts"
+    assert extension_path.exists()
+    assert any("Deployed extension" in step for step in result["steps"])
+
+    extension = extension_path.read_text(encoding="utf-8")
+    assert 'pi.on("session_start"' in extension
+    assert 'event.reason !== "startup"' in extension
+    assert '"memory", "sync", "--project-dir", ctx.cwd' in extension
+
+
+def test_pi_install_is_idempotent(tmp_path, monkeypatch):
+    stub_config_manager(monkeypatch)
+
+    engine.install_agent("pi", str(tmp_path))
+    result = engine.install_agent("pi", str(tmp_path))
+
+    assert result["errors"] == []
+    agents_md = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert agents_md.count(MEMANTO_SENTINEL) == 1
+    assert agents_md.count(MEMANTO_SENTINEL_END) == 1
+    assert list((tmp_path / ".pi" / "extensions").iterdir()) == [
+        tmp_path / ".pi" / "extensions" / "memanto-sync.ts"
+    ]
+
+
+def test_pi_remove_deletes_extension(tmp_path, monkeypatch):
+    stub_config_manager(monkeypatch)
+    engine.install_agent("pi", str(tmp_path))
+
+    result = engine.remove_agent("pi", str(tmp_path))
+
+    assert result["errors"] == []
+    assert any("Removed extension" in step for step in result["steps"])
+    assert not (tmp_path / ".pi" / "extensions").exists()
+    assert not (tmp_path / ".pi" / "skills" / "memanto").exists()
+    assert not (tmp_path / "AGENTS.md").exists()
+
+
+def test_pi_global_paths_match_pi_agent_layout(tmp_path, monkeypatch):
+    """Pi discovers global skills and extensions under ~/.pi/agent/."""
+    stub_config_manager(monkeypatch)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    result = engine.install_agent("pi", str(tmp_path / "project"), is_global=True)
+
+    assert result["errors"] == []
+    assert (tmp_path / ".pi" / "agent" / "AGENTS.md").exists()
+    assert (tmp_path / ".pi" / "agent" / "skills" / "memanto" / "SKILL.md").exists()
+    assert (tmp_path / ".pi" / "agent" / "extensions" / "memanto-sync.ts").exists()
+
+    remove_result = engine.remove_agent("pi", str(tmp_path / "project"), is_global=True)
+
+    assert remove_result["errors"] == []
+    assert not (tmp_path / ".pi" / "agent" / "extensions").exists()
+
+
+def test_agents_without_extension_deploy_none(tmp_path, monkeypatch):
+    """The extension artifact is opt-in; agents without one are unaffected."""
+    stub_config_manager(monkeypatch)
+
+    result = engine.install_agent("codex", str(tmp_path))
+
+    assert result["errors"] == []
+    assert AGENT_REGISTRY["codex"].extension_file is None
+    assert not any(step.startswith("Deployed extension") for step in result["steps"])
+
+    remove_result = engine.remove_agent("codex", str(tmp_path))
+
+    assert remove_result["errors"] == []
+    assert not any(
+        step.startswith("Removed extension") for step in remove_result["steps"]
+    )

--- a/tests/test_connect_engine.py
+++ b/tests/test_connect_engine.py
@@ -72,7 +72,7 @@ def test_remove_claude_code_removes_installed_hook_and_permissions(
     remove_result = engine.remove_agent("claude-code", str(tmp_path))
 
     assert remove_result["errors"] == []
-    assert any("SessionStart hook" in step for step in remove_result["steps"])
+    assert any("Memanto hooks" in step for step in remove_result["steps"])
     assert any("permissions" in step for step in remove_result["steps"])
     assert not (tmp_path / ".claude" / "settings.json").exists()
     assert not (tmp_path / ".claude" / "settings.local.json").exists()
@@ -146,26 +146,6 @@ def test_remove_claude_code_preserves_unrelated_hooks_and_permissions(
     permissions = read_json(permissions_path)
     assert settings["theme"] == "dark"
     assert settings["hooks"]["SessionStart"] == [
-        {
-            "matcher": "startup",
-            "hooks": [
-                {"type": "command", "command": "echo keep"},
-                {
-                    "type": "command",
-                    "command": "memanto memory sync --project-dir .",
-                },
-            ],
-        },
-        {
-            "matcher": "manual",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": "memanto memory sync --project-dir .",
-                    "timeout": 30,
-                }
-            ],
-        },
         {"matcher": "other", "hooks": [{"command": "echo other"}]},
     ]
     assert permissions == {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2344,6 +2344,8 @@ class TestValidateSafeId:
         ("claude-code", True, ".claude/CLAUDE.md"),
         ("windsurf", True, ".codeium/windsurf/.windsurfrules"),
         ("cursor", False, "project/.cursor/rules/memanto.mdc"),
+        ("pi", True, ".pi/agent/AGENTS.md"),
+        ("pi", False, "project/AGENTS.md"),
     ],
 )
 def test_resolve_instruction_file_paths(


### PR DESCRIPTION
- Update instruction and skills template to incur remember and recall operations more often and with better detail
- Introduce memanto dynamic memory markers for future memanto sync changes
- Introduce memanto template versioning markers for instructional md and skill md files for easy versioning detection
- Add versioning checks on status and sync commands and supply versioning warnings accordingly
- Add memanto connect update and ui popup to trigger update or dismiss
- Separate logic between filepath retrieval for global and local connections
- fix escape character bug for ui disconnect
- inject dynamic agent_name into SKILL.md examples
- add frontmatter to copilot instructions.md for auto-ingestion
- Add hooks from agent skills repository to memanto connect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic detection and updating of outdated agent instructions.
  - Added dashboard notifications with version details and Dismiss/Update actions.
  - Added `memanto connect update` for local and global integrations.
  - Added agent-specific extensions and hooks for session startup, context compaction, and command-result notifications.
  - Added automatic memory synchronization and status updates for supported agent sessions.

- **Improvements**
  - Expanded agent guidance with workflow, confidence, provenance, and tagging recommendations.
  - Improved update messages with clearer results and failure diagnostics.
  - Updated connection listings to distinguish local and global instruction files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->