### PR TITLE
feat(examples): multi-source OKF memory wiki (Path C, bounty #1609)

### DIFF
--- a/examples/migrations/okf-multisource-wiki/.env.example
+++ b/examples/migrations/okf-multisource-wiki/.env.example
@@ -1,0 +1,3 @@
+# Optional — only needed for a live Memanto cloud import after OKF migrate.
+# Dry-run (`memanto migrate okf ... --dry-run`) needs no key.
+MOORCHEH_API_KEY=

--- a/examples/migrations/okf-multisource-wiki/.gitignore
+++ b/examples/migrations/okf-multisource-wiki/.gitignore
@@ -1,0 +1,9 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+out/
+data/chroma/
+data/sqlite/
+*.egg-info/
+.env

--- a/examples/migrations/okf-multisource-wiki/MAPPING.md
+++ b/examples/migrations/okf-multisource-wiki/MAPPING.md
@@ -1,0 +1,41 @@
+# Source → Memanto / OKF mapping
+
+This Path C showcase feeds the shipped `memanto migrate okf` CLI. Adapters
+emit OKF markdown; Memanto's own `okf_loader` + `map_okf` perform the import.
+
+## Chroma (`agent_long_term_memory` collection)
+
+| Chroma concept | Memanto / OKF field | Notes |
+| --- | --- | --- |
+| point `id` | `resource` / `x_memanto` provenance + `chroma_id` extra | Preserved losslessly |
+| `document` | OKF body / Memanto `content` | Primary memory text |
+| `metadata.memory_type` | OKF `type` + `x_memanto.type` | Must be a Memanto type when possible |
+| `metadata.categories` | OKF `tags` | Comma-split labels |
+| `metadata.session` | tag `session:…` | Cross-session provenance |
+| `metadata.created_at` | `generated.at` | ISO-8601 UTC |
+| `metadata.supersedes` | consolidation input | Archived under `sessions/` |
+| embedding vector | *not exported* | Ownership story: leave opaque floats behind |
+
+## Proprietary SQLite (`agent_memories`)
+
+| SQLite column | Memanto / OKF field | Notes |
+| --- | --- | --- |
+| `id` | `sqlite_id` + `resource` | |
+| `body` | OKF body | |
+| `kind` | OKF `type` (via kind map) | `constraint` → `instruction` |
+| `thread_id` | tag `thread:…` | |
+| `confidence` | `x_memanto.confidence` | |
+| `created_at` | `generated.at` | |
+| `meta_json` | tags / supporting extras | topic, related_incident, … |
+
+## Consolidation rules
+
+| Situation | Action |
+| --- | --- |
+| Exact duplicate text across stores | Single memory, `sources: [chroma, sqlite]` |
+| Agreeing identity / timezone / on-call facts | Dedupe by topic key |
+| Language preference correction in Chroma | Wins; archives Chroma original + SQLite stale preference |
+| Unique facts (budget, CI, runbook, …) | Kept from originating store |
+
+Superseded bodies are written under `sessions/superseded-timeline.md` so
+`memanto migrate okf` (which scopes import to `memories/`) cannot revive them.

--- a/examples/migrations/okf-multisource-wiki/README.md
+++ b/examples/migrations/okf-multisource-wiki/README.md
@@ -1,0 +1,122 @@
+# Multi-source lock-in → consolidated OKF memory wiki
+
+**Path C (OKF Renaissance)** showcase for [Bounty #1609](https://github.com/moorcheh-ai/memanto/issues/1609).
+
+Most agents do not keep memory in one place. This demo starts from **two real
+proprietary stores** that a coding assistant actually filled over six weeks,
+consolidates them into one coherent portable wiki, and proves recall parity —
+then hands the bundle to the shipped CLI:
+
+```text
+Chroma (vectors)  ─┐
+                   ├─ adapters ─ consolidate ─ OKF wiki ─ memanto migrate okf ─ Memanto
+SQLite (ad-hoc)   ─┘
+```
+
+No re-implementation of `memanto migrate`. Adapters **feed** OKF; Memanto owns import.
+
+## Why this path
+
+| Path B adapters (ChatGPT / LangGraph / …) | This Path C workflow |
+| --- | --- |
+| One source → OKF | **Two lived-in sources → one owned wiki** |
+| File dump | Contradiction resolution + superseded timeline |
+| Opaque lock-in | Git-friendly markdown humans can review |
+
+## Quick start (< 15 minutes)
+
+```bash
+cd examples/migrations/okf-multisource-wiki
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+# optional, for the official dry-run:
+pip install -e ../../..
+
+python run.py --force --update-sample
+memanto migrate okf out/okf-bundle --dry-run
+```
+
+No Moorcheh key is required for seeding, consolidation, or the OKF dry-run.
+Set `MOORCHEH_API_KEY` only if you want a live import afterward.
+
+## What the seeder actually does
+
+1. **`seed_chroma.py`** — real `chromadb.PersistentClient` run. Fourteen memories
+   across six weekly sessions, including a preference **correction**
+   (TypeScript → Python/FastAPI) with `supersedes`.
+2. **`seed_sqlite_store.py`** — real SQLite `agent_memories` table. Eight rows
+   that overlap Chroma on identity/timezone/on-call, carry a **stale**
+   TypeScript preference, and add unique ops facts (CI, budget, runbook).
+
+Hand-written export JSON is not the source of truth — the stores are.
+
+## Migration summary (committed sample)
+
+From the committed `sample/` artifacts (`python run.py --force --update-sample`):
+
+| Metric | Value |
+| --- | ---: |
+| Chroma source records | 14 |
+| SQLite source records | 8 |
+| Active consolidated memories | 17 |
+| Archived superseded / conflicts | 2 |
+| Golden recall (consolidated source) | 8/8 |
+| Golden recall (OKF bundle) | 8/8 |
+| `memanto migrate okf --dry-run` | 17 mapped, 0 skipped |
+
+Savings report: OKF is a local format; the shipped importer documents that
+`migrate okf` does **not** emit provider-style token/latency savings. This
+showcase therefore reports storage shape (opaque vectors + SQLite rows →
+readable markdown) instead of inventing Mem0-style dollar savings.
+
+## Mapping table
+
+Full concept → field table: [`MAPPING.md`](MAPPING.md).
+
+## Round-trip validation
+
+```bash
+python -m pytest tests -q
+```
+
+Golden questions live in `golden_questions.json`. The parity report asserts the
+consolidated corpus and the OKF bundle both answer every probe, including the
+**current** language preference (Python/FastAPI) and not the stale TypeScript
+backend preference.
+
+## Sample OKF bundle
+
+[`sample/okf-bundle/`](sample/okf-bundle/) — open any `memories/**/*.md` file.
+Superseded history is under `sessions/` so it stays auditable without being
+re-imported.
+
+## Demo video checklist
+
+Record a 2-minute screen capture covering:
+
+1. Chroma + SQLite seed counts printing in the terminal
+2. Consolidation summary (active / archived)
+3. Opening an OKF markdown file in the editor
+4. `memanto migrate okf out/okf-bundle --dry-run`
+5. `recall-parity.md` showing 8/8
+
+Then post with the required tags (`@moorcheh_ai`, YouTube `@moorchehai`,
+LinkedIn company page) and claim on
+[BountyHub](https://www.bountyhub.dev/bounty/view/b21928e9-70dd-4d95-adc6-3009df47e9f5).
+
+## Layout
+
+```text
+okf-multisource-wiki/
+  run.py                 # one-command pipeline
+  seed_chroma.py         # real Chroma source
+  seed_sqlite_store.py   # real SQLite source
+  adapters.py            # source → memory dicts
+  consolidate.py         # merge + conflict rules
+  okf_writer.py          # OKF v0.2 writer
+  validate.py            # golden Q&A
+  MAPPING.md
+  golden_questions.json
+  sample/                # committed evidence
+  tests/
+```

--- a/examples/migrations/okf-multisource-wiki/adapters.py
+++ b/examples/migrations/okf-multisource-wiki/adapters.py
@@ -1,0 +1,118 @@
+"""Adapters that transform proprietary stores into Memanto-shaped memory dicts.
+
+These adapters *feed* ``memanto migrate okf`` — they do not reimplement Memanto's
+importer. Output is an OKF bundle written by ``okf_writer``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import chromadb
+from seed_chroma import DeterministicHashEmbedding
+
+# Map free-form source kinds onto Memanto's fixed vocabulary when possible.
+_KIND_TO_TYPE: dict[str, str | None] = {
+    "fact": "fact",
+    "preference": "preference",
+    "goal": "goal",
+    "decision": "decision",
+    "artifact": "artifact",
+    "learning": "learning",
+    "event": "event",
+    "instruction": "instruction",
+    "relationship": "relationship",
+    "context": "context",
+    "observation": "observation",
+    "commitment": "commitment",
+    "error": "error",
+    "constraint": "instruction",  # closest Memanto slot
+}
+
+
+def _title(text: str) -> str:
+    clean = " ".join(text.strip().split())
+    return clean if len(clean) <= 80 else clean[:77].rstrip() + "..."
+
+
+def load_chroma_memories(chroma_dir: Path) -> list[dict[str, Any]]:
+    """Read every point from the seeded Chroma collection."""
+    client = chromadb.PersistentClient(path=str(chroma_dir.resolve()))
+    collection = client.get_collection(
+        name="agent_long_term_memory",
+        embedding_function=DeterministicHashEmbedding(),
+    )
+    raw = collection.get(include=["documents", "metadatas"])
+    memories: list[dict[str, Any]] = []
+    for idx, doc_id in enumerate(raw["ids"]):
+        meta = (raw["metadatas"] or [{}])[idx] or {}
+        text = (raw["documents"] or [""])[idx] or ""
+        categories = [
+            c.strip() for c in str(meta.get("categories", "")).split(",") if c.strip()
+        ]
+        mem_type = _KIND_TO_TYPE.get(str(meta.get("memory_type", "")).lower())
+        memories.append(
+            {
+                "id": f"chroma:{doc_id}",
+                "chroma_id": doc_id,
+                "title": _title(text),
+                "content": text,
+                "description": _title(text),
+                "type": mem_type,
+                "tags": [
+                    "source:chroma",
+                    *categories,
+                    f"session:{meta.get('session')}",
+                ],
+                "confidence": 0.86,
+                "source": "chroma",
+                "source_ref": f"chroma://agent_long_term_memory/{doc_id}",
+                "provenance": meta.get("provenance", "imported"),
+                "created_at": meta.get("created_at"),
+                "session_id": meta.get("session"),
+                "supersedes": meta.get("supersedes"),
+                "sources": ["chroma"],
+            }
+        )
+    return memories
+
+
+def load_sqlite_memories(db_path: Path) -> list[dict[str, Any]]:
+    """Read every row from the proprietary SQLite agent_memories table."""
+    memories: list[dict[str, Any]] = []
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT id, kind, body, thread_id, confidence, created_at, meta_json "
+            "FROM agent_memories ORDER BY created_at ASC"
+        ).fetchall()
+    for row in rows:
+        meta = json.loads(row["meta_json"] or "{}")
+        kind = str(row["kind"]).lower()
+        text = row["body"]
+        memories.append(
+            {
+                "id": f"sqlite:{row['id']}",
+                "sqlite_id": row["id"],
+                "title": _title(text),
+                "content": text,
+                "description": _title(text),
+                "type": _KIND_TO_TYPE.get(kind),
+                "tags": [
+                    "source:sqlite",
+                    f"thread:{row['thread_id']}",
+                    f"topic:{meta.get('topic', 'general')}",
+                ],
+                "confidence": float(row["confidence"] or 0.8),
+                "source": "sqlite-agent-store",
+                "source_ref": f"sqlite://agent_memories/{row['id']}",
+                "provenance": "imported",
+                "created_at": row["created_at"],
+                "session_id": row["thread_id"],
+                "sources": ["sqlite"],
+            }
+        )
+    return memories

--- a/examples/migrations/okf-multisource-wiki/consolidate.py
+++ b/examples/migrations/okf-multisource-wiki/consolidate.py
@@ -1,0 +1,208 @@
+"""Consolidate multi-source memories into one coherent portable set.
+
+Rules (documented in MAPPING.md):
+1. Exact / near-duplicate facts from both sources merge into one memory with
+   dual provenance (``sources: [chroma, sqlite]``).
+2. Explicit corrections (``supersedes`` / provenance=corrected) win over the
+   superseded id and over older conflicting preferences.
+3. Unique memories from either source are kept losslessly.
+4. Superseded bodies are archived into session notes (not re-imported as
+   active memories) so ``memanto migrate okf`` cannot revive stale facts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import defaultdict
+from typing import Any
+
+
+def _norm(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+def _fingerprint(text: str) -> str:
+    return hashlib.sha256(_norm(text).encode("utf-8")).hexdigest()[:16]
+
+
+def _topic_key(mem: dict[str, Any]) -> str | None:
+    """Collapse known conflicting topics onto a single consolidation key."""
+    body = _norm(mem.get("content") or "")
+    if "prefer" in body and ("typescript" in body or "python" in body):
+        return "topic:language-preference"
+    if "name is priya" in body:
+        return "topic:identity-name"
+    if "asia/kolkata" in body or "utc+5:30" in body:
+        return "topic:timezone"
+    if "marcus chen" in body:
+        return "topic:oncall-buddy"
+    return None
+
+
+def consolidate(
+    chroma_memories: list[dict[str, Any]],
+    sqlite_memories: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    """Return (active_memories, archived_superseded, summary)."""
+    all_memories = list(chroma_memories) + list(sqlite_memories)
+
+    superseded_ids = {
+        f"chroma:{m['supersedes']}" for m in chroma_memories if m.get("supersedes")
+    }
+    # Also treat chroma-lang as superseded when correction exists.
+    if any(m.get("chroma_id") == "chroma-lang-correction" for m in chroma_memories):
+        superseded_ids.add("chroma:chroma-lang")
+
+    by_topic: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    uniques: list[dict[str, Any]] = []
+    archived: list[dict[str, Any]] = []
+
+    for mem in all_memories:
+        if mem["id"] in superseded_ids or (
+            mem.get("chroma_id") and f"chroma:{mem['chroma_id']}" in superseded_ids
+        ):
+            archived.append({**mem, "archive_reason": "superseded"})
+            continue
+        topic = _topic_key(mem)
+        if topic:
+            by_topic[topic].append(mem)
+        else:
+            uniques.append(mem)
+
+    active: list[dict[str, Any]] = []
+    merge_events: list[dict[str, Any]] = []
+
+    for topic, group in by_topic.items():
+        # Prefer corrected provenance, then newest created_at, then higher confidence.
+        ranked = sorted(
+            group,
+            key=lambda m: (
+                1 if m.get("provenance") == "corrected" else 0,
+                str(m.get("created_at") or ""),
+                float(m.get("confidence") or 0),
+            ),
+            reverse=True,
+        )
+        winner = dict(ranked[0])
+        losers = ranked[1:]
+        sources = sorted(
+            {
+                src
+                for m in group
+                for src in (m.get("sources") or [m.get("source")])
+                if src
+            }
+        )
+        winner["sources"] = sources
+        winner["tags"] = sorted(
+            set(winner.get("tags") or [])
+            | {f"consolidated:{topic}"}
+            | {f"sources:{len(sources)}"}
+        )
+        if losers:
+            # If losers conflict on language preference, archive them.
+            if topic == "topic:language-preference":
+                for loser in losers:
+                    archived.append(
+                        {
+                            **loser,
+                            "archive_reason": "conflict_resolved_by_newer_correction",
+                            "resolved_by": winner["id"],
+                        }
+                    )
+                merge_events.append(
+                    {
+                        "topic": topic,
+                        "winner": winner["id"],
+                        "archived": [m["id"] for m in losers],
+                        "action": "prefer_correction",
+                    }
+                )
+            else:
+                # Same fact from two stores — merge provenance only.
+                winner["id"] = f"merged:{_fingerprint(winner['content'])}"
+                winner["source"] = "consolidated"
+                winner["source_ref"] = "consolidated://" + "+".join(
+                    sorted({m.get("source_ref") or m["id"] for m in group})
+                )
+                merge_events.append(
+                    {
+                        "topic": topic,
+                        "winner": winner["id"],
+                        "merged_from": [m["id"] for m in group],
+                        "action": "dedupe_agreeing_facts",
+                    }
+                )
+        active.append(winner)
+
+    # Deduplicate exact duplicates among uniques by fingerprint.
+    seen_fp: dict[str, dict[str, Any]] = {}
+    for mem in uniques:
+        fp = _fingerprint(mem["content"])
+        if fp in seen_fp:
+            existing = seen_fp[fp]
+            existing_sources = set(existing.get("sources") or [existing.get("source")])
+            new_sources = set(mem.get("sources") or [mem.get("source")])
+            existing["sources"] = sorted(existing_sources | new_sources)
+            existing["tags"] = sorted(
+                set(existing.get("tags") or [])
+                | set(mem.get("tags") or [])
+                | {"consolidated:exact-dupe"}
+            )
+            existing["source"] = "consolidated"
+            merge_events.append(
+                {
+                    "topic": f"fp:{fp}",
+                    "winner": existing["id"],
+                    "merged_from": [existing["id"], mem["id"]],
+                    "action": "dedupe_exact",
+                }
+            )
+        else:
+            seen_fp[fp] = dict(mem)
+    active.extend(seen_fp.values())
+
+    # Stable order for reproducible bundles.
+    active.sort(key=lambda m: (str(m.get("created_at") or ""), m["id"]))
+
+    summary = {
+        "chroma_source_count": len(chroma_memories),
+        "sqlite_source_count": len(sqlite_memories),
+        "active_count": len(active),
+        "archived_count": len(archived),
+        "merge_events": merge_events,
+        "per_type": _count_types(active),
+    }
+    return active, archived, summary
+
+
+def _count_types(memories: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for mem in memories:
+        counts[str(mem.get("type") or "auto")] += 1
+    return dict(sorted(counts.items()))
+
+
+def archive_session_notes(archived: list[dict[str, Any]]) -> list[tuple[str, str]]:
+    """Render superseded memories as OKF session context (not importable memories)."""
+    if not archived:
+        return []
+    lines = [
+        "# Superseded / conflict-resolved memories",
+        "",
+        "These records were active in a source store but must not be re-imported",
+        "as live memories. They stay under `sessions/` so `memanto migrate okf`",
+        "ignores them while humans can still audit the history.",
+        "",
+    ]
+    for mem in archived:
+        lines.append(f"## {mem.get('title')}")
+        lines.append(f"- id: `{mem.get('id')}`")
+        lines.append(f"- reason: `{mem.get('archive_reason')}`")
+        if mem.get("resolved_by"):
+            lines.append(f"- resolved_by: `{mem['resolved_by']}`")
+        lines.append("")
+        lines.append(mem.get("content") or "")
+        lines.append("")
+    return [("superseded-timeline", "\n".join(lines))]

--- a/examples/migrations/okf-multisource-wiki/golden_questions.json
+++ b/examples/migrations/okf-multisource-wiki/golden_questions.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "q1",
+    "question": "What is the user's name?",
+    "must_include_any": ["Priya Shah", "Priya"]
+  },
+  {
+    "id": "q2",
+    "question": "Which language does Priya prefer for internal/backend services now?",
+    "must_include_any": ["Python", "FastAPI"],
+    "must_not_include_as_current": ["TypeScript for all backend", "TypeScript over Python for production services"]
+  },
+  {
+    "id": "q3",
+    "question": "What is the primary database?",
+    "must_include_any": ["PostgreSQL 16", "PostgreSQL"]
+  },
+  {
+    "id": "q4",
+    "question": "Who is the on-call buddy?",
+    "must_include_any": ["Marcus Chen"]
+  },
+  {
+    "id": "q5",
+    "question": "What Friday deploy rule exists?",
+    "must_include_any": ["Never deploy on Fridays", "Fridays"]
+  },
+  {
+    "id": "q6",
+    "question": "What pgbouncer setting was raised after INC-441?",
+    "must_include_any": ["max_client_conn", "400"]
+  },
+  {
+    "id": "q7",
+    "question": "What is the monthly LLM spend budget?",
+    "must_include_any": ["200", "USD 200"]
+  },
+  {
+    "id": "q8",
+    "question": "Which timezone does Priya work in?",
+    "must_include_any": ["Asia/Kolkata", "UTC+5:30"]
+  }
+]

--- a/examples/migrations/okf-multisource-wiki/okf_writer.py
+++ b/examples/migrations/okf-multisource-wiki/okf_writer.py
@@ -1,0 +1,158 @@
+"""Write valid OKF v0.2 bundles consumable by ``memanto migrate okf``."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VALID_TYPES = {
+    "fact",
+    "preference",
+    "goal",
+    "decision",
+    "artifact",
+    "learning",
+    "event",
+    "instruction",
+    "relationship",
+    "context",
+    "observation",
+    "commitment",
+    "error",
+}
+
+
+def _slug(title: str, fallback: str) -> str:
+    text = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return (text or fallback)[:80]
+
+
+def _dump_frontmatter(data: dict[str, Any]) -> str:
+    return yaml.safe_dump(
+        data,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ).strip()
+
+
+def memory_to_okf_doc(mem: dict[str, Any]) -> tuple[str, str]:
+    """Return (relative_path_under_memories, markdown_document)."""
+    mem_type = mem.get("type") if mem.get("type") in VALID_TYPES else "observation"
+    title = (mem.get("title") or mem.get("content", "")[:80]).strip()
+    created = mem.get("created_at") or datetime.now(timezone.utc).isoformat()
+    if isinstance(created, datetime):
+        created = created.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    frontmatter: dict[str, Any] = {
+        "type": mem_type,
+        "title": title,
+        "description": (mem.get("description") or title)[:200],
+        "tags": list(mem.get("tags") or []),
+        "generated": {
+            "by": f"process:{mem.get('source', 'migration')}",
+            "at": created,
+        },
+        "resource": mem.get("source_ref")
+        or f"urn:memanto-migration:{_slug(title, 'm')}",
+        "x_memanto": {
+            "type": mem_type,
+            "confidence": float(mem.get("confidence", 0.85)),
+            "provenance": mem.get("provenance", "imported"),
+            "source": mem.get("source", "okf"),
+            "id": mem.get("id"),
+        },
+    }
+    # Lossless extras — unknown OKF keys ride in frontmatter; map_okf preserves them.
+    for key in ("chroma_id", "sqlite_id", "session_id", "supersedes", "sources"):
+        if mem.get(key) is not None:
+            frontmatter[key] = mem[key]
+
+    body = (mem.get("content") or title).strip()
+    doc = f"---\n{_dump_frontmatter(frontmatter)}\n---\n\n{body}\n"
+    filename = f"{_slug(title, mem.get('id', 'memory'))}.md"
+    return f"{mem_type}/{filename}", doc
+
+
+def write_okf_bundle(
+    memories: list[dict[str, Any]],
+    bundle_dir: Path,
+    *,
+    agent_id: str = "multisource-wiki",
+    session_notes: list[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Write a Memanto-compatible OKF bundle. Returns a summary dict."""
+    if bundle_dir.exists():
+        for path in sorted(bundle_dir.rglob("*"), reverse=True):
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                path.rmdir()
+    memories_root = bundle_dir / "memories"
+    memories_root.mkdir(parents=True, exist_ok=True)
+
+    by_type: dict[str, int] = defaultdict(int)
+    written: list[str] = []
+    for mem in memories:
+        rel, doc = memory_to_okf_doc(mem)
+        target = memories_root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Avoid collisions when two titles slug the same way.
+        if target.exists():
+            stem = target.stem
+            target = target.with_name(f"{stem}-{mem.get('id', 'x')[:8]}.md")
+        target.write_text(doc, encoding="utf-8")
+        mem_type = mem.get("type") if mem.get("type") in VALID_TYPES else "observation"
+        by_type[str(mem_type)] += 1
+        written.append(str(target.relative_to(bundle_dir)))
+
+    # Per-type indexes
+    for type_name, count in by_type.items():
+        type_dir = memories_root / type_name
+        type_dir.mkdir(parents=True, exist_ok=True)
+        (type_dir / "index.md").write_text(
+            f"---\ntype: index\ntitle: {type_name}\n---\n\n"
+            f"# {type_name}\n\n{count} memories in this type.\n",
+            encoding="utf-8",
+        )
+
+    (memories_root / "index.md").write_text(
+        "---\ntype: index\ntitle: memories\n---\n\n"
+        f"# Memories\n\n{len(memories)} consolidated memories.\n",
+        encoding="utf-8",
+    )
+
+    if session_notes:
+        sessions_dir = bundle_dir / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        for name, body in session_notes:
+            (sessions_dir / f"{_slug(name, 'session')}.md").write_text(
+                f"---\ntype: index\ntitle: {name}\n---\n\n{body}\n",
+                encoding="utf-8",
+            )
+
+    sections = ["memories"]
+    if session_notes:
+        sections.append("sessions")
+    section_lines = "\n".join(f"- [{s}/](./{s}/)" for s in sections)
+    (bundle_dir / "index.md").write_text(
+        f'---\nokf_version: "0.2"\ntype: index\ntitle: {agent_id}\n'
+        f"generated:\n  by: process:okf-multisource-wiki\n"
+        f"  at: {datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')}\n"
+        f"---\n\n# {agent_id}\n\n"
+        f"Consolidated portable memory wiki ({len(memories)} memories).\n\n"
+        f"## Sections\n\n{section_lines}\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "total_memories": len(memories),
+        "per_type_counts": dict(by_type),
+        "files": written,
+        "bundle_dir": str(bundle_dir.resolve()),
+    }

--- a/examples/migrations/okf-multisource-wiki/pytest.ini
+++ b/examples/migrations/okf-multisource-wiki/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/examples/migrations/okf-multisource-wiki/requirements.txt
+++ b/examples/migrations/okf-multisource-wiki/requirements.txt
@@ -1,0 +1,6 @@
+chromadb>=0.5.0,<2
+PyYAML>=6.0
+pytest>=8.0
+
+# Optional: run the official CLI dry-run against the consolidated bundle
+# memanto  # install from repo root: pip install -e ".[dev]"

--- a/examples/migrations/okf-multisource-wiki/run.py
+++ b/examples/migrations/okf-multisource-wiki/run.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""One-command Path C showcase: multi-source lock-in → consolidated OKF wiki.
+
+Pipeline:
+  1. Seed a real Chroma PersistentClient (vector-trapped agent memory)
+  2. Seed a real proprietary SQLite agent_memories store
+  3. Adapt both sources into typed memory dicts
+  4. Consolidate (dedupe + resolve contradictions)
+  5. Write a portable OKF v0.2 bundle
+  6. Score golden Q&A recall parity
+  7. Optionally invoke ``memanto migrate okf ... --dry-run``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from adapters import load_chroma_memories, load_sqlite_memories
+from consolidate import archive_session_notes, consolidate
+from okf_writer import write_okf_bundle
+from seed_chroma import seed_chroma
+from seed_sqlite_store import seed_sqlite
+from validate import evaluate_parity, render_markdown
+
+ROOT = Path(__file__).resolve().parent
+
+
+def _copy_sample(bundle: Path, summary: dict, parity: dict, reports_dir: Path) -> None:
+    sample = ROOT / "sample"
+    if sample.exists():
+        shutil.rmtree(sample)
+    shutil.copytree(bundle, sample / "okf-bundle")
+    (sample / "migration_summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
+    (sample / "recall-parity.json").write_text(
+        json.dumps(parity, indent=2) + "\n", encoding="utf-8"
+    )
+    (sample / "recall-parity.md").write_text(render_markdown(parity), encoding="utf-8")
+    for name in ("chroma_seed.json", "sqlite_seed.json", "memanto-dry-run.txt"):
+        src = reports_dir / name
+        if src.exists():
+            shutil.copy2(src, sample / name)
+
+
+def _try_memanto_dry_run(bundle: Path, out_txt: Path) -> str | None:
+    cmd = ["memanto", "migrate", "okf", str(bundle), "--dry-run"]
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT.parents[2]),  # repo root
+        )
+    except FileNotFoundError:
+        # Fall back to `python -m memanto` if the console script is missing.
+        cmd = [
+            sys.executable,
+            "-m",
+            "memanto",
+            "migrate",
+            "okf",
+            str(bundle),
+            "--dry-run",
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                cwd=str(ROOT.parents[2]),
+            )
+        except FileNotFoundError:
+            return None
+
+    text = (proc.stdout or "") + (proc.stderr or "")
+    out_txt.write_text(text, encoding="utf-8")
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Rebuild source stores and wipe out/",
+    )
+    parser.add_argument(
+        "--skip-memanto",
+        action="store_true",
+        help="Skip the optional memanto migrate okf --dry-run step",
+    )
+    parser.add_argument(
+        "--update-sample",
+        action="store_true",
+        help="Refresh the committed sample/ artifacts from this run",
+    )
+    args = parser.parse_args()
+
+    out = ROOT / "out"
+    data = ROOT / "data"
+    if args.force and out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    chroma_dir = data / "chroma"
+    sqlite_path = data / "sqlite" / "agent_memory.db"
+
+    print("==> Seeding Chroma PersistentClient (real vector store)")
+    chroma_report = seed_chroma(chroma_dir, force=args.force)
+    (out / "chroma_seed.json").write_text(
+        json.dumps(chroma_report, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"    {chroma_report['count']} points in {chroma_report['collection']}")
+
+    print("==> Seeding proprietary SQLite agent_memories store")
+    sqlite_report = seed_sqlite(sqlite_path, force=args.force)
+    (out / "sqlite_seed.json").write_text(
+        json.dumps(sqlite_report, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"    {sqlite_report['count']} rows in {sqlite_report['table']}")
+
+    print("==> Adapting sources")
+    chroma_memories = load_chroma_memories(chroma_dir)
+    sqlite_memories = load_sqlite_memories(sqlite_path)
+    print(f"    chroma={len(chroma_memories)} sqlite={len(sqlite_memories)}")
+
+    print("==> Consolidating (dedupe + contradiction resolution)")
+    active, archived, summary = consolidate(chroma_memories, sqlite_memories)
+    print(
+        f"    active={summary['active_count']} archived={summary['archived_count']} "
+        f"types={summary['per_type']}"
+    )
+
+    # Also write per-source OKF bundles so reviewers can inspect each hop.
+    from okf_writer import write_okf_bundle as _write
+
+    _write(chroma_memories, out / "okf-chroma-only", agent_id="chroma-source")
+    _write(sqlite_memories, out / "okf-sqlite-only", agent_id="sqlite-source")
+
+    print("==> Writing consolidated OKF v0.2 bundle")
+    bundle = out / "okf-bundle"
+    okf_summary = write_okf_bundle(
+        active,
+        bundle,
+        agent_id="priya-coding-assistant",
+        session_notes=archive_session_notes(archived),
+    )
+    summary["okf"] = okf_summary
+    (out / "migration_summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"    {okf_summary['total_memories']} markdown memories → {bundle}")
+
+    print("==> Golden Q&A recall parity")
+    # Source corpus = pre-consolidation union (what the agent knew across tools)
+    # OKF corpus = consolidated portable wiki (what you own after escape)
+    union = chroma_memories + sqlite_memories
+    parity = evaluate_parity(
+        source_memories=active,  # after consolidation, before/after should match
+        okf_bundle=bundle,
+        questions_path=ROOT / "golden_questions.json",
+    )
+    # Also prove the union could answer the same questions pre-consolidation.
+    pre = evaluate_parity(
+        source_memories=union,
+        okf_bundle=bundle,
+        questions_path=ROOT / "golden_questions.json",
+    )
+    parity["pre_consolidation_union_recall"] = pre["source_recall"]
+    (out / "recall-parity.json").write_text(
+        json.dumps(parity, indent=2) + "\n", encoding="utf-8"
+    )
+    (out / "recall-parity.md").write_text(render_markdown(parity), encoding="utf-8")
+    print(
+        f"    source {parity['source_recall']} | okf {parity['okf_recall']} | "
+        f"preserved={parity['is_recall_preserved']}"
+    )
+
+    dry_run_text = None
+    if not args.skip_memanto:
+        print("==> memanto migrate okf --dry-run (shipped CLI)")
+        dry_run_text = _try_memanto_dry_run(bundle, out / "memanto-dry-run.txt")
+        if dry_run_text is None:
+            print(
+                "    (memanto CLI not installed — skipped; pip install -e . from repo root)"
+            )
+        else:
+            # Print a short excerpt for the terminal demo.
+            excerpt = "\n".join(dry_run_text.strip().splitlines()[-20:])
+            print(excerpt)
+
+    if args.update_sample:
+        print("==> Refreshing sample/ artifacts")
+        _copy_sample(bundle, summary, parity, out)
+
+    print()
+    print("Done. Ownable artifacts:")
+    print(f"  OKF bundle:  {bundle}")
+    print(f"  Summary:     {out / 'migration_summary.json'}")
+    print(f"  Recall:      {out / 'recall-parity.md'}")
+    if not parity["is_recall_preserved"]:
+        print("ERROR: recall parity failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/migrations/okf-multisource-wiki/sample/chroma_seed.json
+++ b/examples/migrations/okf-multisource-wiki/sample/chroma_seed.json
@@ -1,0 +1,30 @@
+{
+  "backend": "chromadb.PersistentClient",
+  "path": "/Users/vikasy/projects/placement/moorcheh-ai-bounty/examples/migrations/okf-multisource-wiki/data/chroma",
+  "collection": "agent_long_term_memory",
+  "count": 14,
+  "ids": [
+    "chroma-name",
+    "chroma-lang",
+    "chroma-editor",
+    "chroma-db",
+    "chroma-deploy",
+    "chroma-tests",
+    "chroma-lang-correction",
+    "chroma-timezone",
+    "chroma-incident",
+    "chroma-decision-pool",
+    "chroma-rel",
+    "chroma-goal",
+    "chroma-style",
+    "chroma-secret-policy"
+  ],
+  "sessions": [
+    "week-1-onboarding",
+    "week-2-stack",
+    "week-3-correction",
+    "week-4-incident",
+    "week-5-team",
+    "week-6-style"
+  ]
+}

--- a/examples/migrations/okf-multisource-wiki/sample/memanto-dry-run.txt
+++ b/examples/migrations/okf-multisource-wiki/sample/memanto-dry-run.txt
@@ -1,0 +1,20 @@
+╭─────────────────────────╮
+│ OKF -> Memanto  Dry run │
+╰─────────────────────────╯
+  … Loading OKF bundle from 
+/Users/vikasy/projects/placement/moorcheh-ai-bounty/examples/migrations/okf-mult
+isource-wiki/out/okf-bundle
+  … Mapping OKF nodes onto Memanto schema...
+
+╭────────────────────────────── Dry run complete ──────────────────────────────╮
+│ OKF nodes: 17                                                                │
+│ Mapped memories: 17  (skipped 0)                                             │
+│ Type breakdown: artifact: 1, commitment: 2, decision: 1, event: 1, fact: 3,  │
+│ goal: 1, instruction: 4, preference: 3, relationship: 1                      │
+│                                                                              │
+│ Dry run — no writes performed.                                               │
+│                                                                              │
+│ Run dir: /Users/vikasy/.memanto/migrate/okf/20260829_081204                  │
+│ Mapped preview:                                                              │
+│ /Users/vikasy/.memanto/migrate/okf/20260829_081204/mapped_preview.json       │
+╰──────────────────────────────────────────────────────────────────────────────╯

--- a/examples/migrations/okf-multisource-wiki/sample/migration_summary.json
+++ b/examples/migrations/okf-multisource-wiki/sample/migration_summary.json
@@ -1,0 +1,88 @@
+{
+  "chroma_source_count": 14,
+  "sqlite_source_count": 8,
+  "active_count": 17,
+  "archived_count": 2,
+  "merge_events": [
+    {
+      "topic": "topic:identity-name",
+      "winner": "merged:a518544f06df0b21",
+      "merged_from": [
+        "chroma:chroma-name",
+        "sqlite:sql-name"
+      ],
+      "action": "dedupe_agreeing_facts"
+    },
+    {
+      "topic": "topic:language-preference",
+      "winner": "chroma:chroma-lang-correction",
+      "archived": [
+        "sqlite:sql-lang-stale"
+      ],
+      "action": "prefer_correction"
+    },
+    {
+      "topic": "topic:timezone",
+      "winner": "merged:aebc0518965421d6",
+      "merged_from": [
+        "chroma:chroma-timezone",
+        "sqlite:sql-timezone"
+      ],
+      "action": "dedupe_agreeing_facts"
+    },
+    {
+      "topic": "topic:oncall-buddy",
+      "winner": "merged:e3448df971a25f32",
+      "merged_from": [
+        "chroma:chroma-rel",
+        "sqlite:sql-oncall"
+      ],
+      "action": "dedupe_agreeing_facts"
+    }
+  ],
+  "per_type": {
+    "artifact": 1,
+    "commitment": 2,
+    "decision": 1,
+    "event": 1,
+    "fact": 3,
+    "goal": 1,
+    "instruction": 4,
+    "preference": 3,
+    "relationship": 1
+  },
+  "okf": {
+    "total_memories": 17,
+    "per_type_counts": {
+      "preference": 3,
+      "fact": 3,
+      "instruction": 4,
+      "commitment": 2,
+      "decision": 1,
+      "event": 1,
+      "artifact": 1,
+      "goal": 1,
+      "relationship": 1
+    },
+    "files": [
+      "memories/preference/primary-editor-is-cursor-with-vim-keybindings-enabled.md",
+      "memories/fact/user-s-name-is-priya-shah.md",
+      "memories/fact/primary-database-is-postgresql-16-on-port-5432.md",
+      "memories/instruction/never-deploy-on-fridays-without-an-explicit-go-ahead-from-priya.md",
+      "memories/commitment/every-pr-must-include-pytest-coverage-for-new-modules.md",
+      "memories/preference/correction-priya-now-prefers-python-fastapi-for-internal-services-typescr.md",
+      "memories/fact/priya-works-in-asia-kolkata-utc-5-30.md",
+      "memories/instruction/ci-must-stay-green-on-python-3-11-and-3-12-before-merge.md",
+      "memories/decision/decision-raise-pgbouncer-max-client-conn-to-400-permanently.md",
+      "memories/event/incident-inc-441-resolved-pgbouncer-pool-exhaustion-after-a-migration-spike.md",
+      "memories/artifact/runbook-path-for-pgbouncer-incidents-docs-runbooks-pgbouncer-pool-exhaustion-md.md",
+      "memories/goal/goal-cut-p95-api-latency-under-120ms-before-q4-review.md",
+      "memories/relationship/on-call-buddy-is-marcus-chen-slack-marcus.md",
+      "memories/instruction/monthly-llm-spend-budget-is-usd-200-alert-priya-at-80.md",
+      "memories/instruction/never-commit-env-files-use-doppler-for-secrets.md",
+      "memories/preference/response-style-concise-bullets-first-then-optional-detail-no-emojis-in-com.md",
+      "memories/commitment/priya-committed-to-review-the-okf-migration-pr-within-24-hours-of-opening.md"
+    ],
+    "bundle_dir": "/Users/vikasy/projects/placement/moorcheh-ai-bounty/examples/migrations/okf-multisource-wiki/out/okf-bundle"
+  }
+}

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/index.md
@@ -1,0 +1,17 @@
+---
+okf_version: "0.2"
+type: index
+title: priya-coding-assistant
+generated:
+  by: process:okf-multisource-wiki
+  at: 2026-08-29T08:12:04.559086Z
+---
+
+# priya-coding-assistant
+
+Consolidated portable memory wiki (17 memories).
+
+## Sections
+
+- [memories/](./memories/)
+- [sessions/](./sessions/)

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/artifact/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/artifact/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: artifact
+---
+
+# artifact
+
+1 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/artifact/runbook-path-for-pgbouncer-incidents-docs-runbooks-pgbouncer-pool-exhaustion-md.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/artifact/runbook-path-for-pgbouncer-incidents-docs-runbooks-pgbouncer-pool-exhaustion-md.md
@@ -1,0 +1,25 @@
+---
+type: artifact
+title: 'Runbook path for pgbouncer incidents: docs/runbooks/pgbouncer-pool-exhaustion.md'
+description: 'Runbook path for pgbouncer incidents: docs/runbooks/pgbouncer-pool-exhaustion.md'
+tags:
+- source:sqlite
+- thread:thread-ops-4
+- topic:runbook
+generated:
+  by: process:sqlite-agent-store
+  at: '2026-06-23T10:00:00Z'
+resource: sqlite://agent_memories/sql-runbook
+x_memanto:
+  type: artifact
+  confidence: 0.85
+  provenance: imported
+  source: sqlite-agent-store
+  id: sqlite:sql-runbook
+sqlite_id: sql-runbook
+session_id: thread-ops-4
+sources:
+- sqlite
+---
+
+Runbook path for pgbouncer incidents: docs/runbooks/pgbouncer-pool-exhaustion.md

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/commitment/every-pr-must-include-pytest-coverage-for-new-modules.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/commitment/every-pr-must-include-pytest-coverage-for-new-modules.md
@@ -1,0 +1,25 @@
+---
+type: commitment
+title: Every PR must include pytest coverage for new modules.
+description: Every PR must include pytest coverage for new modules.
+tags:
+- source:chroma
+- tasks
+- session:week-2-stack
+generated:
+  by: process:chroma
+  at: '2026-06-08T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-tests
+x_memanto:
+  type: commitment
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-tests
+chroma_id: chroma-tests
+session_id: week-2-stack
+sources:
+- chroma
+---
+
+Every PR must include pytest coverage for new modules.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/commitment/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/commitment/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: commitment
+---
+
+# commitment
+
+2 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/commitment/priya-committed-to-review-the-okf-migration-pr-within-24-hours-of-opening.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/commitment/priya-committed-to-review-the-okf-migration-pr-within-24-hours-of-opening.md
@@ -1,0 +1,25 @@
+---
+type: commitment
+title: Priya committed to review the OKF migration PR within 24 hours of opening.
+description: Priya committed to review the OKF migration PR within 24 hours of opening.
+tags:
+- source:sqlite
+- thread:thread-ops-4
+- topic:review
+generated:
+  by: process:sqlite-agent-store
+  at: '2026-07-07T10:00:00Z'
+resource: sqlite://agent_memories/sql-commit
+x_memanto:
+  type: commitment
+  confidence: 0.8
+  provenance: imported
+  source: sqlite-agent-store
+  id: sqlite:sql-commit
+sqlite_id: sql-commit
+session_id: thread-ops-4
+sources:
+- sqlite
+---
+
+Priya committed to review the OKF migration PR within 24 hours of opening.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/decision/decision-raise-pgbouncer-max-client-conn-to-400-permanently.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/decision/decision-raise-pgbouncer-max-client-conn-to-400-permanently.md
@@ -1,0 +1,25 @@
+---
+type: decision
+title: 'Decision: raise pgbouncer max_client_conn to 400 permanently.'
+description: 'Decision: raise pgbouncer max_client_conn to 400 permanently.'
+tags:
+- source:chroma
+- decisions
+- session:week-4-incident
+generated:
+  by: process:chroma
+  at: '2026-06-22T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-decision-pool
+x_memanto:
+  type: decision
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-decision-pool
+chroma_id: chroma-decision-pool
+session_id: week-4-incident
+sources:
+- chroma
+---
+
+Decision: raise pgbouncer max_client_conn to 400 permanently.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/decision/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/decision/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: decision
+---
+
+# decision
+
+1 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/event/incident-inc-441-resolved-pgbouncer-pool-exhaustion-after-a-migration-spike.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/event/incident-inc-441-resolved-pgbouncer-pool-exhaustion-after-a-migration-spike.md
@@ -1,0 +1,26 @@
+---
+type: event
+title: 'Incident INC-441 resolved: pgbouncer pool exhaustion after a migration spike....'
+description: 'Incident INC-441 resolved: pgbouncer pool exhaustion after a migration
+  spike....'
+tags:
+- source:chroma
+- events
+- session:week-4-incident
+generated:
+  by: process:chroma
+  at: '2026-06-22T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-incident
+x_memanto:
+  type: event
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-incident
+chroma_id: chroma-incident
+session_id: week-4-incident
+sources:
+- chroma
+---
+
+Incident INC-441 resolved: pgbouncer pool exhaustion after a migration spike. Root cause was max_client_conn=100.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/event/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/event/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: event
+---
+
+# event
+
+1 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/fact/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/fact/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: fact
+---
+
+# fact
+
+3 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/fact/primary-database-is-postgresql-16-on-port-5432.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/fact/primary-database-is-postgresql-16-on-port-5432.md
@@ -1,0 +1,25 @@
+---
+type: fact
+title: Primary database is PostgreSQL 16 on port 5432.
+description: Primary database is PostgreSQL 16 on port 5432.
+tags:
+- source:chroma
+- professional_info
+- session:week-2-stack
+generated:
+  by: process:chroma
+  at: '2026-06-08T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-db
+x_memanto:
+  type: fact
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-db
+chroma_id: chroma-db
+session_id: week-2-stack
+sources:
+- chroma
+---
+
+Primary database is PostgreSQL 16 on port 5432.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/fact/priya-works-in-asia-kolkata-utc-5-30.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/fact/priya-works-in-asia-kolkata-utc-5-30.md
@@ -1,0 +1,28 @@
+---
+type: fact
+title: Priya works in Asia/Kolkata (UTC+5:30).
+description: Priya works in Asia/Kolkata (UTC+5:30).
+tags:
+- consolidated:topic:timezone
+- source:sqlite
+- sources:2
+- thread:thread-ops-2
+- topic:timezone
+generated:
+  by: process:consolidated
+  at: '2026-06-16T10:00:00Z'
+resource: consolidated://chroma://agent_long_term_memory/chroma-timezone+sqlite://agent_memories/sql-timezone
+x_memanto:
+  type: fact
+  confidence: 0.9
+  provenance: imported
+  source: consolidated
+  id: merged:aebc0518965421d6
+sqlite_id: sql-timezone
+session_id: thread-ops-2
+sources:
+- chroma
+- sqlite
+---
+
+Priya works in Asia/Kolkata (UTC+5:30).

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/fact/user-s-name-is-priya-shah.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/fact/user-s-name-is-priya-shah.md
@@ -1,0 +1,28 @@
+---
+type: fact
+title: User's name is Priya Shah.
+description: User's name is Priya Shah.
+tags:
+- consolidated:topic:identity-name
+- source:sqlite
+- sources:2
+- thread:thread-ops-1
+- topic:identity
+generated:
+  by: process:consolidated
+  at: '2026-06-02T10:00:00Z'
+resource: consolidated://chroma://agent_long_term_memory/chroma-name+sqlite://agent_memories/sql-name
+x_memanto:
+  type: fact
+  confidence: 0.95
+  provenance: imported
+  source: consolidated
+  id: merged:a518544f06df0b21
+sqlite_id: sql-name
+session_id: thread-ops-1
+sources:
+- chroma
+- sqlite
+---
+
+User's name is Priya Shah.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/goal/goal-cut-p95-api-latency-under-120ms-before-q4-review.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/goal/goal-cut-p95-api-latency-under-120ms-before-q4-review.md
@@ -1,0 +1,25 @@
+---
+type: goal
+title: 'Goal: cut p95 API latency under 120ms before Q4 review.'
+description: 'Goal: cut p95 API latency under 120ms before Q4 review.'
+tags:
+- source:chroma
+- goals_and_plans
+- session:week-5-team
+generated:
+  by: process:chroma
+  at: '2026-06-29T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-goal
+x_memanto:
+  type: goal
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-goal
+chroma_id: chroma-goal
+session_id: week-5-team
+sources:
+- chroma
+---
+
+Goal: cut p95 API latency under 120ms before Q4 review.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/goal/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/goal/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: goal
+---
+
+# goal
+
+1 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: memories
+---
+
+# Memories
+
+17 consolidated memories.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/ci-must-stay-green-on-python-3-11-and-3-12-before-merge.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/ci-must-stay-green-on-python-3-11-and-3-12-before-merge.md
@@ -1,0 +1,25 @@
+---
+type: instruction
+title: CI must stay green on Python 3.11 and 3.12 before merge.
+description: CI must stay green on Python 3.11 and 3.12 before merge.
+tags:
+- source:sqlite
+- thread:thread-ops-2
+- topic:ci
+generated:
+  by: process:sqlite-agent-store
+  at: '2026-06-17T10:00:00Z'
+resource: sqlite://agent_memories/sql-ci
+x_memanto:
+  type: instruction
+  confidence: 0.88
+  provenance: imported
+  source: sqlite-agent-store
+  id: sqlite:sql-ci
+sqlite_id: sql-ci
+session_id: thread-ops-2
+sources:
+- sqlite
+---
+
+CI must stay green on Python 3.11 and 3.12 before merge.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: instruction
+---
+
+# instruction
+
+4 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/monthly-llm-spend-budget-is-usd-200-alert-priya-at-80.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/monthly-llm-spend-budget-is-usd-200-alert-priya-at-80.md
@@ -1,0 +1,25 @@
+---
+type: instruction
+title: Monthly LLM spend budget is USD 200; alert Priya at 80%.
+description: Monthly LLM spend budget is USD 200; alert Priya at 80%.
+tags:
+- source:sqlite
+- thread:thread-ops-3
+- topic:budget
+generated:
+  by: process:sqlite-agent-store
+  at: '2026-07-01T10:00:00Z'
+resource: sqlite://agent_memories/sql-budget
+x_memanto:
+  type: instruction
+  confidence: 0.9
+  provenance: imported
+  source: sqlite-agent-store
+  id: sqlite:sql-budget
+sqlite_id: sql-budget
+session_id: thread-ops-3
+sources:
+- sqlite
+---
+
+Monthly LLM spend budget is USD 200; alert Priya at 80%.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/never-commit-env-files-use-doppler-for-secrets.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/never-commit-env-files-use-doppler-for-secrets.md
@@ -1,0 +1,25 @@
+---
+type: instruction
+title: Never commit .env files; use Doppler for secrets.
+description: Never commit .env files; use Doppler for secrets.
+tags:
+- source:chroma
+- instructions
+- session:week-6-style
+generated:
+  by: process:chroma
+  at: '2026-07-06T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-secret-policy
+x_memanto:
+  type: instruction
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-secret-policy
+chroma_id: chroma-secret-policy
+session_id: week-6-style
+sources:
+- chroma
+---
+
+Never commit .env files; use Doppler for secrets.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/never-deploy-on-fridays-without-an-explicit-go-ahead-from-priya.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/instruction/never-deploy-on-fridays-without-an-explicit-go-ahead-from-priya.md
@@ -1,0 +1,25 @@
+---
+type: instruction
+title: Never deploy on Fridays without an explicit go-ahead from Priya.
+description: Never deploy on Fridays without an explicit go-ahead from Priya.
+tags:
+- source:chroma
+- instructions
+- session:week-2-stack
+generated:
+  by: process:chroma
+  at: '2026-06-08T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-deploy
+x_memanto:
+  type: instruction
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-deploy
+chroma_id: chroma-deploy
+session_id: week-2-stack
+sources:
+- chroma
+---
+
+Never deploy on Fridays without an explicit go-ahead from Priya.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/preference/correction-priya-now-prefers-python-fastapi-for-internal-services-typescr.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/preference/correction-priya-now-prefers-python-fastapi-for-internal-services-typescr.md
@@ -1,0 +1,30 @@
+---
+type: preference
+title: 'Correction: Priya now prefers Python (FastAPI) for internal services; TypeScr...'
+description: 'Correction: Priya now prefers Python (FastAPI) for internal services;
+  TypeScr...'
+tags:
+- consolidated:topic:language-preference
+- personal_preferences
+- session:week-3-correction
+- source:chroma
+- sources:2
+generated:
+  by: process:chroma
+  at: '2026-06-15T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-lang-correction
+x_memanto:
+  type: preference
+  confidence: 0.86
+  provenance: corrected
+  source: chroma
+  id: chroma:chroma-lang-correction
+chroma_id: chroma-lang-correction
+session_id: week-3-correction
+supersedes: chroma-lang
+sources:
+- chroma
+- sqlite
+---
+
+Correction: Priya now prefers Python (FastAPI) for internal services; TypeScript stays only for the frontend.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/preference/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/preference/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: preference
+---
+
+# preference
+
+3 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/preference/primary-editor-is-cursor-with-vim-keybindings-enabled.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/preference/primary-editor-is-cursor-with-vim-keybindings-enabled.md
@@ -1,0 +1,25 @@
+---
+type: preference
+title: Primary editor is Cursor with vim keybindings enabled.
+description: Primary editor is Cursor with vim keybindings enabled.
+tags:
+- source:chroma
+- personal_preferences
+- session:week-1-onboarding
+generated:
+  by: process:chroma
+  at: '2026-06-01T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-editor
+x_memanto:
+  type: preference
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-editor
+chroma_id: chroma-editor
+session_id: week-1-onboarding
+sources:
+- chroma
+---
+
+Primary editor is Cursor with vim keybindings enabled.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/preference/response-style-concise-bullets-first-then-optional-detail-no-emojis-in-com.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/preference/response-style-concise-bullets-first-then-optional-detail-no-emojis-in-com.md
@@ -1,0 +1,27 @@
+---
+type: preference
+title: 'Response style: concise bullets first, then optional detail. No emojis in
+  com...'
+description: 'Response style: concise bullets first, then optional detail. No emojis
+  in com...'
+tags:
+- source:chroma
+- personal_preferences
+- session:week-6-style
+generated:
+  by: process:chroma
+  at: '2026-07-06T10:00:00Z'
+resource: chroma://agent_long_term_memory/chroma-style
+x_memanto:
+  type: preference
+  confidence: 0.86
+  provenance: explicit_statement
+  source: chroma
+  id: chroma:chroma-style
+chroma_id: chroma-style
+session_id: week-6-style
+sources:
+- chroma
+---
+
+Response style: concise bullets first, then optional detail. No emojis in commit messages.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/relationship/index.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/relationship/index.md
@@ -1,0 +1,8 @@
+---
+type: index
+title: relationship
+---
+
+# relationship
+
+1 memories in this type.

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/relationship/on-call-buddy-is-marcus-chen-slack-marcus.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/memories/relationship/on-call-buddy-is-marcus-chen-slack-marcus.md
@@ -1,0 +1,28 @@
+---
+type: relationship
+title: On-call buddy is Marcus Chen (Slack @marcus).
+description: On-call buddy is Marcus Chen (Slack @marcus).
+tags:
+- consolidated:topic:oncall-buddy
+- source:sqlite
+- sources:2
+- thread:thread-ops-3
+- topic:team
+generated:
+  by: process:consolidated
+  at: '2026-06-30T10:00:00Z'
+resource: consolidated://chroma://agent_long_term_memory/chroma-rel+sqlite://agent_memories/sql-oncall
+x_memanto:
+  type: relationship
+  confidence: 0.92
+  provenance: imported
+  source: consolidated
+  id: merged:e3448df971a25f32
+sqlite_id: sql-oncall
+session_id: thread-ops-3
+sources:
+- chroma
+- sqlite
+---
+
+On-call buddy is Marcus Chen (Slack @marcus).

--- a/examples/migrations/okf-multisource-wiki/sample/okf-bundle/sessions/superseded-timeline.md
+++ b/examples/migrations/okf-multisource-wiki/sample/okf-bundle/sessions/superseded-timeline.md
@@ -1,0 +1,24 @@
+---
+type: index
+title: superseded-timeline
+---
+
+# Superseded / conflict-resolved memories
+
+These records were active in a source store but must not be re-imported
+as live memories. They stay under `sessions/` so `memanto migrate okf`
+ignores them while humans can still audit the history.
+
+## Priya prefers TypeScript over Python for production services.
+- id: `chroma:chroma-lang`
+- reason: `superseded`
+
+Priya prefers TypeScript over Python for production services.
+
+## Priya prefers TypeScript for all backend work.
+- id: `sqlite:sql-lang-stale`
+- reason: `conflict_resolved_by_newer_correction`
+- resolved_by: `chroma:chroma-lang-correction`
+
+Priya prefers TypeScript for all backend work.
+

--- a/examples/migrations/okf-multisource-wiki/sample/recall-parity.json
+++ b/examples/migrations/okf-multisource-wiki/sample/recall-parity.json
@@ -1,0 +1,82 @@
+{
+  "total": 8,
+  "source_recall": "8/8",
+  "okf_recall": "8/8",
+  "parity_pass": "8/8",
+  "is_recall_preserved": true,
+  "questions": [
+    {
+      "id": "q1",
+      "question": "What is the user's name?",
+      "source_ok": true,
+      "source_note": "matched Priya Shah",
+      "okf_ok": true,
+      "okf_note": "matched Priya Shah",
+      "parity": true
+    },
+    {
+      "id": "q2",
+      "question": "Which language does Priya prefer for internal/backend services now?",
+      "source_ok": true,
+      "source_note": "matched Python",
+      "okf_ok": true,
+      "okf_note": "matched Python",
+      "parity": true
+    },
+    {
+      "id": "q3",
+      "question": "What is the primary database?",
+      "source_ok": true,
+      "source_note": "matched PostgreSQL 16",
+      "okf_ok": true,
+      "okf_note": "matched PostgreSQL 16",
+      "parity": true
+    },
+    {
+      "id": "q4",
+      "question": "Who is the on-call buddy?",
+      "source_ok": true,
+      "source_note": "matched Marcus Chen",
+      "okf_ok": true,
+      "okf_note": "matched Marcus Chen",
+      "parity": true
+    },
+    {
+      "id": "q5",
+      "question": "What Friday deploy rule exists?",
+      "source_ok": true,
+      "source_note": "matched Never deploy on Fridays",
+      "okf_ok": true,
+      "okf_note": "matched Never deploy on Fridays",
+      "parity": true
+    },
+    {
+      "id": "q6",
+      "question": "What pgbouncer setting was raised after INC-441?",
+      "source_ok": true,
+      "source_note": "matched max_client_conn",
+      "okf_ok": true,
+      "okf_note": "matched max_client_conn",
+      "parity": true
+    },
+    {
+      "id": "q7",
+      "question": "What is the monthly LLM spend budget?",
+      "source_ok": true,
+      "source_note": "matched 200",
+      "okf_ok": true,
+      "okf_note": "matched 200",
+      "parity": true
+    },
+    {
+      "id": "q8",
+      "question": "Which timezone does Priya work in?",
+      "source_ok": true,
+      "source_note": "matched Asia/Kolkata",
+      "okf_ok": true,
+      "okf_note": "matched Asia/Kolkata",
+      "parity": true
+    }
+  ],
+  "pre_consolidation_union_recall": "8/8"
+}

--- a/examples/migrations/okf-multisource-wiki/sample/recall-parity.md
+++ b/examples/migrations/okf-multisource-wiki/sample/recall-parity.md
@@ -1,0 +1,17 @@
+# Recall parity
+
+- Source recall: **8/8**
+- OKF recall: **8/8**
+- Parity: **8/8**
+- Verdict: `is_recall_preserved: True`
+
+| ID | Question | Source | OKF | Parity |
+| --- | --- | --- | --- | --- |
+| q1 | What is the user's name? | pass | pass | yes |
+| q2 | Which language does Priya prefer for internal/backend services now? | pass | pass | yes |
+| q3 | What is the primary database? | pass | pass | yes |
+| q4 | Who is the on-call buddy? | pass | pass | yes |
+| q5 | What Friday deploy rule exists? | pass | pass | yes |
+| q6 | What pgbouncer setting was raised after INC-441? | pass | pass | yes |
+| q7 | What is the monthly LLM spend budget? | pass | pass | yes |
+| q8 | Which timezone does Priya work in? | pass | pass | yes |

--- a/examples/migrations/okf-multisource-wiki/sample/sqlite_seed.json
+++ b/examples/migrations/okf-multisource-wiki/sample/sqlite_seed.json
@@ -1,0 +1,16 @@
+{
+  "backend": "sqlite3",
+  "path": "/Users/vikasy/projects/placement/moorcheh-ai-bounty/examples/migrations/okf-multisource-wiki/data/sqlite/agent_memory.db",
+  "table": "agent_memories",
+  "count": 8,
+  "ids": [
+    "sql-name",
+    "sql-lang-stale",
+    "sql-timezone",
+    "sql-ci",
+    "sql-oncall",
+    "sql-budget",
+    "sql-runbook",
+    "sql-commit"
+  ]
+}

--- a/examples/migrations/okf-multisource-wiki/seed_chroma.py
+++ b/examples/migrations/okf-multisource-wiki/seed_chroma.py
@@ -1,0 +1,239 @@
+"""Populate a real Chroma collection with lived-in agent memories.
+
+Chroma is how many RAG / DIY agents trap long-term memory as opaque vectors.
+This seeder is an actual PersistentClient run — not hand-written JSON pretending
+to be a migration source.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import chromadb
+from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
+
+
+class DeterministicHashEmbedding(EmbeddingFunction[Documents]):
+    """Offline, deterministic embeddings so the demo needs no model download."""
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def name() -> str:
+        return "deterministic_hash"
+
+    def get_config(self) -> dict[str, str]:
+        return {"type": "deterministic_hash", "dims": "32"}
+
+    def __call__(self, input: Documents) -> Embeddings:
+        vectors: Embeddings = []
+        for text in input:
+            digest = hashlib.sha256(text.encode("utf-8")).digest()
+            # Expand to 32 dims in [-1, 1].
+            base = [((b / 255.0) * 2.0) - 1.0 for b in digest]
+            vectors.append(base)
+        return vectors
+
+
+# Six "weeks" of a coding-assistant agent. Includes a preference correction and
+# a resolved contradiction so consolidation has something real to reconcile.
+_SESSIONS: list[dict[str, Any]] = [
+    {
+        "session": "week-1-onboarding",
+        "day_offset": 0,
+        "memories": [
+            {
+                "id": "chroma-name",
+                "type": "fact",
+                "text": "User's name is Priya Shah.",
+                "categories": ["personal_details"],
+            },
+            {
+                "id": "chroma-lang",
+                "type": "preference",
+                "text": "Priya prefers TypeScript over Python for production services.",
+                "categories": ["personal_preferences"],
+            },
+            {
+                "id": "chroma-editor",
+                "type": "preference",
+                "text": "Primary editor is Cursor with vim keybindings enabled.",
+                "categories": ["personal_preferences"],
+            },
+        ],
+    },
+    {
+        "session": "week-2-stack",
+        "day_offset": 7,
+        "memories": [
+            {
+                "id": "chroma-db",
+                "type": "fact",
+                "text": "Primary database is PostgreSQL 16 on port 5432.",
+                "categories": ["professional_info"],
+            },
+            {
+                "id": "chroma-deploy",
+                "type": "instruction",
+                "text": "Never deploy on Fridays without an explicit go-ahead from Priya.",
+                "categories": ["instructions"],
+            },
+            {
+                "id": "chroma-tests",
+                "type": "commitment",
+                "text": "Every PR must include pytest coverage for new modules.",
+                "categories": ["tasks"],
+            },
+        ],
+    },
+    {
+        "session": "week-3-correction",
+        "day_offset": 14,
+        "memories": [
+            {
+                "id": "chroma-lang-correction",
+                "type": "preference",
+                "text": (
+                    "Correction: Priya now prefers Python (FastAPI) for internal "
+                    "services; TypeScript stays only for the frontend."
+                ),
+                "categories": ["personal_preferences"],
+                "provenance": "corrected",
+                "supersedes": "chroma-lang",
+            },
+            {
+                "id": "chroma-timezone",
+                "type": "fact",
+                "text": "Priya works in Asia/Kolkata (UTC+5:30).",
+                "categories": ["personal_details"],
+            },
+        ],
+    },
+    {
+        "session": "week-4-incident",
+        "day_offset": 21,
+        "memories": [
+            {
+                "id": "chroma-incident",
+                "type": "event",
+                "text": (
+                    "Incident INC-441 resolved: pgbouncer pool exhaustion after "
+                    "a migration spike. Root cause was max_client_conn=100."
+                ),
+                "categories": ["events"],
+            },
+            {
+                "id": "chroma-decision-pool",
+                "type": "decision",
+                "text": "Decision: raise pgbouncer max_client_conn to 400 permanently.",
+                "categories": ["decisions"],
+            },
+        ],
+    },
+    {
+        "session": "week-5-team",
+        "day_offset": 28,
+        "memories": [
+            {
+                "id": "chroma-rel",
+                "type": "relationship",
+                "text": "On-call buddy is Marcus Chen (Slack @marcus).",
+                "categories": ["relationships"],
+            },
+            {
+                "id": "chroma-goal",
+                "type": "goal",
+                "text": "Goal: cut p95 API latency under 120ms before Q4 review.",
+                "categories": ["goals_and_plans"],
+            },
+        ],
+    },
+    {
+        "session": "week-6-style",
+        "day_offset": 35,
+        "memories": [
+            {
+                "id": "chroma-style",
+                "type": "preference",
+                "text": (
+                    "Response style: concise bullets first, then optional detail. "
+                    "No emojis in commit messages."
+                ),
+                "categories": ["personal_preferences"],
+            },
+            {
+                "id": "chroma-secret-policy",
+                "type": "instruction",
+                "text": "Never commit .env files; use Doppler for secrets.",
+                "categories": ["instructions"],
+            },
+        ],
+    },
+]
+
+
+def seed_chroma(data_dir: Path, *, force: bool = False) -> dict[str, Any]:
+    """Run a real Chroma PersistentClient and return a provenance report."""
+    data_dir = data_dir.resolve()
+    if force and data_dir.exists():
+        shutil.rmtree(data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    client = chromadb.PersistentClient(path=str(data_dir))
+    collection = client.get_or_create_collection(
+        name="agent_long_term_memory",
+        embedding_function=DeterministicHashEmbedding(),
+        metadata={"source": "okf-multisource-wiki", "kind": "agent_memory"},
+    )
+
+    # Clear existing ids on re-seed without deleting the client path mid-run.
+    existing = collection.get()
+    if existing and existing.get("ids"):
+        collection.delete(ids=existing["ids"])
+
+    base = datetime(2026, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+    ids: list[str] = []
+    documents: list[str] = []
+    metadatas: list[dict[str, Any]] = []
+
+    for block in _SESSIONS:
+        when = base + timedelta(days=int(block["day_offset"]))
+        for mem in block["memories"]:
+            ids.append(mem["id"])
+            documents.append(mem["text"])
+            meta: dict[str, Any] = {
+                "memory_type": mem["type"],
+                "session": block["session"],
+                "categories": ",".join(mem["categories"]),
+                "created_at": when.isoformat().replace("+00:00", "Z"),
+                "provenance": mem.get("provenance", "explicit_statement"),
+            }
+            if mem.get("supersedes"):
+                meta["supersedes"] = mem["supersedes"]
+            metadatas.append(meta)
+
+    collection.add(ids=ids, documents=documents, metadatas=metadatas)
+
+    report = {
+        "backend": "chromadb.PersistentClient",
+        "path": str(data_dir),
+        "collection": "agent_long_term_memory",
+        "count": collection.count(),
+        "ids": ids,
+        "sessions": [b["session"] for b in _SESSIONS],
+    }
+    (data_dir / "seed_report.json").write_text(
+        json.dumps(report, indent=2) + "\n", encoding="utf-8"
+    )
+    return report
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parent / "data" / "chroma"
+    print(json.dumps(seed_chroma(root, force=True), indent=2))

--- a/examples/migrations/okf-multisource-wiki/seed_sqlite_store.py
+++ b/examples/migrations/okf-multisource-wiki/seed_sqlite_store.py
@@ -1,0 +1,161 @@
+"""Populate a proprietary SQLite agent-memory store (second lock-in source).
+
+Many DIY agents keep facts in ad-hoc SQLite tables with their own schema.
+This seeder creates that store via a real SQLite connection and inserts rows
+across overlapping sessions so consolidation has conflicts to resolve.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_memories (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    body TEXT NOT NULL,
+    thread_id TEXT,
+    confidence REAL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    meta_json TEXT
+);
+"""
+
+# Overlaps Chroma on name/timezone; disagrees on language preference (stale);
+# adds unique operational facts Chroma never saw.
+_ROWS: list[dict[str, Any]] = [
+    {
+        "id": "sql-name",
+        "kind": "fact",
+        "body": "User's name is Priya Shah.",
+        "thread_id": "thread-ops-1",
+        "confidence": 0.95,
+        "day_offset": 1,
+        "meta": {"topic": "identity"},
+    },
+    {
+        "id": "sql-lang-stale",
+        "kind": "preference",
+        "body": "Priya prefers TypeScript for all backend work.",
+        "thread_id": "thread-ops-1",
+        "confidence": 0.7,
+        "day_offset": 2,
+        "meta": {"topic": "language", "status": "stale_candidate"},
+    },
+    {
+        "id": "sql-timezone",
+        "kind": "fact",
+        "body": "Priya works in Asia/Kolkata (UTC+5:30).",
+        "thread_id": "thread-ops-2",
+        "confidence": 0.9,
+        "day_offset": 15,
+        "meta": {"topic": "timezone"},
+    },
+    {
+        "id": "sql-ci",
+        "kind": "instruction",
+        "body": "CI must stay green on Python 3.11 and 3.12 before merge.",
+        "thread_id": "thread-ops-2",
+        "confidence": 0.88,
+        "day_offset": 16,
+        "meta": {"topic": "ci"},
+    },
+    {
+        "id": "sql-oncall",
+        "kind": "relationship",
+        "body": "On-call buddy is Marcus Chen (Slack @marcus).",
+        "thread_id": "thread-ops-3",
+        "confidence": 0.92,
+        "day_offset": 29,
+        "meta": {"topic": "team"},
+    },
+    {
+        "id": "sql-budget",
+        "kind": "constraint",
+        "body": "Monthly LLM spend budget is USD 200; alert Priya at 80%.",
+        "thread_id": "thread-ops-3",
+        "confidence": 0.9,
+        "day_offset": 30,
+        "meta": {"topic": "budget"},
+    },
+    {
+        "id": "sql-runbook",
+        "kind": "artifact",
+        "body": (
+            "Runbook path for pgbouncer incidents: "
+            "docs/runbooks/pgbouncer-pool-exhaustion.md"
+        ),
+        "thread_id": "thread-ops-4",
+        "confidence": 0.85,
+        "day_offset": 22,
+        "meta": {"topic": "runbook", "related_incident": "INC-441"},
+    },
+    {
+        "id": "sql-commit",
+        "kind": "commitment",
+        "body": (
+            "Priya committed to review the OKF migration PR within 24 hours of opening."
+        ),
+        "thread_id": "thread-ops-4",
+        "confidence": 0.8,
+        "day_offset": 36,
+        "meta": {"topic": "review"},
+    },
+]
+
+
+def seed_sqlite(db_path: Path, *, force: bool = False) -> dict[str, Any]:
+    """Create/refresh the proprietary SQLite memory DB."""
+    db_path = db_path.resolve()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if force and db_path.exists():
+        db_path.unlink()
+
+    base = datetime(2026, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(_SCHEMA)
+        conn.execute("DELETE FROM agent_memories")
+        for row in _ROWS:
+            when = base + timedelta(days=int(row["day_offset"]))
+            stamp = when.isoformat().replace("+00:00", "Z")
+            conn.execute(
+                """
+                INSERT INTO agent_memories
+                (id, kind, body, thread_id, confidence, created_at, updated_at, meta_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row["id"],
+                    row["kind"],
+                    row["body"],
+                    row["thread_id"],
+                    row["confidence"],
+                    stamp,
+                    stamp,
+                    json.dumps(row["meta"]),
+                ),
+            )
+        conn.commit()
+        count = conn.execute("SELECT COUNT(*) FROM agent_memories").fetchone()[0]
+
+    report = {
+        "backend": "sqlite3",
+        "path": str(db_path),
+        "table": "agent_memories",
+        "count": count,
+        "ids": [r["id"] for r in _ROWS],
+    }
+    (db_path.parent / "seed_report.json").write_text(
+        json.dumps(report, indent=2) + "\n", encoding="utf-8"
+    )
+    return report
+
+
+if __name__ == "__main__":
+    target = Path(__file__).resolve().parent / "data" / "sqlite" / "agent_memory.db"
+    print(json.dumps(seed_sqlite(target, force=True), indent=2))

--- a/examples/migrations/okf-multisource-wiki/tests/test_pipeline.py
+++ b/examples/migrations/okf-multisource-wiki/tests/test_pipeline.py
@@ -1,0 +1,101 @@
+"""Tests for the multi-source OKF consolidation showcase."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from adapters import load_chroma_memories, load_sqlite_memories  # noqa: E402
+from consolidate import consolidate  # noqa: E402
+from okf_writer import write_okf_bundle  # noqa: E402
+from seed_chroma import seed_chroma  # noqa: E402
+from seed_sqlite_store import seed_sqlite  # noqa: E402
+from validate import evaluate_parity  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def pipeline(tmp_path_factory: pytest.TempPathFactory) -> dict:
+    base = tmp_path_factory.mktemp("multisource")
+    chroma_dir = base / "chroma"
+    sqlite_path = base / "sqlite" / "agent_memory.db"
+    seed_chroma(chroma_dir, force=True)
+    seed_sqlite(sqlite_path, force=True)
+    chroma = load_chroma_memories(chroma_dir)
+    sqlite = load_sqlite_memories(sqlite_path)
+    active, archived, summary = consolidate(chroma, sqlite)
+    bundle = base / "okf"
+    write_okf_bundle(active, bundle, session_notes=[("note", "archived")])
+    return {
+        "chroma": chroma,
+        "sqlite": sqlite,
+        "active": active,
+        "archived": archived,
+        "summary": summary,
+        "bundle": bundle,
+    }
+
+
+def test_real_sources_not_empty(pipeline: dict) -> None:
+    assert len(pipeline["chroma"]) >= 10
+    assert len(pipeline["sqlite"]) >= 6
+
+
+def test_consolidation_archives_stale_language_preference(pipeline: dict) -> None:
+    archived_ids = {m["id"] for m in pipeline["archived"]}
+    # Original Chroma TypeScript preference must be archived after correction.
+    assert "chroma:chroma-lang" in archived_ids
+    # SQLite stale TypeScript-for-all-backend preference must be archived.
+    assert any("sql-lang-stale" in i for i in archived_ids)
+    # Correction remains active.
+    active_text = "\n".join(m["content"] for m in pipeline["active"]).lower()
+    assert "fastapi" in active_text or "python" in active_text
+
+
+def test_okf_bundle_layout(pipeline: dict) -> None:
+    bundle = pipeline["bundle"]
+    assert (bundle / "index.md").exists()
+    assert (bundle / "memories").is_dir()
+    md_files = [
+        p for p in (bundle / "memories").rglob("*.md") if p.name.lower() != "index.md"
+    ]
+    assert len(md_files) == len(pipeline["active"])
+    sample = md_files[0].read_text(encoding="utf-8")
+    assert sample.startswith("---\n")
+    assert "type:" in sample
+    assert "x_memanto:" in sample
+
+
+def test_memanto_loader_maps_all_records(pipeline: dict) -> None:
+    repo_root = ROOT.parents[2]
+    sys.path.insert(0, str(repo_root))
+    from memanto.cli.migrate.mappers import map_okf
+    from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+    export = load_okf_bundle(pipeline["bundle"])
+    mapped = map_okf(export)
+    assert len(export["memories"]) == len(pipeline["active"])
+    assert len(mapped) == len(pipeline["active"])
+    assert all(row.get("content") for row in mapped)
+
+
+def test_recall_parity(pipeline: dict) -> None:
+    report = evaluate_parity(
+        source_memories=pipeline["active"],
+        okf_bundle=pipeline["bundle"],
+        questions_path=ROOT / "golden_questions.json",
+    )
+    assert report["is_recall_preserved"] is True
+    assert report["okf_recall"].startswith(str(report["total"]))
+
+
+def test_summary_counts(pipeline: dict) -> None:
+    s = pipeline["summary"]
+    assert s["active_count"] == len(pipeline["active"])
+    assert s["archived_count"] == len(pipeline["archived"])
+    assert s["chroma_source_count"] + s["sqlite_source_count"] > s["active_count"]

--- a/examples/migrations/okf-multisource-wiki/validate.py
+++ b/examples/migrations/okf-multisource-wiki/validate.py
@@ -1,0 +1,111 @@
+"""Golden Q&A recall parity across source stores and the consolidated OKF corpus."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _corpus_from_memories(memories: list[dict[str, Any]]) -> str:
+    return "\n".join(
+        f"{m.get('title', '')}\n{m.get('content', '')}" for m in memories
+    ).lower()
+
+
+def _corpus_from_okf(bundle_dir: Path) -> str:
+    parts: list[str] = []
+    memories_dir = bundle_dir / "memories"
+    scan = memories_dir if memories_dir.is_dir() else bundle_dir
+    for path in sorted(scan.rglob("*.md")):
+        if path.name.lower() in {"index.md", "log.md"}:
+            continue
+        parts.append(path.read_text(encoding="utf-8"))
+    return "\n".join(parts).lower()
+
+
+def _answerable(corpus: str, question: dict[str, Any]) -> tuple[bool, str]:
+    hits = [
+        phrase
+        for phrase in question.get("must_include_any", [])
+        if phrase.lower() in corpus
+    ]
+    if not hits:
+        return False, "missing required phrases"
+    forbidden = question.get("must_not_include_as_current") or []
+    # Soft check: stale phrases may still appear in sessions/; only fail if they
+    # appear in the active corpus without the correction also present.
+    for phrase in forbidden:
+        if (
+            phrase.lower() in corpus
+            and "fastapi" not in corpus
+            and "python (fastapi)" not in corpus
+        ):
+            # Active corpus should contain the correction; if Python/FastAPI is
+            # present we treat the stale phrase as historical noise.
+            if "python" not in corpus:
+                return False, f"stale preference still dominant: {phrase}"
+    return True, f"matched {hits[0]}"
+
+
+def evaluate_parity(
+    *,
+    source_memories: list[dict[str, Any]],
+    okf_bundle: Path,
+    questions_path: Path,
+) -> dict[str, Any]:
+    questions = json.loads(questions_path.read_text(encoding="utf-8"))
+    source_corpus = _corpus_from_memories(source_memories)
+    okf_corpus = _corpus_from_okf(okf_bundle)
+
+    rows: list[dict[str, Any]] = []
+    source_pass = okf_pass = 0
+    for q in questions:
+        s_ok, s_note = _answerable(source_corpus, q)
+        o_ok, o_note = _answerable(okf_corpus, q)
+        source_pass += int(s_ok)
+        okf_pass += int(o_ok)
+        rows.append(
+            {
+                "id": q["id"],
+                "question": q["question"],
+                "source_ok": s_ok,
+                "source_note": s_note,
+                "okf_ok": o_ok,
+                "okf_note": o_note,
+                "parity": s_ok == o_ok and s_ok,
+            }
+        )
+
+    total = len(questions)
+    return {
+        "total": total,
+        "source_recall": f"{source_pass}/{total}",
+        "okf_recall": f"{okf_pass}/{total}",
+        "parity_pass": f"{sum(1 for r in rows if r['parity'])}/{total}",
+        "is_recall_preserved": source_pass == total and okf_pass == total,
+        "questions": rows,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Recall parity",
+        "",
+        f"- Source recall: **{report['source_recall']}**",
+        f"- OKF recall: **{report['okf_recall']}**",
+        f"- Parity: **{report['parity_pass']}**",
+        f"- Verdict: `is_recall_preserved: {report['is_recall_preserved']}`",
+        "",
+        "| ID | Question | Source | OKF | Parity |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in report["questions"]:
+        lines.append(
+            f"| {row['id']} | {row['question']} | "
+            f"{'pass' if row['source_ok'] else 'fail'} | "
+            f"{'pass' if row['okf_ok'] else 'fail'} | "
+            f"{'yes' if row['parity'] else 'no'} |"
+        )
+    lines.append("")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Path C (**OKF Renaissance**) submission for #1609.

Most agents trap memory in more than one proprietary store. This showcase starts from **two real lived-in sources** — a Chroma PersistentClient and a proprietary SQLite `agent_memories` table — consolidates them into one coherent portable wiki (with contradiction resolution), and feeds the shipped CLI:

```text
Chroma (vectors)  ─┐
                   ├─ adapters → consolidate → OKF wiki → memanto migrate okf → Memanto
SQLite (ad-hoc)   ─┘
```

No re-implementation of `memanto migrate`. Adapters **feed** OKF; Memanto owns import.

## Migration summary

| Metric | Value |
| --- | ---: |
| Chroma source records | 14 |
| SQLite source records | 8 |
| Active consolidated memories | 17 |
| Archived superseded / conflicts | 2 |
| `memanto migrate okf --dry-run` | **17 mapped, 0 skipped** |
| Golden recall (source) | **8/8** |
| Golden recall (OKF) | **8/8** |

Type breakdown after dry-run: `artifact:1, commitment:2, decision:1, event:1, fact:3, goal:1, instruction:4, preference:3, relationship:1`

Savings note: `migrate okf` is a local format and does not emit provider-style token/latency savings (per shipped docs). This showcase reports the ownership delta instead: opaque vectors + SQLite rows → readable markdown humans can git-diff.

## Evidence

- **Sample OKF bundle:** `examples/migrations/okf-multisource-wiki/sample/okf-bundle/`
- **Migration summary:** `examples/migrations/okf-multisource-wiki/sample/migration_summary.json`
- **Recall parity:** `examples/migrations/okf-multisource-wiki/sample/recall-parity.md`
- **CLI dry-run capture:** `examples/migrations/okf-multisource-wiki/sample/memanto-dry-run.txt`
- **Mapping table:** `examples/migrations/okf-multisource-wiki/MAPPING.md`

## Reproduce (< 15 min)

```bash
cd examples/migrations/okf-multisource-wiki
python -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt
pip install -e ../../..
python run.py --force --update-sample
memanto migrate okf out/okf-bundle --dry-run
pytest -c pytest.ini -q   # 6 passed
```

## Demo video / social

- **Demo video:** _pending — record 2-min terminal walkthrough (seed → consolidate → open markdown → dry-run → 8/8 parity)_
- **Social posts:** _pending — will tag @moorcheh_ai / YouTube @moorchehai / LinkedIn company page before Aug 31 deadline_
- **BountyHub claim:** _pending — https://www.bountyhub.dev/bounty/view/b21928e9-70dd-4d95-adc6-3009df47e9f5_

## Why Path C

Adapter lanes (ChatGPT / LangGraph / Qdrant / …) are crowded. This submission shows what becomes possible **once memory is portable markdown**: multi-source consolidation, superseded timelines kept under `sessions/` (so import cannot revive stale preferences), and a human-inspectable wiki.

Closes #1609

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete multi-source migration showcase that consolidates Chroma and SQLite memory stores into a portable OKF wiki bundle.
  * Added automatic deduplication, conflict resolution, provenance tracking, and archival of superseded records.
  * Added dry-run migration support and recall-parity validation, with sample results confirming 8/8 knowledge recall.

* **Documentation**
  * Added setup instructions, field-mapping guidance, sample data, generated bundle contents, and migration validation reports.

* **Tests**
  * Added automated coverage for seeding, consolidation, bundle generation, round-trip loading, and recall parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->