### PR TITLE
fix: OKF export loses lifecycle fields (expired_at, expired_by) — exports dead schema instead

### DIFF
--- a/memanto/app/services/okf_export_service.py
+++ b/memanto/app/services/okf_export_service.py
@@ -416,8 +416,8 @@ class OkfExportService:
             "source",
             "status",
             "updated_at",
-            "expires_at",
-            "ttl_seconds",
+            "expired_at",
+            "expired_by",
         ):
             val = mem.get(key)
             if val not in (None, ""):

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -524,8 +524,8 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
         created_at = _parse_dt(gen_at) or _parse_dt(entry.get("timestamp"))
 
         updated_at = _parse_dt(x_memanto.get("updated_at")) or migrated_at
-        expires_at = _parse_dt(x_memanto.get("expires_at"))
-        ttl_seconds = _parse_positive_int(x_memanto.get("ttl_seconds"))
+        expired_at = _parse_dt(x_memanto.get("expired_at"))
+        expired_by = x_memanto.get("expired_by") if isinstance(x_memanto.get("expired_by"), str) and x_memanto.get("expired_by").strip() else None
 
         original_title = None
         if title and len(title) > _MAX_TITLE_CHARS:
@@ -561,8 +561,8 @@ def map_okf(export: dict[str, Any]) -> list[dict[str, Any]]:
                 "provenance": provenance,
                 "created_at": created_at,
                 "updated_at": updated_at,
-                "expires_at": expires_at,
-                "ttl_seconds": ttl_seconds,
+                "expired_at": expired_at,
+                "expired_by": expired_by,
             }
         )
     return rows

--- a/memanto/cli/migrate/mappers.py
+++ b/memanto/cli/migrate/mappers.py
@@ -16,8 +16,8 @@ accepted by ``SdkClient.batch_remember``:
         "provenance": "imported",
         "created_at": datetime, # original source timestamp (when present)
         "updated_at": datetime, # migration time = now
-        "expires_at": datetime, # source expiration timestamp (when present)
-        "ttl_seconds": int,     # source retention window (when present)
+        "expired_at": datetime, # lifecycle expiry timestamp (when present)
+        "expired_by": str,       # lifecycle expiry reason (when present)
     }
 
 Mappers extract every useful field from the source. Anything that maps

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -119,8 +119,8 @@ def test_memanto_round_trip_preserves_extras(tmp_path):
                 status="active",
                 created_at="2026-05-28T14:30:00Z",
                 updated_at="2026-06-01T09:15:00Z",
-                expires_at="2026-08-01T09:15:00Z",
-                ttl_seconds=5_529_600,
+                expired_at="2026-08-01T09:15:00Z",
+                expired_by="manual",
                 source_ref="https://example.com/db",
             )
         ],
@@ -141,8 +141,8 @@ def test_memanto_round_trip_preserves_extras(tmp_path):
     assert set(pg["tags"]) == {"infra", "db"}
     assert pg["created_at"] is not None
     assert pg["updated_at"].isoformat() == "2026-06-01T09:15:00+00:00"
-    assert pg["expires_at"].isoformat() == "2026-08-01T09:15:00+00:00"
-    assert pg["ttl_seconds"] == 5_529_600
+    assert pg["expired_at"].isoformat() == "2026-08-01T09:15:00+00:00"
+    assert pg["expired_by"] == "manual"
     assert "PostgreSQL 16" in pg["content"]
     assert by_title["Chose Redis"]["type"] == "decision"
 
@@ -155,8 +155,8 @@ def test_okf_import_ignores_invalid_temporal_extensions(tmp_path):
         "title: Durable fact\n"
         "x_memanto:\n"
         "  updated_at: true\n"
-        "  expires_at: true\n"
-        "  ttl_seconds: true\n"
+        "  expired_at: true\n"
+        "  expired_by: true\n"
         "---\n\n"
         "This memory remains importable.\n",
         encoding="utf-8",
@@ -165,8 +165,8 @@ def test_okf_import_ignores_invalid_temporal_extensions(tmp_path):
     row = map_okf(load_okf_bundle(tmp_path))[0]
 
     assert row["updated_at"] is not None
-    assert row["expires_at"] is None
-    assert row["ttl_seconds"] is None
+    assert row["expired_at"] is None
+    assert row["expired_by"] is None
 
 
 def test_okf_invalid_provenance_falls_back_to_imported():
@@ -445,3 +445,46 @@ def test_okf_export_preserves_list_tags(tmp_path):
     fact_md = svc.exports_dir / "agent1_okf" / "memories" / "fact" / "a-fact.md"
     fm = yaml.safe_load(fact_md.read_text(encoding="utf-8").split("---", 2)[1])
     assert set(fm["tags"]) == {"infra", "db"}
+
+def test_okf_round_trip_preserves_expired_lifecycle(tmp_path):
+    """An expired memory's lifecycle stamp (expired_at + expired_by) must
+    survive the OKF export -> import round-trip.
+
+    Regression for BountyHub #770: the export previously wrote the dead
+    ``expires_at`` / ``ttl_seconds`` fields instead of the live
+    ``expired_at`` / ``expired_by`` pair, so re-importing an expired
+    memory lost its audit trail (when it expired and why).
+    """
+    memories_by_type = {
+        "fact": [
+            _mem(
+                "m-exp",
+                "Deprecated API endpoint",
+                "The old REST API at /v1 is no longer supported.",
+                tags=["api", "deprecated"],
+                confidence=0.95,
+                provenance="explicit_statement",
+                source="user",
+                status="expired",
+                created_at="2026-01-15T10:00:00Z",
+                updated_at="2026-06-01T12:00:00Z",
+                expired_at="2026-07-01T00:00:00Z",
+                expired_by="manual",
+            ),
+        ],
+    }
+
+    svc = OkfExportService(exports_dir=tmp_path / "exports")
+    result = svc.write_okf_bundle("agent1", memories_by_type, split="file")
+
+    rows = map_okf(load_okf_bundle(result["output_path"]))
+    assert len(rows) == 1
+
+    row = rows[0]
+    # The lifecycle stamp must round-trip, not the dead schema fields.
+    assert row["expired_at"] is not None
+    assert row["expired_at"].isoformat() == "2026-07-01T00:00:00+00:00"
+    assert row["expired_by"] == "manual"
+    # Dead fields must not appear in the mapped row.
+    assert "expires_at" not in row
+    assert "ttl_seconds" not in row


### PR DESCRIPTION
## Bug

The OKF export serializes **dead schema fields** (`expires_at`, `ttl_seconds`) into the `x_memanto` frontmatter block instead of the **live lifecycle fields** (`expired_at`, `expired_by`). When an expired memory is exported to OKF and re-imported, its expiry audit trail — *when* it expired and *why* — is silently lost.

## Root Cause

`OkfExportService._render_okf_doc` iterates over a hardcoded key list to populate the `x_memanto` block:

```python
for key in (
    "id", "confidence", "provenance", "source", "status",
    "updated_at",
    "expires_at",   # ← dead field (in _REMOVED_SCHEMA_FIELDS)
    "ttl_seconds",  # ← dead field (in _REMOVED_SCHEMA_FIELDS)
):
```

- `expires_at` and `ttl_seconds` were removed from the active schema (they live in `_REMOVED_SCHEMA_FIELDS` in `memory_write_service.py`). The formatted memory item returned by `_format_memory_item` never carries these keys, so `mem.get(key)` always returns `None` and they are never written.
- `expired_at` and `expired_by` — the live lifecycle stamp fields — are **not in the key list**, so they are silently dropped on export.

The `map_okf` mapper mirrors the same mistake: it reads `x_memanto.get("expires_at")` and `x_memanto.get("ttl_seconds")` (which are always absent) and passes them through to the row dict, where Pydantic silently drops them because `MemoryRecord` has no such fields.

## Impact

- **Data loss**: An expired memory exported to OKF and re-imported loses `expired_at` (when it expired) and `expired_by` (why it expired). The `status` field is preserved, so the memory is still marked `expired`, but the audit trail is gone.
- **Round-trip integrity**: The OKF export is documented as a lossless Memanto → OKF → Memanto round-trip, but the lifecycle stamp does not survive.

## Fix

1. **`okf_export_service.py`**: Replace `expires_at` and `ttl_seconds` with `expired_at` and `expired_by` in the `x_memanto` key list.
2. **`mappers.py`**: Read `expired_at` and `expired_by` from `x_memanto` instead of the dead fields. Update the docstring type hint.
3. **`tests/test_okf.py`**: Update existing round-trip tests to use the correct field names and add a new test (`test_okf_round_trip_preserves_expired_lifecycle`) that specifically verifies an expired memory's lifecycle stamp survives the export → import round-trip.

Refs #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OKF exports now preserve expiration metadata using `expired_at` and `expired_by`.
  * OKF imports correctly restore this metadata and safely ignore invalid values.
  * Updated expiration handling prevents obsolete fields from appearing in migrated data.
* **Tests**
  * Added coverage confirming expiration metadata survives an export/import round trip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->