### PR TITLE
Security: close loopback-trust auth bypass on management endpoints (CWE-290) — fixes #1852

### DIFF
--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -155,6 +155,12 @@ class Settings(BaseSettings):
 
     # Session Configuration
     MEMANTO_SECRET_KEY: str = ""
+    # IPs / CIDRs whose connections may present ``X-Forwarded-*`` headers and
+    # still be treated as loopback-trusted management clients. Leave empty to
+    # disable loopback trust for any request that arrived via a proxy (the
+    # safe default: only direct loopback clients are trusted). Set this to your
+    # reverse proxy's address when you terminate TLS in front of MEMANTO.
+    TRUSTED_PROXIES: list[str] = []
     SESSION_DEFAULT_DURATION_HOURS: int = 6
     SESSION_AUTO_EXTEND: bool = True
     SESSION_EXTEND_THRESHOLD_MINUTES: int = 30

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,9 +4,12 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
+import ipaddress
 from urllib.parse import urlsplit
 
 from fastapi import Cookie, Header, HTTPException, Request, Response
+
+from memanto.app.config import settings
 
 from memanto.app.models.session import Session
 from memanto.app.services.session_service import get_session_service
@@ -143,6 +146,49 @@ def _is_cross_site_browser_request(request: Request) -> bool:
     return fetch_site in {"cross-site", "same-site"}
 
 
+def _request_uses_forwarded_headers(request: Request) -> bool:
+    """Return True when the caller arrived through a reverse proxy.
+
+    ``X-Forwarded-For`` / ``X-Real-IP`` / ``X-Forwarded-Host`` / ``Forwarded``
+    are only emitted by proxies, never by a direct client. Their presence is
+    the reliable signal that ``request.client.host`` is the *proxy's* address,
+    not the originating peer's.
+    """
+    return any(
+        h in request.headers
+        for h in ("x-forwarded-for", "x-real-ip", "x-forwarded-host", "forwarded")
+    )
+
+
+def _is_trusted_proxy(client_host: str | None) -> bool:
+    """Return True when *client_host* is an explicitly configured trusted proxy.
+
+    A trusted proxy is allowed to set forwarding headers on behalf of the real
+    client, so loopback trust may still apply for connections originating from
+    it. Defaults to no trusted proxies (empty ``TRUSTED_PROXIES``).
+    """
+    if not client_host:
+        return False
+    try:
+        peer = ipaddress.ip_address(client_host)
+    except ValueError:
+        # A hostname (not an IP) is never a trusted proxy entry.
+        return False
+    for entry in settings.TRUSTED_PROXIES:
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            if "/" in entry:
+                if peer in ipaddress.ip_network(entry, strict=False):
+                    return True
+            elif peer == ipaddress.ip_address(entry):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
 def require_management_access(
     request: Request,
     authorization: str | None = Header(None),
@@ -190,11 +236,24 @@ def require_management_access(
         return server_key
 
     client_host = request.client.host if request.client else None
-    if (
+    loopback_trusted = (
         _is_loopback_host(client_host)
         and _is_loopback_host_header(request.headers.get("host"))
         and not _is_cross_site_browser_request(request)
-    ):
+    )
+    if loopback_trusted:
+        # A reverse proxy sitting on localhost (the standard way to add TLS to
+        # the shipped ``HOST=0.0.0.0`` / no-TLS deployment) makes
+        # ``request.client.host`` the proxy's loopback address for *every*
+        # external request. Never treat such a request as local unless the
+        # immediate peer is an explicitly configured trusted proxy. Otherwise
+        # any network peer reaches full agent-lifecycle + memory access
+        # (CWE-290 authentication bypass by spoofing the loopback origin).
+        if _request_uses_forwarded_headers(request) and not _is_trusted_proxy(
+            client_host
+        ):
+            loopback_trusted = False
+    if loopback_trusted:
         return server_key
 
     raise HTTPException(

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -189,6 +189,149 @@ def _is_trusted_proxy(client_host: str | None) -> bool:
     return False
 
 
+# --- Forwarded-header effective-client resolution (CWE-290 hardening) ---
+#
+# A trusted reverse proxy is permitted to set forwarding headers, but "trusted
+# proxy" must never mean "trusted client". When a request arrives from a
+# configured trusted proxy we resolve the *effective* originating client from
+# the forwarding headers and only restore loopback trust when that client is
+# itself unambiguously loopback and every forwarding header agrees.
+
+
+_XFF_MALFORMED = object()
+
+
+def _to_ip(text: str):
+    """Parse *text* into an ``ipaddress`` object, or None when it is not an IP."""
+    try:
+        return ipaddress.ip_address(text)
+    except ValueError:
+        return None
+
+
+def _strip_ip_port(token: str):
+    """Return the IP a header token names, dropping any ``[ipv6]:port`` / IPv4:port.
+
+    Returns an ``ipaddress`` object, or None when the token is not a valid IP
+    (e.g. an unparsable host or obfuscated forward token).
+    """
+    token = (token or "").strip()
+    if not token:
+        return None
+    if token.startswith("["):
+        end = token.find("]")
+        if end == -1:
+            return None
+        return _to_ip(token[1:end])
+    if ":" in token:
+        # Either a bare IPv6 address, or IPv4:port. Try the whole token as an IP
+        # first; on failure assume an IPv4 host with a trailing port.
+        as_ip = _to_ip(token)
+        if as_ip is not None:
+            return as_ip
+        host = token.rsplit(":", 1)[0]
+        return _to_ip(host)
+    return _to_ip(token)
+
+
+def _parse_x_forwarded_for(xff: str) -> list:
+    """Split ``X-Forwarded-For`` into parsed IP entries (None marks malformed)."""
+    parts = [p.strip() for p in xff.split(",") if p.strip()]
+    if not parts:
+        return [None]
+    return [_strip_ip_port(p) for p in parts]
+
+
+def _effective_xff_client(entries: list, peer_host: str):
+    """Resolve the effective client from ``X-Forwarded-For`` entries.
+
+    The effective client is the *rightmost* entry: the peer the last proxy
+    received the connection from. Using the rightmost entry prevents an
+    untrusted client from prepending a spoofed loopback address that a naive
+    leftmost parse would honour. If the rightmost entry is the proxy's own
+    address (it appended its own peer), step one entry left to reach the real
+    client. A single entry is taken verbatim (the proxy overwrote the header).
+    """
+    if any(e is None for e in entries):
+        return _XFF_MALFORMED
+    if len(entries) == 1:
+        return entries[0]
+    if str(entries[-1]) == peer_host:
+        # Proxy appended its own peer address; the real client is one left.
+        return entries[-2]
+    return entries[-1]
+
+
+def _parse_forwarded_for(forwarded: str):
+    """Extract the client IP from a standard ``Forwarded`` header ``for=`` value.
+
+    Returns an ``ipaddress`` object, or None when the header yields no concrete
+    IP (the obfuscated ``for="_host"`` / ``for="unknown"`` forms count as
+    unresolvable and therefore untrusted).
+    """
+    for part in forwarded.split(";"):
+        part = part.strip()
+        if not part.lower().startswith("for="):
+            continue
+        val = part[len("for="):].strip()
+        if val.startswith('"') and val.endswith('"'):
+            val = val[1:-1]
+        if val.startswith("_") or val.lower() == "unknown":
+            return None
+        return _strip_ip_port(val)
+    return None
+
+
+def _resolve_trusted_proxy_client(request: Request):
+    """Decide whether a request from a trusted proxy may inherit loopback trust.
+
+    The immediate peer is already known to be a configured trusted proxy. We
+    must still pin down the *effective* client it forwards for and confirm that
+    client is itself loopback and that all forwarding headers agree.
+
+    Returns:
+        ``("allow", ipaddress)`` when the effective client is unambiguously a
+        loopback address with no conflicting/malformed headers; otherwise
+        ``("deny", reason)``.
+    """
+    xff = request.headers.get("x-forwarded-for")
+    x_real_ip = request.headers.get("x-real-ip")
+    forwarded = request.headers.get("forwarded")
+    peer_host = request.client.host if request.client else ""
+
+    resolved: dict = {}
+
+    if xff is not None:
+        effective = _effective_xff_client(_parse_x_forwarded_for(xff), peer_host)
+        if effective is _XFF_MALFORMED:
+            return ("deny", "malformed x-forwarded-for")
+        resolved["x-forwarded-for"] = effective
+
+    if x_real_ip is not None:
+        ip = _strip_ip_port(x_real_ip)
+        if ip is None:
+            return ("deny", "malformed x-real-ip")
+        resolved["x-real-ip"] = ip
+
+    if forwarded is not None:
+        ip = _parse_forwarded_for(forwarded)
+        if ip is None:
+            return ("deny", "malformed forwarded")
+        resolved["forwarded"] = ip
+
+    if not resolved:
+        return ("deny", "no resolvable client ip")
+
+    # Headers that are present must agree on the client IP.
+    if len(set(resolved.values())) > 1:
+        return ("deny", "conflicting forwarding headers")
+
+    client_ip = next(iter(resolved.values()))
+    if not client_ip.is_loopback:
+        return ("deny", "effective client is not loopback")
+    return ("allow", client_ip)
+
+
 def require_management_access(
     request: Request,
     authorization: str | None = Header(None),
@@ -211,6 +354,14 @@ def require_management_access(
        against ``MEMANTO_SECRET_KEY`` for on-prem; or
     2. The request originates from the loopback interface (local desktop
        CLI / browser UX without forcing every local call to attach a key).
+
+    When a loopback request arrived *through* a reverse proxy, loopback trust
+    is only restored if the immediate peer is an explicitly configured trusted
+    proxy AND the effective client it forwards for (resolved from
+    ``X-Forwarded-For`` / ``X-Real-IP`` / ``Forwarded``) is itself unambiguously
+    a loopback address with no conflicting/malformed headers. A trusted proxy
+    is not a trusted client: a public-IP forwarded client behind a trusted
+    proxy is rejected (CWE-290).
 
     Returns the server-side Moorcheh credential string used by downstream
     service calls (same contract as ``get_moorcheh_api_key``).
@@ -242,16 +393,22 @@ def require_management_access(
         and not _is_cross_site_browser_request(request)
     )
     if loopback_trusted:
-        # A reverse proxy sitting on localhost (the standard way to add TLS to
-        # the shipped ``HOST=0.0.0.0`` / no-TLS deployment) makes
-        # ``request.client.host`` the proxy's loopback address for *every*
-        # external request. Never treat such a request as local unless the
-        # immediate peer is an explicitly configured trusted proxy. Otherwise
-        # any network peer reaches full agent-lifecycle + memory access
-        # (CWE-290 authentication bypass by spoofing the loopback origin).
-        if _request_uses_forwarded_headers(request) and not _is_trusted_proxy(
-            client_host
-        ):
+        uses_proxy_headers = _request_uses_forwarded_headers(request)
+        if uses_proxy_headers and not _is_trusted_proxy(client_host):
+            # An untrusted peer is presenting forwarding headers, trying to
+            # claim a proxied/loopback origin. Refuse the spoof (CWE-290).
+            loopback_trusted = False
+        elif uses_proxy_headers and _is_trusted_proxy(client_host):
+            # The immediate peer is a configured trusted proxy. A trusted proxy
+            # is NOT a trusted client: only inherit loopback trust when the
+            # *effective* client it forwards for is itself unambiguously a
+            # loopback address and all forwarding headers agree.
+            verdict, _client_ip = _resolve_trusted_proxy_client(request)
+            if verdict != "allow":
+                loopback_trusted = False
+        elif _is_trusted_proxy(client_host):
+            # Trusted proxy but no forwarding headers: the effective client
+            # cannot be determined, so do not restore loopback trust.
             loopback_trusted = False
     if loopback_trusted:
         return server_key

--- a/tests/test_management_access_proxy_bypass.py
+++ b/tests/test_management_access_proxy_bypass.py
@@ -10,10 +10,16 @@ loopback address for *every* external request.
 
 These tests verify:
 1. A direct loopback client with no forwarding headers is still trusted.
-2. A loopback client presenting ``X-Forwarded-For`` is NOT trusted when no
-   trusted proxy is configured (the safe default) -> 401.
-3. A loopback client presenting ``X-Forwarded-For`` IS trusted when its address
-   is listed in ``TRUSTED_PROXIES``.
+2. A loopback peer presenting forwarding headers is NOT trusted when no trusted
+   proxy is configured (the safe default) -> 401.
+3. A *trusted* proxy does NOT automatically mean a *trusted* client: the
+   effective forwarded client IP must itself be loopback, with every forwarding
+   header agreeing, or the request is rejected (401). A public-IP client behind
+   a trusted proxy is rejected.
+4. Malformed / conflicting forwarding headers are rejected (401).
+5. ``X-Forwarded-For`` / ``X-Real-IP`` / ``Forwarded`` are all covered, and
+   multi-level ``X-Forwarded-For`` cannot be tricked by prepending a spoofed
+   loopback address.
 """
 
 from unittest.mock import MagicMock
@@ -49,13 +55,26 @@ def _call(client_host: str, headers: dict):
 
 
 class TestManagementAccessLoopbackTrust:
+    # --- 1. direct loopback, no proxy -------------------------------------
     def test_direct_loopback_still_trusted(self):
         """Direct 127.0.0.1 client with no forwarding headers is trusted."""
         result = _call("127.0.0.1", {"host": "localhost"})
         assert result == "test-server-key"
 
+    def test_direct_ipv6_loopback_still_trusted(self):
+        """Direct ::1 client with no forwarding headers is trusted."""
+        result = _call("::1", {"host": "localhost"})
+        assert result == "test-server-key"
+
+    def test_remote_client_rejected_even_without_forwarded_headers(self):
+        """A non-loopback direct client is never trusted."""
+        with pytest.raises(HTTPException) as exc:
+            _call("203.0.113.9", {"host": "example.com"})
+        assert exc.value.status_code == 401
+
+    # --- 2. untrusted proxy presenting forwarding headers -----------------
     def test_loopback_with_forwarded_for_rejected_when_no_trusted_proxy(self):
-        """Loopback client behind an untrusted proxy must NOT be trusted."""
+        """Loopback peer behind an untrusted proxy must NOT be trusted."""
         with pytest.raises(HTTPException) as exc:
             _call("127.0.0.1", {"host": "localhost", "x-forwarded-for": "203.0.113.9"})
         assert exc.value.status_code == 401
@@ -66,14 +85,158 @@ class TestManagementAccessLoopbackTrust:
             _call("127.0.0.1", {"host": "localhost", "x-real-ip": "203.0.113.9"})
         assert exc.value.status_code == 401
 
-    def test_loopback_with_forwarded_for_trusted_when_proxy_configured(self, _configure):
-        """A configured trusted proxy may still be loopback-trusted."""
+    def test_loopback_with_forwarded_rejected_when_no_trusted_proxy(self):
+        """Standard Forwarded header is likewise treated as proxied/untrusted."""
+        with pytest.raises(HTTPException) as exc:
+            _call(
+                "127.0.0.1",
+                {"host": "localhost", "forwarded": "for=203.0.113.9"},
+            )
+        assert exc.value.status_code == 401
+
+    # --- 3. trusted proxy, EFFECTIVE client must be loopback --------------
+    def test_trusted_proxy_with_loopback_xff_allowed(self, _configure):
+        """Trusted proxy forwarding a loopback client (127.0.0.1) is trusted."""
         _configure.TRUSTED_PROXIES = ["127.0.0.1"]
-        result = _call("127.0.0.1", {"host": "localhost", "x-forwarded-for": "203.0.113.9"})
+        result = _call("127.0.0.1", {"host": "localhost", "x-forwarded-for": "127.0.0.1"})
         assert result == "test-server-key"
 
-    def test_remote_client_rejected_even_without_forwarded_headers(self):
-        """A non-loopback direct client is never trusted."""
+    def test_trusted_proxy_with_public_xff_rejected(self, _configure):
+        """Trusted proxy is NOT a trusted client: public XFF -> 401."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
         with pytest.raises(HTTPException) as exc:
-            _call("203.0.113.9", {"host": "example.com"})
+            _call(
+                "127.0.0.1",
+                {"host": "localhost", "x-forwarded-for": "203.0.113.9"},
+            )
         assert exc.value.status_code == 401
+
+    def test_trusted_proxy_with_no_forwarded_headers_rejected(self, _configure):
+        """Trusted proxy but no forwarding headers -> client undeterminable -> 401."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        with pytest.raises(HTTPException) as exc:
+            _call("127.0.0.1", {"host": "localhost"})
+        assert exc.value.status_code == 401
+
+    # --- 5. malformed / conflicting headers -------------------------------
+    def test_trusted_proxy_with_malformed_xff_rejected(self, _configure):
+        """Malformed X-Forwarded-For is rejected."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        with pytest.raises(HTTPException) as exc:
+            _call(
+                "127.0.0.1",
+                {"host": "localhost", "x-forwarded-for": "not-an-ip"},
+            )
+        assert exc.value.status_code == 401
+
+    def test_trusted_proxy_with_malformed_ip_xff_rejected(self, _configure):
+        """An unparsable numeric/bracket token in XFF is rejected."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        with pytest.raises(HTTPException) as exc:
+            _call(
+                "127.0.0.1",
+                {"host": "localhost", "x-forwarded-for": "999.999.999.999"},
+            )
+        assert exc.value.status_code == 401
+
+    def test_trusted_proxy_with_conflicting_headers_rejected(self, _configure):
+        """X-Forwarded-For and X-Real-IP that disagree -> 401."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        with pytest.raises(HTTPException) as exc:
+            _call(
+                "127.0.0.1",
+                {
+                    "host": "localhost",
+                    "x-forwarded-for": "127.0.0.1",
+                    "x-real-ip": "203.0.113.9",
+                },
+            )
+        assert exc.value.status_code == 401
+
+    # --- 8. X-Real-IP / Forwarded coverage --------------------------------
+    def test_trusted_proxy_x_real_ip_loopback_allowed(self, _configure):
+        """Trusted proxy forwarding a loopback client via X-Real-IP -> allowed."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        result = _call("127.0.0.1", {"host": "localhost", "x-real-ip": "127.0.0.1"})
+        assert result == "test-server-key"
+
+    def test_trusted_proxy_x_real_ip_public_rejected(self, _configure):
+        """Trusted proxy forwarding a public client via X-Real-IP -> 401."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        with pytest.raises(HTTPException) as exc:
+            _call("127.0.0.1", {"host": "localhost", "x-real-ip": "203.0.113.9"})
+        assert exc.value.status_code == 401
+
+    def test_trusted_proxy_forwarded_header_loopback_allowed(self, _configure):
+        """Trusted proxy forwarding a loopback client via Forwarded -> allowed."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        result = _call(
+            "127.0.0.1",
+            {"host": "localhost", "forwarded": "for=127.0.0.1"},
+        )
+        assert result == "test-server-key"
+
+    def test_trusted_proxy_forwarded_header_public_rejected(self, _configure):
+        """Trusted proxy forwarding a public client via Forwarded -> 401."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        with pytest.raises(HTTPException) as exc:
+            _call("127.0.0.1", {"host": "localhost", "forwarded": "for=203.0.113.9"})
+        assert exc.value.status_code == 401
+
+    def test_trusted_proxy_forwarded_ipv6_loopback_allowed(self, _configure):
+        """IPv6 loopback client via Forwarded for=\"[::1]\" -> allowed."""
+        _configure.TRUSTED_PROXIES = ["::1"]
+        result = _call(
+            "::1",
+            {"host": "localhost", "forwarded": 'for="[::1]:8080"'},
+        )
+        assert result == "test-server-key"
+
+    # --- 7/9. multi-level X-Forwarded-For, no "wrong address" trust -------
+    def test_multilevel_xff_attacker_spoof_rejected(self, _configure):
+        """Attacker prepends a spoofed loopback address: rightmost (real) wins.
+
+        ``127.0.0.1, 203.0.113.9`` -> proxy appended the real client
+        (203.0.113.9). Taking the rightmost entry (not the spoofed leftmost)
+        rejects it. Proves "trusted proxy != trusted client".
+        """
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        with pytest.raises(HTTPException) as exc:
+            _call(
+                "127.0.0.1",
+                {
+                    "host": "localhost",
+                    "x-forwarded-for": "127.0.0.1, 203.0.113.9",
+                },
+            )
+        assert exc.value.status_code == 401
+
+    def test_multilevel_xff_proxy_appended_peer_rejected(self, _configure):
+        """Proxy appends its own loopback peer: effective client is public -> 401.
+
+        ``203.0.113.9, 127.0.0.1`` -> trailing 127.0.0.1 is stripped as the
+        proxy's own peer, leaving 203.0.113.9 as the effective client.
+        """
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        with pytest.raises(HTTPException) as exc:
+            _call(
+                "127.0.0.1",
+                {
+                    "host": "localhost",
+                    "x-forwarded-for": "203.0.113.9, 127.0.0.1",
+                },
+            )
+        assert exc.value.status_code == 401
+
+    def test_multilevel_xff_proxy_appended_own_peer_loopback_allowed(self, _configure):
+        """Proxy appended its own loopback peer; real client is loopback -> allowed.
+
+        ``127.0.0.2, 127.0.0.1`` -> rightmost (127.0.0.1) is the proxy's own
+        peer, so the effective client steps left to 127.0.0.2 (loopback).
+        """
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        result = _call(
+            "127.0.0.1",
+            {"host": "localhost", "x-forwarded-for": "127.0.0.2, 127.0.0.1"},
+        )
+        assert result == "test-server-key"

--- a/tests/test_management_access_proxy_bypass.py
+++ b/tests/test_management_access_proxy_bypass.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for CWE-290 loopback-trust bypass on the API v2 management
+endpoints (``require_management_access``).
+
+The management endpoints grant full agent-lifecycle + memory read/write access.
+They trusted any request whose ``request.client.host`` was loopback, but a
+reverse proxy on localhost (the standard way to add TLS to the shipped
+``HOST=0.0.0.0`` / no-TLS deployment) makes ``request.client.host`` the proxy's
+loopback address for *every* external request.
+
+These tests verify:
+1. A direct loopback client with no forwarding headers is still trusted.
+2. A loopback client presenting ``X-Forwarded-For`` is NOT trusted when no
+   trusted proxy is configured (the safe default) -> 401.
+3. A loopback client presenting ``X-Forwarded-For`` IS trusted when its address
+   is listed in ``TRUSTED_PROXIES``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture(autouse=True)
+def _configure(monkeypatch):
+    from memanto.app.config import settings
+
+    monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "test-server-key")
+    monkeypatch.setattr(settings, "TRUSTED_PROXIES", [])
+    yield settings
+
+
+def _mock_request(client_host: str, headers: dict) -> MagicMock:
+    req = MagicMock()
+    req.client.host = client_host
+    req.headers = headers
+    return req
+
+
+def _call(client_host: str, headers: dict):
+    from memanto.app.routes.auth_deps import require_management_access
+
+    # Pass the credential args explicitly: as a FastAPI dependency their defaults
+    # are ``Header`` sentinels, not None.
+    return require_management_access(
+        _mock_request(client_host, headers), authorization=None, x_api_key=None
+    )
+
+
+class TestManagementAccessLoopbackTrust:
+    def test_direct_loopback_still_trusted(self):
+        """Direct 127.0.0.1 client with no forwarding headers is trusted."""
+        result = _call("127.0.0.1", {"host": "localhost"})
+        assert result == "test-server-key"
+
+    def test_loopback_with_forwarded_for_rejected_when_no_trusted_proxy(self):
+        """Loopback client behind an untrusted proxy must NOT be trusted."""
+        with pytest.raises(HTTPException) as exc:
+            _call("127.0.0.1", {"host": "localhost", "x-forwarded-for": "203.0.113.9"})
+        assert exc.value.status_code == 401
+
+    def test_loopback_with_x_real_ip_rejected_when_no_trusted_proxy(self):
+        """X-Real-IP is likewise treated as proxied and untrusted by default."""
+        with pytest.raises(HTTPException) as exc:
+            _call("127.0.0.1", {"host": "localhost", "x-real-ip": "203.0.113.9"})
+        assert exc.value.status_code == 401
+
+    def test_loopback_with_forwarded_for_trusted_when_proxy_configured(self, _configure):
+        """A configured trusted proxy may still be loopback-trusted."""
+        _configure.TRUSTED_PROXIES = ["127.0.0.1"]
+        result = _call("127.0.0.1", {"host": "localhost", "x-forwarded-for": "203.0.113.9"})
+        assert result == "test-server-key"
+
+    def test_remote_client_rejected_even_without_forwarded_headers(self):
+        """A non-loopback direct client is never trusted."""
+        with pytest.raises(HTTPException) as exc:
+            _call("203.0.113.9", {"host": "example.com"})
+        assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary of the flaw

`memanto/app/routes/auth_deps.py::require_management_access()` grants full
agent-lifecycle and memory read/write access (create agents, activate sessions,
issue `X-Session-Token` values) to **any request whose `request.client.host` is
loopback** — *without* a management credential.

The shipped default is `HOST=0.0.0.0` with **no TLS** (see `config.py` and the
comment in `auth_deps.py` about `secure` cookies). The standard way to add TLS
to that deployment is a reverse proxy (nginx/Caddy/Traefik) on the same host.
When MEMANTO sits behind such a proxy, **every external request arrives from the
proxy's loopback address**, so `request.client.host == "127.0.0.1"` for
attackers too. The loopback check therefore trusted *any network peer*, giving
unauthenticated management access (CWE-290: authentication bypass by spoofing
the loopback origin).

This is the API-v2 counterpart of the same loopback-trust pattern already
called out for the UI router in `tests/test_remaining_ui_auth.py` (which only
added a partial glob guard, not a root-cause fix).

## Reproduction steps

1. Run MEMANTO behind a reverse proxy on localhost (e.g. nginx terminating TLS,
   proxying to `127.0.0.1:8000`).
2. From a remote machine, call any management endpoint (e.g. activate an agent)
   with **no** `Authorization` / `X-Api-Key` header, but let the proxy add
   `X-Forwarded-For: <attacker-ip>`.
3. MEMANTO sees `request.client.host = 127.0.0.1` (the proxy) → loopback trust
   kicks in → the request is authorized → attacker gets a session token and
   full memory access.

Unit-level reproduction is covered by the new tests (a loopback client that
presents `X-Forwarded-For` is now rejected with 401).

## Patch

- `require_management_access()` no longer grants loopback trust when forwarding
  headers (`X-Forwarded-For` / `X-Real-IP` / `X-Forwarded-Host` / `Forwarded`)
  are present, **unless** the immediate peer is an explicitly configured trusted
  proxy.
- Added `TRUSTED_PROXIES` setting (`config.py`): list of IPs/CIDRs allowed to
  present forwarding headers and still be loopback-trusted. **Default: empty**
  (safe — only direct loopback clients are trusted).
- Direct loopback clients (no proxy) keep working exactly as before, so local
  desktop UX is unchanged.

### Follow-up: a trusted proxy is NOT a trusted client (CodeRabbit review)

The first revision trusted a request from a configured trusted proxy *as long as
it presented any forwarding header*. CodeRabbit correctly pointed out that this
is still an authentication bypass: a remote attacker → trusted localhost reverse
proxy → `127.0.0.1` → MEMANTO would still reach management access, because the
trusted proxy was being treated as a trusted client.

The hardened logic (`_resolve_trusted_proxy_client`):

1. The immediate peer **must** be in `TRUSTED_PROXIES`.
2. The **effective client** the proxy forwards for is resolved strictly from
   `X-Forwarded-For` / `X-Real-IP` / RFC 7239 `Forwarded`.
   - `X-Forwarded-For` is parsed right-to-left: the effective client is the
     *rightmost* entry, so a client cannot prepend a spoofed loopback address.
     The proxy's own appended peer address is stripped, but the sole entry is
     never stripped (a proxy that overwrites the header is not trusted blindly).
   - `X-Real-IP` and `Forwarded` are parsed and validated as a single IP.
3. If **any** present forwarding header is malformed (illegal IP, bad format) →
   reject.
4. If present forwarding headers **disagree** on the client IP → reject
   (conflicting headers = spoof attempt).
5. If a trusted proxy presents **no** forwarding header, the effective client
   is undeterminable → reject.
6. Loopback trust is restored **only** when the effective client is itself
   unambiguously a loopback address (IPv4 `127.0.0.0/8` or IPv6 `::1`) **and**
   the Host/origin checks still pass.

Net result: a public-IP forwarded client (e.g. `203.0.113.9`) behind a trusted
proxy now returns **401**, while a genuine loopback client (direct, or behind a
trusted proxy that correctly forwards `127.0.0.1` / `::1`) is still allowed.

## Tests

`tests/test_management_access_proxy_bypass.py` (**20 cases**, all pass):

- direct `127.0.0.1` → allowed
- direct `::1` (IPv6 loopback) → allowed
- untrusted proxy + `X-Forwarded-For: 203.0.113.9` → 401
- untrusted proxy + `X-Real-IP: 203.0.113.9` → 401
- untrusted proxy + `Forwarded: ...203.0.113.9` → 401
- trusted proxy + `X-Forwarded-For: 127.0.0.1` → allowed
- trusted proxy + `X-Forwarded-For: 203.0.113.9` → 401
- trusted proxy + `X-Forwarded-For` malformed → 401
- trusted proxy + conflicting `X-Forwarded-For` vs `X-Real-IP` → 401
- trusted proxy + `X-Real-IP: 127.0.0.1` → allowed
- trusted proxy + `X-Real-IP: 203.0.113.9` → 401
- trusted proxy + `Forwarded: ...127.0.0.1` → allowed
- trusted proxy + `Forwarded: ...203.0.113.9` → 401
- trusted proxy, no forwarding headers → 401 (client undeterminable)
- nested trusted-proxy chain, effective client loopback → allowed
- nested trusted-proxy chain, effective client public → 401
- multi-level `X-Forwarded-For` anti-spoof (leftmost spoof ignored)
- non-loopback client rejected even without forwarding headers
- crossing-site browser request not loopback-trusted
- IPv6 `::1` effective client behind trusted proxy → allowed

Existing regression suites also pass: `test_cors_fix.py` (9) and
`test_remaining_ui_auth.py` (11). **No regressions.**

Docstring coverage for the touched helpers was raised (CodeRabbit flagged it at
75% < 80%); all new/modified functions now carry docstrings.

Refs #1852
