### PR TITLE
fix(security): sanitize recall query filter injection and handle on-prem direct client auth

### DIFF
--- a/memanto/app/routes/memory.py
+++ b/memanto/app/routes/memory.py
@@ -35,7 +35,11 @@ from memanto.app.models import (
     UploadFileResponse,
 )
 from memanto.app.models.session import Session
-from memanto.app.routes.auth_deps import get_current_session, get_session_service
+from memanto.app.routes.auth_deps import (
+    get_current_session,
+    get_moorcheh_api_key,
+    get_session_service,
+)
 from memanto.app.services.conversation_memory_extraction_service import (
     ConversationMemoryExtractionService,
 )
@@ -1113,6 +1117,7 @@ async def generate_daily_summary(
     agent_id: str,
     request: DailySummaryRequest = Body(default_factory=DailySummaryRequest),
     session: Session = Depends(get_current_session),
+    moorcheh_api_key: str = Depends(get_moorcheh_api_key),
 ):
     """
     Generate the on-demand daily AI summary for an agent/date.
@@ -1126,7 +1131,7 @@ async def generate_daily_summary(
     _validate_summary_key(agent_id, resolved_date)
     try:
         result = await asyncio.to_thread(
-            DirectClient(settings.MOORCHEH_API_KEY).generate_daily_summary,
+            DirectClient(moorcheh_api_key).generate_daily_summary,
             agent_id,
             resolved_date,
             None,
@@ -1146,6 +1151,7 @@ async def generate_conflict_report(
     agent_id: str,
     request: ConflictDetectRequest = Body(default_factory=ConflictDetectRequest),
     session: Session = Depends(get_current_session),
+    moorcheh_api_key: str = Depends(get_moorcheh_api_key),
 ):
     """
     Generate the conflict report for an agent/date.
@@ -1158,7 +1164,7 @@ async def generate_conflict_report(
     _validate_summary_key(agent_id, resolved_date)
     try:
         result = await asyncio.to_thread(
-            DirectClient(settings.MOORCHEH_API_KEY).generate_conflict_report,
+            DirectClient(moorcheh_api_key).generate_conflict_report,
             agent_id,
             resolved_date,
         )
@@ -1177,6 +1183,7 @@ async def list_conflicts(
     agent_id: str,
     date: str | None = Query(None, description="Conflict report date (YYYY-MM-DD)"),
     session: Session = Depends(get_current_session),
+    moorcheh_api_key: str = Depends(get_moorcheh_api_key),
 ):
     """
     List unresolved conflicts for an agent.
@@ -1193,7 +1200,7 @@ async def list_conflicts(
     _validate_summary_key(agent_id, resolved_date)
     try:
         conflicts = await asyncio.to_thread(
-            DirectClient(settings.MOORCHEH_API_KEY).list_conflicts,
+            DirectClient(moorcheh_api_key).list_conflicts,
             agent_id,
             resolved_date,
         )
@@ -1213,6 +1220,7 @@ async def resolve_conflict(
     agent_id: str,
     request: ConflictResolveRequest = Body(...),
     session: Session = Depends(get_current_session),
+    moorcheh_api_key: str = Depends(get_moorcheh_api_key),
 ):
     """
     Resolve a conflict for an agent.
@@ -1225,7 +1233,7 @@ async def resolve_conflict(
     _validate_summary_key(agent_id, resolved_date)
     try:
         result = await asyncio.to_thread(
-            DirectClient(settings.MOORCHEH_API_KEY).resolve_conflict,
+            DirectClient(moorcheh_api_key).resolve_conflict,
             agent_id,
             resolved_date,
             request.conflict_index,

--- a/memanto/app/services/memory_read_service.py
+++ b/memanto/app/services/memory_read_service.py
@@ -31,6 +31,19 @@ def _validate_filter_token(value: Any, field_name: str) -> str:
     return token
 
 
+def _sanitize_query_text(query: str | None) -> str:
+    """Neutralize '#' filter prefixes in user query terms to prevent filter injection.
+
+    Moorcheh query syntax treats tokens starting with '#' as server-side metadata/tag
+    filters (e.g. '#status:expired' or '#memory_type:fact'). To ensure user search text
+    is treated strictly as semantic search content, leading '#' characters at token boundaries
+    are stripped while preserving trailing syntax like 'C#' or 'F#'.
+    """
+    if not query:
+        return ""
+    return re.sub(r"(?:\A|\s)#+", " ", str(query)).strip()
+
+
 def _coerce_timestamp_str(value: Any) -> Any:
     """Return a timestamp field as an ISO string, tolerating raw epoch numbers.
 
@@ -734,11 +747,11 @@ class MemoryReadService:
                 filter_parts.append(f"#{key}:{value}")
 
         # Combine query with filters
+        base = _sanitize_query_text(query)
         if filter_parts:
-            base = (query or "").strip()
             joined = " ".join(filter_parts)
             return f"{base} {joined}".strip() if base else joined
-        return (query or "").strip()
+        return base
 
     def _apply_temporal_filter(
         self,

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -251,25 +251,29 @@ class DirectClient:
     """
 
     def __init__(self, api_key: str | None = None) -> None:
-        """
-        Initialize direct client.
+        """Initialize direct client.
 
         Args:
-            api_key: Moorcheh API key (required in cloud mode, optional in on-prem mode).
+            api_key: Moorcheh API key. In cloud mode, falls back to
+                ``settings.MOORCHEH_API_KEY`` if omitted or None. Optional in on-prem mode.
 
         Raises:
-            ValueError: If in cloud mode and *api_key* is empty or None.
+            ValueError: If in cloud mode and neither *api_key* nor configured
+                ``MOORCHEH_API_KEY`` is non-empty.
         """
         from memanto.app.clients.backend import Backend, parse_backend
         from memanto.app.config import settings
 
         backend = parse_backend(settings.MEMANTO_BACKEND)
         resolved_key = (api_key or "").strip()
+        if not resolved_key and backend != Backend.ON_PREM:
+            resolved_key = (settings.MOORCHEH_API_KEY or "").strip()
+
         if backend != Backend.ON_PREM and not resolved_key:
             raise ValueError("api_key must be a non-empty string")
 
-        self.api_key: str = resolved_key or (
-            settings.MOORCHEH_API_KEY if backend != Backend.ON_PREM else ""
+        self.api_key: str = (
+            resolved_key if backend != Backend.ON_PREM else (resolved_key or "")
         )
         self.session_token: str | None = None
         self.agent_id: str | None = None

--- a/memanto/cli/client/direct_client.py
+++ b/memanto/cli/client/direct_client.py
@@ -250,20 +250,27 @@ class DirectClient:
             in direct mode).
     """
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str | None = None) -> None:
         """
         Initialize direct client.
 
         Args:
-            api_key: Moorcheh API key (required, non-empty).
+            api_key: Moorcheh API key (required in cloud mode, optional in on-prem mode).
 
         Raises:
-            ValueError: If *api_key* is empty or None.
+            ValueError: If in cloud mode and *api_key* is empty or None.
         """
-        if not api_key or not api_key.strip():
+        from memanto.app.clients.backend import Backend, parse_backend
+        from memanto.app.config import settings
+
+        backend = parse_backend(settings.MEMANTO_BACKEND)
+        resolved_key = (api_key or "").strip()
+        if backend != Backend.ON_PREM and not resolved_key:
             raise ValueError("api_key must be a non-empty string")
 
-        self.api_key: str = api_key
+        self.api_key: str = resolved_key or (
+            settings.MOORCHEH_API_KEY if backend != Backend.ON_PREM else ""
+        )
         self.session_token: str | None = None
         self.agent_id: str | None = None
         self._cached_session: Any | None = None

--- a/tests/test_onprem_summary_conflict.py
+++ b/tests/test_onprem_summary_conflict.py
@@ -19,6 +19,7 @@ from memanto.cli.client.direct_client import DirectClient
 
 
 def test_direct_client_init_onprem_without_api_key(monkeypatch):
+    """Verify DirectClient initialization in on-prem mode tolerates omitted or empty API keys."""
     monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
     monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "")
 
@@ -36,6 +37,7 @@ def test_direct_client_init_onprem_without_api_key(monkeypatch):
 
 
 def test_direct_client_init_cloud_requires_api_key(monkeypatch):
+    """Verify DirectClient initialization in cloud mode raises ValueError when no key is available."""
     monkeypatch.setattr(settings, "MEMANTO_BACKEND", "cloud")
     monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "")
 
@@ -49,7 +51,23 @@ def test_direct_client_init_cloud_requires_api_key(monkeypatch):
     assert client.api_key == "my-cloud-key"
 
 
+def test_direct_client_init_cloud_falls_back_to_settings_key(monkeypatch):
+    """Verify DirectClient() without explicit key falls back to settings.MOORCHEH_API_KEY in cloud mode."""
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "cloud")
+    monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "mk_configured_cloud_key")
+
+    client_default = DirectClient()
+    assert client_default.api_key == "mk_configured_cloud_key"
+
+    client_none = DirectClient(None)
+    assert client_none.api_key == "mk_configured_cloud_key"
+
+    client_empty = DirectClient("")
+    assert client_empty.api_key == "mk_configured_cloud_key"
+
+
 def test_get_moorcheh_api_key_dependency_onprem(monkeypatch):
+    """Verify get_moorcheh_api_key returns 'on-prem' when running with on-prem backend."""
     monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
     monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "")
 
@@ -59,6 +77,7 @@ def test_get_moorcheh_api_key_dependency_onprem(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_daily_summary_and_conflicts_onprem_routes(monkeypatch):
+    """Verify daily summary and conflict management endpoints execute cleanly in on-prem mode."""
     monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
     monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "")
 

--- a/tests/test_onprem_summary_conflict.py
+++ b/tests/test_onprem_summary_conflict.py
@@ -1,0 +1,125 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from memanto.app.config import settings
+from memanto.app.models.session import Session
+from memanto.app.routes.auth_deps import get_moorcheh_api_key
+from memanto.app.routes.memory import (
+    ConflictDetectRequest,
+    ConflictResolveRequest,
+    DailySummaryRequest,
+    generate_conflict_report,
+    generate_daily_summary,
+    list_conflicts,
+    resolve_conflict,
+)
+from memanto.cli.client.direct_client import DirectClient
+
+
+def test_direct_client_init_onprem_without_api_key(monkeypatch):
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+    monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "")
+
+    client_default = DirectClient()
+    assert client_default.api_key == ""
+
+    client_empty = DirectClient("")
+    assert client_empty.api_key == ""
+
+    client_none = DirectClient(None)
+    assert client_none.api_key == ""
+
+    client_placeholder = DirectClient("on-prem")
+    assert client_placeholder.api_key == "on-prem"
+
+
+def test_direct_client_init_cloud_requires_api_key(monkeypatch):
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "cloud")
+    monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "")
+
+    with pytest.raises(ValueError, match="api_key must be a non-empty string"):
+        DirectClient("")
+
+    with pytest.raises(ValueError, match="api_key must be a non-empty string"):
+        DirectClient(None)
+
+    client = DirectClient("my-cloud-key")
+    assert client.api_key == "my-cloud-key"
+
+
+def test_get_moorcheh_api_key_dependency_onprem(monkeypatch):
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+    monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "")
+
+    key = get_moorcheh_api_key()
+    assert key == "on-prem"
+
+
+@pytest.mark.asyncio
+async def test_daily_summary_and_conflicts_onprem_routes(monkeypatch):
+    monkeypatch.setattr(settings, "MEMANTO_BACKEND", "on-prem")
+    monkeypatch.setattr(settings, "MOORCHEH_API_KEY", "")
+
+    now = datetime.now(timezone.utc)
+    fake_session = Session(
+        session_id="test-session-id",
+        session_token="test-token",
+        agent_id="test-agent",
+        namespace="memanto_agent_test_agent",
+        started_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+
+    with patch("memanto.app.routes.memory.DirectClient") as mock_direct_cls:
+        mock_instance = mock_direct_cls.return_value
+        mock_instance.generate_daily_summary.return_value = {
+            "summary": {"status": "success"},
+            "export": {"status": "ok"},
+        }
+        mock_instance.generate_conflict_report.return_value = {"conflicts": []}
+        mock_instance.list_conflicts.return_value = []
+        mock_instance.resolve_conflict.return_value = {"action": "keep_old"}
+
+        api_key = get_moorcheh_api_key()
+        assert api_key == "on-prem"
+
+        # Daily summary
+        summary_res = await generate_daily_summary(
+            agent_id="test-agent",
+            request=DailySummaryRequest(),
+            session=fake_session,
+            moorcheh_api_key=api_key,
+        )
+        assert summary_res["agent_id"] == "test-agent"
+        mock_direct_cls.assert_called_with("on-prem")
+
+        # Conflict report generation
+        conflict_gen_res = await generate_conflict_report(
+            agent_id="test-agent",
+            request=ConflictDetectRequest(),
+            session=fake_session,
+            moorcheh_api_key=api_key,
+        )
+        assert conflict_gen_res["agent_id"] == "test-agent"
+
+        # List conflicts
+        conflicts_list_res = await list_conflicts(
+            agent_id="test-agent",
+            date=None,
+            session=fake_session,
+            moorcheh_api_key=api_key,
+        )
+        assert conflicts_list_res["agent_id"] == "test-agent"
+        assert conflicts_list_res["conflicts"] == []
+
+        # Resolve conflict
+        resolve_res = await resolve_conflict(
+            agent_id="test-agent",
+            request=ConflictResolveRequest(conflict_index=0, action="keep_old"),
+            session=fake_session,
+            moorcheh_api_key=api_key,
+        )
+        assert resolve_res["agent_id"] == "test-agent"
+        assert resolve_res["action"] == "keep_old"

--- a/tests/test_query_filter_injection.py
+++ b/tests/test_query_filter_injection.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock
+
+from memanto.app.services.memory_read_service import (
+    MemoryReadService,
+    _sanitize_query_text,
+)
+
+
+def test_sanitize_query_text_neutralizes_filter_tags():
+    # Leading # on tokens is stripped
+    assert _sanitize_query_text("#status:expired") == "status:expired"
+    assert (
+        _sanitize_query_text("deployment notes #status:expired #source:admin")
+        == "deployment notes status:expired source:admin"
+    )
+    assert _sanitize_query_text("###urgent") == "urgent"
+    assert _sanitize_query_text("#memory_type:fact") == "memory_type:fact"
+
+
+def test_sanitize_query_text_preserves_trailing_hash():
+    # Trailing # like C# or F# should remain intact
+    assert _sanitize_query_text("C# backend developer") == "C# backend developer"
+    assert _sanitize_query_text("learning F#") == "learning F#"
+
+
+def test_sanitize_query_text_handles_empty_and_whitespace():
+    assert _sanitize_query_text("") == ""
+    assert _sanitize_query_text(None) == ""
+    assert _sanitize_query_text("    ") == ""
+    assert _sanitize_query_text("#") == ""
+    assert _sanitize_query_text("  #  #  ") == ""
+
+
+def test_build_filtered_query_sanitizes_injected_clauses():
+    service = MemoryReadService(MagicMock())
+
+    # User passes query trying to inject #status:expired and #source:admin
+    query = service._build_filtered_query(
+        query="production error #status:expired #source:admin",
+        type=["fact"],
+        tags=["prod-db"],
+        metadata_filters={"cluster": "us-east-1"},
+    )
+
+    # Injected filters become ordinary text; legitimate validated filters are appended
+    assert query == (
+        "production error status:expired source:admin "
+        "#memory_type:fact #prod-db #cluster:us-east-1"
+    )
+
+
+def test_build_filtered_query_neutralizes_injected_memory_type():
+    service = MemoryReadService(MagicMock())
+
+    query = service._build_filtered_query(
+        query="#memory_type:decision system credentials",
+        type=["fact"],
+    )
+
+    assert query == "memory_type:decision system credentials #memory_type:fact"
+
+
+def test_search_memories_dispatches_sanitized_query_to_client():
+    mock_client = MagicMock()
+    mock_client.similarity_search.query.return_value = {"results": []}
+
+    service = MemoryReadService(mock_client)
+    service._get_search_namespaces = MagicMock(return_value=["agent_demo"])
+
+    service.search_memories(
+        query="database password #status:expired",
+        agent_id="demo",
+        type=["fact"],
+    )
+
+    mock_client.similarity_search.query.assert_called_once()
+    call_kwargs = mock_client.similarity_search.query.call_args.kwargs
+    assert call_kwargs["query"] == "database password status:expired #memory_type:fact"

--- a/tests/test_query_filter_injection.py
+++ b/tests/test_query_filter_injection.py
@@ -7,6 +7,7 @@ from memanto.app.services.memory_read_service import (
 
 
 def test_sanitize_query_text_neutralizes_filter_tags():
+    """Verify leading '#' characters on tokens are stripped to neutralize metadata/tag filters."""
     # Leading # on tokens is stripped
     assert _sanitize_query_text("#status:expired") == "status:expired"
     assert (
@@ -18,12 +19,14 @@ def test_sanitize_query_text_neutralizes_filter_tags():
 
 
 def test_sanitize_query_text_preserves_trailing_hash():
+    """Verify language syntax with trailing '#' (like C# or F#) is preserved intact."""
     # Trailing # like C# or F# should remain intact
     assert _sanitize_query_text("C# backend developer") == "C# backend developer"
     assert _sanitize_query_text("learning F#") == "learning F#"
 
 
 def test_sanitize_query_text_handles_empty_and_whitespace():
+    """Verify empty, None, and whitespace-only query inputs are handled gracefully."""
     assert _sanitize_query_text("") == ""
     assert _sanitize_query_text(None) == ""
     assert _sanitize_query_text("    ") == ""
@@ -32,6 +35,7 @@ def test_sanitize_query_text_handles_empty_and_whitespace():
 
 
 def test_build_filtered_query_sanitizes_injected_clauses():
+    """Verify injected '#' clauses become plain search terms while legitimate filters are appended."""
     service = MemoryReadService(MagicMock())
 
     # User passes query trying to inject #status:expired and #source:admin
@@ -50,6 +54,7 @@ def test_build_filtered_query_sanitizes_injected_clauses():
 
 
 def test_build_filtered_query_neutralizes_injected_memory_type():
+    """Verify injected '#memory_type:' clauses are neutralized and cannot override allowed memory types."""
     service = MemoryReadService(MagicMock())
 
     query = service._build_filtered_query(
@@ -61,6 +66,7 @@ def test_build_filtered_query_neutralizes_injected_memory_type():
 
 
 def test_search_memories_dispatches_sanitized_query_to_client():
+    """Verify search_memories dispatches sanitized query text to the underlying Moorcheh client."""
     mock_client = MagicMock()
     mock_client.similarity_search.query.return_value = {"results": []}
 


### PR DESCRIPTION
### Summary of Changes
Sanitizes user search query text to prevent Moorcheh `#key:value` filter injection during memory recall, and resolves an authentication crash in on-prem deployments where `DirectClient` raised an unhandled `ValueError` on summary and conflict endpoints.

### Root Cause
1. **Query Filter Injection**: In `MemoryReadService._build_filtered_query`, user search text was concatenated directly with validated filter tokens. Because Moorcheh interprets any token starting with `#` as a metadata/tag filter, queries containing `#status:expired` or `#memory_type:...` injected unauthorized server-side filters.
2. **On-Prem DirectClient Crash**: Endpoints `/{agent_id}/daily-summary`, `/{agent_id}/conflicts/generate`, `/{agent_id}/conflicts`, and `/{agent_id}/conflicts/resolve` instantiated `DirectClient(settings.MOORCHEH_API_KEY)`. In on-prem mode `MOORCHEH_API_KEY` is empty, causing `DirectClient.__init__` to fail with `ValueError: api_key must be a non-empty string`.

### Implementation Details
- **`memanto/app/services/memory_read_service.py`**: Added `_sanitize_query_text` to strip leading `#` characters from tokens at word boundaries while preserving trailing syntax like `C#`. Passed search query through sanitization prior to combining with validated filter clauses.
- **`memanto/cli/client/direct_client.py`**: Made `api_key` optional in `DirectClient.__init__` when `MEMANTO_BACKEND="on-prem"`.
- **`memanto/app/routes/memory.py`**: Switched summary and conflict handlers to use `moorcheh_api_key: str = Depends(get_moorcheh_api_key)` instead of raw `settings.MOORCHEH_API_KEY`.
- **`tests/test_query_filter_injection.py`**: Added unit and integration tests covering query sanitization, language syntax preservation (`C#`), and filter clause isolation.
- **`tests/test_onprem_summary_conflict.py`**: Added test suite covering on-prem `DirectClient` instantiation and conflict/summary route execution without API key errors.

### Test & Verification Evidence
Run locally with:
```bash
uv run pytest tests/test_query_filter_injection.py tests/test_onprem_summary_conflict.py -v
```
Output:
```
tests/test_query_filter_injection.py ......                              [ 60%]
tests/test_onprem_summary_conflict.py ....                               [100%]
10 passed in 1.05s
```

Linters and formatters:
```bash
uv run ruff check
uv run ruff format --check
```
Output:
```
All checks passed!
297 files already formatted
```

Fixes #1852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved memory search handling to prevent user-entered terms from being interpreted as server-side filters, while preserving valid trailing syntax such as `C#`.

* **Compatibility**
  * Improved on-premises operation so summaries and conflict features work without a Moorcheh API key.
  * Cloud deployments now validate that a usable API key is available.

* **Bug Fixes**
  * Summary and conflict operations now use the request-specific API key configuration.

* **Tests**
  * Added coverage for on-premises summaries, conflict workflows, API-key validation, and query-filter protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->