### PR TITLE
fix(ts): authenticate remote management requests

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -139,6 +139,7 @@ export class Memanto {
   private readonly agentId: string;
   private readonly encodedAgentId: string;
   private readonly autoCreate: boolean;
+  private readonly apiKey?: string;
   private sessionToken: string | null = null;
   private starting: Promise<void> | null = null;
 
@@ -147,6 +148,7 @@ export class Memanto {
     this.agentId = opts.agentId;
     this.encodedAgentId = encodeURIComponent(opts.agentId);
     this.autoCreate = opts.autoCreate ?? true;
+    this.apiKey = opts.apiKey;
     this.lifecycle = new ServerLifecycle(opts);
   }
 
@@ -324,7 +326,7 @@ export class Memanto {
     const baseUrl = this.lifecycle.baseUrl;
     const res = await fetch(`${baseUrl}/api/v2/agents`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.managementHeaders(),
       body: JSON.stringify({
         agent_id: this.agentId,
         pattern: input.pattern,
@@ -416,14 +418,16 @@ export class Memanto {
 
   private async createAgentIfMissing(): Promise<void> {
     const baseUrl = this.lifecycle.baseUrl;
-    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}`);
+    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}`, {
+      headers: this.managementHeaders(),
+    });
     if (res.ok) return;
     if (res.status !== 404) {
       throw await asError(res, "Failed to look up agent");
     }
     const create = await fetch(`${baseUrl}/api/v2/agents`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.managementHeaders(),
       body: JSON.stringify({ agent_id: this.agentId }),
     });
     if (!create.ok && create.status !== 409) {
@@ -435,6 +439,7 @@ export class Memanto {
     const baseUrl = this.lifecycle.baseUrl;
     const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}/activate`, {
       method: "POST",
+      headers: this.managementHeaders(),
     });
     if (!res.ok) throw await asError(res, "Failed to activate agent");
     const session = (await res.json()) as SessionRecord;
@@ -474,6 +479,8 @@ export class Memanto {
     };
     if (requireSession) {
       headers["X-Session-Token"] = this.sessionToken ?? "";
+    } else if (this.apiKey) {
+      headers["X-Api-Key"] = this.apiKey;
     }
     const serializedBody = body === undefined ? undefined : JSON.stringify(body);
     const send = () =>
@@ -482,6 +489,14 @@ export class Memanto {
     if (!res.ok) throw await asError(res, `${method} ${path} failed`);
     if (res.status === 204) return undefined as T;
     return (await res.json()) as T;
+  }
+
+  private managementHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.apiKey) headers["X-Api-Key"] = this.apiKey;
+    return headers;
   }
 
   private async requestFileUpload<T = unknown>(

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -323,8 +323,7 @@ export class Memanto {
 
   async createAgent(input: CreateAgentInput = {}) {
     await this.lifecycle.start();
-    const baseUrl = this.lifecycle.baseUrl;
-    const res = await fetch(`${baseUrl}/api/v2/agents`, {
+    const res = await this.managementFetch("/api/v2/agents", {
       method: "POST",
       headers: this.managementHeaders(),
       body: JSON.stringify({
@@ -417,15 +416,14 @@ export class Memanto {
   }
 
   private async createAgentIfMissing(): Promise<void> {
-    const baseUrl = this.lifecycle.baseUrl;
-    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}`, {
+    const res = await this.managementFetch(`/api/v2/agents/${this.encodedAgentId}`, {
       headers: this.managementHeaders(),
     });
     if (res.ok) return;
     if (res.status !== 404) {
       throw await asError(res, "Failed to look up agent");
     }
-    const create = await fetch(`${baseUrl}/api/v2/agents`, {
+    const create = await this.managementFetch("/api/v2/agents", {
       method: "POST",
       headers: this.managementHeaders(),
       body: JSON.stringify({ agent_id: this.agentId }),
@@ -436,8 +434,7 @@ export class Memanto {
   }
 
   private async activate(): Promise<void> {
-    const baseUrl = this.lifecycle.baseUrl;
-    const res = await fetch(`${baseUrl}/api/v2/agents/${this.encodedAgentId}/activate`, {
+    const res = await this.managementFetch(`/api/v2/agents/${this.encodedAgentId}/activate`, {
       method: "POST",
       headers: this.managementHeaders(),
     });
@@ -484,19 +481,37 @@ export class Memanto {
     }
     const serializedBody = body === undefined ? undefined : JSON.stringify(body);
     const send = () =>
-      fetch(`${baseUrl}${path}`, { method, headers, body: serializedBody });
+      requireSession
+        ? fetch(`${baseUrl}${path}`, { method, headers, body: serializedBody })
+        : this.managementFetch(path, { method, headers, body: serializedBody });
     const res = await this.sendWithSessionRetry(send, headers, requireSession);
     if (!res.ok) throw await asError(res, `${method} ${path} failed`);
     if (res.status === 204) return undefined as T;
     return (await res.json()) as T;
   }
 
+  /** Build headers for requests that require the server management credential. */
   private managementHeaders(): Record<string, string> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
     if (this.apiKey) headers["X-Api-Key"] = this.apiKey;
     return headers;
+  }
+
+  /** Reject credentialed plaintext remote URLs and never follow redirects. */
+  private managementFetch(path: string, init: RequestInit = {}): Promise<Response> {
+    const url = new URL(`${this.lifecycle.baseUrl}${path}`);
+    const hostname = url.hostname.toLowerCase();
+    const loopback =
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "[::1]" ||
+      hostname === "::1";
+    if (this.apiKey && url.protocol !== "https:" && !loopback) {
+      throw new Error("Management API key requires an HTTPS remote baseUrl");
+    }
+    return fetch(url, { ...init, redirect: "error" });
   }
 
   private async requestFileUpload<T = unknown>(

--- a/sdks/typescript/test/memanto.test.ts
+++ b/sdks/typescript/test/memanto.test.ts
@@ -16,6 +16,7 @@ interface Recorded {
 function startFakeApi(
   agentId = "test-agent",
   opts: {
+    requiredApiKey?: string;
     expireFirstSession?: boolean;
     expireFirstUpload?: boolean;
     rejectAllSessions?: boolean;
@@ -48,6 +49,19 @@ function startFakeApi(
         };
 
         if (url === "/health") return reply(200, { status: "ok" });
+        const agentUrl = `/api/v2/agents/${encodedAgentId}`;
+        const isManagementRequest =
+          url === "/api/v2/status" ||
+          url === "/api/v2/agents" ||
+          (url === agentUrl && ["GET", "DELETE"].includes(req.method ?? "")) ||
+          url === `${agentUrl}/activate`;
+        if (
+          opts.requiredApiKey &&
+          isManagementRequest &&
+          req.headers["x-api-key"] !== opts.requiredApiKey
+        ) {
+          return reply(401, { detail: "invalid API key" });
+        }
         if (url === "/api/v2/status" && req.method === "GET")
           return reply(200, {
             session_id: "existing-session",
@@ -196,6 +210,35 @@ describe("Memanto", () => {
 
     const res = await m.recall({ query: "coffee" });
     expect(res).toMatchObject({ count: 0 });
+  });
+
+  it("authenticates remote management requests with apiKey", async () => {
+    const apiKey = "mch_remote_test_key";
+    const api = await startFakeApi("test-agent", { requiredApiKey: apiKey });
+    cleanupFns.push(api.close);
+
+    const m = new Memanto({ agentId: "test-agent", baseUrl: api.url, apiKey });
+    cleanupFns.push(() => m.close());
+
+    await m.remember({ content: "Remote servers require management auth" });
+    await m.status();
+
+    const managementRequests = api.recorded.filter((r) =>
+      [
+        "/api/v2/agents/test-agent",
+        "/api/v2/agents",
+        "/api/v2/agents/test-agent/activate",
+        "/api/v2/status",
+      ].includes(r.url),
+    );
+    expect(managementRequests).toHaveLength(4);
+    expect(
+      managementRequests.every((r) => r.headers["x-api-key"] === apiKey),
+    ).toBe(true);
+
+    const remember = api.recorded.find((r) => r.url.endsWith("/remember"));
+    expect(remember?.headers["x-session-token"]).toBe("fake-token");
+    expect(remember?.headers["x-api-key"]).toBeUndefined();
   });
 
   it("reactivates once and retries when the cached session expires", async () => {


### PR DESCRIPTION
## Summary

The TypeScript SDK was not including the configured API key when connecting to an existing Memanto server.

This affected agent lookup, creation, activation, status, listing, and deletion requests used during remote deployments.

## Security impact

Memanto uses separate credentials for separate request classes:

- `X-Api-Key` for agent-management operations
- `X-Session-Token` for memory operations

The SDK was omitting the management credential when using a remote `baseUrl`. The SDK could not complete its bootstrap flow against a server enforcing management authentication.

The fix restores the management authentication boundary and adds protections around credential transport:

- Remote API-key requests require HTTPS.
- Local loopback HTTP remains available for local development.
- Management requests do not follow redirects, preventing the API key from being forwarded to an unintended host.
- Memory requests continue using only the session token.

## Reproduction basis

Configure the SDK to connect to an existing server:

```ts
const memanto = new Memanto({
  agentId: "test-agent",
  baseUrl: "https://memanto.example.com",
  apiKey: "management-key",
});
```

Before this change, requests such as the following were sent without `X-Api-Key`:

```text
GET  /api/v2/agents/test-agent
POST /api/v2/agents
POST /api/v2/agents/test-agent/activate
GET  /api/v2/status
```

A server enforcing management authentication returned `401`, preventing the SDK from completing startup.

No production API key, tenant, or Moorcheh data was used.

## Changes

- Store the optional API key in the TypeScript client.
- Send `X-Api-Key` on management and activation requests.
- Send `X-Api-Key` for requests that do not require a session.
- Keep memory requests authenticated with `X-Session-Token`.
- Reject credentialed remote HTTP URLs.
- Disable redirects for management requests.
- Add regression coverage for required management authentication and header separation.

## Verification

```text
npm test -- --run
npm run typecheck
npm run build
git diff --check
```

Results:

- 50 tests passed
- TypeScript check passed
- Production bundle built successfully
- No whitespace errors

## Checklist

- [x] Management requests include the configured API key.
- [x] Memory requests continue using the session token.
- [x] Remote credentialed requests require HTTPS.
- [x] Management redirects are disabled.
- [x] Regression coverage added.
- [x] Existing TypeScript tests pass.
- [x] No real credentials or tenant data included.
- [x] No unrelated API behavior changed.

Related bounty: #1852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional API key support for SDK management requests.
  - API keys are automatically included where required, while session-based requests remain unchanged.

- **Bug Fixes**
  - Improved authentication handling for agent creation, activation, status checks, and related management operations.
  - Management requests now require secure HTTPS connections when API key authentication is enabled and do not follow redirects.

- **Tests**
  - Added coverage verifying API key headers are sent correctly and rejected when missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->