### PR TITLE
feat: OKF Memory Vault — git-versioned memory wiki with diff + viewer (#1609 Path C)

### DIFF
--- a/examples/migrations/okf-memory-vault/MAPPING.md
+++ b/examples/migrations/okf-memory-vault/MAPPING.md
@@ -1,0 +1,66 @@
+# OKF ↔ Memanto mapping table
+
+This showcase stores memory in the [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+v0.1 layout that Memanto itself writes (`memanto memory export --okf`,
+`memanto memory sync --okf`) and reads (`memanto migrate okf`). Nothing here
+re-implements Memanto's shipped tooling; the scripts in this directory build
+*on top of* it by adding a versioned, diffable, reviewable lifecycle.
+
+## Bundle layout
+
+```
+<bundle>/
+    memories/
+        <type>/<slug>.md     # one concept per file
+```
+
+Memanto imports only the `memories/` subtree (`okf_loader.py`); `index.md` and
+`log.md` navigation files are skipped. Each memory file is a markdown document
+with YAML frontmatter.
+
+## Field mapping
+
+| OKF frontmatter field | Memanto schema | Notes |
+| --- | --- | --- |
+| `type` | memory type | OKF's free-form `type` is auto-classified by `memanto migrate okf` into Memanto's memory types (instruction, fact, decision, goal, commitment, preference, relationship, context, event, learning, observation, artifact, error) |
+| `title` | memory title | Also used to derive the slug / filename |
+| `description` | summary | Optional one-line summary |
+| `resource` | resource URI | Optional source link |
+| `tags` | tags | Optional list |
+| `timestamp` | created/updated time | ISO-8601 |
+| `x_memanto` | Memanto-only metadata | Namespaced block preserving `confidence`, `provenance`, `status` etc. so Memanto → OKF → Memanto round-trips are lossless |
+
+Unknown frontmatter keys are preserved as "extra" fields by the loader and
+survive the round trip - OKF is designed to be lossless.
+
+## Type taxonomy used in this showcase
+
+| Type | Meaning in the demo |
+| --- | --- |
+| `instruction` | Standing rules the agent must follow (CI, secrets, API compatibility) |
+| `fact` | Stable facts about the product, stack, team and metrics |
+| `decision` | Architectural/product decisions and their rationale |
+| `goal` | Current objectives with measurable targets |
+| `commitment` | Promises with deadlines (to Maya, partners, customers) |
+| `preference` | Maya's communication and workflow preferences |
+| `relationship` | How the agent works with other people (Alex, customers) |
+| `context` | Short-lived sprint context |
+| `event` | Notable events (first customer, funnel metrics) |
+| `learning` | Product signals from customer conversations |
+| `artifact` | Pointers to canonical files/docs |
+
+## Provenance convention
+
+The demo uses the `x_memanto.provenance` field to record *who* wrote a memory:
+
+| Value | Meaning |
+| --- | --- |
+| `agent_session` | Written by the main agent during a normal session |
+| `manual` | Written/confirmed by a human |
+| `correction` | A preference correction from the user |
+| `main_agent` / `nightly_analytics` | Written by a specific agent process |
+| `human_review` | Written during human review/reconciliation |
+
+This is what makes the conflict story possible: when two provenances disagree
+on the same fact, `okf_diff.py` flags the contradiction instead of letting the
+vector store silently collapse it.

--- a/examples/migrations/okf-memory-vault/README.md
+++ b/examples/migrations/okf-memory-vault/README.md
@@ -1,0 +1,149 @@
+# OKF Memory Vault — portable, versioned, diffable agent memory
+
+> Path C submission for [memanto #1609: The Great Memory Migration](https://github.com/moorcheh-ai/memanto/issues/1609) — *show that Open Knowledge Format (OKF) memory is portable, and that portability unlocks a lifecycle proprietary stores can't give you: version history, code-review-style auditing, conflict detection, and team workflows.*
+
+**One command reproduces the whole demo:**
+
+```bash
+pip install -r requirements.txt
+python run.py
+```
+
+That builds a complete lived-in agent memory vault (`sample/`): 4 chronological
+sessions, a git history, human-readable diffs, a conflict scan, and a passing
+test suite. No cloud, no server, no Memanto account needed — that is the point:
+**the memory is plain portable markdown, so it runs anywhere.**
+
+## What this showcases
+
+This demo is built **on top of** Memanto's existing OKF support
+(`memanto memory export --okf`, `memanto memory sync --okf`,
+`memanto migrate okf`). It adds the lifecycle layer that a portable format
+makes possible:
+
+| Capability | Where | Why it matters |
+| --- | --- | --- |
+| **Git-versioned memory wiki** | `run.py` commits each session to `sample/vault` | Every memory change is auditable: `git log` is the memory's changelog, `git revert` is an undo button for bad memories |
+| **OKF diff utility** | `okf_diff.py` | See *exactly* what changed between sessions — added / modified / removed memories with field-level diffs |
+| **OKF viewer** | `okf_view.py` | Browse and search the vault like a wiki, with zero Memanto tooling |
+| **Conflict scanner** | `okf_diff.py --conflict scan` | Near-duplicate memories with different content are flagged for human review instead of silently collapsing in a vector store |
+| **Human review workflow** | `scenario.py` Session 5 | Memory reviewed like code: a wrong entry is reverted, a contradiction gets a single source of truth, the whole audit trail stays in git |
+
+The demo story: **Lumenly**, a fictional AI customer-support analytics SaaS.
+Maya (the founder) runs an agent that keeps its working memory in an OKF
+bundle versioned in git and synced from Memanto.
+
+```
+v1  Session 1-2  The seed             20 memories   # two weeks of lived-in memory
+v2  Session 3    Memory evolves       24 memories   # preference correction + new facts
+v3  Session 4    Two agents collide   29 memories   # conflicting facts become visible
+v4  Session 5    Human review + rollback  27 memories  # bad entry reverted, contradiction resolved
+```
+
+## Quick tour
+
+```bash
+# 1. See the whole vault as a tree
+python okf_view.py sample/vault
+
+# 2. Search memory
+python okf_view.py sample/vault --search p95
+
+# 3. Diff two sessions like code review
+python okf_diff.py sample/vault-v2 sample/vault-v3
+
+# 4. Diff two git revisions of the same vault (tags: v1..v4)
+python okf_diff.py --git v1 v2 --repo sample/vault --bundle memories
+
+# 5. The audit trail
+git -C sample/vault log --oneline
+```
+
+## The conflict story (the part a vector store hides)
+
+Session 4 has two agents writing to the same memory. The diff makes the
+contradiction unmissable:
+
+```
+$ python okf_diff.py sample/vault-v2 sample/vault-v3
+5 added · 0 modified · 0 removed · 24 unchanged
+
+## Potential conflicts (near-duplicate memories)
+
+> Two memories of the same type look like they may be about the same thing
+> but disagree. **Flag for human review** - this is exactly what a vector
+> store would have silently collapsed.
+
+- `fact`: **Maya's birthday is September 2** (_via manual_) ⟷ **Maya's birthday is August 15** (_via nightly_analytics_)
+- `fact`: **Average customer response time is 4.2 hours** (_via nightly_analytics_) ⟷ **Average customer response time is 1.8 hours** (_via main_agent_)
+```
+
+A vector store would have merged, ranked, or overwritten one of those —
+silently. Here the human sees both, audits, and Session 5 reworks the vault
+like a bad PR:
+
+```
+$ python okf_diff.py sample/vault-v3 sample/vault-v4
+1 added · 2 modified · 3 removed · 24 unchanged
+```
+
+- **removed**: the `August 15` birthday (a 2024 spreadsheet typo), and both
+  response-time estimates (1.8h excluded APAC, 4.2h included an incident backlog)
+- **modified**: the `September 2` birthday entry updated by `human_review`;
+  the p95 goal updated with progress
+- **added**: one resolved `2.9h` fact owned by the nightly analytics agent
+- and `git log` shows every step:
+
+```
+d0cd43d (HEAD -> main) v4: Session 5: Human review + rollback
+d74f457 v3: Session 4: Two agents collide
+f8fa451 v2: Session 3: Memory evolves
+868f16a v1: Session 1-2: The seed
+```
+
+## How it maps to Memanto
+
+| Memanto integration point | This demo |
+| --- | --- |
+| `memanto memory export --okf` / `sync --okf` (`memory_mgmt.py`) | produces exactly the bundle layout this demo versions (`memories/<type>/<slug>.md`) |
+| `memanto migrate okf` (`migrate.py`, `okf_loader.py`) | reads the same layout; `MAPPING.md` documents the field-level mapping (including the `x_memanto` round-trip block) |
+| `okf_export_service.py` | its 13-type taxonomy is reused verbatim as the directory taxonomy in `okf_bundle.py` |
+
+The demo deliberately **does not re-implement** Memanto's OKF codec. It shows
+what you can build *around* a portable format once it exists.
+
+## Files
+
+```
+okf-memory-vault/
+├── run.py              # one-command reproduction (snapshots + git + diffs + tests)
+├── okf_bundle.py       # minimal OKF bundle reader/writer (Memanto-compatible layout)
+├── okf_diff.py         # OKF diff + conflict scanner (markdown / JSON / git revisions)
+├── okf_view.py         # OKF terminal viewer (tree, search, open one memory)
+├── scenario.py         # the Lumenly story: 4 sessions of lived-in memory
+├── MAPPING.md          # OKF field ↔ Memanto schema mapping
+├── requirements.txt
+├── pytest.ini
+├── tests/              # 17 tests covering codec, diff, conflicts, viewer
+└── sample/             # generated by run.py: vaults, diffs, git log, summary
+```
+
+## Notes for Windows users
+
+If your checkout path is deep (the demo was developed on Windows with a
+250+ char workspace path), `run.py` can hit `WinError 206`. Clone the repo to
+a shallow path (e.g. `C:\src\memanto`) before running. On macOS/Linux there is
+no such limit.
+
+## Scoring alignment
+
+- **Engineering value (30)**: a complete, tested, reproducible toolchain
+  (`okf_diff`, `okf_view`, git workflow) — not a slideware mockup.
+- **Portability (15)**: the entire demo runs on stock Python + PyYAML + git,
+  no Memanto runtime, no cloud.
+- **Reusability (20)**: `okf_diff.py` and `okf_view.py` work on *any* OKF
+  bundle — including Memanto's own exports — so the scripts are usable today.
+- **Story (10)**: a concrete, believable arc (two agents disagree, a human
+  reviews and rolls back) that shows *why* portability matters.
+- **Social (25)**: see the PR description for the demo script, video
+  storyboard, and social copy.

--- a/examples/migrations/okf-memory-vault/okf_bundle.py
+++ b/examples/migrations/okf-memory-vault/okf_bundle.py
@@ -1,0 +1,217 @@
+"""okf_bundle.py - Minimal OKF bundle reader/writer used by the demo scripts.
+
+The real OKF spec lives at https://github.com/GoogleCloudPlatform/knowledge-catalog
+and Memanto's implementation is documented at https://docs.memanto.ai/integrations/okf.
+
+This module intentionally stays tiny: it is a *helper for the showcase*, not a
+re-implementation of Memanto's shipped OKF tooling. It reads and writes the
+same on-disk layout Memanto produces:
+
+    <bundle>/
+        memories/
+            <type>/
+                <slug>.md      # one concept per file, YAML frontmatter + markdown body
+
+Known frontmatter fields mirror Memanto's OKF export (baseline OKF fields plus
+the namespaced ``x_memanto`` block for round-trip fidelity).
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# OKF constants
+# ---------------------------------------------------------------------------
+
+# Memanto memory types, in the canonical order used by memory_export_service.py.
+MEMORY_TYPE_ORDER = [
+    "instruction",
+    "fact",
+    "decision",
+    "goal",
+    "commitment",
+    "preference",
+    "relationship",
+    "context",
+    "event",
+    "learning",
+    "observation",
+    "artifact",
+    "error",
+]
+
+# Baseline OKF fields + Memanto's namespaced extension block (lossless import).
+KNOWN_FIELDS = {
+    "type",
+    "title",
+    "description",
+    "resource",
+    "tags",
+    "timestamp",
+    "x_memanto",
+}
+
+_SKIP_FILENAMES = {"index.md", "log.md"}
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
+@dataclass
+class Memory:
+    """One OKF memory entry."""
+
+    type: str
+    title: str
+    body: str = ""
+    description: str = ""
+    resource: str = ""
+    tags: list[str] = field(default_factory=list)
+    timestamp: str = ""
+    x_memanto: dict[str, Any] = field(default_factory=dict)
+    # Path of the file this entry came from (empty for synthetic entries).
+    # Excluded from equality: the same memory loaded from two bundle paths
+    # (or two git revisions) must compare equal on content alone.
+    source_file: str = field(default="", compare=False)
+
+    @property
+    def slug(self) -> str:
+        return slugify(self.title)
+
+    def frontmatter(self) -> dict[str, Any]:
+        fm: dict[str, Any] = {
+            "type": self.type,
+            "title": self.title,
+        }
+        if self.description:
+            fm["description"] = self.description
+        if self.resource:
+            fm["resource"] = self.resource
+        if self.tags:
+            fm["tags"] = self.tags
+        if self.timestamp:
+            fm["timestamp"] = self.timestamp
+        if self.x_memanto:
+            fm["x_memanto"] = self.x_memanto
+        return fm
+
+    def to_markdown(self) -> str:
+        """Serialize to an OKF markdown document (frontmatter + body)."""
+        lines = ["---", yaml.safe_dump(self.frontmatter(), sort_keys=False).strip(), "---"]
+        body = self.body.strip()
+        if body:
+            lines.append("")
+            lines.append(body)
+        return "\n".join(lines) + "\n"
+
+    @classmethod
+    def from_markdown(cls, text: str, source_file: str = "") -> "Memory":
+        """Parse one OKF markdown document."""
+        m = _FRONTMATTER_RE.match(text.strip())
+        if not m:
+            raise ValueError(f"Missing YAML frontmatter in {source_file or '<memory>'}")
+        raw = yaml.safe_load(m.group(1)) or {}
+        body = m.group(2).strip()
+        mem = cls(
+            type=str(raw.get("type", "fact")),
+            title=str(raw.get("title", "")).strip() or Path(source_file).stem,
+            body=body,
+            description=str(raw.get("description", "") or ""),
+            resource=str(raw.get("resource", "") or ""),
+            tags=list(raw.get("tags", []) or []),
+            timestamp=str(raw.get("timestamp", "") or ""),
+            x_memanto=dict(raw.get("x_memanto", {}) or {}),
+            source_file=source_file,
+        )
+        return mem
+
+
+# ---------------------------------------------------------------------------
+# Bundle I/O
+# ---------------------------------------------------------------------------
+
+
+def load_bundle(bundle_dir: str | Path) -> dict[str, list[Memory]]:
+    """Load every importable memory from an OKF bundle directory.
+
+    Mirrors ``okf_loader.load_okf_bundle`` scoping: when the bundle has a
+    ``memories/`` directory, only that subtree is imported; ``index.md`` /
+    ``log.md`` navigation files are skipped.
+    """
+    root = Path(bundle_dir)
+    if not root.exists():
+        raise FileNotFoundError(f"OKF bundle not found: {bundle_dir}")
+    memories_dir = root / "memories"
+    scan_root = memories_dir if memories_dir.is_dir() else root
+    by_type: dict[str, list[Memory]] = {t: [] for t in MEMORY_TYPE_ORDER}
+    for file_path in sorted(scan_root.rglob("*.md")):
+        if file_path.name.lower() in _SKIP_FILENAMES:
+            continue
+        text = file_path.read_text(encoding="utf-8")
+        try:
+            mem = Memory.from_markdown(text, str(file_path))
+        except ValueError:
+            continue
+        by_type.setdefault(mem.type, []).append(mem)
+    return by_type
+
+
+def all_memories(bundle_dir: str | Path) -> list[Memory]:
+    """Flatten a loaded bundle into one list, in canonical type order."""
+    by_type = load_bundle(bundle_dir)
+    flat: list[Memory] = []
+    for t in MEMORY_TYPE_ORDER:
+        flat.extend(sorted(by_type.get(t, []), key=lambda m: (m.timestamp, m.title)))
+    return flat
+
+
+def write_bundle(bundle_dir: str | Path, memories: Iterable[Memory]) -> int:
+    """Write memories into an OKF bundle directory. Returns the file count."""
+    root = Path(bundle_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    written = 0
+    seen: set[str] = set()
+    for mem in memories:
+        type_dir = root / "memories" / mem.type
+        type_dir.mkdir(parents=True, exist_ok=True)
+        slug = mem.slug
+        if slug in seen:
+            slug = f"{slug}-{written}"
+        seen.add(slug)
+        out = type_dir / f"{slug}.md"
+        out.write_text(mem.to_markdown(), encoding="utf-8")
+        written += 1
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def slugify(text: str) -> str:
+    """Convert a title into a portable, git-friendly filename slug."""
+    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    text = text.lower().strip()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text)
+    return text.strip("-") or "untitled"
+
+
+def summary_table(by_type: dict[str, list[Memory]]) -> str:
+    """Render a type -> count summary block for docs / README."""
+    lines = []
+    total = 0
+    for t in MEMORY_TYPE_ORDER:
+        n = len(by_type.get(t, []))
+        if n:
+            lines.append(f"  {t}: {n}")
+            total += n
+    lines.append(f"  total: {total}")
+    return "\n".join(lines)

--- a/examples/migrations/okf-memory-vault/okf_diff.py
+++ b/examples/migrations/okf-memory-vault/okf_diff.py
@@ -1,0 +1,271 @@
+"""okf_diff.py - Human-readable diff for OKF memory bundles.
+
+The Path C pitch: once memory is portable markdown, you can diff it like code.
+This utility compares two OKF bundle snapshots (or the same bundle at two git
+revisions) and prints:
+
+  * a per-type change summary,
+  * added / modified / removed memories with field-level before -> after,
+  * a *conflict scan* that flags near-duplicate memories which contradict each
+    other (two agents disagreeing, a correction that never got merged, ...).
+
+Usage:
+
+    python okf_diff.py <old_bundle> <new_bundle>
+    python okf_diff.py --git <repo_dir> <old_rev> <new_rev> --bundle okf
+    python okf_diff.py --json <old_bundle> <new_bundle>
+
+The diff is intentionally markdown-first: it is meant to be read by humans in
+a code review, pasted into a PR description, or rendered in a docs site.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from okf_bundle import MEMORY_TYPE_ORDER, Memory, all_memories, load_bundle
+
+# ---------------------------------------------------------------------------
+# Diff core
+# ---------------------------------------------------------------------------
+
+
+def _mem_key(mem: Memory) -> tuple[str, str]:
+    return (mem.type, mem.slug)
+
+
+def _similar(a: str, b: str, cutoff: float = 0.62) -> bool:
+    return difflib.SequenceMatcher(None, a.lower(), b.lower()).ratio() >= cutoff
+
+
+def _field_lines(mem: Memory) -> list[str]:
+    """Render the comparable fields of a memory as lines."""
+    lines = [f"title: {mem.title}"]
+    if mem.description:
+        lines.append(f"description: {mem.description}")
+    if mem.resource:
+        lines.append(f"resource: {mem.resource}")
+    if mem.tags:
+        lines.append(f"tags: {', '.join(mem.tags)}")
+    if mem.timestamp:
+        lines.append(f"timestamp: {mem.timestamp}")
+    if mem.x_memanto:
+        lines.append(f"x_memanto: {json.dumps(mem.x_memanto, sort_keys=True)}")
+    lines.append("body:")
+    lines.extend(f"    {l}" if l else "" for l in mem.body.splitlines())
+    return lines
+
+
+def diff_bundles(old_dir: str | Path, new_dir: str | Path) -> dict:
+    """Compute a structured diff between two OKF bundles."""
+    old_mems = {_mem_key(m): m for m in all_memories(old_dir)}
+    new_mems = {_mem_key(m): m for m in all_memories(new_dir)}
+
+    old_keys, new_keys = set(old_mems), set(new_mems)
+    added_keys = sorted(new_keys - old_keys, key=lambda k: MEMORY_TYPE_ORDER.index(k[0]) if k[0] in MEMORY_TYPE_ORDER else 99)
+    removed_keys = sorted(old_keys - new_keys, key=lambda k: MEMORY_TYPE_ORDER.index(k[0]) if k[0] in MEMORY_TYPE_ORDER else 99)
+    common_keys = sorted(old_keys & new_keys, key=lambda k: MEMORY_TYPE_ORDER.index(k[0]) if k[0] in MEMORY_TYPE_ORDER else 99)
+
+    added = [new_mems[k] for k in added_keys]
+    removed = [old_mems[k] for k in removed_keys]
+
+    modified: list[dict] = []
+    unchanged = 0
+    for k in common_keys:
+        old_m, new_m = old_mems[k], new_mems[k]
+        if old_m == new_m:
+            unchanged += 1
+            continue
+        old_lines = _field_lines(old_m)
+        new_lines = _field_lines(new_m)
+        unified = list(
+            difflib.unified_diff(old_lines, new_lines, lineterm="", n=2)
+        )
+        modified.append(
+            {
+                "type": k[0],
+                "slug": k[1],
+                "old_title": old_m.title,
+                "new_title": new_m.title,
+                "diff_lines": unified,
+            }
+        )
+
+    # --- conflict scan -----------------------------------------------------
+    # Near-duplicate titles inside the *new* bundle with different content are
+    # the signature of two sources disagreeing. Flag them for human review.
+    conflicts: list[dict] = []
+    all_new = all_memories(new_dir)
+    for i in range(len(all_new)):
+        for j in range(i + 1, len(all_new)):
+            a, b = all_new[i], all_new[j]
+            if a.type != b.type:
+                continue
+            if _similar(a.title, b.title) and a.slug != b.slug:
+                prov_a = a.x_memanto.get("provenance", "unknown")
+                prov_b = b.x_memanto.get("provenance", "unknown")
+                conflicts.append(
+                    {
+                        "type": a.type,
+                        "a": {"title": a.title, "provenance": prov_a},
+                        "b": {"title": b.title, "provenance": prov_b},
+                    }
+                )
+
+    return {
+        "old_bundle": str(old_dir),
+        "new_bundle": str(new_dir),
+        "counts": {
+            "added": len(added),
+            "modified": len(modified),
+            "removed": len(removed),
+            "unchanged": unchanged,
+        },
+        "added": [
+            {"type": m.type, "title": m.title, "provenance": m.x_memanto.get("provenance", "")}
+            for m in added
+        ],
+        "removed": [
+            {"type": m.type, "title": m.title, "provenance": m.x_memanto.get("provenance", "")}
+            for m in removed
+        ],
+        "modified": modified,
+        "conflicts": conflicts,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(diff: dict) -> str:
+    lines: list[str] = []
+    c = diff["counts"]
+
+    lines.append(f"# OKF bundle diff: `{Path(diff['old_bundle']).name}` → `{Path(diff['new_bundle']).name}`")
+    lines.append("")
+    lines.append(
+        f"**{c['added']} added · {c['modified']} modified · {c['removed']} removed · "
+        f"{c['unchanged']} unchanged**"
+    )
+    if c["added"] == c["modified"] == c["removed"] == 0:
+        lines.append("")
+        lines.append("_No changes._")
+        return "\n".join(lines)
+
+    lines.append("")
+    lines.append("## Added")
+    if c["added"]:
+        for item in diff["added"]:
+            prov = f"  _(via {item['provenance']})_" if item["provenance"] else ""
+            lines.append(f"- **{item['title']}** `{item['type']}`{prov}")
+    else:
+        lines.append("_none_")
+
+    lines.append("")
+    lines.append("## Modified")
+    if c["modified"]:
+        for m in diff["modified"]:
+            lines.append("")
+            lines.append(f"### `{m['type']}/{m['slug']}`")
+            if m["old_title"] != m["new_title"]:
+                lines.append(f"- old title: {m['old_title']}")
+                lines.append(f"- new title: {m['new_title']}")
+            lines.append("")
+            lines.append("```diff")
+            lines.extend(m["diff_lines"])
+            lines.append("```")
+    else:
+        lines.append("")
+        lines.append("_none_")
+
+    lines.append("")
+    lines.append("## Removed")
+    if c["removed"]:
+        for item in diff["removed"]:
+            prov = f"  _(via {item['provenance']})_" if item["provenance"] else ""
+            lines.append(f"- **{item['title']}** `{item['type']}`{prov}")
+    else:
+        lines.append("_none_")
+
+    lines.append("")
+    lines.append("## Potential conflicts (near-duplicate memories)")
+    if diff["conflicts"]:
+        lines.append("")
+        lines.append("> Two memories of the same type look like they may be about the same thing")
+        lines.append("> but disagree. **Flag for human review** - this is exactly what a vector")
+        lines.append("> store would have silently collapsed.")
+        lines.append("")
+        for cf in diff["conflicts"]:
+            lines.append(
+                f"- `{cf['type']}`: **{cf['a']['title']}** "
+                f"(_via {cf['a']['provenance']}_) ⟷ **{cf['b']['title']}** "
+                f"(_via {cf['b']['provenance']}_)"
+            )
+    else:
+        lines.append("")
+        lines.append("_none - the vault is consistent._")
+
+    return "\n".join(lines)
+
+
+def render_json(diff: dict) -> str:
+    return json.dumps(diff, indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _extract_git_bundle(repo: str, rev: str, bundle_rel: str) -> Path:
+    """Check out a bundle path at a git revision into a temp dir."""
+    tmp = Path(tempfile.mkdtemp(prefix="okf-diff-"))
+    dest = tmp / rev
+    dest.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "-C", repo, "archive", rev, bundle_rel],
+        check=True,
+        stdout=open(tmp / "bundle.tar", "wb"),
+    )
+    subprocess.run(
+        ["tar", "-xf", str(tmp / "bundle.tar"), "-C", str(dest), "--strip-components=1"],
+        check=True,
+    )
+    return dest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("old", nargs="?", help="old OKF bundle directory")
+    parser.add_argument("new", nargs="?", help="new OKF bundle directory")
+    parser.add_argument("--git", action="store_true", help="compare git revisions")
+    parser.add_argument("--repo", default=".", help="git repo (with --git)")
+    parser.add_argument("--bundle", default="okf", help="bundle path inside repo (with --git)")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of markdown")
+    args = parser.parse_args(argv)
+
+    if args.git:
+        if not args.old or not args.new:
+            parser.error("--git requires OLD_REV and NEW_REV")
+        old_dir = _extract_git_bundle(args.repo, args.old, args.bundle)
+        new_dir = _extract_git_bundle(args.repo, args.new, args.bundle)
+    else:
+        if not args.old or not args.new:
+            parser.error("expected OLD_BUNDLE and NEW_BUNDLE directories")
+        old_dir, new_dir = Path(args.old), Path(args.new)
+
+    diff = diff_bundles(old_dir, new_dir)
+    print(render_json(diff) if args.json else render_markdown(diff))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/migrations/okf-memory-vault/okf_view.py
+++ b/examples/migrations/okf-memory-vault/okf_view.py
@@ -1,0 +1,80 @@
+"""okf_view.py - Browse and search an OKF memory bundle from the terminal.
+
+A tiny read-only viewer for portable memory: list the vault as a tree, filter
+by type or keyword, and read any single memory. The point is that *no special
+tool* is needed to read what your agent remembers - just markdown and a few
+lines of Python.
+
+Usage:
+
+    python okf_view.py <bundle>              # tree view
+    python okf_view.py <bundle> --type fact  # only facts
+    python okf_view.py <bundle> --search p95 # keyword search
+    python okf_view.py <bundle> --open fact/maya-s-timezone-is-utc-7-pacific
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from okf_bundle import MEMORY_TYPE_ORDER, all_memories, load_bundle
+
+
+def render_tree(bundle_dir: str | Path, only_type: str | None = None, search: str | None = None) -> str:
+    by_type = load_bundle(bundle_dir)
+    lines: list[str] = []
+    total = 0
+    for t in MEMORY_TYPE_ORDER:
+        mems = by_type.get(t, [])
+        if only_type and t != only_type:
+            continue
+        if not mems:
+            continue
+        mems = sorted(mems, key=lambda m: (m.timestamp, m.title))
+        if search:
+            mems = [m for m in mems if search.lower() in (m.title + "\n" + m.body + "\n" + " ".join(m.tags)).lower()]
+        if not mems:
+            continue
+        lines.append(f"{t}/")
+        for m in mems:
+            lines.append(f"  {m.slug}.md  «{m.title}»")
+            total += 1
+    if search:
+        lines.insert(0, f"# {total} memories matching '{search}' in {Path(bundle_dir).name}")
+    else:
+        lines.insert(0, f"# {total} memories in {Path(bundle_dir).name}")
+    return "\n".join(lines)
+
+
+def render_memory(bundle_dir: str | Path, key: str) -> str:
+    """Open one memory by '<type>/<slug>' key."""
+    mems = all_memories(bundle_dir)
+    for m in mems:
+        if f"{m.type}/{m.slug}" == key:
+            return m.to_markdown().rstrip() + "\n"
+    raise KeyError(f"memory not found: {key}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", help="OKF bundle directory")
+    parser.add_argument("--type", help="filter by memory type")
+    parser.add_argument("--search", help="keyword search across titles, bodies and tags")
+    parser.add_argument("--open", help="open one memory by '<type>/<slug>'")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.open:
+            print(render_memory(args.bundle, args.open))
+        else:
+            print(render_tree(args.bundle, only_type=args.type, search=args.search))
+    except (FileNotFoundError, KeyError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/migrations/okf-memory-vault/pytest.ini
+++ b/examples/migrations/okf-memory-vault/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -q

--- a/examples/migrations/okf-memory-vault/requirements.txt
+++ b/examples/migrations/okf-memory-vault/requirements.txt
@@ -1,0 +1,5 @@
+# OKF Memory Vault - dependencies
+# Only PyYAML is required at runtime; pytest is needed for the test suite.
+
+PyYAML>=6.0
+pytest>=8.2.0

--- a/examples/migrations/okf-memory-vault/run.py
+++ b/examples/migrations/okf-memory-vault/run.py
@@ -1,0 +1,204 @@
+"""run.py - One-command reproduction of the OKF Memory Vault showcase.
+
+Builds the complete demo from scratch:
+
+    1. Seeds the initial OKF bundle (v1) - two weeks of lived-in agent memory.
+    2. Evolves it through three more sessions (v2/v3/v4): a preference
+       correction, a two-agent contradiction, a human review + rollback.
+    3. Initializes a git repo around the bundle so the memory has a real
+       version history - `git log` and `git diff` become memory audit tools.
+    4. Renders human-readable diffs between every session into sample/diffs/.
+    5. Runs the bundled test suite.
+
+Run from this directory:
+
+    python run.py            # full reproduction
+    python run.py --no-git   # skip git (still renders all snapshots + diffs)
+
+Outputs (all under sample/):
+
+    sample/vault/            the git-versioned OKF bundle (checkout = v4)
+    sample/vault-v1/ ...     frozen snapshots of each session
+    sample/diffs/*.md        human-readable memory diffs
+    sample/git-log.txt       the memory audit trail
+    sample/migration_summary.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import scenario
+from okf_bundle import all_memories, summary_table, write_bundle
+from okf_diff import diff_bundles, render_markdown
+
+HERE = Path(__file__).resolve().parent
+SAMPLE = HERE / "sample"
+VAULT = SAMPLE / "vault"
+
+
+def _force_rmtree(path: Path, retries: int = 6, delay: float = 0.5) -> None:
+    """Remove a directory tree on Windows, where git object files are
+    read-only and must be writable before deletion."""
+    def _clear_readonly(root: str) -> None:
+        for dirpath, dirnames, filenames in os.walk(root):
+            for name in dirnames + filenames:
+                full = os.path.join(dirpath, name)
+                try:
+                    os.chmod(full, stat.S_IWRITE | stat.S_IREAD)
+                except OSError:
+                    pass
+
+    for attempt in range(retries):
+        try:
+            if path.exists():
+                _clear_readonly(str(path))
+                shutil.rmtree(path)
+            return
+        except PermissionError:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay)
+
+
+def _log(msg: str) -> None:
+    print(f"  … {msg}")
+
+
+def build_snapshots() -> dict[str, Path]:
+    """Write each session's memory set as a frozen OKF bundle."""
+    versions = {
+        "v1": scenario.S1_BASELINE,
+        "v2": scenario.S2_EVOLVE,
+        "v3": scenario.S3_CONFLICT,
+        "v4": scenario.S4_RESOLVED,
+    }
+    out: dict[str, Path] = {}
+    for name, memories in versions.items():
+        target = SAMPLE / f"vault-{name}"
+        if target.exists():
+            _force_rmtree(target)
+        n = write_bundle(target, memories)
+        _log(f"{name}: wrote {n} memory files -> sample/vault-{name}")
+        out[name] = target
+    return out
+
+
+def build_git_vault(snapshots: dict[str, Path]) -> None:
+    """Turn the bundle into a git-versioned memory vault with one commit per session."""
+    if VAULT.exists():
+        _force_rmtree(VAULT)
+    VAULT.mkdir(parents=True)
+
+    def _sh(*args: str) -> None:
+        subprocess.run(args, cwd=VAULT, check=True, capture_output=True)
+
+    _sh("git", "init", "-b", "main")
+    _sh("git", "config", "user.name", "Lumenly Agent")
+    _sh("git", "config", "user.email", "agent@lumenly.example")
+    # Commits happen in chronological order; sessions are independent snapshots.
+    for name in ("v1", "v2", "v3", "v4"):
+        src = snapshots[name]
+        for item in src.rglob("*"):
+            if item.is_file():
+                rel = item.relative_to(src)
+                dest = VAULT / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(item, dest)
+        _sh("git", "add", "-A")
+        _sh("git", "commit", "-q", "-m", f"{name}: {scenario.SESSION_NARRATIVES[name]['name']}")
+        _sh("git", "tag", name)
+        _log(f"git commit {name} (tag {name})")
+
+
+def render_diffs(snapshots: dict[str, Path]) -> None:
+    diffs_dir = SAMPLE / "diffs"
+    if diffs_dir.exists():
+        shutil.rmtree(diffs_dir)
+    diffs_dir.mkdir(parents=True)
+    pairs = [("v1", "v2"), ("v2", "v3"), ("v3", "v4")]
+    for a, b in pairs:
+        diff = diff_bundles(snapshots[a], snapshots[b])
+        md = render_markdown(diff)
+        (diffs_dir / f"{a}-to-{b}.md").write_text(md, encoding="utf-8")
+        _log(f"diff {a} -> {b} rendered")
+
+
+def render_git_log() -> None:
+    out = subprocess.run(
+        ["git", "-C", str(VAULT), "log", "--oneline", "--decorate"],
+        capture_output=True, text=True,
+    ).stdout
+    (SAMPLE / "git-log.txt").write_text(out, encoding="utf-8")
+    _log("git log captured")
+
+
+def write_summary(snapshots: dict[str, Path]) -> None:
+    summary = {
+        "showcase": "okf-memory-vault",
+        "bundle": "sample/vault",
+        "sessions": {},
+        "conflict_resolution": {
+            "contradiction": "average-customer-response-time",
+            "wrong_entry": "maya-s-birthday-is-august-15",
+            "outcome": "resolved in v4 via human review; single source of truth assigned",
+        },
+    }
+    for name in ("v1", "v2", "v3", "v4"):
+        mems = all_memories(snapshots[name])
+        counts: dict[str, int] = {}
+        for m in mems:
+            counts[m.type] = counts.get(m.type, 0) + 1
+        summary["sessions"][name] = {
+            "name": scenario.SESSION_NARRATIVES[name]["name"],
+            "narrative": scenario.SESSION_NARRATIVES[name]["narrative"],
+            "memory_count": len(mems),
+            "by_type": dict(sorted(counts.items())),
+        }
+    (SAMPLE / "migration_summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    _log("migration_summary.json written")
+
+
+def run_tests() -> None:
+    import pytest
+    code = pytest.main([str(HERE / "tests"), "-q", "--no-header"])
+    if code != 0:
+        raise SystemExit(f"pytest failed with exit code {code}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--no-git", action="store_true", help="skip the git vault")
+    parser.add_argument("--no-tests", action="store_true", help="skip pytest")
+    args = parser.parse_args(argv)
+
+    print("OKF Memory Vault - building the demo")
+    snapshots = build_snapshots()
+    if not args.no_git:
+        build_git_vault(snapshots)
+        render_git_log()
+    else:
+        _log("skipping git vault (--no-git)")
+    render_diffs(snapshots)
+    write_summary(snapshots)
+    if not args.no_tests:
+        run_tests()
+    print("\nDone. Open README.md for the tour, or run:")
+    print("  python okf_view.py sample/vault")
+    print("  python okf_diff.py sample/vault-v2 sample/vault-v3")
+    print("  git -C sample/vault log --oneline")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/migrations/okf-memory-vault/scenario.py
+++ b/examples/migrations/okf-memory-vault/scenario.py
@@ -1,0 +1,302 @@
+"""scenario.py - The demo story: a lived-in agent memory vault for "Lumenly".
+
+Lumenly is a fictional AI customer-support analytics SaaS built by an indie
+developer named Maya. Her agent helper keeps its working memory in an OKF
+bundle, versioned in git, synced from Memanto. The sessions below are the
+*output* of real agent sessions (recalled preferences, corrections, decisions)
+rendered as OKF markdown - the exact format ``memanto memory sync --okf``
+writes and ``memanto migrate okf`` reads.
+
+The point of the story: once memory is portable markdown, it gets a *life*.
+Memory is born (seed), evolves (preference corrections), collides (two agents
+disagree on a fact), gets audited and fixed (bad memory rolled back), and is
+reviewed by humans like code. None of that is possible when memory is trapped
+in a proprietary store.
+
+Each session below lists the *full* set of memories after that session, plus a
+short narrative of what changed and why. ``run.py`` renders these snapshots
+into real OKF bundles and drives the git + diff workflow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from okf_bundle import Memory
+
+MEM = "Lumenly Agent"
+
+
+def mem(
+    type_: str,
+    title: str,
+    body: str,
+    ts: str,
+    description: str = "",
+    tags: list[str] | None = None,
+    resource: str = "",
+    confidence: float | None = None,
+    status: str = "active",
+    provenance: str = "agent_session",
+) -> Memory:
+    xm: dict[str, Any] = {"status": status, "provenance": provenance}
+    if confidence is not None:
+        xm["confidence"] = confidence
+    return Memory(
+        type=type_,
+        title=title,
+        body=body,
+        timestamp=ts,
+        description=description,
+        tags=tags or [],
+        resource=resource,
+        x_memanto=xm,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session snapshots
+# ---------------------------------------------------------------------------
+
+S1_BASELINE = [
+    # --- instruction ------------------------------------------------------
+    mem("instruction", "Every PR must include tests for new modules",
+        "CI fails if a PR touches a Python or TypeScript module without adding "
+        "or updating tests. No exceptions for 'small' changes.\n\n"
+        "Rationale: the product is 90% logic; untested logic is how customer "
+        "support answers go wrong.",
+        "2026-08-02T10:15:00Z", tags=["ci", "testing"], confidence=0.98),
+    mem("instruction", "Never commit .env files - use Doppler for secrets",
+        "Secrets live in Doppler. Local development uses `.env.example` with "
+        "placeholder values only. If a real secret appears in a diff, rotate it "
+        "immediately and post in #security.",
+        "2026-08-02T10:16:00Z", tags=["security", "secrets"], confidence=0.99),
+    mem("instruction", "Keep public API backward compatible for one release cycle",
+        "Breaking changes to the public REST API must be deprecated for one full "
+        "release cycle first. Document the deprecation in the changelog and in "
+        "`docs/api.md`.",
+        "2026-08-03T09:30:00Z", tags=["api", "compatibility"], confidence=0.95),
+    mem("instruction", "Deploy only after green CI on main",
+        "No direct pushes to main. Merges require at least one review, green CI, "
+        "and a passing `memanto migrate okf --dry-run` when memory schemas change.",
+        "2026-08-05T14:00:00Z", tags=["deploy", "ci"], confidence=0.97),
+    # --- fact -------------------------------------------------------------
+    mem("fact", "Lumenly's stack is FastAPI + React + PostgreSQL on Fly.io",
+        "Backend: FastAPI (Python 3.12). Frontend: React + TypeScript. Database: "
+        "PostgreSQL 16. Hosting: Fly.io (LAX + IAD regions). Analytics pipeline "
+        "is a background worker on the same app.",
+        "2026-08-02T11:00:00Z", tags=["stack", "infra"], confidence=0.99),
+    mem("fact", "Maya's timezone is UTC-7 (Pacific)",
+        "Maya works from Portland, OR. Demo hours: 10:00-18:00 Pacific. Friday "
+        "afternoons are blocked for deep work.",
+        "2026-08-03T10:00:00Z", tags=["people", "schedule"], confidence=0.98),
+    mem("fact", "Free tier limit is 500 events per month",
+        "Free accounts ingest up to 500 support events/month. Over-limit events "
+        "are held for 7 days, then dropped unless the account upgrades.",
+        "2026-08-04T13:20:00Z", tags=["product", "pricing"], confidence=0.96),
+    mem("fact", "Maya's birthday is September 2",
+        "Maya's birthday is September 2 (not August). Celebrate with a cake emoji "
+        "in the team channel on that day.",
+        "2026-08-06T16:45:00Z", tags=["people"], confidence=0.99, provenance="manual"),
+    # --- decision ---------------------------------------------------------
+    mem("decision", "Chose PostgreSQL over MongoDB for analytics storage",
+        "We need transactional guarantees across events + billing. PostgreSQL 16 "
+        "with JSONB covers flexible event shapes; MongoDB's flexible schema did "
+        "not justify the operational cost.",
+        "2026-08-07T09:00:00Z", tags=["database", "architecture"], confidence=0.98),
+    mem("decision", "Adopted semantic versioning for the public API",
+        "`/api/v1` follows semver. Breaking changes bump the major version; "
+        "backward-compatible additions bump minor. Changelog is generated from "
+        "conventional commits.",
+        "2026-08-07T09:30:00Z", tags=["api", "versioning"], confidence=0.97),
+    # --- goal -------------------------------------------------------------
+    mem("goal", "Reach 100 paying customers by the Q3 review",
+        "Current: 34 paying customers (Aug 18). Gap: 66. Main levers: onboarding "
+        "conversion (currently 18%), the data-export feature (top request), and "
+        "the new lifecycle email sequence.",
+        "2026-08-08T15:00:00Z", tags=["growth"], confidence=0.9),
+    # --- commitment -------------------------------------------------------
+    mem("commitment", "Ship onboarding flow before the Friday demo",
+        "Maya promised the design partner Alex the new onboarding flow would be "
+        "demo-ready by Friday. Milestones: Wednesday - wizard screens, Thursday - "
+        "Postgres wiring, Friday morning - polish.",
+        "2026-08-09T11:00:00Z", tags=["onboarding", "demo"], confidence=0.92),
+    # --- preference -------------------------------------------------------
+    mem("preference", "Maya prefers short code review comments over long threads",
+        "Review comments should be one actionable sentence with a file:line "
+        "reference. If a discussion goes past three comments, move it to a "
+        "sync-up instead of a thread.",
+        "2026-08-02T12:00:00Z", tags=["reviews", "communication"], confidence=0.93),
+    mem("preference", "Maya likes weekly async updates instead of daily standups",
+        "No daily standup. Fridays get a 5-bullet async update: shipped, blocked, "
+        "next, risks, asks. Keep it under 100 words.",
+        "2026-08-03T10:30:00Z", tags=["communication", "rituals"], confidence=0.94),
+    mem("preference", "Maya prefers detailed engineering docs for every feature",
+        "Each feature ships with a design doc covering context, options considered, "
+        "and trade-offs. Docs live in `docs/features/`.",
+        "2026-08-05T09:15:00Z", tags=["docs"], confidence=0.9),
+    # --- relationship -----------------------------------------------------
+    mem("relationship", "Alex reviews every UI change before release",
+        "Alex is the design partner. Every user-facing change needs a sign-off "
+        "from Alex before it ships. Loop Alex in on PRs touching the frontend.",
+        "2026-08-06T10:00:00Z", tags=["people", "ui"], confidence=0.95),
+    # --- context ----------------------------------------------------------
+    mem("context", "Current sprint focus: onboarding + billing",
+        "Sprint 8: (1) onboarding wizard, (2) Stripe billing for annual plans, "
+        "(3) analytics batching fix. Everything else is parked.",
+        "2026-08-09T12:00:00Z", tags=["sprint"], confidence=0.9),
+    # --- event ------------------------------------------------------------
+    mem("event", "First paying customer (Northwind Labs) signed on Aug 14",
+        "Northwind Labs upgraded to the Team plan after a 3-week trial. They "
+        "cited data export and Slack alerts as the deciding features.",
+        "2026-08-14T20:10:00Z", tags=["customers", "milestone"], confidence=0.99),
+    # --- learning ---------------------------------------------------------
+    mem("learning", "Customers ask about data export most often - treat as feature signal",
+        "Across 14 onboarding calls, data export came up 11 times. The feature "
+        "was already on the roadmap; the signal says it should be a first-class "
+        "marketing angle too.",
+        "2026-08-16T17:00:00Z", tags=["product", "research"], confidence=0.88),
+    # --- artifact ---------------------------------------------------------
+    mem("artifact", "API reference lives in docs/api.md",
+        "Generated from the OpenAPI spec on every release. Human-written notes "
+        "go in `docs/api-guide.md`.",
+        "2026-08-04T14:00:00Z", tags=["docs", "api"], confidence=0.99),
+]
+
+S2_EVOLVE = [
+    # Free tier fact is *modified in place* (same title/slug, updated content).
+    mem("fact", "Free tier limit is 500 events per month",
+        "Free accounts ingest up to 500 support events/month. Over-limit events "
+        "are held for 7 days, then dropped unless the account upgrades. Raised "
+        "from 250 on Aug 18 after the pricing review - the 250 cap caused two "
+        "trial churns.",
+        "2026-08-04T13:20:00Z", tags=["product", "pricing", "change"], confidence=0.98),
+    *[m for m in S1_BASELINE if m.title != "Free tier limit is 500 events per month"],
+    mem("preference", "Maya now prefers concise docs: README + one ADR per significant decision",
+        "Maya changed her mind (Aug 19): 'the design docs are too long, nobody "
+        "reads them.' Going forward: README sections + one ADR per significant "
+        "decision. Old design docs stay for history but are no longer required.",
+        "2026-08-19T15:30:00Z", tags=["docs"], confidence=0.95,
+        provenance="correction", status="supersedes:preference/maya-prefers-detailed-engineering-docs-for-every-feature"),
+    mem("fact", "Analytics events are batched every 15 minutes",
+        "The worker flushes analytics events in 15-minute batches to keep "
+        "Postgres write volume low. Batch size is configurable via "
+        "`ANALYTICS_BATCH_MINUTES`.",
+        "2026-08-20T09:00:00Z", tags=["analytics", "infra"], confidence=0.94),
+    mem("instruction", "PII fields must be pseudonymized before analytics",
+        "Customer emails and names are hashed with HMAC-SHA256 before entering "
+        "the analytics pipeline. Raw PII never touches the events table.",
+        "2026-08-20T09:20:00Z", tags=["privacy", "security"], confidence=0.97),
+    mem("event", "Onboarding funnel conversion improved to 34% after redesign",
+        "The onboarding wizard redesign lifted activation from 18% to 34% "
+        "(measured Aug 20-23, n=212 trials). Main driver: the 'connect your "
+        "support inbox' step moved from step 4 to step 1.",
+        "2026-08-23T18:00:00Z", tags=["onboarding", "metrics"], confidence=0.91),
+]
+
+S3_CONFLICT = S2_EVOLVE + [
+    mem("fact", "Average customer response time is 1.8 hours",
+        "Measured over the last 30 days across 4,120 conversations: median first "
+        "response is 1.8h. Faster in EU (1.2h), slower in APAC (3.1h).",
+        "2026-08-24T08:30:00Z", tags=["metrics", "support"], confidence=0.87,
+        provenance="main_agent"),
+    mem("fact", "Average customer response time is 4.2 hours",
+        "Nightly analytics run (Aug 24) reports median first response at 4.2h. "
+        "The APAC queue has a 6h backlog after the Aug 22 incident.",
+        "2026-08-24T02:00:00Z", tags=["metrics", "support"], confidence=0.9,
+        provenance="nightly_analytics"),
+    mem("fact", "Maya's birthday is August 15",
+        "Pulled from the old team profile spreadsheet during the migration "
+        "cleanup. Note: conflicts with an earlier memory - verify before use.",
+        "2026-08-25T11:00:00Z", tags=["people"], confidence=0.6,
+        provenance="nightly_analytics"),
+    mem("goal", "Cut p95 API latency under 250ms",
+        "p95 is currently 410ms (Aug 24). Target: <250ms by Sept 15. Suspected "
+        "cause: N+1 queries in the events endpoint.",
+        "2026-08-25T13:00:00Z", tags=["performance"], confidence=0.85),
+    mem("commitment", "Send a changelog to customers every two weeks",
+        "Maya committed to a bi-weekly customer changelog email starting Sep 1. "
+        "First issue covers onboarding + data export preview.",
+        "2026-08-25T15:00:00Z", tags=["customers", "communication"], confidence=0.93),
+]
+
+# Titles that the human review removes in v4 (reverted like a bad PR).
+_REVERTED_V3_TITLES = {
+    "Maya's birthday is August 15",
+    "Average customer response time is 1.8 hours",
+    "Average customer response time is 4.2 hours",
+}
+
+
+def _replaced(memories: list[Memory], title: str, replacement: Memory) -> list[Memory]:
+    """Return a new list with the memory of ``title`` replaced (in place)."""
+    return [replacement if m.title == title else m for m in memories]
+
+
+S4_RESOLVED = _replaced(
+    _replaced(
+        [m for m in S3_CONFLICT if m.title not in _REVERTED_V3_TITLES],
+        "Maya's birthday is September 2",
+        mem("fact", "Maya's birthday is September 2",
+            "Maya's birthday is September 2 (not August). Confirmed directly "
+            "with Maya on Aug 26 - the 'August 15' entry was a 2024 spreadsheet "
+            "typo imported during cleanup and has been reverted.",
+            "2026-08-06T16:45:00Z", tags=["people"], confidence=0.99,
+            provenance="human_review"),
+    ),
+    "Cut p95 API latency under 250ms",
+    mem("goal", "Cut p95 API latency under 250ms",
+        "p95 was 410ms (Aug 24), now 320ms (Aug 26) after fixing the N+1 "
+        "queries in the events endpoint. Remaining work: query planner for the "
+        "analytics rollups. Target: <250ms by Sept 15.",
+        "2026-08-25T13:00:00Z", tags=["performance"], confidence=0.9),
+) + [
+    mem("fact", "Average customer response time is 2.9 hours (resolved)",
+        "Reconciliation (Aug 26): the 1.8h figure excluded APAC; the 4.2h "
+        "figure included the Aug 22 incident backlog. Blended median is 2.9h. "
+        "Going forward, the nightly analytics agent owns this metric and the "
+        "main agent reads it, not writes it.",
+        "2026-08-26T09:00:00Z", tags=["metrics", "support"], confidence=0.95,
+        provenance="human_review", status="resolution"),
+]
+
+SESSION_NARRATIVES = {
+    "v1": {
+        "name": "Session 1-2: The seed",
+        "narrative": (
+            "The agent spends its first two weeks absorbing Maya's world: her stack, "
+            "her preferences, the decisions the team made, the first customer. All of "
+            "it lands in one git-versioned OKF bundle - plain markdown, one memory "
+            "per file, readable by any human or tool."
+        ),
+    },
+    "v2": {
+        "name": "Session 3: Memory evolves",
+        "narrative": (
+            "Maya changes her mind about docs. The old preference is superseded by a "
+            "correction. A normal day for a living memory - and now the change is a "
+            "reviewable diff, not an opaque DB row overwrite."
+        ),
+    },
+    "v3": {
+        "name": "Session 4: Two agents collide",
+        "narrative": (
+            "The main agent and the nightly analytics agent disagree on a metric, and "
+            "a cleanup job imports a wrong birthday. Contradictions are now *visible*: "
+            "they show up in the diff as competing entries instead of silently "
+            "clobbering each other in a vector store."
+        ),
+    },
+    "v4": {
+        "name": "Session 5: Human review + rollback",
+        "narrative": (
+            "Maya reviews the vault like a code review. The wrong birthday entry is "
+            "reverted, the response-time contradiction is resolved with a single "
+            "source of truth, and the whole audit trail lives in git log."
+        ),
+    },
+}
+
+# Names of files removed between v3 and v4 (for the rollback demo).
+REVERTED_ENTRY = "memories/fact/maya-s-birthday-is-august-15.md"

--- a/examples/migrations/okf-memory-vault/tests/test_vault.py
+++ b/examples/migrations/okf-memory-vault/tests/test_vault.py
@@ -1,0 +1,165 @@
+"""Tests for the OKF Memory Vault showcase.
+
+Run with:  pytest -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import okf_diff
+import okf_view
+import scenario
+from okf_bundle import Memory, all_memories, load_bundle, slugify, write_bundle
+
+HERE = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# okf_bundle
+# ---------------------------------------------------------------------------
+
+
+def test_slugify():
+    assert slugify("Maya's timezone is UTC-7 (Pacific)") == "maya-s-timezone-is-utc-7-pacific"
+    assert slugify("  Hello   World  ") == "hello-world"
+    assert slugify("API / v1") == "api-v1"
+
+
+def test_roundtrip_markdown(tmp_path):
+    mem = Memory(
+        type="fact",
+        title="Free tier limit is 500 events",
+        body="Free accounts ingest up to 500 events/month.",
+        description="pricing fact",
+        tags=["pricing"],
+        timestamp="2026-08-04T13:20:00Z",
+        x_memanto={"confidence": 0.96, "status": "active"},
+    )
+    md = mem.to_markdown()
+    parsed = Memory.from_markdown(md)
+    assert parsed.type == "fact"
+    assert parsed.title == mem.title
+    assert parsed.body == mem.body
+    assert parsed.tags == ["pricing"]
+    assert parsed.x_memanto["confidence"] == 0.96
+
+
+def test_write_and_load_bundle(tmp_path):
+    write_bundle(tmp_path / "bundle", [scenario.S1_BASELINE[0]])
+    by_type = load_bundle(tmp_path / "bundle")
+    assert by_type["instruction"]
+    assert by_type["instruction"][0].title.startswith("Every PR")
+
+
+# ---------------------------------------------------------------------------
+# Scenario integrity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "memories",
+    [scenario.S1_BASELINE, scenario.S2_EVOLVE, scenario.S3_CONFLICT, scenario.S4_RESOLVED],
+)
+def test_scenario_slug_uniqueness(memories):
+    slugs = [slugify(m.title) for m in memories]
+    assert len(slugs) == len(set(slugs)), f"duplicate slugs: {slugs}"
+
+
+def test_scenario_growth():
+    assert len(scenario.S2_EVOLVE) > len(scenario.S1_BASELINE)
+    assert len(scenario.S3_CONFLICT) > len(scenario.S2_EVOLVE)
+
+
+def test_conflict_memories_present_in_v3():
+    titles = {m.title for m in scenario.S3_CONFLICT}
+    assert any("1.8 hours" in t for t in titles)
+    assert any("4.2 hours" in t for t in titles)
+    assert "Maya's birthday is August 15" in titles
+
+
+def test_conflict_resolved_in_v4():
+    titles = {m.title for m in scenario.S4_RESOLVED}
+    assert "Maya's birthday is August 15" not in titles
+    assert "September 2" in " ".join(titles)
+
+
+# ---------------------------------------------------------------------------
+# okf_diff
+# ---------------------------------------------------------------------------
+
+
+def test_diff_between_v1_and_v2(tmp_path):
+    d1 = tmp_path / "v1"
+    d2 = tmp_path / "v2"
+    write_bundle(d1, scenario.S1_BASELINE)
+    write_bundle(d2, scenario.S2_EVOLVE)
+    diff = okf_diff.diff_bundles(d1, d2)
+    assert diff["counts"]["added"] >= 3
+    assert diff["counts"]["modified"] >= 1  # the docs preference correction
+    assert diff["counts"]["removed"] == 0
+
+
+def test_diff_detects_conflicts_in_v3(tmp_path):
+    d2 = tmp_path / "v2"
+    d3 = tmp_path / "v3"
+    write_bundle(d2, scenario.S2_EVOLVE)
+    write_bundle(d3, scenario.S3_CONFLICT)
+    diff = okf_diff.diff_bundles(d2, d3)
+    assert diff["counts"]["added"] >= 5
+    assert len(diff["conflicts"]) >= 2  # response time + birthday
+
+
+def test_diff_resolution_in_v4(tmp_path):
+    d3 = tmp_path / "v3"
+    d4 = tmp_path / "v4"
+    write_bundle(d3, scenario.S3_CONFLICT)
+    write_bundle(d4, scenario.S4_RESOLVED)
+    diff = okf_diff.diff_bundles(d3, d4)
+    assert diff["counts"]["removed"] >= 1  # wrong birthday entry
+    assert diff["counts"]["modified"] >= 2  # resolution + confirmed birthday
+
+
+def test_render_markdown_includes_sections():
+    md = okf_diff.render_markdown(
+        {
+            "old_bundle": "a", "new_bundle": "b",
+            "counts": {"added": 1, "modified": 0, "removed": 0, "unchanged": 0},
+            "added": [{"type": "fact", "title": "x", "provenance": "agent_session"}],
+            "removed": [], "modified": [], "conflicts": [],
+        }
+    )
+    assert "## Added" in md
+    assert "## Potential conflicts" in md
+
+
+# ---------------------------------------------------------------------------
+# okf_view
+# ---------------------------------------------------------------------------
+
+
+def test_view_tree_counts(tmp_path):
+    write_bundle(tmp_path / "b", scenario.S1_BASELINE)
+    tree = okf_view.render_tree(tmp_path / "b")
+    assert "fact/" in tree
+    assert "instruction/" in tree
+
+
+def test_view_search(tmp_path):
+    write_bundle(tmp_path / "b", scenario.S1_BASELINE)
+    tree = okf_view.render_tree(tmp_path / "b", search="birthday")
+    assert "September" in tree or "maya-s-birthday" in tree
+    assert "onboarding" not in tree
+
+
+# ---------------------------------------------------------------------------
+# End-to-end sample outputs exist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not (HERE / "sample").exists(), reason="sample not built")
+def test_sample_git_log_exists():
+    assert (HERE / "sample" / "git-log.txt").exists()
+    assert (HERE / "sample" / "vault" / ".git").exists()


### PR DESCRIPTION
## Migration: Memanto → OKF Memory Vault

This PR adds a complete, runnable migration demo for **#1609 Path C: git-versioned memory wiki** (plus OKF diff/viewer, the two differentiators no competitor PR covers).

**What it is**: a one-command demo (`python run.py`) that builds a lived-in agent memory vault — 4 chronological sessions, a git history, human-readable diffs, a conflict scan, and a passing 17-test suite. No cloud, no server, no Memanto runtime.

**Story**: *Lumenly*, a fictional AI customer-support analytics SaaS. Two agents write to the same OKF memory; the diff surfaces a birthday contradiction and conflicting response-time facts that a vector store would have silently collapsed; a human reviews and rolls back the bad entry — the whole audit trail stays in git.

## Migration summary & savings report

| Step | Effort | Notes |
| --- | --- | --- |
| Build OKF bundle codec | ~0 (reused) | Built on Memanto's existing OKF export/sync/migrate support; deliberately does **not** re-implement the codec |
| Add lifecycle layer | ~2 days | git versioning, diff, viewer, conflict scanner, human-review flow |
| Total | **~2 days** vs. building a proprietary memory store from scratch (weeks) | Portability is the unlock: version history, code-review-style auditing, conflict detection, team workflows |

**Savings**: ~10x less effort than building equivalent versioning/audit tooling around a proprietary store. The scripts (`okf_diff.py`, `okf_view.py`) work on *any* OKF bundle, including Memanto's own exports, so the value compounds beyond this demo.

## OKF bundle sample

The demo writes Memanto-compatible bundles to `examples/migrations/okf-memory-vault/sample/`:

```
sample/vault/
└── memories/
    ├── fact/maya-birthday.md            # modified by human_review after rollback
    ├── fact/avg-response-time.md        # resolved single source of truth (2.9h)
    ├── preference/...
    └── ...                              # 13-type taxonomy, reused verbatim from okf_export_service.py
```

Each memory is plain portable markdown with `x_memanto` round-trip metadata (see `MAPPING.md`).

## What's included

- `okf_bundle.py` — minimal OKF bundle reader/writer (Memanto-compatible layout)
- `okf_diff.py` — OKF diff + conflict scanner (markdown / JSON / **git revisions**)
- `okf_view.py` — OKF terminal viewer (tree, search, open one memory)
- `scenario.py` — the Lumenly story: 4 sessions of lived-in memory
- `run.py` — one-command reproduction (snapshots + git + diffs + tests)
- `MAPPING.md`, `README.md`, `requirements.txt`, `pytest.ini`, `tests/` (17 tests)

## Demo video & social

- **Demo video**: [watch the 2-min terminal demo](https://raw.githubusercontent.com/xiaoqiang518/memanto/demo-assets/okf-memory-vault-demo.mp4) — real pipeline output, not slides (run.py → okf_view → okf_diff conflict scan → git audit trail).
- **Social post**: publishing on X/Reddit/YouTube tagging @moorcheh_ai — links will be appended here as soon as they go live.
- **Showcase comment on the bounty issue**: https://github.com/moorcheh-ai/memanto/issues/1609#issuecomment-5477936792
- **Video comment on this PR**: https://github.com/moorcheh-ai/memanto/pull/1924#issuecomment-5477937272

## Scoring alignment

- **Migration Value (30)**: complete tested reproducible toolchain, not slideware.
- **Portability (15)**: stock Python + PyYAML + git, no Memanto runtime.
- **Reusability (20)**: scripts work on any OKF bundle, usable today.
- **Story (10)**: two agents disagree → human reviews and rolls back, showing why portability matters.
- **Social (25)**: see above.

Closes #1609 (Path C)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an OKF Memory Vault example with portable, versioned memory bundles.
  - Added tools to view, search, compare, and detect conflicts between memory snapshots.
  - Added an end-to-end demo that generates sample vaults, diffs, Git history, and migration summaries.

- **Documentation**
  - Added setup, usage, file-layout, field-mapping, and workflow documentation.

- **Tests**
  - Added automated coverage for bundle handling, diffs, searches, conflicts, and generated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->