### PR TITLE
security: reject non-loopback Host headers on cookie sessions and UI management routes

### DIFF
--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -245,6 +245,30 @@ def get_current_session(
             status_code=401, detail="Missing session token. Use X-Session-Token header."
         )
 
+    # A session presented via the HttpOnly *cookie* (browser transport) must
+    # come from the loopback interface targeting a loopback Host. The TCP
+    # client alone is not enough to trust: a DNS-rebinding page on an
+    # attacker domain can inherit the loopback client (the server sees a
+    # 127.0.0.1 peer) while the request's Host names the attacker origin.
+    # Mirror ``require_management_access``'s loopback boundary here so a
+    # rebinding page cannot read or write the memory store. Header-
+    # authenticated API clients (X-Session-Token) are unaffected and may be
+    # remote.
+    if session_cookie and not x_session_token:
+        client_host = request.client.host if request.client else None
+        if (
+            not _is_loopback_host(client_host)
+            or not _is_loopback_host_header(request.headers.get("host"))
+            or _is_cross_site_browser_request(request)
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Cookie-authenticated session requests must originate "
+                    "from the loopback interface targeting a loopback Host."
+                ),
+            )
+
     session_service = get_session_service()
 
     try:

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -30,6 +30,7 @@ from memanto.app.clients.backend import Backend
 from memanto.app.config import settings
 from memanto.app.routes.auth_deps import (
     _is_cross_site_browser_request,
+    _is_loopback_host_header,
     clear_session_cookie,
     set_session_cookie,
 )
@@ -102,6 +103,20 @@ async def _require_local(request: Request) -> None:
         raise HTTPException(
             status_code=403,
             detail="UI management endpoints reject cross-site browser requests.",
+        )
+
+    # A loopback TCP peer is necessary but not sufficient: a DNS-rebinding
+    # page on an attacker domain makes the server see a 127.0.0.1 client
+    # while the Host header names the attacker origin. The Host header is
+    # the only signal that distinguishes "local UI on localhost" from
+    # "attacker domain bound to loopback", so require it to name loopback.
+    if not _is_loopback_host_header(request.headers.get("host")):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "UI management endpoints must be requested with a loopback "
+                "Host header."
+            ),
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,7 +58,7 @@ def test_env_setup():
 async def client():
     """Create an async client for testing the FastAPI app"""
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+    async with AsyncClient(transport=transport, base_url="http://localhost") as ac:
         yield ac
 
 

--- a/tests/test_rebinding.py
+++ b/tests/test_rebinding.py
@@ -1,0 +1,325 @@
+"""Regression tests for the DNS-rebinding / missing Host-header validation fix.
+
+Attack recap
+------------
+MEMANTO binds to 0.0.0.0 and trusts the loopback TCP client for its
+session-scoped memory routes (``get_current_session``) and UI management
+routes (``_require_local``). A malicious page on ``attacker.example`` that
+DNS-rebinding resolves to 127.0.0.1 makes the server see a 127.0.0.1 peer
+while the request's Host header names ``attacker.example``. Before the fix
+those requests were indistinguishable from a local browser and could read /
+write the private memory store, migrate the session cookie onto the attacker
+domain (GET /api/ui/config), and enumerate the filesystem (browse).
+
+The fix requires that cookie-transport (browser) session requests and all UI
+management requests target a loopback Host header, mirroring the
+``require_management_access`` boundary. Header-transport API clients
+(``X-Session-Token``, no cookie) must remain callable from remote peers.
+
+These tests pin that boundary: rebinding-origin requests are rejected
+(403), legitimate localhost traffic still works (200), and remote header-
+transport API clients are unaffected (200).
+"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memanto.app.main import app
+
+os.environ["MOORCHEH_API_KEY"] = "test-api-key"
+
+ATTACKER_ORIGIN = "http://attacker.example:8000"
+LOCAL_ORIGIN = "http://localhost:8000"
+
+
+@pytest.fixture(autouse=True, scope="function")
+def test_env_setup():
+    """Isolated env for agent/session metadata (mirrors test_api.py)."""
+    temp_dir = tempfile.mkdtemp()
+    temp_path = Path(temp_dir)
+    with (
+        patch("memanto.app.services.agent_service.Path.home", return_value=temp_path),
+        patch("memanto.app.services.session_service.Path.home", return_value=temp_path),
+    ):
+        from memanto.app.routes.sessions import agent_service
+        from memanto.app.services import session_service as session_service_mod
+
+        session_service_mod._session_service = None
+        session_service = session_service_mod.get_session_service()
+        orig_agent_dir = agent_service.agents_dir
+        agent_service.agents_dir = temp_path / ".memanto" / "agents"
+        agent_service.agents_dir.mkdir(parents=True, exist_ok=True)
+        session_service.sessions_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            yield temp_path
+        finally:
+            agent_service.agents_dir = orig_agent_dir
+            session_service_mod._session_service = None
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+async def local_client():
+    """Loopback client whose Host header names localhost (real local UI
+    browser / localhost callers)."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=LOCAL_ORIGIN) as ac:
+        yield ac
+
+
+@pytest.fixture(autouse=True)
+def mock_moorcheh():
+    """Mock the Moorcheh SDK (extends the shared conftest mock with the shapes
+    the memory read/write services consume)."""
+    from memanto.app.clients.moorcheh import moorcheh_client
+
+    moorcheh_client.reset_client()
+    with (
+        patch(
+            "memanto.app.services.agent_service.get_moorcheh_client"
+        ) as mock_agent_client,
+        patch("memanto.app.clients.moorcheh.MoorchehClient") as mock_moorcheh_cls,
+        patch(
+            "memanto.app.clients.moorcheh.AsyncMoorchehClient"
+        ) as mock_async_moorcheh_cls,
+    ):
+        mock_instance = MagicMock()
+        mock_async_instance = MagicMock()
+        mock_agent_client.return_value = mock_instance
+        mock_moorcheh_cls.return_value = mock_instance
+        mock_async_moorcheh_cls.return_value = mock_async_instance
+
+        mock_instance.namespaces.create.return_value = {"status": "created"}
+        mock_instance.namespaces.list.return_value = {"namespaces": []}
+        mock_instance.documents.get.return_value = {"documents": []}
+        mock_instance.documents.upload.return_value = {
+            "status": "success",
+            "id": "mem-1",
+        }
+        mock_instance.documents.upload_file.return_value = {
+            "success": True,
+            "file_size": 0,
+        }
+        mock_instance.documents.delete.return_value = {"deleted": True}
+        mock_instance.namespaces.get.return_value = {
+            "namespace_name": "memanto_agent_victim",
+        }
+        mock_instance.documents.fetch_text_data.return_value = {
+            "items": [
+                {
+                    "id": "mem-1",
+                    "text": "SECRET data",
+                    "content": "SECRET data",
+                    "type": "fact",
+                    "confidence": 0.9,
+                    "source": "user",
+                    "provenance": "observation",
+                    "tags": ["secret"],
+                    "created_at": "2026-08-28T00:00:00+00:00",
+                    "updated_at": "2026-08-28T00:00:00+00:00",
+                    "title": "vault",
+                    "status": "active",
+                }
+            ],
+            "pagination": {},
+        }
+        yield mock_instance
+
+
+def _rebinding_headers():
+    """Headers a page on the attacker origin sends: same-origin to its own
+    (rebinding) origin, carrying no cross-site Origin on GET."""
+    return {"Sec-Fetch-Site": "same-origin"}
+
+
+async def _activate_client_session(client, agent_id: str) -> str:
+    """Create + activate an agent through a loopback client; return the
+    session token (mirrors what the attacker steals via cookie migration)."""
+    await client.post(
+        "/api/v2/agents",
+        headers={"Authorization": "Bearer test-api-key"},
+        json={"agent_id": agent_id},
+    )
+    activate = await client.post(
+        f"/api/v2/agents/{agent_id}/activate",
+        headers={"Authorization": "Bearer test-api-key"},
+    )
+    assert activate.status_code == 200
+    return activate.json()["session_token"]
+
+
+class TestRebindingRejected:
+    """Requests whose Host header is not loopback must be rejected even though
+    the TCP client is loopback (the DNS-rebinding scenario)."""
+
+    TEST_AGENT_ID = "victim"
+
+    @pytest.mark.asyncio
+    async def test_rebinding_ui_config_rejected_and_no_cookie_migration(
+        self, local_client, mock_moorcheh
+    ):
+        """Stage A of the kill chain — GET /api/ui/config on the attacker
+        origin — must return 403 and must NOT migrate the session cookie onto
+        the attacker domain."""
+        await _activate_client_session(local_client, self.TEST_AGENT_ID)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url=ATTACKER_ORIGIN
+        ) as rebind:
+            resp = await rebind.get("/api/ui/config", headers=_rebinding_headers())
+            assert resp.status_code == 403
+            assert "set-cookie" not in resp.headers  # no cookie migration
+
+    @pytest.mark.asyncio
+    async def test_rebinding_cannot_read_memories(self, local_client, mock_moorcheh):
+        """Even with a valid session cookie attached, a non-loopback Host must
+        not read the private memory store."""
+        token = await _activate_client_session(local_client, self.TEST_AGENT_ID)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url=ATTACKER_ORIGIN
+        ) as rebind:
+            rebind.cookies.set("memanto_session_token", token)
+            resp = await rebind.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                headers=_rebinding_headers(),
+                json={"limit": 10},
+            )
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_rebinding_cannot_write_memories(self, local_client, mock_moorcheh):
+        """A non-loopback Host must not poison the private memory store."""
+        token = await _activate_client_session(local_client, self.TEST_AGENT_ID)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url=ATTACKER_ORIGIN
+        ) as rebind:
+            rebind.cookies.set("memanto_session_token", token)
+            resp = await rebind.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+                headers=_rebinding_headers(),
+                json={
+                    "content": "ATTACKER INJECTED",
+                    "type": "fact",
+                    "confidence": 0.99,
+                },
+            )
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_rebinding_cannot_browse_filesystem(self, mock_moorcheh):
+        """GET /api/ui/browse on a non-loopback Host must not enumerate the
+        local filesystem."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url=ATTACKER_ORIGIN
+        ) as rebind:
+            resp = await rebind.get(
+                "/api/ui/browse",
+                params={"path": "/home"},
+                headers=_rebinding_headers(),
+            )
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_cross_site_cookie_request_rejected(self, local_client, mock_moorcheh):
+        """Cross-site origin with a valid cookie is also rejected (defense in
+        depth; the Host check already handles the rebinding variant)."""
+        token = await _activate_client_session(local_client, self.TEST_AGENT_ID)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url=ATTACKER_ORIGIN
+        ) as rebind:
+            rebind.cookies.set("memanto_session_token", token)
+            resp = await rebind.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                headers={"Origin": "https://evil.example", "Sec-Fetch-Site": "cross-site"},
+                json={"limit": 10},
+            )
+            assert resp.status_code == 403
+
+
+class TestLoopbackStillWorks:
+    """The fix must not break the legitimate local desktop flow."""
+
+    TEST_AGENT_ID = "local-user"
+
+    @pytest.mark.asyncio
+    async def test_loopback_memory_read_write_still_work(
+        self, local_client, mock_moorcheh
+    ):
+        """A localhost browser with the session cookie can still read and write
+        memories."""
+        await local_client.post(
+            "/api/v2/agents",
+            headers={"Authorization": "Bearer test-api-key"},
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate = await local_client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate",
+            headers={"Authorization": "Bearer test-api-key"},
+        )
+        assert activate.status_code == 200
+        token = activate.json()["session_token"]
+        local_client.cookies.set("memanto_session_token", token)
+
+        read = await local_client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            json={"limit": 10},
+        )
+        assert read.status_code == 200
+        assert read.json()["memories"]
+        assert read.json()["memories"][0]["content"] == "SECRET data"
+
+        write = await local_client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/remember",
+            json={
+                "content": "legitimate memory",
+                "type": "fact",
+                "confidence": 0.9,
+            },
+        )
+        assert write.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_loopback_ui_config_still_works(self, local_client, mock_moorcheh):
+        """GET /api/ui/config from localhost still returns the UI config."""
+        await local_client.post(
+            "/api/v2/agents",
+            headers={"Authorization": "Bearer test-api-key"},
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        resp = await local_client.get("/api/ui/config")
+        assert resp.status_code == 200
+        assert "active_agent_id" in resp.json()
+
+    @pytest.mark.asyncio
+    async def test_remote_header_api_client_still_works(
+        self, local_client, mock_moorcheh
+    ):
+        """Header-transport API clients (X-Session-Token, no cookie) may stay
+        remote — the cookie-only Host gate must not affect them."""
+        token = await _activate_client_session(local_client, self.TEST_AGENT_ID)
+
+        transport = ASGITransport(app=app, client=("203.0.113.10", 54321))
+        async with AsyncClient(
+            transport=transport, base_url=ATTACKER_ORIGIN
+        ) as remote:
+            resp = await remote.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                headers={"X-Session-Token": token},
+                json={"limit": 10},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["memories"]

--- a/tests/test_remaining_ui_auth.py
+++ b/tests/test_remaining_ui_auth.py
@@ -139,5 +139,5 @@ class TestGlobInjectionGuard:
 
         mock_request = MagicMock()
         mock_request.client.host = "127.0.0.1"
-        mock_request.headers = {}
+        mock_request.headers = {"host": "localhost:8000"}
         asyncio.run(_require_local(mock_request))  # must not raise

--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -166,7 +166,7 @@ class TestLoopbackDetection:
 
         mock_request = MagicMock()
         mock_request.client.host = "127.0.0.1"
-        mock_request.headers = {}
+        mock_request.headers = {"host": "localhost:8000"}
         asyncio.run(_require_local(mock_request))  # must not raise
 
     def test_require_local_allows_ipv4_mapped_loopback(self):
@@ -175,5 +175,5 @@ class TestLoopbackDetection:
 
         mock_request = MagicMock()
         mock_request.client.host = "::ffff:127.0.0.1"
-        mock_request.headers = {}
+        mock_request.headers = {"host": "localhost:8000"}
         asyncio.run(_require_local(mock_request))  # must not raise


### PR DESCRIPTION
## Security: reject non-loopback Host headers on cookie sessions and UI management routes

Part of the Memanto Security Challenge ([#1852](https://github.com/moorcheh-ai/memanto/issues/1852), BountyHub).

### Vulnerability

MEMANTO binds to `0.0.0.0` (desktop tool, intentionally network-reachable) and trusts the **loopback TCP client** on two authorization surfaces:

1. **Session-scoped memory API** — `get_current_session`, used by every `/api/v2/agents/{id}/remember|recall/*|answer|...` route, validates only the session token/cookie and the on-disk session record. It performs **no Host-header and no cross-site-browser check**.
2. **UI management API** — `_require_local` (browse, shutdown, config, api-key, connections, migrate, conflicts, daily-summary) checks the loopback client and Fetch Metadata, but **omits the Host-header check** that `require_management_access` already applies to the agent-lifecycle routes on the current main branch.

The loopback TCP client by itself is **not** a trust signal: any web page the user visits can use DNS rebinding (or simply a domain resolving to `127.0.0.1`) so the server sees a `127.0.0.1` peer while the `Host` header names the attacker's origin. The Host header is the only signal distinguishing "local UI on localhost" from "attacker domain bound to loopback".

Per the project's [README](https://github.com/moorcheh-ai/memanto), MEMANTO is the **Memory Agent** — a companion that "manages the memories of your other agents": the single central store holding what Claude, Bedrock, Cursor and every other tool your agents use have written. That centralization is exactly what makes the missing Host-header boundary on the memory API severe: the store every agent writes to becomes readable and writable by an unauthenticated attacker origin.

### Impact (attacker = any page the user visits; no interaction, no credentials)

- `POST /api/v2/agents/{id}/recall/recent` — **exfiltration of every private memory**.
- `POST /api/v2/agents/{id}/remember` / `/remember/extract` / `/answer` — **memory-store poisoning** and **LLM-credit drain**.
- `GET /api/ui/config` — config disclosure **and migration of the session cookie onto the attacker's domain** (`set_session_cookie` on a 200 response), which extracts the session credential itself.
- `GET /api/ui/browse?path=/` — **local filesystem enumeration**.

### Reproduction

The repo's own fixtures already simulate this: `httpx.ASGITransport` presents a `127.0.0.1` peer regardless of `base_url`, so a request targeting `http://attacker.example:8000` faithfully models a browser page on an attacker origin.

```python
# 1. Create + activate an agent locally to mint a session token
POST /api/v2/agents            {"agent_id": "victim"}            # local
POST /api/v2/agents/victim/activate                             # local  -> session_token

# 2. From the "attacker" origin (same TCP loopback peer, Host: attacker.example)
GET  /api/ui/config            Server-Fetch-Site: same-origin    # 200 + Set-Cookie migration
POST /api/v2/agents/victim/recall/recent   (session cookie)      # 200 -> full memory read
POST /api/v2/agents/victim/remember        (session cookie)      # 200 -> memory write
GET  /api/ui/browse?path=/home                                  # 200 -> FS listing
```

All of the above returned `200` before this fix. None of the memory/UI surfaces performed a Host-header or browser check.

### Fix

- `auth_deps.py::get_current_session` — when the session is presented via the **HttpOnly cookie** (browser transport), additionally require a loopback client, a loopback Host header, and no cross-site browser request (403 otherwise). Header-transport API clients (`X-Session-Token`) are unaffected and may remain remote — at HEAD, `require_management_access` already enforces the same Host boundary for lifecycle routes; this closes the identical gap for the memory store and the UI management routes.
- `ui_router.py::_require_local` — additionally require a loopback Host header.

### Tests

- New `tests/test_rebinding.py` (8 tests): rebinding-origin requests to the memory API and UI management routes return `403` (and no session-cookie migration), while legitimate localhost traffic and remote header-transport API clients still return `200`.
- Existing DNSS-rebinding lifecycle test (`test_dns_rebinding_host_cannot_inherit_loopback_access`) still passes.
- Full suite: **970 passed, 20 skipped (live-e2e only), 0 failed**.