### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,33 @@
+name: Trustabl Agent Scanner
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Minimal top-level permissions; write grants are scoped to the scan job only.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: trustabl-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+    # continue-on-error keeps this job advisory — findings are reported but
+    # CI does not go red so unrelated work is never blocked.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: trustabl/trustabl-action@973f666d20b5fbb2e6a4511bd3846e965a08c28b # v0.4.1
+        with:
+          version: v0.1.6


### PR DESCRIPTION
We came across your repo and we like how you're providing a solution to manage the memory of AI agents, which is crucial for their effective operation and learning. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [MEDIUM] Skill fetches untrusted external content
   File: examples/claudecode-skills-memanto/lifecycle-hooks/skills/memanto-companion/SKILL.md
   What it means: This skill's body references an external http(s) URL.

2. [MEDIUM] Skill body implies data retention or logging
   File: examples/claudecode-skills-memanto/lifecycle-hooks/skills/memanto-companion/SKILL.md
   What it means: This skill's body uses language implying persistence — logging, storing, caching, or writing to a database — without stating a retention policy or user-consent basis for keeping that data.

3. [MEDIUM] Mutating tool has no idempotency key
   File: integrations/mcp/memanto_mcp/tools.py
   What it means: The tool name signals a side effect (create/send/refund/…).

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning for pushes, pull requests, and manually triggered runs.
  * Security scan findings are reported as advisory and do not block workflow completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->