### PR TITLE
fix: auto session regenerate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,8 @@ MOORCHEH_API_KEY=your_api_key_here
 # SESSION_AUTO_RENEW_ENABLED=True
 # SESSION_AUTO_RENEW_INTERVAL_HOURS=6
 # SESSION_EXTEND_THRESHOLD_MINUTES=30
+# Issue a fresh session on the first request after one has fully expired,
+# instead of failing with 401. Still requires management access (a valid
+# management credential or a loopback caller), and never revives a session
+# that was explicitly ended.
+# SESSION_AUTO_RECREATE_ENABLED=True

--- a/docs/SESSION_ARCHITECTURE.md
+++ b/docs/SESSION_ARCHITECTURE.md
@@ -347,6 +347,33 @@ def validate_session(session_token: str) -> Session:
     return Session(**payload)
 ```
 
+#### Auto-Recreate After Expiry
+
+When `auto_recreate_enabled` is on (the default), a request that presents a
+token whose session has *fully lapsed* is not rejected outright — MEMANTO
+issues a brand-new session and continues, returning the replacement token in
+the `X-Session-Token` response header (and refreshing the cookie for browser
+callers). This is what lets you pick MEMANTO back up after an idle gap without
+hitting "No active session".
+
+Three rules bound it:
+
+- **Authorization is unchanged.** Recreation runs behind the same
+  `require_management_access` check as explicit activation — a valid management
+  credential or a loopback caller. A stolen expired token on its own buys
+  nothing, and anyone who *does* pass that check could already call
+  `/activate` directly, so no new capability is granted.
+- **Logout is authoritative.** A session ended via `/deactivate` is
+  `TERMINATED` and is never revived; the caller must activate explicitly.
+- **Stale tokens never supersede a newer session.** The token's `session_id`
+  must still match the persisted record, so an old token cannot displace a
+  session that was already replaced.
+
+Note the trade-off: with auto-recreate on, expiry no longer bounds how long a
+leaked token remains useful to a caller who also has management access. Set
+`SESSION_AUTO_RECREATE_ENABLED=False` (or `auto_recreate_enabled: false`) where
+that matters.
+
 ### 3. Agent Isolation
 
 ```python
@@ -420,6 +447,13 @@ memanto:
     extend_threshold_minutes: 30  # Extend if < 30 min remaining
     auto_renew_enabled: true
     auto_renew_interval_hours: 6  # Fresh session every 6 hours
+    auto_recreate_enabled: true   # Fresh session on first request after expiry
+
+  # The two booleans above are overlaid onto the server settings at startup.
+  # An explicitly exported SESSION_AUTO_RENEW_ENABLED / SESSION_AUTO_RECREATE_ENABLED
+  # wins, so containerised deployments stay environment-driven. The numeric
+  # session fields are read by the CLI only; set them via SESSION_* env vars
+  # to change server behaviour.
 
   cli:
     interactive_mode: true

--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -56,6 +56,21 @@ if _config_file.exists():
             if _smart_parse is not None:
                 os.environ["AUTO_PARSE_ENABLED"] = str(_smart_parse)
 
+            # Session toggles. The Web UI and ``memanto config`` persist these
+            # to config.yaml, but SessionService reads them off ``settings``,
+            # so without this they would be inert for the server and only
+            # half-honoured by the CLI. Use setdefault so an explicitly
+            # exported SESSION_AUTO_* (containerised deployments) still wins.
+            _session = _memanto.get("session", {})
+            if isinstance(_session, dict):
+                for _yaml_key, _env_key in (
+                    ("auto_renew_enabled", "SESSION_AUTO_RENEW_ENABLED"),
+                    ("auto_recreate_enabled", "SESSION_AUTO_RECREATE_ENABLED"),
+                ):
+                    _toggle = _session.get(_yaml_key)
+                    if isinstance(_toggle, bool):
+                        os.environ.setdefault(_env_key, str(_toggle))
+
             # Backend selection (cloud | on-prem)
             _backend = _memanto.get("backend")
             if _backend:
@@ -99,6 +114,7 @@ class SessionConfig(BaseModel):
     warn_before_expiry_minutes: int = 15
     auto_renew_enabled: bool = True
     auto_renew_interval_hours: int = 6
+    auto_recreate_enabled: bool = True
 
 
 class CLIConfig(BaseModel):
@@ -144,6 +160,9 @@ class Settings(BaseSettings):
     SESSION_EXTEND_THRESHOLD_MINUTES: int = 30
     SESSION_AUTO_RENEW_ENABLED: bool = True
     SESSION_AUTO_RENEW_INTERVAL_HOURS: int = 6
+    # Transparently issue a fresh session (new token) when a request presents
+    # an expired-but-not-terminated token. Gated behind management access.
+    SESSION_AUTO_RECREATE_ENABLED: bool = True
 
     # Memory Configuration
     DEFAULT_TTL_SECONDS: int = 3600  # 1 hour

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -182,12 +182,16 @@ def get_current_session(
     response: Response,
     x_session_token: str | None = Header(None),
     session_cookie: str | None = Cookie(None, alias=SESSION_COOKIE_NAME),
+    authorization: str | None = Header(None),
+    x_api_key: str | None = Header(None, alias="X-Api-Key"),
 ) -> Session:
     """
     Get and validate current session
 
     Args:
         x_session_token: Session token header
+        authorization: Bearer management credential (for auto-recreate)
+        x_api_key: Management credential header (for auto-recreate)
 
     Returns:
         Validated Session
@@ -234,5 +238,58 @@ def get_current_session(
 
         return session
 
-    except (SessionExpiredError, SessionNotFoundError, InvalidSessionTokenError) as e:
+    except SessionExpiredError as e:
+        # The presented token belongs to a session that has fully lapsed.
+        # With SESSION_AUTO_RECREATE_ENABLED the caller gets a fresh session
+        # on this first operation — but only after passing the same
+        # management-access check as explicit activation (valid API key or
+        # loopback origin), so a stolen stale token alone is worthless.
+        recreated = _maybe_auto_recreate_session(
+            request=request,
+            response=response,
+            session_token=session_token,
+            x_session_token=x_session_token,
+            session_cookie=session_cookie,
+            authorization=authorization,
+            x_api_key=x_api_key,
+        )
+        if recreated is None:
+            raise map_error_to_http_exception(e)
+        return recreated
+
+    except (SessionNotFoundError, InvalidSessionTokenError) as e:
         raise map_error_to_http_exception(e)
+
+
+def _maybe_auto_recreate_session(
+    request: Request,
+    response: Response,
+    session_token: str,
+    x_session_token: str | None,
+    session_cookie: str | None,
+    authorization: str | None,
+    x_api_key: str | None,
+) -> Session | None:
+    """Attempt transparent recreation of an expired session.
+
+    Returns the fresh Session, or None when recreation does not apply
+    (disabled by config, terminated/logout session, superseded token) or is
+    not authorized — in which case the original expiry error surfaces.
+    """
+    try:
+        require_management_access(request, authorization, x_api_key)
+    except HTTPException:
+        return None
+
+    recreated = get_session_service().check_and_auto_recreate(session_token)
+    if recreated is None:
+        return None
+
+    # Mirror the auto-renewal handoff: refresh the browser cookie and/or
+    # return the replacement token so the next request authenticates.
+    if session_cookie:
+        set_session_cookie(response, recreated.session_token, request)
+    if x_session_token:
+        response.headers["X-Session-Token"] = recreated.session_token
+
+    return recreated

--- a/memanto/app/services/session_service.py
+++ b/memanto/app/services/session_service.py
@@ -417,26 +417,34 @@ class SessionService:
         session_file = self.sessions_dir / f"{agent_id}.json"
         return self._load_session_file(session_file)
 
+    def _read_active_marker_agent_id(self) -> str | None:
+        """Read the agent_id the active marker points at, or None.
+
+        Caller must hold ``_active_marker_lock``.
+        """
+        active_link = self.sessions_dir / "active"
+        try:
+            # Read symlink (or file on Windows). Another process can replace
+            # or remove the marker while this process holds its local lock.
+            if active_link.is_symlink():
+                return active_link.readlink().stem
+            with open(active_link) as f:
+                return f.read().strip()
+        except OSError:
+            return None
+
     def get_active_session(self) -> Session | None:
         """
         Get currently active session
 
         Returns:
-            Session object or None if no active session or session is expired
+            Session object or None when there is no active marker, or the
+            marker named a session that has lapsed and could not be
+            auto-recreated.
         """
         with self._active_marker_lock:
-            active_link = self.sessions_dir / "active"
-
-            try:
-                # Read symlink (or file on Windows). Another process can replace
-                # or remove the marker while this process holds its local lock.
-                if active_link.is_symlink():
-                    target = active_link.readlink()
-                    agent_id = target.stem
-                else:
-                    with open(active_link) as f:
-                        agent_id = f.read().strip()
-            except OSError:
+            agent_id = self._read_active_marker_agent_id()
+            if agent_id is None:
                 return None
 
             try:
@@ -450,13 +458,36 @@ class SessionService:
             if not session:
                 return None
 
-            # If session is expired, clear the stale marker and return None.
-            # The marker lock is re-entrant for this cleanup path.
-            if not session.is_active():
-                self._clear_active_session()
-                return None
+            if session.is_active():
+                return session
 
-            return session
+            expired_token = session.session_token
+
+        # The marker names a session that has lapsed. Auto-recreate has to run
+        # outside the marker lock: it takes the agent lifecycle lock, and
+        # delete_session takes those two in the opposite order, so holding both
+        # here would invert the lock order.
+        #
+        # This is what keeps MEMANTO usable after an idle gap. Every CLI entry
+        # point resolves its session through this marker, so clearing it on
+        # expiry stranded the caller with "No active session. Call
+        # activate_agent()" regardless of the auto-recreate setting.
+        recreated = self.check_and_auto_recreate(expired_token)
+        if recreated is not None:
+            return recreated
+
+        # Recreation declined (disabled by config, or the session was
+        # terminated). Drop the stale marker, but only if it still names the
+        # same lapsed session - another thread may have activated since.
+        with self._active_marker_lock:
+            if self._read_active_marker_agent_id() == agent_id:
+                try:
+                    current = self.get_session(agent_id)
+                except (ValueError, OSError):
+                    current = None
+                if current is None or not current.is_active():
+                    self._clear_active_session()
+        return None
 
     def end_session(self, agent_id: str) -> SessionSummary:
         """
@@ -570,6 +601,63 @@ class SessionService:
                 )
 
         return None
+
+    def check_and_auto_recreate(
+        self,
+        session_token: str,
+    ) -> Session | None:
+        """
+        Recreate an expired session as a fresh one if auto-recreate is enabled.
+
+        Complements check_and_auto_renew: renewal keeps a *live* session
+        going near expiry, while this path transparently issues a brand-new
+        session (new JWT, fresh expiry window) when a caller presents the
+        token of a session that has already fully lapsed. Deliberately
+        terminated sessions are never resurrected; callers must activate
+        explicitly after logout. Authorization is the route layer's job
+        (management credential or loopback), same as explicit activation.
+
+        Args:
+            session_token: The expired JWT presented by the caller
+        Returns:
+            New Session if recreated, None when recreation does not apply
+        """
+        if not settings.SESSION_AUTO_RECREATE_ENABLED:
+            return None
+
+        try:
+            payload = jwt.decode(session_token, self.secret_key, algorithms=["HS256"])
+            token = SessionToken(**payload)
+        except (jwt.InvalidTokenError, ValidationError):
+            # Not ours / malformed / unsignable: leave it to normal validation
+            # to surface the right error.
+            return None
+
+        try:
+            agent_lock = self._lock_for_agent(token.agent_id)
+        except ValueError:
+            # A token we signed but whose agent_id is no longer a safe id.
+            # Leave it to normal validation to reject rather than raising an
+            # unhandled 500 out of the auth dependency.
+            return None
+
+        with agent_lock:
+            session = self.get_session(token.agent_id)
+            if not session or session.session_id != token.session_id:
+                # Unknown agent, or the persisted record was replaced by a
+                # newer session — never supersede it from a stale token.
+                return None
+
+            if session.status == SessionStatus.TERMINATED or session.is_active():
+                # Logout is authoritative; live sessions are handled by the
+                # regular validation/auto-renewal flow instead.
+                return None
+
+            return self.create_session(
+                agent_id=token.agent_id,
+                pattern=session.pattern,
+                duration_hours=settings.SESSION_DEFAULT_DURATION_HOURS,
+            )
 
     def _save_session(self, session: Session) -> None:
         """Save session to file.

--- a/memanto/app/ui/routes/ui_router.py
+++ b/memanto/app/ui/routes/ui_router.py
@@ -213,6 +213,17 @@ async def update_ui_config(updates: dict, _: None = Depends(_require_local)):
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+        # config.yaml is overlaid onto settings at process start, so apply the
+        # session toggles to the running server too - otherwise flipping them
+        # in the UI would not take effect until the next restart.
+        for _yaml_key, _settings_attr in (
+            ("auto_renew_enabled", "SESSION_AUTO_RENEW_ENABLED"),
+            ("auto_recreate_enabled", "SESSION_AUTO_RECREATE_ENABLED"),
+        ):
+            _toggle = updates["session"].get(_yaml_key)
+            if isinstance(_toggle, bool):
+                setattr(settings, _settings_attr, _toggle)
+
     if "cli" in updates and isinstance(updates["cli"], dict):
         data = _config_manager.load_yaml()
         if "cli" not in data:

--- a/memanto/app/ui/static/index.html
+++ b/memanto/app/ui/static/index.html
@@ -4195,6 +4195,7 @@
                 </div>
                 <div style="display:flex;flex-direction:column;gap:12px;margin-top:8px">
                     ${cfgToggle('cfgSessAutoRenew', 'Auto-renew sessions before expiry', sess.auto_renew_enabled ?? true)}
+                    ${cfgToggle('cfgSessAutoRecreate', 'Auto-create a fresh session after expiry (next request)', sess.auto_recreate_enabled ?? true)}
                 </div>
             </div>
             <!-- ANSWER CONFIG -->
@@ -4328,6 +4329,7 @@
                         extend_threshold_minutes: parseInt(document.getElementById('cfgSessExtendThreshold').value) || 30,
                         auto_renew_enabled: document.getElementById('cfgSessAutoRenew').checked,
                         auto_renew_interval_hours: parseInt(document.getElementById('cfgSessRenewInterval').value) || 6,
+                        auto_recreate_enabled: document.getElementById('cfgSessAutoRecreate').checked,
                     },
                     answer: isOnPrem()
                         ? (() => {

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -389,7 +389,17 @@ class DirectClient:
         try:
             # Validate JWT token
             token_payload = session_service.validate_session(self.session_token)
-        except (SessionExpiredError, InvalidSessionTokenError):
+        except SessionExpiredError:
+            # The stored session fully lapsed (e.g. the process was idle past
+            # its expiry). With auto-recreate enabled, transparently issue a
+            # fresh session on this first operation instead of failing.
+            recreated = session_service.check_and_auto_recreate(self.session_token)
+            if recreated is None:
+                raise
+            self._cached_session = recreated
+            self.session_token = recreated.session_token
+            return recreated
+        except InvalidSessionTokenError:
             # Surface the same specific session errors as the service
             raise
 

--- a/memanto/cli/client/sdk_client.py
+++ b/memanto/cli/client/sdk_client.py
@@ -221,7 +221,17 @@ class SdkClient:
         try:
             # Validate JWT token
             token_payload = session_service.validate_session(self.session_token)
-        except (SessionExpiredError, InvalidSessionTokenError):
+        except SessionExpiredError:
+            # The stored session fully lapsed (e.g. the process was idle past
+            # its expiry). With auto-recreate enabled, transparently issue a
+            # fresh session on this first operation instead of failing.
+            recreated = session_service.check_and_auto_recreate(self.session_token)
+            if recreated is None:
+                raise
+            self._cached_session = recreated
+            self.session_token = recreated.session_token
+            return recreated
+        except InvalidSessionTokenError:
             # Surface the same specific session errors as the service
             raise
 

--- a/memanto/cli/commands/_shared.py
+++ b/memanto/cli/commands/_shared.py
@@ -11,6 +11,7 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 
+from memanto.app.config import settings
 from memanto.app.services.session_service import get_session_service
 from memanto.app.utils.errors import InvalidSessionTokenError, SessionExpiredError
 
@@ -119,16 +120,19 @@ def get_client() -> SdkClient:
 
     # Restore active session if available
     active_agent_id, active_session_token = config_manager.get_active_session()
-    session_cfg = config_manager.get_session_config()
 
     if active_session_token and active_agent_id:
         client.session_token = active_session_token
         client.agent_id = active_agent_id
 
-        # Validate the stored token (signature + expiry) and silently re-activate
-        # when auto-renew is enabled. The old expiry-only check missed invalid
-        # signatures, which broke analyze LLM narratives mid-run.
-        if session_cfg.get("auto_renew_enabled", True):
+        # Expiry is already handled upstream: get_active_session() auto-recreates
+        # a lapsed session, so the token above is fresh. What remains here is a
+        # token that no longer verifies at all - typically a rotated
+        # MEMANTO_SECRET_KEY - which used to break analyze LLM narratives
+        # mid-run. Gate it on the same single toggle as every other path
+        # (settings, which config.yaml feeds) rather than re-reading the YAML,
+        # so turning auto-recreate off disables it everywhere.
+        if settings.SESSION_AUTO_RECREATE_ENABLED:
             session_service = get_session_service()
             needs_reactivate = False
             try:

--- a/memanto/cli/config/manager.py
+++ b/memanto/cli/config/manager.py
@@ -56,7 +56,11 @@ _SESSION_CONFIG_LIMITS = {
     "warn_before_expiry_minutes": (1, 1440),
     "auto_renew_interval_hours": (1, 168),
 }
-_SESSION_CONFIG_BOOLEANS = {"auto_extend", "auto_renew_enabled"}
+_SESSION_CONFIG_BOOLEANS = {
+    "auto_extend",
+    "auto_renew_enabled",
+    "auto_recreate_enabled",
+}
 
 
 def _validate_positive_int_config(name: str, value, minimum: int, maximum: int) -> int:
@@ -444,6 +448,7 @@ class ConfigManager:
             "warn_before_expiry_minutes": 15,
             "auto_renew_enabled": True,
             "auto_renew_interval_hours": 6,
+            "auto_recreate_enabled": True,
         }
         defaults.update(self._dict_section(self.load_yaml(), "session"))
         return defaults

--- a/sdks/typescript/openapi.json
+++ b/sdks/typescript/openapi.json
@@ -104,6 +104,22 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
             "name": "X-Api-Key",
             "in": "header",
             "required": false,
@@ -203,6 +219,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           },
           {
@@ -317,6 +349,22 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
             "name": "X-Api-Key",
             "in": "header",
             "required": false,
@@ -424,6 +472,22 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
             "name": "X-Api-Key",
             "in": "header",
             "required": false,
@@ -511,6 +575,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           },
           {
@@ -614,6 +694,38 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
             "name": "memanto_session_token",
             "in": "cookie",
             "required": false,
@@ -697,6 +809,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           },
           {
@@ -802,6 +930,38 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
             "name": "memanto_session_token",
             "in": "cookie",
             "required": false,
@@ -888,6 +1048,38 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
             "name": "memanto_session_token",
             "in": "cookie",
             "required": false,
@@ -968,6 +1160,38 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -1072,6 +1296,38 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
             "name": "memanto_session_token",
             "in": "cookie",
             "required": false,
@@ -1143,6 +1399,38 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           },
           {
@@ -1227,6 +1515,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           },
           {
@@ -1332,6 +1636,22 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
             "name": "X-Api-Key",
             "in": "header",
             "required": false,
@@ -1431,6 +1751,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           },
           {
@@ -1545,6 +1881,22 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
             "name": "X-Api-Key",
             "in": "header",
             "required": false,
@@ -1656,6 +2008,22 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
             "name": "X-Api-Key",
             "in": "header",
             "required": false,
@@ -1746,6 +2114,22 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
             "name": "X-Api-Key",
             "in": "header",
             "required": false,
@@ -1831,6 +2215,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           },
           {
@@ -1934,6 +2334,38 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
             "name": "memanto_session_token",
             "in": "cookie",
             "required": false,
@@ -2017,6 +2449,38 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Api-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
             "name": "memanto_session_token",
             "in": "cookie",
             "required": false,
@@ -2088,6 +2552,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           },
           {
@@ -2191,6 +2671,22 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
             "name": "X-Api-Key",
             "in": "header",
             "required": false,
@@ -2290,6 +2786,22 @@
                 }
               ],
               "title": "X-Session-Token"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           },
           {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,22 @@ def reset_auto_parse(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def reset_session_toggles(monkeypatch):
+    """Pin the session toggles to their defaults for every test.
+
+    ``memanto.app.config`` overlays ``~/.memanto/config.yaml`` onto ``settings``
+    at import time, so a developer who has switched auto-renew or auto-recreate
+    off locally would otherwise change how the suite behaves. Tests that
+    exercise the disabled path override this with their own ``patch.object``.
+    The overlay itself is covered in ``tests/test_session_config_overlay.py``.
+    """
+    from memanto.app.config import settings
+
+    monkeypatch.setattr(settings, "SESSION_AUTO_RENEW_ENABLED", True)
+    monkeypatch.setattr(settings, "SESSION_AUTO_RECREATE_ENABLED", True)
+
+
+@pytest.fixture(autouse=True)
 def force_cloud_backend(monkeypatch):
     """Force ``settings.MEMANTO_BACKEND='cloud'`` and a placeholder API key so
     the dispatcher never tries to instantiate ``OnPremClient`` during

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import tempfile
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -3018,3 +3019,166 @@ class TestRealpathGuard:
         assert not os.path.realpath(malicious_path).startswith(
             os.path.realpath(tmp_dir) + os.sep
         )
+
+
+class TestSessionAutoRecreate:
+    """Coming back to MEMANTO after a session has fully lapsed.
+
+    ``SESSION_AUTO_RECREATE_ENABLED`` (default on) issues a brand-new session
+    on the first operation that presents an expired-but-not-terminated token,
+    instead of failing with 401. It is gated by the same management-access
+    check as explicit activation, so a stolen stale token alone is worthless.
+    """
+
+    TEST_AGENT_ID = "test-agent"
+
+    @staticmethod
+    def _remote_client():
+        """Client whose requests look like they came from a network peer.
+
+        The default ``ASGITransport`` reports ``127.0.0.1``, which satisfies
+        ``require_management_access``'s loopback branch and would hide any
+        regression in the credential check.
+        """
+        transport = ASGITransport(app=app, client=("203.0.113.5", 5000))
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    async def _activate_expired(self, client, auth_headers):
+        """Create the agent and return a session token that has already lapsed."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        # duration 0 makes expires_at == started_at, so the JWT is fully
+        # lapsed once the clock moves past it.
+        with patch.object(settings, "SESSION_DEFAULT_DURATION_HOURS", 0):
+            activate_resp = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+            )
+        assert activate_resp.status_code == 200
+        time.sleep(1)
+        client.cookies = Cookies()
+        return activate_resp.json()["session_token"]
+
+    @pytest.mark.asyncio
+    async def test_header_expired_session_auto_recreates_fresh_token(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """The first operation after expiry succeeds and hands back a new token."""
+        old_token = await self._activate_expired(client, auth_headers)
+
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers={**auth_headers, "X-Session-Token": old_token},
+            json={},
+        )
+        assert response.status_code == 200
+
+        new_token = response.headers.get("x-session-token")
+        assert new_token
+        assert new_token != old_token
+
+        # The expired token no longer authenticates; the new one does.
+        stale_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers={**auth_headers, "X-Session-Token": old_token},
+            json={},
+        )
+        assert stale_response.status_code == 401
+
+        fresh_response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers={**auth_headers, "X-Session-Token": new_token},
+            json={},
+        )
+        assert fresh_response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_remote_caller_without_credential_gets_no_new_session(
+        self, mock_moorcheh
+    ):
+        """A stale token alone must not buy a session from off-box.
+
+        Auto-recreate is gated on ``require_management_access``. For a
+        non-loopback peer that means a valid management credential; without one
+        (or with the wrong one) the plain expiry 401 has to stand and no
+        replacement token may be handed out.
+        """
+        auth_headers = {"Authorization": f"Bearer {settings.MOORCHEH_API_KEY}"}
+
+        async with self._remote_client() as remote:
+            expired_token = await self._activate_expired(remote, auth_headers)
+
+            for label, headers in (
+                ("no credential", {"X-Session-Token": expired_token}),
+                (
+                    "wrong credential",
+                    {
+                        "X-Session-Token": expired_token,
+                        "Authorization": "Bearer not-the-management-key",
+                    },
+                ),
+            ):
+                response = await remote.post(
+                    f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                    headers=headers,
+                    json={},
+                )
+                assert response.status_code == 401, label
+                assert "x-session-token" not in response.headers, label
+
+            # Same expired token, correct credential: recreation applies.
+            authorized = await remote.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                headers={**auth_headers, "X-Session-Token": expired_token},
+                json={},
+            )
+            assert authorized.status_code == 200
+            assert authorized.headers.get("x-session-token")
+
+    @pytest.mark.asyncio
+    async def test_terminated_session_is_not_auto_recreated(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Logout is authoritative: an explicitly ended session stays dead."""
+        await client.post(
+            "/api/v2/agents",
+            headers=auth_headers,
+            json={"agent_id": self.TEST_AGENT_ID},
+        )
+        activate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/activate", headers=auth_headers
+        )
+        token = activate_resp.json()["session_token"]
+
+        deactivate_resp = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/deactivate",
+            headers={**auth_headers, "X-Session-Token": token},
+        )
+        assert deactivate_resp.status_code == 200
+
+        client.cookies = Cookies()
+        response = await client.post(
+            f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+            headers={**auth_headers, "X-Session-Token": token},
+            json={},
+        )
+        assert response.status_code == 401
+        assert "x-session-token" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_expired_session_auto_recreate_can_be_disabled(
+        self, client, auth_headers, mock_moorcheh
+    ):
+        """Disabling SESSION_AUTO_RECREATE_ENABLED restores the plain 401."""
+        token = await self._activate_expired(client, auth_headers)
+
+        with patch.object(settings, "SESSION_AUTO_RECREATE_ENABLED", False):
+            response = await client.post(
+                f"/api/v2/agents/{self.TEST_AGENT_ID}/recall/recent",
+                headers={**auth_headers, "X-Session-Token": token},
+                json={},
+            )
+        assert response.status_code == 401
+        assert "x-session-token" not in response.headers

--- a/tests/test_session_config_overlay.py
+++ b/tests/test_session_config_overlay.py
@@ -1,0 +1,98 @@
+"""Session toggles in ~/.memanto/config.yaml must actually reach ``settings``.
+
+The Web UI and ``memanto config`` persist ``session.auto_renew_enabled`` /
+``session.auto_recreate_enabled`` to config.yaml, but ``SessionService`` reads
+them off ``settings``. The overlay that connects the two runs at import time in
+``memanto.app.config``, so these tests exercise it in a subprocess with a
+throwaway HOME rather than reloading the module (which would rebuild the
+``settings`` singleton other tests already hold a reference to).
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+_PROBE = (
+    "from memanto.app.config import settings;"
+    "print(settings.SESSION_AUTO_RENEW_ENABLED, settings.SESSION_AUTO_RECREATE_ENABLED)"
+)
+
+_SESSION_ENV_VARS = ("SESSION_AUTO_RENEW_ENABLED", "SESSION_AUTO_RECREATE_ENABLED")
+
+
+def _run_probe(home, env_overrides=None):
+    """Import settings in a fresh process rooted at *home*; return the toggles."""
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)  # Path.home() on Windows
+    for var in _SESSION_ENV_VARS:
+        env.pop(var, None)
+    env.update(env_overrides or {})
+
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=os.getcwd(),
+    )
+    assert result.returncode == 0, result.stderr
+    renew, recreate = result.stdout.split()
+    return renew == "True", recreate == "True"
+
+
+@pytest.fixture
+def home_with_session_config(tmp_path):
+    """Build a throwaway HOME and write the given session block into it."""
+
+    def _write(body):
+        config_dir = tmp_path / ".memanto"
+        config_dir.mkdir(exist_ok=True)
+        (config_dir / "config.yaml").write_text(body)
+        return tmp_path
+
+    return _write
+
+
+def test_yaml_toggles_reach_settings(home_with_session_config):
+    """Turning the toggles off in config.yaml disables them for the services."""
+    home = home_with_session_config(
+        "memanto:\n"
+        "  session:\n"
+        "    auto_renew_enabled: false\n"
+        "    auto_recreate_enabled: false\n"
+    )
+
+    assert _run_probe(home) == (False, False)
+
+
+def test_environment_overrides_yaml(home_with_session_config):
+    """An explicit SESSION_AUTO_* env var wins over config.yaml.
+
+    Containerised deployments configure MEMANTO through the environment and
+    must not be silently overridden by a config.yaml mounted from the host.
+    """
+    home = home_with_session_config(
+        "memanto:\n"
+        "  session:\n"
+        "    auto_renew_enabled: false\n"
+        "    auto_recreate_enabled: false\n"
+    )
+
+    assert _run_probe(home, {"SESSION_AUTO_RECREATE_ENABLED": "true"}) == (False, True)
+
+
+def test_missing_or_malformed_config_keeps_defaults(home_with_session_config):
+    """Absent, non-boolean, or unparsable config leaves the defaults standing."""
+    empty_home = home_with_session_config("")
+    assert _run_probe(empty_home) == (True, True)
+
+    wrong_type = home_with_session_config(
+        "memanto:\n  session:\n    auto_recreate_enabled: 'maybe'\n"
+    )
+    assert _run_probe(wrong_type) == (True, True)
+
+    not_a_mapping = home_with_session_config("memanto:\n  session: []\n")
+    assert _run_probe(not_a_mapping) == (True, True)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9,6 +9,7 @@ import os
 import stat
 import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -26,7 +27,7 @@ from memanto.app.services.agent_service import AgentService
 from memanto.app.services.memory_write_service import MemoryWriteService
 from memanto.app.services.session_service import SessionService
 from memanto.app.utils import atomic_write
-from memanto.app.utils.errors import InvalidSessionTokenError
+from memanto.app.utils.errors import InvalidSessionTokenError, SessionExpiredError
 
 
 class TestSessionService:
@@ -401,6 +402,162 @@ class TestSessionService:
         assert summary.session_id == renewed.session_id
         with pytest.raises(InvalidSessionTokenError):
             session_service.validate_session(renewed.session_token)
+
+    def test_check_and_auto_recreate_revives_expired_session(
+        self, session_service, monkeypatch
+    ):
+        """A lapsed session gets a fresh one on the next operation when enabled."""
+        monkeypatch.setattr(settings, "SESSION_AUTO_RECREATE_ENABLED", True)
+        original = session_service.create_session(
+            agent_id="test-agent",
+            pattern=AgentPattern.SUPPORT,
+            duration_hours=0,  # Expires immediately
+        )
+        time.sleep(1)  # Ensure utc_now() has moved past expires_at
+
+        recreated = session_service.check_and_auto_recreate(original.session_token)
+
+        assert recreated is not None
+        assert recreated.agent_id == "test-agent"
+        assert recreated.pattern == AgentPattern.SUPPORT
+        assert recreated.session_id != original.session_id
+        payload = session_service.validate_session(recreated.session_token)
+        assert payload.session_id == recreated.session_id
+
+    def test_check_and_auto_recreate_invalidates_old_token(
+        self, session_service, monkeypatch
+    ):
+        """The expired token must not authenticate after recreation."""
+        monkeypatch.setattr(settings, "SESSION_AUTO_RECREATE_ENABLED", True)
+        original = session_service.create_session(
+            agent_id="test-agent", duration_hours=0
+        )
+        time.sleep(1)
+
+        recreated = session_service.check_and_auto_recreate(original.session_token)
+        assert recreated is not None
+
+        # The old token's own expiry fails validation first.
+        with pytest.raises(SessionExpiredError):
+            session_service.validate_session(original.session_token)
+
+    def test_check_and_auto_recreate_never_revives_terminated_session(
+        self, session_service
+    ):
+        """Logout is authoritative: a terminated session stays dead."""
+        original = session_service.create_session(
+            agent_id="test-agent", duration_hours=1
+        )
+        session_service.end_session("test-agent")
+
+        assert session_service.check_and_auto_recreate(original.session_token) is None
+        with pytest.raises(InvalidSessionTokenError):
+            session_service.validate_session(original.session_token)
+
+    def test_check_and_auto_recreate_skips_active_session(self, session_service):
+        """Live sessions are handled by normal validation/auto-renewal."""
+        session = session_service.create_session(
+            agent_id="test-agent", duration_hours=1
+        )
+
+        assert session_service.check_and_auto_recreate(session.session_token) is None
+        session_service.validate_session(session.session_token)
+
+    def test_check_and_auto_recreate_disabled_by_config(
+        self, session_service, monkeypatch
+    ):
+        """Disabling the flag restores the plain expiry error path."""
+        monkeypatch.setattr(settings, "SESSION_AUTO_RECREATE_ENABLED", False)
+        original = session_service.create_session(
+            agent_id="test-agent", duration_hours=0
+        )
+        time.sleep(1)
+
+        with pytest.raises(SessionExpiredError):
+            session_service.validate_session(original.session_token)
+        assert session_service.check_and_auto_recreate(original.session_token) is None
+
+    def test_check_and_auto_recreate_ignores_foreign_and_malformed_tokens(
+        self, session_service, monkeypatch
+    ):
+        """Only the token matching the persisted (expired) session qualifies."""
+        monkeypatch.setattr(settings, "SESSION_AUTO_RECREATE_ENABLED", True)
+        session = session_service.create_session(
+            agent_id="test-agent", duration_hours=0
+        )
+        time.sleep(1)
+
+        foreign_token = jwt.encode(
+            {
+                "agent_id": "test-agent",
+                "namespace": "memanto_agent_test-agent",
+                "session_id": "sess-never-persisted",
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "expires_at": (
+                    datetime.now(timezone.utc) - timedelta(hours=1)
+                ).isoformat(),
+            },
+            session_service.secret_key,
+            algorithm="HS256",
+        )
+
+        assert session_service.check_and_auto_recreate("not-a-jwt") is None
+        assert session_service.check_and_auto_recreate(foreign_token) is None
+        assert (
+            session_service.check_and_auto_recreate(session.session_token) is not None
+        )
+
+    def test_get_active_session_recreates_lapsed_session(
+        self, session_service, monkeypatch
+    ):
+        """The active marker survives expiry when auto-recreate is enabled.
+
+        Regression test for the CLI path: every ``memanto`` command resolves
+        its session through ``get_active_session()``. Clearing the marker on
+        expiry stranded the caller with "No active session. Call
+        activate_agent()" - the exact failure auto-recreate exists to prevent.
+        """
+        monkeypatch.setattr(settings, "SESSION_AUTO_RECREATE_ENABLED", True)
+        original = session_service.create_session(
+            agent_id="test-agent",
+            pattern=AgentPattern.SUPPORT,
+            duration_hours=0,
+        )
+        time.sleep(1)
+
+        active = session_service.get_active_session()
+
+        assert active is not None
+        assert active.session_id != original.session_id
+        assert active.agent_id == "test-agent"
+        assert active.pattern == AgentPattern.SUPPORT
+        assert active.is_active()
+        # The marker now points at the replacement, so the next process sees it.
+        assert (session_service.sessions_dir / "active").exists()
+        session_service.validate_session(active.session_token)
+
+    def test_get_active_session_clears_marker_when_recreate_disabled(
+        self, session_service, monkeypatch
+    ):
+        """With the toggle off, expiry still clears the stale marker."""
+        monkeypatch.setattr(settings, "SESSION_AUTO_RECREATE_ENABLED", False)
+        session_service.create_session(agent_id="test-agent", duration_hours=0)
+        time.sleep(1)
+
+        assert session_service.get_active_session() is None
+        assert not (session_service.sessions_dir / "active").exists()
+
+    def test_get_active_session_does_not_revive_terminated_session(
+        self, session_service, monkeypatch
+    ):
+        """Logout clears the marker and auto-recreate must not restore it."""
+        monkeypatch.setattr(settings, "SESSION_AUTO_RECREATE_ENABLED", True)
+        session_service.create_session(agent_id="test-agent", duration_hours=0)
+        session_service.end_session("test-agent")
+        time.sleep(1)
+
+        assert session_service.get_active_session() is None
+        assert not (session_service.sessions_dir / "active").exists()
 
     def test_end_session(self, session_service):
         """Test ending session"""


### PR DESCRIPTION
- Auto session regenerate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic creation of a fresh session after expiration on the next request.
  - Added a configuration toggle for enabling or disabling session recreation.
  - Added management-access checks for session recreation.
  - Added support for updating this setting immediately from the configuration page.

- **Bug Fixes**
  - Expired sessions can now recover without requiring manual activation.
  - Explicitly terminated sessions are never recreated.
  - Replacement session tokens are returned and applied automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->