### PR TITLE
fix(security): redact secrets from error responses

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -50,6 +50,7 @@ from memanto.app.utils.errors import (
     AuthorizationError,
     MemoryOperationError,
     map_error_to_http_exception,
+    redact_sensitive_text,
 )
 from memanto.app.utils.temporal_helpers import (
     END_OF_DAY,
@@ -397,7 +398,8 @@ def resolve_recall_limit(request_limit: int | None) -> int:
         limit = int(raw_limit)
     except (TypeError, ValueError) as e:
         raise HTTPException(
-            status_code=400, detail=f"Invalid recall configuration: {e}"
+            status_code=400,
+            detail=redact_sensitive_text(f"Invalid recall configuration: {e}"),
         ) from e
     if limit < 1:
         raise HTTPException(
@@ -954,7 +956,8 @@ async def recall(
         )
     except (TypeError, ValueError) as e:
         raise HTTPException(
-            status_code=400, detail=f"Invalid recall configuration: {e}"
+            status_code=400,
+            detail=redact_sensitive_text(f"Invalid recall configuration: {e}"),
         )
     try:
         # Initialize memory read service
@@ -1573,7 +1576,7 @@ async def get_policy_preset(
     try:
         policy = load_preset(name)
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=redact_sensitive_text(str(e)))
 
     return {
         "name": name,
@@ -1602,7 +1605,7 @@ async def apply_policy_preset(
     try:
         policy = load_preset(request.name)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=redact_sensitive_text(str(e)))
 
     try:
         service = MemoryPolicyService(client)

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -33,6 +33,7 @@ from memanto.app.routes.auth_deps import (
     clear_session_cookie,
     set_session_cookie,
 )
+from memanto.app.utils.errors import redact_sensitive_text
 from memanto.app.utils.temporal_helpers import utc_date_str
 from memanto.app.utils.validation import validate_safe_id
 from memanto.cli.client.direct_client import DirectClient
@@ -207,13 +208,17 @@ async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
             try:
                 server_updates["port"] = _validate_server_port(server_updates["port"])
             except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
+                raise HTTPException(
+                    status_code=400, detail=redact_sensitive_text(str(exc))
+                ) from exc
 
     if "schedule_time" in updates:
         try:
             _config_manager.set_schedule_time(updates["schedule_time"])
         except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
+            raise HTTPException(
+                status_code=400, detail=redact_sensitive_text(str(e))
+            ) from e
 
     if "session" in updates:
         if not isinstance(updates["session"], dict):
@@ -221,7 +226,9 @@ async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
         try:
             _config_manager.set_session_config(updates["session"])
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(
+                status_code=400, detail=redact_sensitive_text(str(exc))
+            ) from exc
 
     if "cli" in updates and isinstance(updates["cli"], dict):
         data = _config_manager.load_yaml()
@@ -255,7 +262,9 @@ async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
                     kiosk_mode=ans.get("kiosk_mode") if "kiosk_mode" in ans else None,
                 )
             except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
+                raise HTTPException(
+                    status_code=400, detail=redact_sensitive_text(str(exc))
+                ) from exc
 
     if "recall" in updates and isinstance(updates["recall"], dict):
         rec = updates["recall"]
@@ -355,11 +364,12 @@ def _update_onprem_answer(ans: dict) -> None:
     except ImportError as e:
         raise HTTPException(
             status_code=500,
-            detail=f"moorcheh-client not installed: {e}",
+            detail=redact_sensitive_text(f"moorcheh-client not installed: {e}"),
         )
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Failed to persist LLM config: {e}"
+            status_code=500,
+            detail=redact_sensitive_text(f"Failed to persist LLM config: {e}"),
         )
 
     _config_manager.set_onprem_state(llm_provider=provider, llm_model=model)
@@ -466,7 +476,10 @@ async def _do_restart_onprem_backend(_asyncio, subprocess, _httpx):
     try:
         await _asyncio.to_thread(subprocess.run, up_args, check=True, timeout=300)
     except subprocess.CalledProcessError as e:
-        raise HTTPException(status_code=500, detail=f"`moorcheh up` failed: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=redact_sensitive_text(f"`moorcheh up` failed: {e}"),
+        )
     except subprocess.TimeoutExpired:
         raise HTTPException(
             status_code=500, detail="`moorcheh up` timed out after 5 minutes."
@@ -628,7 +641,10 @@ async def read_daily_summary(
     try:
         content = path.read_text(encoding="utf-8")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to read summary: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=redact_sensitive_text(f"Failed to read summary: {e}"),
+        )
     return {
         "exists": True,
         "agent_id": agent_id,
@@ -666,7 +682,7 @@ async def generate_daily_summary(
         )
         return {"agent_id": agent_id, "date": date, **result}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=redact_sensitive_text(str(e)))
 
 
 @router.post("/api/ui/conflicts/generate")
@@ -696,7 +712,7 @@ async def generate_conflict_report(
         result = client.generate_conflict_report(agent_id=str(agent_id), date=str(date))
         return {"agent_id": agent_id, "date": date, **result}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=redact_sensitive_text(str(e)))
 
 
 @router.post("/api/ui/conflicts/resolve")
@@ -737,9 +753,9 @@ async def resolve_conflict(body: dict, _: None = Depends(_require_local)):
         )
         return result
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=redact_sensitive_text(str(e)))
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=redact_sensitive_text(str(e)))
 
 
 @router.get("/api/ui/connections")
@@ -1059,7 +1075,7 @@ def _migrate_langfuse_config(options: dict) -> Any:
         try:
             return [parse_score_rule(str(item)) for item in raw]
         except ScoreRuleError as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
+            raise HTTPException(status_code=400, detail=redact_sensitive_text(str(exc)))
 
     def number(key: str, fallback: float | None) -> float | None:
         if options.get(key) in (None, ""):
@@ -1086,7 +1102,7 @@ def _migrate_langfuse_config(options: dict) -> Any:
         )
         return CaptureConfig.from_project(merged)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=redact_sensitive_text(str(exc)))
 
 
 def _migrate_langfuse_export(api_key: str, options: dict) -> tuple[str, dict]:
@@ -1128,9 +1144,12 @@ def _migrate_langfuse_export(api_key: str, options: dict) -> tuple[str, dict]:
             discover=discover,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=redact_sensitive_text(str(exc)))
     except Exception as exc:
-        raise HTTPException(status_code=502, detail=f"Langfuse export failed: {exc}")
+        raise HTTPException(
+            status_code=502,
+            detail=redact_sensitive_text(f"Langfuse export failed: {exc}"),
+        )
     return str(export_path), export
 
 
@@ -1186,7 +1205,9 @@ def _migrate_load_or_export(
         except (json.JSONDecodeError, OSError, ValueError) as exc:
             raise HTTPException(
                 status_code=400,
-                detail=f"Export file is not valid JSON: {file_path} ({exc})",
+                detail=redact_sensitive_text(
+                    f"Export file is not valid JSON: {file_path} ({exc})"
+                ),
             )
 
     if not api_key or not api_key.strip():
@@ -1211,7 +1232,10 @@ def _migrate_load_or_export(
     try:
         export_path, export = exporter(api_key.strip(), dest)
     except Exception as e:
-        raise HTTPException(status_code=502, detail=f"{provider} export failed: {e}")
+        raise HTTPException(
+            status_code=502,
+            detail=redact_sensitive_text(f"{provider} export failed: {e}"),
+        )
     return str(export_path), export
 
 
@@ -1444,7 +1468,10 @@ async def migrate_import(body: dict, _: None = Depends(_require_local)):
                 on_progress=None,
             )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Import failed: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=redact_sensitive_text(f"Import failed: {e}"),
+        )
     elapsed_ms = round((time.perf_counter() - started) * 1000)
 
     savings = _migrate_savings(provider, export)

--- a/memanto/app/utils/errors.py
+++ b/memanto/app/utils/errors.py
@@ -2,9 +2,101 @@
 Error Handling and Mapping
 """
 
+import re
+from collections.abc import Mapping
 from typing import Any
 
 from fastapi import HTTPException
+
+_REDACTED = "[REDACTED]"
+
+_AUTH_HEADER_PATTERN = re.compile(
+    r"\b(Authorization\s*:\s*(?:Bearer|Basic|Token)\s+)([^\s,'\"}]+)",
+    re.IGNORECASE,
+)
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"\b(api[_-]?key|session[_-]?token|access[_-]?token|refresh[_-]?token|"
+    r"password|secret)\b(\s*[:=]\s*)([^\s,'\"}]+)",
+    re.IGNORECASE,
+)
+_CLI_SECRET_ARG_PATTERN = re.compile(
+    r"((?:--|/)[A-Za-z0-9_-]*(?:api[-_]?key|token|secret|password)"
+    r"[A-Za-z0-9_-]*(?:['\"]?,\s*['\"]|\s+))([^'\"\s,]+)",
+    re.IGNORECASE,
+)
+_BARE_SECRET_PATTERN = re.compile(
+    r"\b(?:mk_[A-Za-z0-9_-]{16,}|sk-[A-Za-z0-9_-]{16,}|"
+    r"gh[opsru]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}|"
+    r"hf_[A-Za-z0-9_]{16,}|xox[baprs]-[A-Za-z0-9-]{16,})\b"
+)
+_JWT_PATTERN = re.compile(
+    r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"
+)
+_SENSITIVE_DETAIL_KEYS = {
+    "api_key",
+    "apikey",
+    "authorization",
+    "password",
+    "secret",
+    "session_token",
+    "token",
+    "x_api_key",
+    "access_token",
+    "refresh_token",
+}
+
+
+def redact_sensitive_text(text: str) -> str:
+    """Redact secrets from text before exposing it to API callers."""
+    redacted = _AUTH_HEADER_PATTERN.sub(rf"\1{_REDACTED}", text)
+    redacted = _SECRET_ASSIGNMENT_PATTERN.sub(rf"\1\2{_REDACTED}", redacted)
+    redacted = _CLI_SECRET_ARG_PATTERN.sub(rf"\1{_REDACTED}", redacted)
+    redacted = _JWT_PATTERN.sub(_REDACTED, redacted)
+    return _BARE_SECRET_PATTERN.sub(_REDACTED, redacted)
+
+
+def _is_sensitive_detail_key(key: object) -> bool:
+    normalized = str(key).lower().replace("-", "_")
+    return normalized in _SENSITIVE_DETAIL_KEYS or normalized.endswith(
+        ("_api_key", "_password", "_secret", "_token")
+    )
+
+
+def sanitize_error_details(value: Any) -> Any:
+    """Recursively redact secrets from details included in client errors."""
+    if isinstance(value, str):
+        return redact_sensitive_text(value)
+
+    if isinstance(value, bytes):
+        return redact_sensitive_text(value.decode(errors="replace"))
+
+    if isinstance(value, Mapping):
+        return {
+            key: _REDACTED
+            if _is_sensitive_detail_key(key)
+            else sanitize_error_details(item)
+            for key, item in value.items()
+        }
+
+    if isinstance(value, list):
+        return [sanitize_error_details(item) for item in value]
+
+    if isinstance(value, tuple):
+        return tuple(sanitize_error_details(item) for item in value)
+
+    return value
+
+
+def _http_error(
+    status_code: int,
+    error_type: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+) -> HTTPException:
+    return HTTPException(
+        status_code=status_code,
+        detail=create_error_response(error_type, message, details),
+    )
 
 
 class MemantoError(Exception):
@@ -96,117 +188,49 @@ def map_error_to_http_exception(error: Exception) -> HTTPException:
     """Map internal errors to HTTP exceptions"""
 
     if isinstance(error, HTTPException):
-        return error
+        return HTTPException(
+            status_code=error.status_code,
+            detail=sanitize_error_details(error.detail),
+            headers=error.headers,
+        )
 
     if isinstance(error, ValidationError):
-        return HTTPException(
-            status_code=400,
-            detail={
-                "error": "ValidationError",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(400, "ValidationError", error.message, error.details)
 
     elif isinstance(error, MemoryOperationError):
-        return HTTPException(
-            status_code=500,
-            detail={
-                "error": "MemoryOperationError",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(500, "MemoryOperationError", error.message, error.details)
 
     elif isinstance(error, NamespaceError):
-        return HTTPException(
-            status_code=400,
-            detail={
-                "error": "NamespaceError",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(400, "NamespaceError", error.message, error.details)
 
     elif isinstance(error, AuthenticationError):
-        return HTTPException(
-            status_code=401,
-            detail={
-                "error": "AuthenticationError",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(401, "AuthenticationError", error.message, error.details)
 
     elif isinstance(error, AuthorizationError):
-        return HTTPException(
-            status_code=403,
-            detail={
-                "error": "AuthorizationError",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(403, "AuthorizationError", error.message, error.details)
 
     elif isinstance(error, SessionExpiredError):
-        return HTTPException(
-            status_code=401,
-            detail={
-                "error": "SessionExpired",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(401, "SessionExpired", error.message, error.details)
 
     elif isinstance(error, SessionNotFoundError):
-        return HTTPException(
-            status_code=404,
-            detail={
-                "error": "SessionNotFound",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(404, "SessionNotFound", error.message, error.details)
 
     elif isinstance(error, InvalidSessionTokenError):
-        return HTTPException(
-            status_code=401,
-            detail={
-                "error": "InvalidSessionToken",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(401, "InvalidSessionToken", error.message, error.details)
 
     elif isinstance(error, AgentNotFoundError):
-        return HTTPException(
-            status_code=404,
-            detail={
-                "error": "AgentNotFound",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(404, "AgentNotFound", error.message, error.details)
 
     elif isinstance(error, AgentAlreadyExistsError):
-        return HTTPException(
-            status_code=409,
-            detail={
-                "error": "AgentAlreadyExists",
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return _http_error(409, "AgentAlreadyExists", error.message, error.details)
 
     else:
         # Generic server error
-        return HTTPException(
-            status_code=500,
-            detail={
-                "error": "InternalServerError",
-                "message": "An unexpected error occurred",
-                "details": {"original_error": str(error)},
-            },
+        return _http_error(
+            500,
+            "InternalServerError",
+            "An unexpected error occurred",
+            {"original_error": str(error)},
         )
 
 
@@ -214,4 +238,8 @@ def create_error_response(
     error_type: str, message: str, details: dict[str, Any] | None = None
 ) -> dict[str, Any]:
     """Create standardized error response"""
-    return {"error": error_type, "message": message, "details": details or {}}
+    return {
+        "error": error_type,
+        "message": redact_sensitive_text(message),
+        "details": sanitize_error_details(details or {}),
+    }

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -1,0 +1,86 @@
+from fastapi import HTTPException
+
+from memanto.app.utils.errors import (
+    MemoryOperationError,
+    create_error_response,
+    map_error_to_http_exception,
+)
+
+
+def test_generic_errors_redact_secrets_from_client_details():
+    api_key = "mk_" + ("a" * 40)
+    session_token = "eyJ" + ("b" * 20) + "." + ("c" * 20) + "." + ("d" * 20)
+    error = RuntimeError(
+        f"upstream failed with Authorization: Bearer {api_key} "
+        f"session_token={session_token}"
+    )
+
+    http_error = map_error_to_http_exception(error)
+    rendered_detail = repr(http_error.detail)
+
+    assert http_error.status_code == 500
+    assert api_key not in rendered_detail
+    assert session_token not in rendered_detail
+    assert "[REDACTED]" in rendered_detail
+
+
+def test_memanto_errors_redact_nested_detail_values():
+    github_token = "gho_" + ("e" * 36)
+    openai_key = "sk-proj-" + ("f" * 40)
+    session_token = "eyJ" + ("g" * 20) + "." + ("h" * 20) + "." + ("i" * 20)
+    error = MemoryOperationError(
+        f"backend rejected api_key={openai_key}",
+        details={
+            "headers": {"Authorization": f"Bearer {github_token}"},
+            "records": [{"session_token": session_token}],
+            "safe": "kept",
+        },
+    )
+
+    http_error = map_error_to_http_exception(error)
+    rendered_detail = repr(http_error.detail)
+
+    assert http_error.status_code == 500
+    assert "kept" in rendered_detail
+    assert github_token not in rendered_detail
+    assert openai_key not in rendered_detail
+    assert session_token not in rendered_detail
+    assert "[REDACTED]" in rendered_detail
+
+
+def test_http_exceptions_are_sanitized_when_remapped():
+    github_token = "ghp_" + ("k" * 36)
+    error = HTTPException(
+        status_code=403,
+        detail={"error": f"Authorization: Bearer {github_token}"},
+        headers={"Retry-After": "1"},
+    )
+
+    http_error = map_error_to_http_exception(error)
+    rendered_detail = repr(http_error.detail)
+
+    assert http_error.status_code == 403
+    assert http_error.headers == {"Retry-After": "1"}
+    assert github_token not in rendered_detail
+    assert "[REDACTED]" in rendered_detail
+
+
+def test_create_error_response_redacts_sensitive_fields():
+    api_key = "mk_" + ("j" * 40)
+    cli_key = "provider-key-value-12345"
+
+    response = create_error_response(
+        "ValidationError",
+        "bad request",
+        {
+            "x-api-key": api_key,
+            "hint": f"use api_key={api_key}",
+            "command": f"['moorcheh', 'up', '--embedding-api-key', '{cli_key}']",
+        },
+    )
+    rendered_response = repr(response)
+
+    assert api_key not in rendered_response
+    assert cli_key not in rendered_response
+    assert response["details"]["x-api-key"] == "[REDACTED]"
+    assert "[REDACTED]" in rendered_response


### PR DESCRIPTION
Refs #1852

## Security finding
Some API/UI error paths echoed raw exception text back to clients. Upstream SDK, HTTP client, and subprocess exceptions can include credentials in their string representation, such as `Authorization: Bearer <token>`, `api_key=<key>`, JWT-like session tokens, or command arguments like `--embedding-api-key <key>`. The generic error mapper also included `details.original_error = str(error)` in 500 responses.

## Fix
- Add centralized redaction for authorization headers, common API key formats, JWT-like values, sensitive key/value assignments, and CLI secret flags.
- Sanitize standardized Memanto error responses, nested `details`, and already-created `HTTPException` instances that are remapped.
- Apply the same redaction to direct HTTPException paths in memory and UI routes that previously exposed `str(e)` or exception f-strings.
- Add unit tests covering generic exceptions, MemantoError detail payloads, remapped HTTPException details, and CLI secret arguments.

## Validation
- `.venv\Scripts\python.exe -m ruff check memanto\app\utils\errors.py memanto\app\routes\memory.py memanto\app\ui\routes\ui_router.py tests\test_error_redaction.py`
- `.venv\Scripts\python.exe -m ruff format --check memanto\app\utils\errors.py memanto\app\routes\memory.py memanto\app\ui\routes\ui_router.py tests\test_error_redaction.py`
- `.venv\Scripts\python.exe -m pytest tests\test_error_redaction.py -q`
- `.venv\Scripts\python.exe -m pytest tests\test_ui_auth.py tests\test_remaining_ui_auth.py tests\test_memory_policy.py -q`
- `.venv\Scripts\python.exe -m pytest -q` passes locally; live Moorcheh E2E tests are skipped without a real API key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sensitive information is now automatically removed from error messages and response details.
  - Configuration, policy, export, migration, and processing errors no longer expose credentials, tokens, authorization headers, file paths, or other confidential values.
  - Existing HTTP error status codes and headers are preserved while details are sanitized.

- **Tests**
  - Added coverage confirming redaction across nested error details and common credential formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->