### PR TITLE
Add Obsidian vault to OKF migration showcase

### DIFF
--- a/examples/migrations/obsidian-to-okf/.gitignore
+++ b/examples/migrations/obsidian-to-okf/.gitignore
@@ -1,0 +1,1 @@
+.sample-okf.lock

--- a/examples/migrations/obsidian-to-okf/.gitignore
+++ b/examples/migrations/obsidian-to-okf/.gitignore
@@ -1,1 +1,2 @@
 .sample-okf.lock
+.round-trip-okf.lock

--- a/examples/migrations/obsidian-to-okf/LIVE_EVIDENCE.md
+++ b/examples/migrations/obsidian-to-okf/LIVE_EVIDENCE.md
@@ -1,0 +1,83 @@
+# Live Memanto round-trip evidence
+
+Run on 2026-09-08 against a dedicated Moorcheh-backed agent named
+`obsidian-okf-bounty`. No API key, token, or account identifier is stored in
+this repository.
+
+## Shipped CLI dry run
+
+```text
+memanto migrate okf sample-okf --dry-run --agent obsidian-okf-bounty
+
+OKF nodes: 21
+Mapped memories: 21 (skipped 0)
+Type breakdown: artifact: 10, context: 1, decision: 1, fact: 7, goal: 2
+Dry run -- no writes performed.
+```
+
+## Live import
+
+```text
+memanto migrate okf sample-okf --agent obsidian-okf-bounty
+
+OKF nodes: 21
+Mapped memories: 21 (skipped 0)
+Imported: 21
+Failed: 0
+Batches: 1
+```
+
+## Live semantic recall
+
+The three deterministic questions from `run_demo.py` were repeated against the
+live agent with `memanto recall`. The expected source memory ranked first for
+all three:
+
+| Query | Top live result | Time |
+|---|---|---:|
+| Who is the protagonist? | `Mara Vance` | 1.28 s |
+| What system governs lamplight memory? | `Lamplight Memory` | 1.28 s |
+| What is the Bureau trying to keep forgotten? | `Bureau of Continuance` | 1.13 s |
+
+Live golden recall: **3/3**.
+
+## Portable export and reload
+
+```text
+memanto memory export --okf --output round-trip-okf \
+  --agent obsidian-okf-bounty
+
+Facts: 7
+Decisions: 1
+Goals: 2
+Context: 1
+Artifacts: 10
+Exported: 21
+Completed in 8.05 s
+```
+
+The generated memory bundle is checked in at `round-trip-okf/`. The unrelated
+local CLI session transcript was excluded from the public artifact; Memanto's
+OKF loader intentionally scopes imports to `memories/`. Reloading the published
+post-Memanto memory artifact with the shipped importer produced:
+
+```text
+OKF nodes: 21
+Mapped memories: 21 (skipped 0)
+Type breakdown: artifact: 10, context: 1, decision: 1, fact: 7, goal: 2
+```
+
+This proves record-count parity, type parity, live semantic recall, and a valid
+portable export. Memanto's existing OKF mapper intentionally bounds unknown
+supporting-data values to 200 characters and caps the complete footer; therefore
+long nested `x_obsidian` values are fully available in `sample-okf/` but may be
+abbreviated in `round-trip-okf/`. The note bodies, mapped schema fields, source
+references, and recall-critical content survive the live round trip.
+
+## Savings-report applicability
+
+The shipped `memanto migrate okf` command explicitly reports that OKF is a local
+bundle and has no provider savings report. Fabricating token, latency, or storage
+savings would be misleading. The measurable Path-B funnel for this run is
+21 source notes -> 21 mapped memories -> 21 imported memories -> 21 exported
+memories, with zero skipped or failed records.

--- a/examples/migrations/obsidian-to-okf/README.md
+++ b/examples/migrations/obsidian-to-okf/README.md
@@ -1,6 +1,6 @@
 # Obsidian vault → Memanto → portable OKF
 
-Watch the [112-second end-to-end demo](./demo.mp4): a real 21-note Obsidian
+Watch the [66-second end-to-end demo](./demo.mp4): a real 21-note Obsidian
 vault is dry-run mapped, imported into a live Memanto agent, recalled with three
 semantic questions, exported back to OKF, and reloaded with zero skipped items.
 

--- a/examples/migrations/obsidian-to-okf/README.md
+++ b/examples/migrations/obsidian-to-okf/README.md
@@ -1,0 +1,81 @@
+# Obsidian vault → Memanto → portable OKF
+
+This example turns an existing Obsidian vault into an OKF v0.2 bundle that
+Memanto can inspect with `--dry-run` and import with `memanto migrate okf`.
+Conversion is local and deterministic: private vault content never needs an LLM.
+
+## Why this path matters
+
+Obsidian users already own Markdown, but Obsidian-specific wikilinks, embeds,
+application frontmatter, and missing memory types limit portability. This adapter:
+
+- preserves every non-empty Markdown note and its original frontmatter;
+- converts only unambiguous, resolvable `[[wikilinks]]` and keeps dead links visible;
+- maps explicit or conventional note semantics onto Memanto's 13 memory types;
+- records source paths, source hashes, provenance, and an honest migration receipt;
+- writes a bundle accepted by Memanto's shipped OKF loader and mapper.
+
+## Reproduce in one command
+
+From the repository root:
+
+```bash
+python examples/migrations/obsidian-to-okf/run_demo.py
+```
+
+The command migrates the checked-in 21-note Inkswell Obsidian vault, validates
+the output with Memanto production code, runs three golden recall checks, and
+writes `sample-okf/validation-report.json`.
+
+To preview your own vault without writing files:
+
+```bash
+python examples/migrations/obsidian-to-okf/obsidian_to_okf.py \
+  /path/to/vault /path/to/output --dry-run
+```
+
+Then use the shipped toolchain:
+
+```bash
+memanto migrate okf /path/to/output --dry-run
+memanto migrate okf /path/to/output --agent my-agent
+memanto memory export --okf --output /path/to/portable-export
+```
+
+## Mapping table
+
+| Obsidian signal | Memanto type | OKF preservation |
+|---|---|---|
+| Existing supported `type` | Same type | `type`, `x_memanto.type` |
+| Inkswell `codex` entity | `fact` | Body plus all source frontmatter |
+| Inkswell `longform` project | `goal` | Body plus project schema |
+| Draft folder | `artifact` | Original prose and path |
+| Plan filename | `decision` | Planning body and metadata |
+| Decisions/goals/daily/etc. folder or tag | Matching semantic type | Tags and metadata |
+| No semantic signal | `context` | No invented classification detail |
+
+## Real-data evidence
+
+`sample-source-vault/` is the complete public sample vault from
+[`leethobbit/obsidian-inkswell-plugin`](https://github.com/leethobbit/obsidian-inkswell-plugin)
+at commit `e49b3a0e87576938950ef82289603b809dc24a82`. It contains a lived-in
+fiction project with project metadata, 12 scene drafts, seven linked Codex
+entities, aliases, custom frontmatter, and intentional dead-link examples. It is
+MIT licensed; attribution is preserved in `THIRD_PARTY_LICENSE` and
+`SOURCE_PROVENANCE.md`.
+
+The test suite verifies dry-run safety, output-path safety, frontmatter
+preservation, link behavior, and production Memanto import compatibility:
+
+```bash
+pytest examples/migrations/obsidian-to-okf/tests -q
+ruff check examples/migrations/obsidian-to-okf
+ruff format --check examples/migrations/obsidian-to-okf
+```
+
+## Limitations
+
+- Ambiguous or missing wikilinks stay untouched and are listed in the report.
+- Obsidian Canvas and plugin databases are excluded; this adapter migrates Markdown.
+- The deterministic golden check proves content survived Memanto's loader/mapper.
+  A live semantic-recall demo still requires an active Memanto backend.

--- a/examples/migrations/obsidian-to-okf/README.md
+++ b/examples/migrations/obsidian-to-okf/README.md
@@ -1,5 +1,9 @@
 # Obsidian vault → Memanto → portable OKF
 
+Watch the [112-second end-to-end demo](./demo.mp4): a real 21-note Obsidian
+vault is dry-run mapped, imported into a live Memanto agent, recalled with three
+semantic questions, exported back to OKF, and reloaded with zero skipped items.
+
 This example turns an existing Obsidian vault into an OKF v0.2 bundle that
 Memanto can inspect with `--dry-run` and import with `memanto migrate okf`.
 Conversion is local and deterministic: private vault content never needs an LLM.

--- a/examples/migrations/obsidian-to-okf/README.md
+++ b/examples/migrations/obsidian-to-okf/README.md
@@ -73,9 +73,22 @@ ruff check examples/migrations/obsidian-to-okf
 ruff format --check examples/migrations/obsidian-to-okf
 ```
 
+## Verified live round trip
+
+On 2026-09-08, the checked-in bundle was imported into a dedicated live
+Moorcheh-backed Memanto agent with the shipped CLI. All 21 records imported in
+one batch with zero failures. The three golden semantic queries returned the
+expected source memory first, and `memanto memory export --okf` produced the
+checked-in [`round-trip-okf/`](round-trip-okf/) bundle in 8.05 seconds. Loading
+that exported bundle again mapped all 21 records with the same type counts.
+
+See [`LIVE_EVIDENCE.md`](LIVE_EVIDENCE.md) for commands, measured results, and
+the explicit reason an OKF import has no provider savings report.
+
 ## Limitations
 
 - Ambiguous or missing wikilinks stay untouched and are listed in the report.
 - Obsidian Canvas and plugin databases are excluded; this adapter migrates Markdown.
-- The deterministic golden check proves content survived Memanto's loader/mapper.
-  A live semantic-recall demo still requires an active Memanto backend.
+- Memanto's production OKF mapper intentionally bounds unknown supporting-data
+  values. Full nested Obsidian extensions remain in `sample-okf/`; long values
+  can be abbreviated in the post-Memanto `round-trip-okf/` artifact.

--- a/examples/migrations/obsidian-to-okf/SOURCE_PROVENANCE.md
+++ b/examples/migrations/obsidian-to-okf/SOURCE_PROVENANCE.md
@@ -1,0 +1,12 @@
+# Source provenance
+
+- Repository: https://github.com/leethobbit/obsidian-inkswell-plugin
+- Commit: `e49b3a0e87576938950ef82289603b809dc24a82`
+- Imported path: `examples/sample-vault/`
+- Source license: MIT, copyright 2026 Daniel King
+- Source SHA-256 (ordered relative paths and file bytes):
+  `5edc939e73e6e23eaf936ce1d76f33d1f9415cab03999ce061aaddd7a47e53e7`
+
+The source is a complete, publicly distributed Obsidian sample vault with a
+mid-draft novel, project state, linked story-bible entities, scene metadata, and
+revision history. No records were invented for this migration showcase.

--- a/examples/migrations/obsidian-to-okf/THIRD_PARTY_LICENSE
+++ b/examples/migrations/obsidian-to-okf/THIRD_PARTY_LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Daniel King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/migrations/obsidian-to-okf/demo.mp4
+++ b/examples/migrations/obsidian-to-okf/demo.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e87179bedc8a46b2bf1aeda881d5d70075fe5f3fb13cdf78eda930b00c7def0
+size 1146089

--- a/examples/migrations/obsidian-to-okf/demo.mp4
+++ b/examples/migrations/obsidian-to-okf/demo.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e87179bedc8a46b2bf1aeda881d5d70075fe5f3fb13cdf78eda930b00c7def0
-size 1146089
+oid sha256:0af3a9179172deeb289f8eacaf4f1522103e2df7ac064e30f117f18bcf2ebb27
+size 920961

--- a/examples/migrations/obsidian-to-okf/obsidian_to_okf.py
+++ b/examples/migrations/obsidian-to-okf/obsidian_to_okf.py
@@ -1,0 +1,289 @@
+"""Convert an Obsidian vault into an importable Open Knowledge Format bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import quote
+
+import yaml
+
+FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n?", re.DOTALL)
+WIKILINK_RE = re.compile(r"(?P<embed>!)?\[\[(?P<target>[^\]\n]+)\]\]")
+HEADING_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+MEMORY_TYPES = {
+    "instruction",
+    "fact",
+    "decision",
+    "goal",
+    "commitment",
+    "preference",
+    "relationship",
+    "context",
+    "event",
+    "learning",
+    "observation",
+    "artifact",
+    "error",
+}
+
+
+@dataclass
+class Report:
+    source_files: int = 0
+    converted_files: int = 0
+    skipped_files: int = 0
+    wikilinks_converted: int = 0
+    embeds_converted: int = 0
+    unresolved_links: list[dict[str, str]] = field(default_factory=list)
+    type_counts: dict[str, int] = field(default_factory=dict)
+    source_sha256: str = ""
+
+
+def _normalise_tags(value: Any) -> list[str]:
+    if isinstance(value, str):
+        values = re.split(r"[,\s]+", value)
+    elif isinstance(value, list):
+        values = [str(item) for item in value]
+    else:
+        values = []
+    return sorted({item.strip().lstrip("#") for item in values if item.strip()})
+
+
+def _parse_note(text: str) -> tuple[dict[str, Any], str]:
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}, text
+    try:
+        metadata = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    return metadata, text[match.end() :]
+
+
+def _title(metadata: dict[str, Any], body: str, source: Path) -> str:
+    candidate = metadata.get("title")
+    if candidate:
+        return str(candidate).strip()
+    heading = HEADING_RE.search(body)
+    return heading.group(1).strip() if heading else source.stem
+
+
+def _memory_type(metadata: dict[str, Any], relative: Path) -> str:
+    explicit = str(metadata.get("type", "")).strip().lower()
+    if explicit in MEMORY_TYPES:
+        return explicit
+
+    # Common Obsidian application schemas carry stronger meaning than folder
+    # names. Keep this deterministic: no LLM or private-data upload is needed.
+    if metadata.get("codex"):
+        return "fact"
+    if metadata.get("longform") or metadata.get("inkswell"):
+        return "goal"
+    if any(part.lower().startswith("draft") for part in relative.parts):
+        return "artifact"
+    if "plan" in relative.stem.lower():
+        return "decision"
+
+    terms = {part.lower() for part in relative.parts}
+    terms.update(tag.lower() for tag in _normalise_tags(metadata.get("tags")))
+    rules = (
+        ("decision", {"decision", "decisions"}),
+        ("goal", {"goal", "goals", "project", "projects"}),
+        ("preference", {"preference", "preferences"}),
+        ("event", {"daily", "journal", "meeting", "meetings"}),
+        ("learning", {"learning", "learnings", "lesson", "lessons"}),
+        ("error", {"error", "errors", "incident", "incidents"}),
+        ("artifact", {"artifact", "artifacts", "reference", "references"}),
+    )
+    for memory_type, matches in rules:
+        if terms & matches:
+            return memory_type
+    return "context"
+
+
+def _description(body: str) -> str | None:
+    without_code = re.sub(r"```.*?```", "", body, flags=re.DOTALL)
+    for paragraph in re.split(r"\n\s*\n", without_code):
+        cleaned = re.sub(r"^(?:#{1,6}|[-*>])\s*", "", paragraph.strip())
+        if cleaned and not cleaned.startswith("!"):
+            return re.sub(r"\s+", " ", cleaned)[:280]
+    return None
+
+
+def _timestamp(metadata: dict[str, Any], source: Path) -> str:
+    for key in ("timestamp", "date", "created", "created_at", "updated"):
+        value = metadata.get(key)
+        if value:
+            return str(value)
+    modified = datetime.fromtimestamp(source.stat().st_mtime, tz=timezone.utc)
+    return modified.isoformat().replace("+00:00", "Z")
+
+
+def _note_index(files: list[Path], root: Path) -> dict[str, list[Path]]:
+    index: dict[str, list[Path]] = {}
+    for path in files:
+        relative = path.relative_to(root)
+        keys = {path.stem.casefold(), relative.with_suffix("").as_posix().casefold()}
+        for key in keys:
+            index.setdefault(key, []).append(relative)
+    return index
+
+
+def _resolve_target(raw_target: str, index: dict[str, list[Path]]) -> Path | None:
+    note_part = raw_target.split("#", 1)[0].split("^", 1)[0].strip()
+    if not note_part:
+        return None
+    key = PurePosixPath(note_part.replace("\\", "/")).with_suffix("").as_posix()
+    matches = index.get(key.casefold())
+    if not matches and "/" not in key:
+        matches = index.get(PurePosixPath(key).name.casefold())
+    return matches[0] if matches and len(matches) == 1 else None
+
+
+def _rewrite_links(
+    body: str,
+    source_relative: Path,
+    index: dict[str, list[Path]],
+    report: Report,
+) -> str:
+    output_relative = source_relative.with_suffix(".md")
+
+    def replace(match: re.Match[str]) -> str:
+        raw = match.group("target")
+        target_and_alias = raw.split("|", 1)
+        raw_target = target_and_alias[0].strip()
+        alias = target_and_alias[1].strip() if len(target_and_alias) == 2 else ""
+        resolved = _resolve_target(raw_target, index)
+        if resolved is None:
+            report.unresolved_links.append(
+                {"source": source_relative.as_posix(), "target": raw_target}
+            )
+            return match.group(0)
+
+        suffix = ""
+        if "#" in raw_target:
+            suffix = "#" + raw_target.split("#", 1)[1]
+        elif "^" in raw_target:
+            suffix = "#^" + raw_target.split("^", 1)[1]
+        destination = resolved.with_suffix(".md")
+        relative_url = PurePosixPath(
+            *([".."] * len(output_relative.parent.parts)), *destination.parts
+        ).as_posix()
+        if output_relative.parent == Path("."):
+            relative_url = destination.as_posix()
+        label = alias or PurePosixPath(raw_target.split("#", 1)[0]).name
+        report.wikilinks_converted += 1
+        if match.group("embed"):
+            report.embeds_converted += 1
+            return f"![{label}]({quote(relative_url, safe='/#')}{suffix})"
+        return f"[{label}]({quote(relative_url, safe='/#')}{suffix})"
+
+    return WIKILINK_RE.sub(replace, body)
+
+
+def _source_digest(files: list[Path], root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in files:
+        digest.update(path.relative_to(root).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def convert_vault(source: Path, output: Path, *, dry_run: bool = False) -> Report:
+    source = source.resolve()
+    output = output.resolve()
+    if not source.is_dir():
+        raise ValueError(f"Vault is not a directory: {source}")
+    if output == source or source in output.parents:
+        raise ValueError("Output must be outside the source vault")
+
+    files = sorted(
+        path
+        for path in source.rglob("*.md")
+        if ".obsidian" not in path.relative_to(source).parts
+        and not any(part.startswith(".") for part in path.relative_to(source).parts)
+    )
+    report = Report(
+        source_files=len(files), source_sha256=_source_digest(files, source)
+    )
+    index = _note_index(files, source)
+    rendered: list[tuple[Path, str]] = []
+
+    for path in files:
+        relative = path.relative_to(source)
+        metadata, body = _parse_note(path.read_text(encoding="utf-8-sig"))
+        if not body.strip() and not metadata:
+            report.skipped_files += 1
+            continue
+        memory_type = _memory_type(metadata, relative)
+        report.type_counts[memory_type] = report.type_counts.get(memory_type, 0) + 1
+        converted_body = _rewrite_links(body, relative, index, report).strip()
+        frontmatter: dict[str, Any] = {
+            "type": memory_type,
+            "title": _title(metadata, body, path),
+            "description": _description(body),
+            "tags": _normalise_tags(metadata.get("tags")),
+            "timestamp": _timestamp(metadata, path),
+            "resource": f"obsidian://open?path={quote(relative.as_posix())}",
+            "x_memanto": {
+                "type": memory_type,
+                "source": "obsidian",
+                "provenance": "observed",
+            },
+            "x_obsidian": {
+                "source_path": relative.as_posix(),
+                # Preserve the exact parsed source mapping even when a field
+                # also has a normalized OKF counterpart.
+                "frontmatter": metadata,
+            },
+        }
+        frontmatter = {
+            key: value
+            for key, value in frontmatter.items()
+            if value not in (None, [], {})
+        }
+        yaml_text = yaml.safe_dump(
+            frontmatter, sort_keys=False, allow_unicode=True
+        ).strip()
+        rendered.append((relative, f"---\n{yaml_text}\n---\n\n{converted_body}\n"))
+        report.converted_files += 1
+
+    if not dry_run:
+        if output.exists():
+            shutil.rmtree(output)
+        output.mkdir(parents=True)
+        for relative, text in rendered:
+            destination = output / "memories" / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(text, encoding="utf-8")
+        (output / "migration-report.json").write_text(
+            json.dumps(asdict(report), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("vault", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    report = convert_vault(args.vault, args.output, dry_run=args.dry_run)
+    print(json.dumps(asdict(report), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/index.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/index.md
@@ -1,0 +1,8 @@
+---
+okf_version: "0.2"
+---
+
+# obsidian-okf-bounty — OKF bundle
+
+- [memories](memories/index.md) — 21 memories across 5 type(s)
+- [metrics](metrics/index.md) — aggregate stats & visualizations

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/01-the-last-lamp-on-vesper-row-2.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/01-the-last-lamp-on-vesper-row-2.md
@@ -1,0 +1,54 @@
+---
+type: artifact
+title: 01 - The Last Lamp on Vesper Row
+description: The last lamp on Vesper Row stood crooked on its post, the way it had
+  for as long as Mara could remember, and she loved it a little for that.
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/01%20-%20The%20Last%20Lamp%20on%20Vesper%20Row.md
+x_memanto:
+  id: a289b0b4-9678-4fab-879c-b008859825b1
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+The last lamp on Vesper Row stood crooked on its post, the way it had for as long as Mara could remember, and she loved it a little for that.
+
+She climbed the three rungs of her ladder, opened the small glass door, and let the wick take the flame from her taper. The light did not so much brighten as*settle* — a warmth that had nothing to do with heat. Down the length of the
+row, behind shuttered windows, the people of the district slept, and their day
+went into the lamps the way water finds the lowest place. A first kiss on the
+tram. An argument left unfinished. The particular blue of a kettle bought
+secondhand. The Lattice drank it all and held it, so that no one had to carry
+the whole weight of a life awake.
+
+That was the trade, and Mara was good at it. Not ambitious — good. She knew
+every crooked post on three streets, knew which lamps guttered in the damp off
+the canal and which burned clean. She knew the order to light them so the row
+came up like a held breath let slowly out.
+
+[TODO: land the mother's line here or in scene 2? See beat "theme-stated".]
+
+[RESEARCH: Find out how water works.]
+
+
+Her mother had lit these same posts, and her mother's mother. *Some things are
+only true while someone remembers them*, her mother used to say, which Mara had
+taken for sentiment until the night she understood it was a job description.
+
+She came down the ladder, folded it under her arm, and stood a moment in the
+finished light. The row glowed. The district dreamed into the glass. Somewhere a
+clock let go of midnight.
+
+It was, she would think later, the last ordinary night she would ever have —
+and she had spent it perfectly, lighting lamps, wanting nothing.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Draft 1\01 - The Last Lamp on Vesper Row.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/01%20-%20The%20Last%20Lamp%20on%20Vesper%20Row.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Draft 1/01 - The Last Lamp on Vesper Row.md; frontmatter={'status': 'revised', 'pov': 'Mara Vance', 'chapter': 'One', 'act': 'Act I', 'plotlines': ['Th...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/01-the-last-lamp-on-vesper-row.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/01-the-last-lamp-on-vesper-row.md
@@ -1,0 +1,38 @@
+---
+type: artifact
+title: 01 - The Last Lamp on Vesper Row
+description: 'Second-draft note: this scene is a stub in the sample, kept short to
+  demonstrate the draft switcher without duplicating the whole book.'
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/Scenes/01%20-%20The%20Last%20Lamp%20on%20Vesper%20Row.md
+x_memanto:
+  id: f2538cd8-ae15-4015-8b80-0ea4d8916810
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+Second-draft note: this scene is a stub in the sample, kept short to demonstrate the draft switcher without duplicating the whole book.
+
+Second-draft note: this scene is a stub in the sample, kept short to demonstrate
+the draft switcher without duplicating the whole book.
+
+Mara set her thumb to the last lamp on Vesper Row and let it drink. The filament
+took the day the way it always did — the baker's first oven, a child's lost tooth,
+the small unremembered weather of a street going to sleep — and gave it back as a
+steady amber that would hold until dawn.
+
+In the first draft she walked the whole route to get here. This time the city is
+already dark behind her, and the reader starts where the story does: one lamp, one
+keeper, one memory she is about to find that was never hers to hold.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Drafts\Second Draft\Scenes\01 - The Last Lamp on Vesper Row.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/Scenes/01%20-%20The%20Last%20Lamp%20on%20Vesper%20Row.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/01 - The Last Lamp on Vesper Row.md; frontmatter={'status': 'draft', 'pov': 'Mara Vance', 'synopsis': 'A tighter second-pass...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/02-what-the-light-remembers-2.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/02-what-the-light-remembers-2.md
@@ -1,0 +1,36 @@
+---
+type: artifact
+title: 02 - What the Light Remembers
+description: 'Second-draft note: another short stub, here to give the switcher a second
+  scene to show.'
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/Scenes/02%20-%20What%20the%20Light%20Remembers.md
+x_memanto:
+  id: 57c142fa-0bc8-4740-ad6b-c1a50a3a52d0
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+Second-draft note: another short stub, here to give the switcher a second scene to show.
+
+Second-draft note: another short stub, here to give the switcher a second scene to
+show.
+
+The lamp showed her a room. Not Vesper Row, not the undercroft stair she knew by
+feel — a room with a window facing a sea she had never lived beside, and a voice
+saying her name in a register she had never used.
+
+She should have logged it and moved on. In this draft she doesn't move on, and the
+chapter ends there, on the threshold of a life the light insists she remembers.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Drafts\Second Draft\Scenes\02 - What the Light Remembers.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/Scenes/02%20-%20What%20the%20Light%20Remembers.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/02 - What the Light Remembers.md; frontmatter={'status': 'idea', 'pov': 'Mara Vance', 'synopsis': 'Bring the wrong memory fo...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/02-what-the-light-remembers.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/02-what-the-light-remembers.md
@@ -1,0 +1,63 @@
+---
+type: artifact
+title: 02 - What the Light Remembers
+description: It happened at the seventh lamp, the clean-burning one outside the locksmith's.
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/02%20-%20What%20the%20Light%20Remembers.md
+x_memanto:
+  id: 1fc51284-0296-4646-aaee-a652d02bdc5e
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+It happened at the seventh lamp, the clean-burning one outside the locksmith's.
+
+Mara touched the flame to the wick, and instead of settling, the light *reached*
+for her. She felt it the way you feel someone read over your shoulder. Then the
+glass went bright and silver and she was — elsewhere.
+
+A room she had never entered. Low ceiling, a smell of cold stone and machine
+oil. Rows and rows of unlit lamps receding into a dark that did not end. A
+woman's voice, very close, saying a name — *Edran* — with a tenderness that
+broke in the middle of it. The grief in it was enormous and precise and entirely
+not Mara's, and yet she stood inside it as if it had her own teeth.
+
+Then she was back on Vesper Row with her taper guttering and her heart going
+like a fist on a door.
+
+Lamps held the district's memories. That was the trade. But a lamp gave its
+memory *back* only to the one who'd left it, and only on purpose — and Mara had
+never been in that room, had never known an Edran, had never grieved like that
+in her life.
+
+She stood very still and made herself breathe. The locksmith's window was dark.
+The row glowed on, ordinary, dreaming. Only the seventh lamp seemed to watch her
+now, the way the crooked one never had.
+
+[DIALOGUE: Mara says something low to the seventh lamp — defiant, or afraid? Find the line in revision.]
+
+[NOTE: mirror this room's "cold stone and machine oil" in the Undercroft reveal, scene 4.]
+
+[RESEARCH: coin a lamplighter's word for a leaked memory — "a bleed"?]
+
+A lamp had shown her a memory that was not hers to be shown. Which meant either
+she was losing her mind, or something in the Lattice had begun to leak — and
+some part of her, the part that had lit these posts for fifteen years and wanted
+nothing, knew with cold certainty which one it was.
+
+She did not report it. She told herself she would, in the morning. She climbed
+down, folded the ladder, and walked home not lighting the eighth lamp, the
+ninth, the tenth — leaving the rest of Vesper Row dark behind her for the first
+time in her working life, and not noticing until she reached her door.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Draft 1\02 - What the Light Remembers.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/02%20-%20What%20the%20Light%20Remembers.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Draft 1/02 - What the Light Remembers.md; frontmatter={'status': 'written', 'pov': 'Mara Vance', 'chapter': 'One', 'act': 'Act I', 'plotlines': ['The L...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/03-inspector-coll.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/03-inspector-coll.md
@@ -1,0 +1,61 @@
+---
+type: artifact
+title: 03 - Inspector Coll
+description: Coll did not like the morning light in the lower districts. It was honest
+  light, and honest light made people careful, and careful people were harder to read.
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/03%20-%20Inspector%20Coll.md
+x_memanto:
+  id: 9150b806-bf0a-492a-831a-d03ed0b0df26
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+Coll did not like the morning light in the lower districts. It was honest light, and honest light made people careful, and careful people were harder to read.
+
+Coll did not like the morning light in the lower districts. It was honest light,
+and honest light made people careful, and careful people were harder to read.
+
+He stood at the foot of Vesper Row with the audit slate cradled against his
+chest and counted the unlit lamps. Three. Four. Seven, if you went to the end.
+A lamplighter's route left dark was a small thing on paper and a very large thing
+in practice, because the Lattice did not tolerate gaps. A gap was where memory
+pooled, and pooled memory was where the trouble of the last generation had
+started.
+
+The lamplighter came up the row toward him with a ladder under her arm and the
+particular flat calm of someone who has decided not to be afraid. Vance, the
+roll said. Mara Vance. He had read the name twice on the tram and told himself
+it meant nothing.
+
+"You left your route," he said, by way of good morning.
+
+"I came back to finish it." She set the ladder down. "Bad taper. It happens."
+
+It did not happen — not to a lighter with fifteen clean years — and they both
+knew he knew it. He let the silence do its work. She let it, too, which was
+interesting. Most people filled a silence with the truth eventually. She filled
+it with nothing at all, and watched him while she did.
+
+[NOTE: Coll's interiority is too on-the-nose here — trust the reader more in revision.]
+
+"The Bureau takes an interest when a row goes dark," he said. "Continuance is
+fragile in the lower districts. You understand."
+
+"I understand the Bureau takes an interest," she said.
+
+He almost smiled. He filed the name again, and the face with it, and the small
+cold fact that he had no record of ever meeting her and was nonetheless
+*certain* that he had.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Draft 1\03 - Inspector Coll.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/03%20-%20Inspector%20Coll.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Draft 1/03 - Inspector Coll.md; frontmatter={'status': 'draft', 'pov': 'Inspector Coll', 'chapter': 'Two', 'act': 'Act I', 'plotlines': ['Coll & the Bu...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/04-the-undercroft.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/04-the-undercroft.md
@@ -1,0 +1,51 @@
+---
+type: artifact
+title: 04 - The Undercroft
+description: The stair was where the old lighters' songs said it would be — behind
+  the third lock-house on the canal, under a grate everyone had agreed for a generation
+  was sealed.
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/04%20-%20The%20Undercroft.md
+x_memanto:
+  id: fee48a7d-c577-4342-a214-b39bd5585378
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+The stair was where the old lighters' songs said it would be — behind the third lock-house on the canal, under a grate everyone had agreed for a generation was sealed.
+
+The stair was where the old lighters' songs said it would be — behind the third
+lock-house on the canal, under a grate everyone had agreed for a generation was
+sealed.
+
+It was not sealed. It had only been agreed to be.
+
+Mara went down with a hooded lamp and the conviction, equal parts terror and
+relief, that she had stopped pretending. Below the lock-house the air changed:
+cold stone, machine oil, the exact smell of the memory that was not hers. She
+knew the room before she reached it the way you know the last step of your own
+stairs in the dark.
+
+And then the room — low ceiling, rows of unlit lamps receding past the edge of
+her light, more than a district could ever fill, more than a city. The Undercroft.
+The place stray memory drained to. The place the Bureau had spent a generation
+insisting did not exist, in the patient, official way they insisted on all the
+things that frightened them most.
+
+She lifted her lamp. The nearest unlit lamp on the shelf turned, very slightly,
+toward the flame — and Mara understood that down here, she was not the one doing
+the reading.
+
+[NOTE: This is the threshold. Make sure scene 03 plants that Coll fears exactly this place.]
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Draft 1\04 - The Undercroft.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/04%20-%20The%20Undercroft.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Draft 1/04 - The Undercroft.md; frontmatter={'status': 'draft', 'pov': 'Mara Vance', 'chapter': 'Three', 'act': 'Act II', 'plotlines': ['The Leaking Me...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/05-a-memory-not-her-own.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/05-a-memory-not-her-own.md
@@ -1,0 +1,36 @@
+---
+type: artifact
+title: 05 - A Memory Not Her Own
+description: '[NOTE: OUTLINE ONLY — not yet drafted. Beat: Midpoint (false victory).]'
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/05%20-%20A%20Memory%20Not%20Her%20Own.md
+x_memanto:
+  id: 53872dc0-1ca3-4908-97a5-05b660ff857b
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+[NOTE: OUTLINE ONLY — not yet drafted. Beat: Midpoint (false victory).]
+
+Beats to hit in this scene:
+
+- Mara reads the grief-memory all the way through. *Edran* was a lighter too — the last one to come down here before the Undercroft was "sealed."
+- Reveal: the Archive doesn't just store memory, it *keeps* it — it has kept Edran's, intact, for a generation, waiting.
+- Turn: it has been waiting for someone who can read as well as light. That is vanishingly rare. That is Mara.
+- False victory: she thinks she has found a wonder. The reader should feel the trap close a half-beat before she does.
+- Plant: reading costs the reader something. She doesn't notice what, yet.
+- Exit on the choice that breaks her into the back half of the book.
+
+Tone: awe shading into dread. Keep her competent — she is never a victim of the plot, only of her own curiosity.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Draft 1\05 - A Memory Not Her Own.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/05%20-%20A%20Memory%20Not%20Her%20Own.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Draft 1/05 - A Memory Not Her Own.md; frontmatter={'status': 'outlined', 'pov': 'Mara Vance', 'chapter': 'Three', 'act': 'Act II', 'plotlines': ['The L...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/06-the-archivist-s-bargain.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/06-the-archivist-s-bargain.md
@@ -1,0 +1,33 @@
+---
+type: artifact
+title: 06 - The Archivist's Bargain
+description: '[NOTE: IDEA STAGE — captured so the beat and the Codex links exist.]'
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/06%20-%20The%20Archivist%27s%20Bargain.md
+x_memanto:
+  id: 9499d858-db1c-449d-9b99-2573248a8b2f
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+[NOTE: IDEA STAGE — captured so the beat and the Codex links exist.]
+
+The Archive makes its offer. The price is the thing Mara has been not-looking-at since scene 01.
+
+Questions to answer before drafting:
+
+- What did Mara lose? (Her mother's last memory? Her own?)
+- What does the Archive actually want read, and to whom?
+- Where is Coll while this happens?
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Draft 1\06 - The Archivist's Bargain.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/06%20-%20The%20Archivist%27s%20Bargain.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Draft 1/06 - The Archivist's Bargain.md; frontmatter={'status': 'idea', 'pov': 'Mara Vance', 'chapter': 'Four', 'act': 'Act II', 'plotlines': ['The Lea...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/07-blackout.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/07-blackout.md
@@ -1,0 +1,30 @@
+---
+type: artifact
+title: 07 - Blackout
+description: '[NOTE: IDEA STAGE — the Act 3 low point, captured for now.]'
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/07%20-%20Blackout.md
+x_memanto:
+  id: 051ef4ba-7bc7-4ce7-ae77-9c7f92ca0dfa
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+[NOTE: IDEA STAGE — the Act 3 low point, captured for now.]
+
+The "whiff of death" beat. Vesper Row goes dark and stays dark; the district
+wakes up a stranger to itself. Coll has to decide what he is willing to remember
+in order to fix it — which is the cost the Archive named back at the midpoint,
+arriving for him instead of Mara.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Draft 1\07 - Blackout.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/07%20-%20Blackout.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Draft 1/07 - Blackout.md; frontmatter={'status': 'idea', 'pov': 'Inspector Coll', 'chapter': 'Five', 'act': 'Act III', 'plotlines': ['Coll & the Bureau...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/08-what-the-dark-remembers.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/08-what-the-dark-remembers.md
@@ -1,0 +1,46 @@
+---
+type: artifact
+title: 08 - What the Dark Remembers
+description: '[NOTE: OUTLINE ONLY — the Break-into-3 / Finale / Final-image beats,
+  captured so the structure closes. Draft after the Act 2 scenes land.]'
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/08%20-%20What%20the%20Dark%20Remembers.md
+x_memanto:
+  id: 43060bd5-7c9c-49db-8cbe-d3ad021b18ba
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: artifact
+---
+
+[NOTE: OUTLINE ONLY — the Break-into-3 / Finale / Final-image beats, captured so the structure closes. Draft after the Act 2 scenes land.]
+
+The row is dark and it is not coming back on its own. Mara knows that the way
+she knows which posts gutter in the damp: not as a fear, as a fact. Coll is
+beside her on the canal stair, and for once the Bureau man has nothing to write
+down.
+
+She does not try to save Vesper Row. That is the turn — she stops trying to put
+the day back the way it was and goes down to the Archive to *remember* it
+instead, reading herself into the store so the erased hours have somewhere to
+live that a blackout can't reach.
+
+[TODO: find the single line she says to Coll on the stair before she goes down — it should rhyme with her mother's "some things are only true while someone remembers them."]
+
+Then the relight: not from her taper but from the Archive's own kept light, the
+row coming up post by post like a held breath let slowly out — the opening
+image, inverted. And the cost the Archive named at the midpoint, paid at last:
+she keeps the one memory she had spent years not carrying, awake now, hers.
+
+Final image — Mara lights the last lamp on Vesper Row again. But she is the
+reader now, and the glass, when it settles, remembers her too.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Draft 1\08 - What the Dark Remembers.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/08%20-%20What%20the%20Dark%20Remembers.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Draft 1/08 - What the Dark Remembers.md; frontmatter={'status': 'outlined', 'pov': 'Mara Vance', 'chapter': 'Six', 'act': 'Act III', 'synopsis': "Mara ...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/index.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/artifact/index.md
@@ -1,0 +1,12 @@
+# artifact (10)
+
+- [05 - A Memory Not Her Own](05-a-memory-not-her-own.md)
+- [07 - Blackout](07-blackout.md)
+- [02 - What the Light Remembers](02-what-the-light-remembers.md)
+- [02 - What the Light Remembers](02-what-the-light-remembers-2.md)
+- [06 - The Archivist's Bargain](06-the-archivist-s-bargain.md)
+- [01 - The Last Lamp on Vesper Row](01-the-last-lamp-on-vesper-row.md)
+- [01 - The Last Lamp on Vesper Row](01-the-last-lamp-on-vesper-row-2.md)
+- [08 - What the Dark Remembers](08-what-the-dark-remembers.md)
+- [04 - The Undercroft](04-the-undercroft.md)
+- [03 - Inspector Coll](03-inspector-coll.md)

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/context/index.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/context/index.md
@@ -1,0 +1,3 @@
+# context (1)
+
+- [👋 Start Here — the Inkswell sample project](start-here-the-inkswell-sample-project.md)

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/context/start-here-the-inkswell-sample-project.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/context/start-here-the-inkswell-sample-project.md
@@ -1,0 +1,130 @@
+---
+type: context
+title: 👋 Start Here — the Inkswell sample project
+description: 👋 Start Here — the Inkswell sample project
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=_Start%20Here.md
+x_memanto:
+  id: 883ec3be-d43b-43eb-869b-49210044f702
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: context
+---
+
+# 👋 Start Here — the Inkswell sample project
+
+Welcome. This vault is a **complete, mid-draft novel** so you can see what
+Inkswell looks like in real use instead of an empty project. The book is
+*[The Lamplighter's Archive](Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md)* — original fiction, included so the sample is
+free to ship (see [licensing](#licensing)).
+
+> [!tip] First time? Do these two things
+> 1. **Enable the plugin.** Settings (⚙) → *Community plugins* → turn **off**
+>    Restricted Mode → enable **Inkswell**. (A fresh vault starts in Restricted
+>    Mode, so community plugins are off until you allow them.)
+> 2. **Open the workspace.** Click the **pen-tip ribbon icon** on the left, or
+>    run the command *"Open Inkswell projects"* (Ctrl/Cmd-P). Pick
+>    **The Lamplighter's Archive** in the project selector at the top.
+
+---
+
+## The five-minute tour
+
+Inkswell is one tab with a **left icon rail**, grouped into sections: **Home**,
+the writing pipeline (**Plan · Write · Revise · Publish**), **Codex · Track**,
+and **Search · Help** pinned at the bottom. Each stop does one job:
+
+| Stop | What you'll see in this sample |
+|------|-------------------------------|
+| **Home** | The project's **hero card** — cover art, logline, theme, and a progress bar toward the 90k target — above the scene list with per-scene word counts and status colors. Click a scene to open the **Inspector** (status, POV, chapter, plotlines, characters, word target). |
+| **Plan → Overview** | Novel-level planning — logline, theme, genre, audience, plus a linked **planning note** holding the synopsis, plot groundwork, and a 3-act outline. The high-level view, before anything is broken into beats or scenes. |
+| **Plan → Beats** | A *Save the Cat!* beat sheet filled through the finale — early beats ticked, a couple of later ones still open. Each beat has a **+ new scene** button that creates the scene and links it to the beat. |
+| **Plan → Structure** | Three views of the same scenes behind a **Tree · Board · Grid** switcher. **Tree** is the Act › Chapter › Scene **outline** — drag to reorder, with per-chapter word targets. **Board** is the same scenes as draggable status cards. **Grid** is the **Plot Grid**: a plotline × chapter matrix (The Leaking Memory, Coll & the Bureau, Mara's Grief, The Lattice) where an empty stretch is a visible pacing signal. |
+| **Write** | A distraction-light Live-Preview editor that walks the manuscript in order. To-do markers (`[RESEARCH: …]`, `[NOTE: …]`, `[DIALOGUE: …]`) highlight inline — use the topbar **Insert** buttons (or `Ctrl/Cmd-Shift-T/R/D/S/N`) to drop your own, and **Log issue** to capture a fix without stopping. The right sidebar has a **Scene / Revision** switcher — **Revision** lists every marker and logged decision across the book; click one to jump. Start a **Sprint** from the Write toolbar or the status bar. |
+| **Revise → Audit / Analysis** | **Audit**: the per-scene **14-point checklist** (scenes 1–2 partly audited), Story/Page project checklists, the scene-**purpose** lift-out verdict, a **scene-openings** variety strip, the **character-arc** grid (Mara is tracked from "wants nothing" to the finale), and a **style-sheet** scan. **Analysis**: readability, word-frequency, and echo reports over the prose. |
+| **Revise → To-dos** | Everything left to fix in one scene-grouped worklist: every to-do marker across the manuscript (click one to jump straight to it in the editor) plus the invisible-revision **decisions** — typed & prioritized (continuity/plot-hole…) — tick one applied once you've made the change. Filter it all with one chip row. |
+| **Publish → Compile / Checklist / Launch** | **Compile**: the export pipeline (groups scenes into chapters). **Checklist**: the self-publishing master checklist + the **book-metadata worksheet** (both partly filled). **Launch**: the **pre-order timeline** (release date + Medium strategy → computed milestone dates) and budget/cover/marketing/ARC trackers. |
+| **Codex** | The story bible: characters, locations, a world, a concept, and a faction. Open **Mara Vance** — her **Appears in** list finds every scene that names her automatically, and clicking one opens that scene in **Write** at the first mention. Every entry is **scoped to the series** *The Lattice Cycle* (its **Scope** field), so it follows the book across the cycle but won't clutter an unrelated project. |
+| **Track** | Word-goal rings, a writing-history chart, a 26-week heatmap, streaks, sprint stats, and a **By chapter** breakdown against the per-chapter targets. A **deadline** is set, so Project targets shows a **pace verdict** and the draft-milestone zone. Set today's **mood** in Goals. |
+| **Search** | Full-text search across every scene's prose and synopsis. Pick the scope — this draft, the whole story, the series, or the vault — and narrow with status/POV/chapter/plotline/character filters. Click a hit to jump to it in Write, where it flashes. |
+
+> [!tip] Too many surfaces?
+> Any optional feature — Beats, Board, Plot Grid, the Revise Audit/Analysis
+> tabs, the Publishing checklist/Launch planner, or the Write writing-prompts
+> button — can be turned off in **Settings → Features** (or right-click a tab and
+> *Hide*). It's completely lossless: hiding only stops rendering, your notes and
+> stored data are untouched, and re-enabling brings everything back.
+
+---
+
+## How the sample maps to the data
+
+Nothing here is magic — it's all plain Markdown you can inspect:
+
+- **The project** is defined by the `longform:` and `inkswell:` frontmatter on
+  [The Lamplighter's Archive](Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md) (the index note). That one block declares the
+  scene order, the word target, the overview, the beat sheet, the **acts /
+  chapters / plotlines** structure, the compile recipe, the series, and the
+  revision log.
+- **The project has two drafts.** Both index notes share the same
+  `longform.title`, so Inkswell groups them into one *story* with a **draft
+  switcher** at the top of the project. The main book is the first draft (its
+  scenes live in `Draft 1/`); a short **Second Draft** stub lives in
+  `Drafts/Second Draft/Scenes/` purely to show the feature. Story-level metadata
+  (cover, logline, goals, series) is shared from the first draft — each draft
+  just carries its own scene set, word counts, and Search scope.
+- **Each scene** lives in [Draft 1/](Writing/The%20Lamplighter's%20Archive/Draft%201/) with flat frontmatter:
+  `status`, `pov`, `chapter`, `act`, `plotlines`, `characters`, `location`,
+  `targetWords`. Those fields drive the colors, the Inspector, the Outline and
+  Plot Grid, and the Track tallies. The Plot Grid and Outline are pure
+  projections of these — a scene joins a plotline or chapter just by naming it,
+  so the views can never drift from the manuscript.
+- **Codex entries** in [Codex/](Writing/Codex/) are just notes carrying a `codex:` key.
+  Scenes link to them with ordinary `[[wikilinks]]` in their `characters` /
+  `location` fields, and the Codex panel finds the references automatically.
+  Each entry here also carries `codex-series: The Lattice Cycle`, which **scopes**
+  it to that series — it shows in pickers for every book in the cycle but is hidden
+  from unrelated projects. (Use `codex-project: "[[Book]]"` to scope to a single
+  book, or leave both off to share an entry globally. New entries inherit the
+  active project's scope automatically; folder location is just tidy storage —
+  the tag is what controls visibility.)
+- **Sprint and daily-word history** is *not* in these notes — it lives in the
+  plugin's `data.json`. That's why it travels with this vault but wouldn't travel
+  with a loose folder of chapters.
+
+## Try editing something
+
+The fastest way to feel the loop:
+
+1. Go to **Write**, open scene **02 – What the Light Remembers**, and add a
+   sentence. The status-bar word count for today goes up immediately.
+2. Open **Track** — today's ring and the history chart reflect your new words.
+3. On **Home**, change a scene's status in the Inspector and watch the color and
+   the Track → Structure tally update.
+
+> [!warning] About the dates in Track
+> The seeded writing history is anchored to **June 2026**, so the *Today / Week /
+> Month* rings and the current-streak read "live" around then. Opening this vault
+> much later is harmless — the **history chart, heatmap, and sprint list still
+> render** — but the rings reset because there are no entries for the real
+> current date. Write a few words (step 1 above) and today's ring fills back in.
+> Also note the seeded "today" is a **Monday**, so the Week ring starts fresh.
+
+## Licensing
+
+*The Lamplighter's Archive* and all Codex entries here are **original work**
+created for this sample and distributed under the same license as the plugin.
+No public-domain or third-party text is bundled, so there are no edition,
+translation, or jurisdiction concerns — you can ship, fork, or rewrite it freely.
+
+---
+[Supporting data]
+- OKF source: memories\_Start Here.md
+- OKF resource: obsidian://open?path=_Start%20Here.md
+- Links: The Lamplighter's Archive -> Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md, licensing -> #licensing, The Lamplighter's Archive -> Writing/The%20Lamplighter%27s%20Archiv...
+- OKF x_obsidian: source_path=_Start Here.md; frontmatter={}

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/decision/index.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/decision/index.md
@@ -1,0 +1,3 @@
+# decision (1)
+
+- [The Lamplighter's Archive — Plan](the-lamplighter-s-archive-plan.md)

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/decision/the-lamplighter-s-archive-plan.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/decision/the-lamplighter-s-archive-plan.md
@@ -1,0 +1,79 @@
+---
+type: decision
+title: The Lamplighter's Archive — Plan
+description: The Lamplighter's Archive — Plan
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive%20%E2%80%94%20Plan.md
+x_memanto:
+  id: 4796e463-fd62-44f1-b89a-31670ff4cc39
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: decision
+---
+
+# The Lamplighter's Archive — Plan
+
+*Planning note for [The Lamplighter's Archive](../../Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md). Inkswell reads the sections
+below into **Plan → Overview**; edit them there or here — it's the same note.*
+
+## Synopsis
+
+In the city of Aszmar, each day is poured into the street-lamps at dusk: a first
+kiss, an argument left unfinished, the blue of a secondhand kettle. The Lattice
+drinks it and holds it, so no one has to carry a whole life awake. Mara Vance
+tends a small route on Vesper Row and wants nothing more than that — until a lamp
+shows her a memory that was never hers. Following the leak leads her down into
+the Undercroft, to the sealed Archive the city spent a generation forgetting,
+which has been waiting for a lighter who can *read* as well as light. When the
+Bureau's blackout wipes the row to bury what she's found, Mara stops trying to
+put the day back the way it was and chooses instead to remember it — becoming
+the Archive's reader, and keeping, at last, the one memory she'd buried.
+
+## Plot groundwork
+
+- **The rule of the world:** lamplight *stores* memory, it doesn't merely
+  illuminate. (Continuity decision `rev-lamplight-stores` — treat early "light"
+  references as retroactively about memory.)
+- **The Archive is sentient** and has intent, not just storage
+  (`rev-archive-sentient`). It bargains; it waits; it chooses Mara.
+- **The buried thing:** Mara lost someone and has stopped letting herself
+  remember it. The Archive's price is exactly that memory — carried awake.
+- **The antagonist is procedure, not a villain:** the Bureau of Continuance
+  keeps the city stable by deciding what may be remembered. Coll is its
+  instrument who turns.
+
+## Act I
+
+Establish the trade, the Lattice, and Mara's contented, unambitious life
+(*Opening Image*, *Setup*). A lamp shows her a memory that cannot be hers — the
+*Catalyst* — and she hides it. Inspector Coll arrives from the Bureau to audit
+the dark stretch, more interested in Mara than the lamps: the *Debate*. Chapters
+One–Two.
+
+## Act II
+
+Mara finds the access stair and descends into the sealed Undercroft (*Break into
+Two*). Inside, she reads the grief-memory to its end and learns the Archive has
+been waiting for her — a false victory, the *Midpoint*. The Archive offers its
+bargain: read for it, and be given back what she lost. The Bureau closes in.
+Chapters Three–Four.
+
+## Act III
+
+The blackout wipes Vesper Row — *All Is Lost* — and takes the memory she went
+down to protect (*Dark Night of the Soul*). Mara goes back down and stops trying
+to save the row; she reads herself into the Archive instead (*Break into
+Three*), relights the district from its own kept light (*Finale*), and keeps the
+buried memory awake (*Final Image*, mirroring the opening). Chapters Five–Six.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\The Lamplighter's Archive — Plan.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive%20%E2%80%94%20Plan.md
+- Links: The Lamplighter's Archive -> ../../Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/The Lamplighter's Archive — Plan.md; frontmatter={}

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/aszmar.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/aszmar.md
@@ -1,0 +1,28 @@
+---
+type: fact
+title: Aszmar
+description: Aszmar
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/Codex/Aszmar.md
+x_memanto:
+  id: 86212eea-f7dd-42ed-bd69-f4ab08d04b48
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: fact
+---
+
+# Aszmar
+
+The city and world of *The Lattice Cycle*. A place that solved the unbearable
+weight of remembering by agreeing, collectively, to set it down each night.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\Codex\Aszmar.md
+- OKF resource: obsidian://open?path=Writing/Codex/Aszmar.md
+- OKF x_obsidian: source_path=Writing/Codex/Aszmar.md; frontmatter={'codex': 'world', 'codex-series': 'The Lattice Cycle', 'aliases': [], 'geography': 'A canal city built in tiers, lower wards in fog, upper wards in...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/bureau-of-continuance.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/bureau-of-continuance.md
@@ -1,0 +1,29 @@
+---
+type: fact
+title: Bureau of Continuance
+description: Bureau of Continuance
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/Codex/Bureau%20of%20Continuance.md
+x_memanto:
+  id: f75d3d96-63e2-4d59-8805-8a73cf3839b5
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: fact
+---
+
+# Bureau of Continuance
+
+Administers the Lattice and guards the Accords. Its real work is maintenance of a
+shared forgetting — which makes anyone who starts remembering, like Mara, a
+problem it is institutionally unequipped to solve gently.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\Codex\Bureau of Continuance.md
+- OKF resource: obsidian://open?path=Writing/Codex/Bureau%20of%20Continuance.md
+- OKF x_obsidian: source_path=Writing/Codex/Bureau of Continuance.md; frontmatter={'codex': 'faction', 'codex-series': 'The Lattice Cycle', 'aliases': ['The Bureau'], 'type': 'Governing body / memory authority', 'si...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/index.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/index.md
@@ -1,0 +1,9 @@
+# fact (7)
+
+- [Bureau of Continuance](bureau-of-continuance.md)
+- [Mara Vance](mara-vance.md)
+- [The Lattice](the-lattice.md)
+- [Aszmar](aszmar.md)
+- [Lamplight Memory](lamplight-memory.md)
+- [The Undercroft Archive](the-undercroft-archive.md)
+- [Inspector Coll](inspector-coll.md)

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/inspector-coll.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/inspector-coll.md
@@ -1,0 +1,29 @@
+---
+type: fact
+title: Inspector Coll
+description: Inspector Coll
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/Codex/Inspector%20Coll.md
+x_memanto:
+  id: 303571a6-b22e-4a79-bcd3-5b4dfc8e38d0
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: fact
+---
+
+# Inspector Coll
+
+A Bureau auditor sent to explain a darkened row. He is far more troubled by the
+lamplighter than by the lamps — and cannot say why, because the answer is one of
+the things he long ago arranged not to keep.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\Codex\Inspector Coll.md
+- OKF resource: obsidian://open?path=Writing/Codex/Inspector%20Coll.md
+- OKF x_obsidian: source_path=Writing/Codex/Inspector Coll.md; frontmatter={'codex': 'character', 'codex-series': 'The Lattice Cycle', 'aliases': ['The auditor'], 'role': 'Antagonist (initially)', 'function': "Stand...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/lamplight-memory.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/lamplight-memory.md
@@ -1,0 +1,29 @@
+---
+type: fact
+title: Lamplight Memory
+description: Lamplight Memory
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/Codex/Lamplight%20Memory.md
+x_memanto:
+  id: 5e7ac198-b1b3-4379-a8fd-dc62ddc5e008
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: fact
+---
+
+# Lamplight Memory
+
+The soft magic of *The Lattice Cycle*. Codified here so every scene that touches
+it stays consistent — and so the rules the plot will eventually break are
+written down before they break.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\Codex\Lamplight Memory.md
+- OKF resource: obsidian://open?path=Writing/Codex/Lamplight%20Memory.md
+- OKF x_obsidian: source_path=Writing/Codex/Lamplight Memory.md; frontmatter={'codex': 'concept', 'codex-series': 'The Lattice Cycle', 'aliases': ['The trade', 'Giving the day'], 'type': 'Memory storage / soft magic...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/mara-vance.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/mara-vance.md
@@ -1,0 +1,35 @@
+---
+type: fact
+title: Mara Vance
+description: Mara Vance
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/Codex/Mara%20Vance.md
+x_memanto:
+  id: 917873b7-7775-4bb7-9bf8-6dcf176770f8
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: fact
+---
+
+# Mara Vance
+
+The lamplighter of Vesper Row, third of her line to tend the same crooked posts.
+Fifteen clean years and no ambition beyond a finished row at midnight — until a
+lamp shows her a memory that isn't hers.
+
+> [!note] Codex entity
+> This is a **character** entry. Inkswell finds it by the `codex: character`
+> frontmatter key. Scenes that list `[Mara Vance](../../Writing/Codex/Mara%20Vance.md)` in their `characters` field
+> show up automatically under *References* in the Codex panel.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\Codex\Mara Vance.md
+- OKF resource: obsidian://open?path=Writing/Codex/Mara%20Vance.md
+- Links: Mara Vance -> ../../Writing/Codex/Mara%20Vance.md
+- OKF x_obsidian: source_path=Writing/Codex/Mara Vance.md; frontmatter={'codex': 'character', 'codex-series': 'The Lattice Cycle', 'aliases': ['The lighter on Vesper Row'], 'role': 'Protagonist', 'age': '34', 'gende...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/the-lattice.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/the-lattice.md
@@ -1,0 +1,28 @@
+---
+type: fact
+title: The Lattice
+description: The Lattice
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/Codex/The%20Lattice.md
+x_memanto:
+  id: b5e03dc3-10c5-4975-9701-b9ddfa08590d
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: fact
+---
+
+# The Lattice
+
+The memory-grid of Aszmar: streets of lamps that drink the day from the people
+who live beneath them. Mara tends one small, crooked stretch of it.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\Codex\The Lattice.md
+- OKF resource: obsidian://open?path=Writing/Codex/The%20Lattice.md
+- OKF x_obsidian: source_path=Writing/Codex/The Lattice.md; frontmatter={'codex': 'location', 'codex-series': 'The Lattice Cycle', 'aliases': ['The grid', 'The lamps'], 'type': 'City-wide memory network', 'parent': ...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/the-undercroft-archive.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/fact/the-undercroft-archive.md
@@ -1,0 +1,28 @@
+---
+type: fact
+title: The Undercroft Archive
+description: The Undercroft Archive
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/Codex/The%20Undercroft%20Archive.md
+x_memanto:
+  id: 9e305570-c93c-45e8-a199-ea6eee24a416
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: fact
+---
+
+# The Undercroft Archive
+
+The place memory drains to when a row goes dark. The Bureau spent a generation
+insisting it wasn't there. It was there the whole time, and it has been waiting.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\Codex\The Undercroft Archive.md
+- OKF resource: obsidian://open?path=Writing/Codex/The%20Undercroft%20Archive.md
+- OKF x_obsidian: source_path=Writing/Codex/The Undercroft Archive.md; frontmatter={'codex': 'location', 'codex-series': 'The Lattice Cycle', 'aliases': ['The Undercroft', 'The Archive'], 'type': 'Sealed sub-level b...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/goal/index.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/goal/index.md
@@ -1,0 +1,4 @@
+# goal (2)
+
+- [The Lamplighter's Archive](the-lamplighter-s-archive.md)
+- [The Lamplighter's Archive — Second Draft](the-lamplighter-s-archive-second-draft.md)

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/goal/the-lamplighter-s-archive-second-draft.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/goal/the-lamplighter-s-archive-second-draft.md
@@ -1,0 +1,38 @@
+---
+type: goal
+title: The Lamplighter's Archive — Second Draft
+description: The Lamplighter's Archive — Second Draft
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/The%20Lamplighter%27s%20Archive%20%E2%80%94%20Second%20Draft.md
+x_memanto:
+  id: 187b4871-f6f2-4556-a974-6ee35287f188
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: goal
+---
+
+# The Lamplighter's Archive — Second Draft
+
+A second draft of the same project, kept deliberately short in the sample. It's
+here to show Inkswell's **multi-draft** support.
+
+This note shares the same `longform.title` as the first draft, so Inkswell groups
+both into one *story* and offers a **draft switcher** at the top of the project.
+Each draft keeps its own scene folder — the first draft lives in `Draft 1/`, this
+one in its own `Drafts/Second Draft/Scenes/` folder, exactly as the **New draft**
+command creates it.
+
+Story-level metadata (cover, logline, goals, series) lives on the *base draft*
+(the first draft, whose folder is the project root), so every draft shares it.
+The switcher just changes which set of scenes you're writing and tracking.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\Drafts\Second Draft\The Lamplighter's Archive — Second Draft.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/The%20Lamplighter%27s%20Archive%20%E2%80%94%20Second%20Draft.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/Drafts/Second Draft/The Lamplighter's Archive — Second Draft.md; frontmatter={'longform': {'format': 'scenes', 'title': "The Lamplighter's Archive", 'd...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/goal/the-lamplighter-s-archive.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/goal/the-lamplighter-s-archive.md
@@ -1,0 +1,42 @@
+---
+type: goal
+title: The Lamplighter's Archive
+description: The Lamplighter's Archive
+generated:
+  by: process:obsidian
+  at: '2026-09-08T10:02:37.432129+00:00'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md
+x_memanto:
+  id: 7359b396-6e95-47b1-8a6c-d87eb99e421f
+  confidence: 0.8
+  provenance: observed
+  source: obsidian
+  status: active
+  updated_at: '2026-09-08T10:02:37.432129+00:00'
+  type: goal
+---
+
+# The Lamplighter's Archive
+
+> *Book One of [The Lattice Cycle](../../Writing/Codex/Aszmar.md).*
+
+This is the **project index** — Inkswell reads the `longform` and `inkswell`
+blocks above to assemble the project. You normally never edit this by hand;
+the panels (Plan, Write, Track, Publish) write to it for you.
+
+Open the **Inkswell** view (pen-tool ribbon icon, or the command
+*"Open Inkswell projects"*) and this project will be listed. New here? Start
+with [_Start Here](../../_Start%20Here.md).
+
+## Logline
+
+A lamplighter who tends the memory-lamps of a sleeping city lights one that
+shows her a memory she never lived — and follows it down into the sealed Archive
+the city has spent a generation pretending to forget.
+
+---
+[Supporting data]
+- OKF source: memories\Writing\The Lamplighter's Archive\The Lamplighter's Archive.md
+- OKF resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md
+- Links: The Lattice Cycle -> ../../Writing/Codex/Aszmar.md, _Start Here -> ../../_Start%20Here.md
+- OKF x_obsidian: source_path=Writing/The Lamplighter's Archive/The Lamplighter's Archive.md; frontmatter={'longform': {'format': 'scenes', 'title': "The Lamplighter's Archive", 'draftTitle': 'First Draft', 'sceneFo...

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/memories/index.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/memories/index.md
@@ -1,0 +1,7 @@
+# Memories (21)
+
+- [fact](fact/index.md)
+- [decision](decision/index.md)
+- [goal](goal/index.md)
+- [context](context/index.md)
+- [artifact](artifact/index.md)

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/metrics/index.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/metrics/index.md
@@ -1,0 +1,3 @@
+# Metrics
+
+- [overview](overview.md)

--- a/examples/migrations/obsidian-to-okf/round-trip-okf/metrics/overview.md
+++ b/examples/migrations/obsidian-to-okf/round-trip-okf/metrics/overview.md
@@ -1,0 +1,46 @@
+---
+type: Metrics Overview
+title: Aggregate Metrics
+---
+
+# Metrics — aggregate
+
+> 21 memories
+
+
+---
+
+## 📊 Visual Insights
+
+### Memory Activity Timeline
+
+```
+Hour  00  03  06  09  12  15  18  21  24
+      ╠═══╬═══╬═══╬═══╬═══╬═══╬═══╬═══╣
+                  ●●●●                
+```
+
+**21** memories across **1** active hours
+
+### Memory Type Distribution
+
+```
+ARTIFACT  ████████████████████ 10
+FACT      ██████████████ 7
+GOAL      ████ 2
+DECISION  ██ 1
+CONTEXT   ██ 1
+```
+
+### Confidence Overview
+
+| Metric          | Value |
+|-----------------|-------|
+| Total Memories  | 21     |
+| Avg Confidence  | 0.80  |
+| High (≥0.8)     | 21     |
+| Medium (0.5–0.8)| 0     |
+| Low (<0.5)      | 0     |
+
+*Visualizations auto-generated at Sep 08, 2026 11:03 AM*
+

--- a/examples/migrations/obsidian-to-okf/run_demo.py
+++ b/examples/migrations/obsidian-to-okf/run_demo.py
@@ -1,0 +1,70 @@
+"""Run the checked-in real-vault migration and deterministic fidelity gate."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+REPOSITORY_ROOT = ROOT.parents[2]
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from obsidian_to_okf import convert_vault  # noqa: E402
+
+from memanto.cli.migrate.mappers import map_okf  # noqa: E402
+from memanto.cli.migrate.okf_loader import load_okf_bundle  # noqa: E402
+
+GOLDEN_QUERIES = {
+    "Who is the protagonist?": ("Mara Vance", "protagonist"),
+    "What system governs lamplight memory?": ("Lamplight Memory", "soft magic"),
+    "What is the Bureau trying to keep forgotten?": (
+        "Bureau of Continuance",
+        "shared forgetting",
+    ),
+}
+
+
+def _score(rows: list[dict[str, object]]) -> dict[str, bool]:
+    corpus = {
+        str(row.get("title")): str(row.get("content", "")).casefold() for row in rows
+    }
+    return {
+        question: expected.casefold() in corpus.get(title, "")
+        for question, (title, expected) in GOLDEN_QUERIES.items()
+    }
+
+
+def main() -> None:
+    source = ROOT / "sample-source-vault"
+    output = ROOT / "sample-okf"
+    report = convert_vault(source, output)
+    loaded = load_okf_bundle(output)
+    mapped = map_okf(loaded)
+    golden = _score(mapped)
+    receipt = {
+        "source": "leethobbit/obsidian-inkswell-plugin sample vault",
+        "source_records": report.source_files,
+        "okf_records": len(loaded["memories"]),
+        "mapped_memories": len(mapped),
+        "source_sha256": report.source_sha256,
+        "type_counts": report.type_counts,
+        "resolvable_wikilinks_converted": report.wikilinks_converted,
+        "unresolved_wikilinks_preserved": len(report.unresolved_links),
+        "golden_recall": golden,
+        "golden_recall_score": f"{sum(golden.values())}/{len(golden)}",
+        "is_lossless_by_record_count": (
+            report.source_files == len(loaded["memories"]) == len(mapped)
+        ),
+    }
+    (output / "validation-report.json").write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps({"migration": asdict(report), "validation": receipt}, indent=2))
+    if not receipt["is_lossless_by_record_count"] or not all(golden.values()):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Aszmar.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Aszmar.md
@@ -1,0 +1,32 @@
+---
+type: fact
+title: Aszmar
+description: Aszmar
+timestamp: '2026-09-08T07:51:53.511881Z'
+resource: obsidian://open?path=Writing/Codex/Aszmar.md
+x_memanto:
+  type: fact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/Codex/Aszmar.md
+  frontmatter:
+    codex: world
+    codex-series: The Lattice Cycle
+    aliases: []
+    geography: A canal city built in tiers, lower wards in fog, upper wards in clean
+      light.
+    culture: Built around the daily ritual of "giving the day to the lamps." To carry
+      your own memories awake is seen as both proud and slightly unwell.
+    politics: Governed by the Bureau of Continuance, which administers the Lattice
+      and guards the Accords.
+    magicTech: Lamplight memory — see [[Lamplight Memory]]. Lighters light; rarer
+      still are those who can read.
+    history: The Continuance Accords ended the violent era of "kept" minds and established
+      the Lattice. One sealed failure — the Undercroft — underlies everything since.
+---
+
+# Aszmar
+
+The city and world of *The Lattice Cycle*. A place that solved the unbearable
+weight of remembering by agreeing, collectively, to set it down each night.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Bureau of Continuance.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Bureau of Continuance.md
@@ -1,0 +1,32 @@
+---
+type: fact
+title: Bureau of Continuance
+description: Bureau of Continuance
+timestamp: '2026-09-08T07:51:53.511881Z'
+resource: obsidian://open?path=Writing/Codex/Bureau%20of%20Continuance.md
+x_memanto:
+  type: fact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/Codex/Bureau of Continuance.md
+  frontmatter:
+    codex: faction
+    codex-series: The Lattice Cycle
+    aliases:
+    - The Bureau
+    type: Governing body / memory authority
+    size: City-wide civil service with auditors in every district
+    goal: Keep Continuance intact and the Undercroft forgotten.
+    territory:
+    - '[[The Lattice]]'
+    - '[[The Undercroft Archive]]'
+    leadership:
+    - '[[Inspector Coll]]'
+---
+
+# Bureau of Continuance
+
+Administers the Lattice and guards the Accords. Its real work is maintenance of a
+shared forgetting — which makes anyone who starts remembering, like Mara, a
+problem it is institutionally unequipped to solve gently.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Inspector Coll.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Inspector Coll.md
@@ -1,0 +1,43 @@
+---
+type: fact
+title: Inspector Coll
+description: Inspector Coll
+timestamp: '2026-09-08T07:51:53.513311Z'
+resource: obsidian://open?path=Writing/Codex/Inspector%20Coll.md
+x_memanto:
+  type: fact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/Codex/Inspector Coll.md
+  frontmatter:
+    codex: character
+    codex-series: The Lattice Cycle
+    aliases:
+    - The auditor
+    role: Antagonist (initially)
+    function: Stands in the hero's way
+    memorableTrait: Uses silence as a tool; never fills a pause.
+    age: '51'
+    gender: Man
+    occupation: Inspector, Bureau of Continuance
+    traits: 'Patient. Uses silence as a tool. Believes order is mercy and is mostly
+      wrong
+
+      about that in the ways that matter.
+
+      '
+    motivation: To keep Continuance intact in the lower districts — and to avoid remembering
+      why he already knows Mara's face.
+    flaw: Has filed his own past in the Undercroft and calls the gap "discipline."
+    arc: From enforcing the city's forgetting to choosing, at the lowest point, to
+      remember.
+    relationships:
+    - '[[Mara Vance]]'
+---
+
+# Inspector Coll
+
+A Bureau auditor sent to explain a darkened row. He is far more troubled by the
+lamplighter than by the lamps — and cannot say why, because the answer is one of
+the things he long ago arranged not to keep.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Lamplight Memory.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Lamplight Memory.md
@@ -1,0 +1,42 @@
+---
+type: fact
+title: Lamplight Memory
+description: Lamplight Memory
+timestamp: '2026-09-08T07:51:53.513311Z'
+resource: obsidian://open?path=Writing/Codex/Lamplight%20Memory.md
+x_memanto:
+  type: fact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/Codex/Lamplight Memory.md
+  frontmatter:
+    codex: concept
+    codex-series: The Lattice Cycle
+    aliases:
+    - The trade
+    - Giving the day
+    type: Memory storage / soft magic system
+    rules: 'Lit lamps draw the day''s memories from the people who live beneath them.
+      A lamp
+
+      returns a memory only to the one who left it, and only on purpose.
+
+      '
+    limitations: 'A darkened row makes memory pool and leak. "Reading" — taking a
+      memory that is
+
+      not yours — is vanishingly rare and is never free; the reader pays a cost they
+
+      rarely notice in time.
+
+      '
+    significance: The premise the whole series turns on. Establishes that memory in
+      Aszmar is a material, a currency, and a vulnerability.
+---
+
+# Lamplight Memory
+
+The soft magic of *The Lattice Cycle*. Codified here so every scene that touches
+it stays consistent — and so the rules the plot will eventually break are
+written down before they break.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Mara Vance.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/Mara Vance.md
@@ -1,0 +1,49 @@
+---
+type: fact
+title: Mara Vance
+description: Mara Vance
+timestamp: '2026-09-08T07:51:53.513311Z'
+resource: obsidian://open?path=Writing/Codex/Mara%20Vance.md
+x_memanto:
+  type: fact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/Codex/Mara Vance.md
+  frontmatter:
+    codex: character
+    codex-series: The Lattice Cycle
+    aliases:
+    - The lighter on Vesper Row
+    role: Protagonist
+    age: '34'
+    gender: Woman
+    occupation: Lamplighter, Vesper Row district
+    traits: 'Quietly excellent at a trade she has no ambition to leave. Notices everything,
+
+      says a third of it. Brave in the specific way of people who have already
+
+      decided not to be afraid.
+
+      '
+    motivation: To put the leaking memory back where it belongs — and, underneath
+      that, to stop having to not-remember the thing she lost.
+    flaw: Mistakes endurance for peace. Will carry anything rather than set it down
+      and look at it.
+    appearance: Lean, weather-roughened hands, a lighter's burn-scar along one wrist.
+    arc: From wanting nothing, to wanting one true thing badly enough to pay the Archive's
+      price for it.
+    relationships:
+    - '[[Inspector Coll]]'
+---
+
+# Mara Vance
+
+The lamplighter of Vesper Row, third of her line to tend the same crooked posts.
+Fifteen clean years and no ambition beyond a finished row at midnight — until a
+lamp shows her a memory that isn't hers.
+
+> [!note] Codex entity
+> This is a **character** entry. Inkswell finds it by the `codex: character`
+> frontmatter key. Scenes that list `[Mara Vance](../../Writing/Codex/Mara%20Vance.md)` in their `characters` field
+> show up automatically under *References* in the Codex panel.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/The Lattice.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/The Lattice.md
@@ -1,0 +1,44 @@
+---
+type: fact
+title: The Lattice
+description: The Lattice
+timestamp: '2026-09-08T07:51:53.514439Z'
+resource: obsidian://open?path=Writing/Codex/The%20Lattice.md
+x_memanto:
+  type: fact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/Codex/The Lattice.md
+  frontmatter:
+    codex: location
+    codex-series: The Lattice Cycle
+    aliases:
+    - The grid
+    - The lamps
+    type: City-wide memory network
+    parent: '[[Aszmar]]'
+    region: Lower and upper districts of Aszmar
+    climate: Damp; canal fog in the lower wards
+    population: Roughly two million dreamers
+    atmosphere: 'At night the whole city glows in held breath — every lamp a small
+      warm vault.
+
+      By day, an ordinary working city that has agreed not to ask where the weight
+      of
+
+      its days has gone.
+
+      '
+    significance: The Lattice stores the population's memories in lamplight so no
+      one carries a whole life awake. It is the world's central marvel and its central
+      lie.
+    history: Built after the Continuance Accords ended the era of "kept" minds. The
+      Undercroft beneath it was sealed a generation ago after an incident the Bureau
+      does not name.
+---
+
+# The Lattice
+
+The memory-grid of Aszmar: streets of lamps that drink the day from the people
+who live beneath them. Mara tends one small, crooked stretch of it.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/The Undercroft Archive.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/Codex/The Undercroft Archive.md
@@ -1,0 +1,34 @@
+---
+type: fact
+title: The Undercroft Archive
+description: The Undercroft Archive
+timestamp: '2026-09-08T07:51:53.514439Z'
+resource: obsidian://open?path=Writing/Codex/The%20Undercroft%20Archive.md
+x_memanto:
+  type: fact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/Codex/The Undercroft Archive.md
+  frontmatter:
+    codex: location
+    codex-series: The Lattice Cycle
+    aliases:
+    - The Undercroft
+    - The Archive
+    type: Sealed sub-level beneath the canal locks
+    parent: '[[Aszmar]]'
+    region: Below the lower districts
+    atmosphere: Cold stone and machine oil; rows of unlit lamps receding past the
+      edge of any light.
+    significance: Where stray and "drained" memory pools. Officially does not exist.
+      Has kept one lighter's memories intact for a generation, waiting for someone
+      who can read them.
+    history: Sealed after the incident that ended the last generation of lighters.
+      The seal was always an agreement, never a lock.
+---
+
+# The Undercroft Archive
+
+The place memory drains to when a row goes dark. The Bureau spent a generation
+insisting it wasn't there. It was there the whole time, and it has been waiting.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/01 - The Last Lamp on Vesper Row.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/01 - The Last Lamp on Vesper Row.md
@@ -1,0 +1,77 @@
+---
+type: artifact
+title: 01 - The Last Lamp on Vesper Row
+description: The last lamp on Vesper Row stood crooked on its post, the way it had
+  for as long as Mara could remember, and she loved it a little for that.
+timestamp: '2026-09-08T07:51:53.515488Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/01%20-%20The%20Last%20Lamp%20on%20Vesper%20Row.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Draft 1/01 - The Last Lamp on Vesper
+    Row.md
+  frontmatter:
+    status: revised
+    pov: Mara Vance
+    chapter: One
+    act: Act I
+    plotlines:
+    - The Lattice
+    synopsis: Mara lights the last lamp on her night route as the district sleeps,
+      content in a small life — the opening image of the city's memory kept safe for
+      one more night.
+    characters:
+    - '[[Mara Vance]]'
+    location: '[[The Lattice]]'
+    targetWords: 1400
+    color: '#6B9BD1'
+    revScene:
+      startsRight: true
+      described: true
+      goalConflict: true
+      shift: true
+      purpose: true
+      endsUncertain: true
+      consistent: true
+    revSceneNote: Strong opening image; confirm the 'last ordinary night' line still
+      lands after act-1 trims.
+    revVerdict: keep
+    revPurpose: Establishes the Lattice and Mara's contentment; without it the catalyst
+      in scene 2 has no baseline to overturn.
+    revArc:
+    - character: '[[Mara Vance]]'
+      internal: Content; wants nothing.
+      external: An ordinary night on her route.
+---
+
+The last lamp on Vesper Row stood crooked on its post, the way it had for as long as Mara could remember, and she loved it a little for that.
+
+She climbed the three rungs of her ladder, opened the small glass door, and let the wick take the flame from her taper. The light did not so much brighten as*settle* — a warmth that had nothing to do with heat. Down the length of the
+row, behind shuttered windows, the people of the district slept, and their day
+went into the lamps the way water finds the lowest place. A first kiss on the
+tram. An argument left unfinished. The particular blue of a kettle bought
+secondhand. The Lattice drank it all and held it, so that no one had to carry
+the whole weight of a life awake.
+
+That was the trade, and Mara was good at it. Not ambitious — good. She knew
+every crooked post on three streets, knew which lamps guttered in the damp off
+the canal and which burned clean. She knew the order to light them so the row
+came up like a held breath let slowly out.
+
+[TODO: land the mother's line here or in scene 2? See beat "theme-stated".]
+
+[RESEARCH: Find out how water works.]
+
+
+Her mother had lit these same posts, and her mother's mother. *Some things are
+only true while someone remembers them*, her mother used to say, which Mara had
+taken for sentiment until the night she understood it was a job description.
+
+She came down the ladder, folded it under her arm, and stood a moment in the
+finished light. The row glowed. The district dreamed into the glass. Somewhere a
+clock let go of midnight.
+
+It was, she would think later, the last ordinary night she would ever have —
+and she had spent it perfectly, lighting lamps, wanting nothing.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/02 - What the Light Remembers.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/02 - What the Light Remembers.md
@@ -1,0 +1,79 @@
+---
+type: artifact
+title: 02 - What the Light Remembers
+description: It happened at the seventh lamp, the clean-burning one outside the locksmith's.
+timestamp: '2026-09-08T07:51:53.515488Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/02%20-%20What%20the%20Light%20Remembers.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Draft 1/02 - What the Light Remembers.md
+  frontmatter:
+    status: written
+    pov: Mara Vance
+    chapter: One
+    act: Act I
+    plotlines:
+    - The Leaking Memory
+    - The Lattice
+    synopsis: A lamp on her route shows Mara a memory that cannot be hers — a room
+      she has never entered, a name she has never heard. The catalyst.
+    characters:
+    - '[[Mara Vance]]'
+    location: '[[The Lattice]]'
+    targetWords: 1600
+    color: '#6B9BD1'
+    revScene:
+      startsRight: true
+      goalConflict: true
+      shift: true
+      endsUncertain: true
+    revSceneNote: Catalyst lands; line-edit the vision paragraph and resolve the [RESEARCH]/[DIALOGUE]
+      to-dos.
+    revArc:
+    - character: '[[Mara Vance]]'
+      internal: Certainty cracks; unsettled.
+      external: A memory that isn't hers — and she hides it.
+---
+
+It happened at the seventh lamp, the clean-burning one outside the locksmith's.
+
+Mara touched the flame to the wick, and instead of settling, the light *reached*
+for her. She felt it the way you feel someone read over your shoulder. Then the
+glass went bright and silver and she was — elsewhere.
+
+A room she had never entered. Low ceiling, a smell of cold stone and machine
+oil. Rows and rows of unlit lamps receding into a dark that did not end. A
+woman's voice, very close, saying a name — *Edran* — with a tenderness that
+broke in the middle of it. The grief in it was enormous and precise and entirely
+not Mara's, and yet she stood inside it as if it had her own teeth.
+
+Then she was back on Vesper Row with her taper guttering and her heart going
+like a fist on a door.
+
+Lamps held the district's memories. That was the trade. But a lamp gave its
+memory *back* only to the one who'd left it, and only on purpose — and Mara had
+never been in that room, had never known an Edran, had never grieved like that
+in her life.
+
+She stood very still and made herself breathe. The locksmith's window was dark.
+The row glowed on, ordinary, dreaming. Only the seventh lamp seemed to watch her
+now, the way the crooked one never had.
+
+[DIALOGUE: Mara says something low to the seventh lamp — defiant, or afraid? Find the line in revision.]
+
+[NOTE: mirror this room's "cold stone and machine oil" in the Undercroft reveal, scene 4.]
+
+[RESEARCH: coin a lamplighter's word for a leaked memory — "a bleed"?]
+
+A lamp had shown her a memory that was not hers to be shown. Which meant either
+she was losing her mind, or something in the Lattice had begun to leak — and
+some part of her, the part that had lit these posts for fifteen years and wanted
+nothing, knew with cold certainty which one it was.
+
+She did not report it. She told herself she would, in the morning. She climbed
+down, folded the ladder, and walked home not lighting the eighth lamp, the
+ninth, the tenth — leaving the rest of Vesper Row dark behind her for the first
+time in her working life, and not noticing until she reached her door.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/03 - Inspector Coll.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/03 - Inspector Coll.md
@@ -1,0 +1,64 @@
+---
+type: artifact
+title: 03 - Inspector Coll
+description: Coll did not like the morning light in the lower districts. It was honest
+  light, and honest light made people careful, and careful people were harder to read.
+timestamp: '2026-09-08T07:51:53.516814Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/03%20-%20Inspector%20Coll.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Draft 1/03 - Inspector Coll.md
+  frontmatter:
+    status: draft
+    pov: Inspector Coll
+    chapter: Two
+    act: Act I
+    plotlines:
+    - Coll & the Bureau
+    synopsis: An inspector from the Bureau of Continuance arrives to audit the dark
+      stretch of Vesper Row. He is more interested in Mara than in the lamps. The
+      debate.
+    characters:
+    - '[[Mara Vance]]'
+    - '[[Inspector Coll]]'
+    location: '[[The Lattice]]'
+    targetWords: 1500
+---
+
+Coll did not like the morning light in the lower districts. It was honest light,
+and honest light made people careful, and careful people were harder to read.
+
+He stood at the foot of Vesper Row with the audit slate cradled against his
+chest and counted the unlit lamps. Three. Four. Seven, if you went to the end.
+A lamplighter's route left dark was a small thing on paper and a very large thing
+in practice, because the Lattice did not tolerate gaps. A gap was where memory
+pooled, and pooled memory was where the trouble of the last generation had
+started.
+
+The lamplighter came up the row toward him with a ladder under her arm and the
+particular flat calm of someone who has decided not to be afraid. Vance, the
+roll said. Mara Vance. He had read the name twice on the tram and told himself
+it meant nothing.
+
+"You left your route," he said, by way of good morning.
+
+"I came back to finish it." She set the ladder down. "Bad taper. It happens."
+
+It did not happen — not to a lighter with fifteen clean years — and they both
+knew he knew it. He let the silence do its work. She let it, too, which was
+interesting. Most people filled a silence with the truth eventually. She filled
+it with nothing at all, and watched him while she did.
+
+[NOTE: Coll's interiority is too on-the-nose here — trust the reader more in revision.]
+
+"The Bureau takes an interest when a row goes dark," he said. "Continuance is
+fragile in the lower districts. You understand."
+
+"I understand the Bureau takes an interest," she said.
+
+He almost smiled. He filed the name again, and the face with it, and the small
+cold fact that he had no record of ever meeting her and was nonetheless
+*certain* that he had.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/04 - The Undercroft.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/04 - The Undercroft.md
@@ -1,0 +1,52 @@
+---
+type: artifact
+title: 04 - The Undercroft
+description: The stair was where the old lighters' songs said it would be — behind
+  the third lock-house on the canal, under a grate everyone had agreed for a generation
+  was sealed.
+timestamp: '2026-09-08T07:51:53.516814Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/04%20-%20The%20Undercroft.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Draft 1/04 - The Undercroft.md
+  frontmatter:
+    status: draft
+    pov: Mara Vance
+    chapter: Three
+    act: Act II
+    plotlines:
+    - The Leaking Memory
+    synopsis: Following the leak, Mara finds the access stair to the sealed Undercroft
+      beneath the canal locks and goes down. Break into Act Two.
+    characters:
+    - '[[Mara Vance]]'
+    location: '[[The Undercroft Archive]]'
+    targetWords: 1800
+---
+
+The stair was where the old lighters' songs said it would be — behind the third
+lock-house on the canal, under a grate everyone had agreed for a generation was
+sealed.
+
+It was not sealed. It had only been agreed to be.
+
+Mara went down with a hooded lamp and the conviction, equal parts terror and
+relief, that she had stopped pretending. Below the lock-house the air changed:
+cold stone, machine oil, the exact smell of the memory that was not hers. She
+knew the room before she reached it the way you know the last step of your own
+stairs in the dark.
+
+And then the room — low ceiling, rows of unlit lamps receding past the edge of
+her light, more than a district could ever fill, more than a city. The Undercroft.
+The place stray memory drained to. The place the Bureau had spent a generation
+insisting did not exist, in the patient, official way they insisted on all the
+things that frightened them most.
+
+She lifted her lamp. The nearest unlit lamp on the shelf turned, very slightly,
+toward the flame — and Mara understood that down here, she was not the one doing
+the reading.
+
+[NOTE: This is the threshold. Make sure scene 03 plants that Coll fears exactly this place.]

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/05 - A Memory Not Her Own.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/05 - A Memory Not Her Own.md
@@ -1,0 +1,45 @@
+---
+type: artifact
+title: 05 - A Memory Not Her Own
+description: '[NOTE: OUTLINE ONLY — not yet drafted. Beat: Midpoint (false victory).]'
+timestamp: '2026-09-08T07:51:53.516814Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/05%20-%20A%20Memory%20Not%20Her%20Own.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Draft 1/05 - A Memory Not Her Own.md
+  frontmatter:
+    status: outlined
+    pov: Mara Vance
+    chapter: Three
+    act: Act II
+    plotlines:
+    - The Leaking Memory
+    - Mara's Grief
+    synopsis: Inside the Archive, Mara reads the grief-memory to its end and learns
+      the Archive has been waiting for a lighter who can read as well as light. False
+      victory — the midpoint turn.
+    characters:
+    - '[[Mara Vance]]'
+    location: '[[The Undercroft Archive]]'
+    targetWords: 1800
+    revArc:
+    - character: '[[Mara Vance]]'
+      internal: Claims the pull instead of fearing it.
+      external: Reads the Archive — and it answers to her.
+---
+
+[NOTE: OUTLINE ONLY — not yet drafted. Beat: Midpoint (false victory).]
+
+Beats to hit in this scene:
+
+- Mara reads the grief-memory all the way through. *Edran* was a lighter too — the last one to come down here before the Undercroft was "sealed."
+- Reveal: the Archive doesn't just store memory, it *keeps* it — it has kept Edran's, intact, for a generation, waiting.
+- Turn: it has been waiting for someone who can read as well as light. That is vanishingly rare. That is Mara.
+- False victory: she thinks she has found a wonder. The reader should feel the trap close a half-beat before she does.
+- Plant: reading costs the reader something. She doesn't notice what, yet.
+- Exit on the choice that breaks her into the back half of the book.
+
+Tone: awe shading into dread. Keep her competent — she is never a victim of the plot, only of her own curiosity.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/06 - The Archivist's Bargain.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/06 - The Archivist's Bargain.md
@@ -1,0 +1,38 @@
+---
+type: artifact
+title: 06 - The Archivist's Bargain
+description: '[NOTE: IDEA STAGE — captured so the beat and the Codex links exist.]'
+timestamp: '2026-09-08T07:51:53.518215Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/06%20-%20The%20Archivist%27s%20Bargain.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Draft 1/06 - The Archivist's Bargain.md
+  frontmatter:
+    status: idea
+    pov: Mara Vance
+    chapter: Four
+    act: Act II
+    plotlines:
+    - The Leaking Memory
+    - Mara's Grief
+    synopsis: The Archive offers Mara a bargain — read for it, and it will give her
+      back something she lost and has stopped letting herself remember. Bad guys close
+      in.
+    characters:
+    - '[[Mara Vance]]'
+    location: '[[The Undercroft Archive]]'
+    targetWords: 1700
+---
+
+[NOTE: IDEA STAGE — captured so the beat and the Codex links exist.]
+
+The Archive makes its offer. The price is the thing Mara has been not-looking-at since scene 01.
+
+Questions to answer before drafting:
+
+- What did Mara lose? (Her mother's last memory? Her own?)
+- What does the Archive actually want read, and to whom?
+- Where is Coll while this happens?

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/07 - Blackout.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/07 - Blackout.md
@@ -1,0 +1,35 @@
+---
+type: artifact
+title: 07 - Blackout
+description: '[NOTE: IDEA STAGE — the Act 3 low point, captured for now.]'
+timestamp: '2026-09-08T07:51:53.518215Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/07%20-%20Blackout.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Draft 1/07 - Blackout.md
+  frontmatter:
+    status: idea
+    pov: Inspector Coll
+    chapter: Five
+    act: Act III
+    plotlines:
+    - Coll & the Bureau
+    - The Lattice
+    synopsis: Every lamp on Vesper Row is wiped at once. Coll arrives to a row that
+      has forgotten itself — and realizes too late what, and who, the blackout was
+      meant to erase. All is lost.
+    characters:
+    - '[[Inspector Coll]]'
+    location: '[[The Lattice]]'
+    targetWords: 1500
+---
+
+[NOTE: IDEA STAGE — the Act 3 low point, captured for now.]
+
+The "whiff of death" beat. Vesper Row goes dark and stays dark; the district
+wakes up a stranger to itself. Coll has to decide what he is willing to remember
+in order to fix it — which is the cost the Archive named back at the midpoint,
+arriving for him instead of Mara.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/08 - What the Dark Remembers.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Draft 1/08 - What the Dark Remembers.md
@@ -1,0 +1,57 @@
+---
+type: artifact
+title: 08 - What the Dark Remembers
+description: '[NOTE: OUTLINE ONLY — the Break-into-3 / Finale / Final-image beats,
+  captured so the structure closes. Draft after the Act 2 scenes land.]'
+timestamp: '2026-09-08T07:51:53.519216Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Draft%201/08%20-%20What%20the%20Dark%20Remembers.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Draft 1/08 - What the Dark Remembers.md
+  frontmatter:
+    status: outlined
+    pov: Mara Vance
+    chapter: Six
+    act: Act III
+    synopsis: Mara goes back down to the dark Archive and stops trying to save Vesper
+      Row — she reads herself into it instead, so the erased day has somewhere to
+      live. She relights the row from the Archive's own store and keeps, awake, the
+      one memory she'd buried. The finale and final image.
+    characters:
+    - '[[Mara Vance]]'
+    - '[[Inspector Coll]]'
+    location: '[[The Lattice]]'
+    targetWords: 1600
+    color: '#6B9BD1'
+    revArc:
+    - character: '[[Mara Vance]]'
+      internal: Sets the weight down and looks at it — chooses to remember rather
+        than endure.
+      external: Becomes the Archive's reader; relights the row and carries the buried
+        memory awake.
+---
+
+[NOTE: OUTLINE ONLY — the Break-into-3 / Finale / Final-image beats, captured so the structure closes. Draft after the Act 2 scenes land.]
+
+The row is dark and it is not coming back on its own. Mara knows that the way
+she knows which posts gutter in the damp: not as a fear, as a fact. Coll is
+beside her on the canal stair, and for once the Bureau man has nothing to write
+down.
+
+She does not try to save Vesper Row. That is the turn — she stops trying to put
+the day back the way it was and goes down to the Archive to *remember* it
+instead, reading herself into the store so the erased hours have somewhere to
+live that a blackout can't reach.
+
+[TODO: find the single line she says to Coll on the stair before she goes down — it should rhyme with her mother's "some things are only true while someone remembers them."]
+
+Then the relight: not from her taper but from the Archive's own kept light, the
+row coming up post by post like a held breath let slowly out — the opening
+image, inverted. And the cost the Archive named at the midpoint, paid at last:
+she keeps the one memory she had spent years not carrying, awake now, hers.
+
+Final image — Mara lights the last lamp on Vesper Row again. But she is the
+reader now, and the glass, when it settles, remembers her too.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/01 - The Last Lamp on Vesper Row.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/01 - The Last Lamp on Vesper Row.md
@@ -1,0 +1,32 @@
+---
+type: artifact
+title: 01 - The Last Lamp on Vesper Row
+description: 'Second-draft note: this scene is a stub in the sample, kept short to
+  demonstrate the draft switcher without duplicating the whole book.'
+timestamp: '2026-09-08T07:51:53.519722Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/Scenes/01%20-%20The%20Last%20Lamp%20on%20Vesper%20Row.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/01 - The
+    Last Lamp on Vesper Row.md
+  frontmatter:
+    status: draft
+    pov: Mara Vance
+    synopsis: A tighter second-pass opening — start on the lamp already lit, not the
+      walk to it.
+---
+
+Second-draft note: this scene is a stub in the sample, kept short to demonstrate
+the draft switcher without duplicating the whole book.
+
+Mara set her thumb to the last lamp on Vesper Row and let it drink. The filament
+took the day the way it always did — the baker's first oven, a child's lost tooth,
+the small unremembered weather of a street going to sleep — and gave it back as a
+steady amber that would hold until dawn.
+
+In the first draft she walked the whole route to get here. This time the city is
+already dark behind her, and the reader starts where the story does: one lamp, one
+keeper, one memory she is about to find that was never hers to hold.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/02 - What the Light Remembers.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/02 - What the Light Remembers.md
@@ -1,0 +1,30 @@
+---
+type: artifact
+title: 02 - What the Light Remembers
+description: 'Second-draft note: another short stub, here to give the switcher a second
+  scene to show.'
+timestamp: '2026-09-08T07:51:53.522084Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/Scenes/02%20-%20What%20the%20Light%20Remembers.md
+x_memanto:
+  type: artifact
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/02 - What
+    the Light Remembers.md
+  frontmatter:
+    status: idea
+    pov: Mara Vance
+    synopsis: Bring the wrong memory forward sooner; end on the room she has never
+      entered.
+---
+
+Second-draft note: another short stub, here to give the switcher a second scene to
+show.
+
+The lamp showed her a room. Not Vesper Row, not the undercroft stair she knew by
+feel — a room with a window facing a sea she had never lived beside, and a voice
+saying her name in a register she had never used.
+
+She should have logged it and moved on. In this draft she doesn't move on, and the
+chapter ends there, on the threshold of a life the light insists she remembers.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Drafts/Second Draft/The Lamplighter's Archive — Second Draft.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/Drafts/Second Draft/The Lamplighter's Archive — Second Draft.md
@@ -1,0 +1,41 @@
+---
+type: goal
+title: The Lamplighter's Archive — Second Draft
+description: The Lamplighter's Archive — Second Draft
+timestamp: '2026-09-08T07:51:53.524086Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/Drafts/Second%20Draft/The%20Lamplighter%27s%20Archive%20%E2%80%94%20Second%20Draft.md
+x_memanto:
+  type: goal
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/Drafts/Second Draft/The Lamplighter's
+    Archive — Second Draft.md
+  frontmatter:
+    longform:
+      format: scenes
+      title: The Lamplighter's Archive
+      draftTitle: Second Draft
+      sceneFolder: Scenes
+      scenes:
+      - 01 - The Last Lamp on Vesper Row
+      - 02 - What the Light Remembers
+      ignoredFiles: []
+    inkswell:
+      draftCreated: 2026-07-10 09:00:00+00:00
+---
+
+# The Lamplighter's Archive — Second Draft
+
+A second draft of the same project, kept deliberately short in the sample. It's
+here to show Inkswell's **multi-draft** support.
+
+This note shares the same `longform.title` as the first draft, so Inkswell groups
+both into one *story* and offers a **draft switcher** at the top of the project.
+Each draft keeps its own scene folder — the first draft lives in `Draft 1/`, this
+one in its own `Drafts/Second Draft/Scenes/` folder, exactly as the **New draft**
+command creates it.
+
+Story-level metadata (cover, logline, goals, series) lives on the *base draft*
+(the first draft, whose folder is the project root), so every draft shares it.
+The switcher just changes which set of scenes you're writing and tracking.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/The Lamplighter's Archive — Plan.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/The Lamplighter's Archive — Plan.md
@@ -1,0 +1,69 @@
+---
+type: decision
+title: The Lamplighter's Archive — Plan
+description: The Lamplighter's Archive — Plan
+timestamp: '2026-09-08T07:51:53.525081Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive%20%E2%80%94%20Plan.md
+x_memanto:
+  type: decision
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/The Lamplighter's Archive — Plan.md
+  frontmatter: {}
+---
+
+# The Lamplighter's Archive — Plan
+
+*Planning note for [The Lamplighter's Archive](../../Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md). Inkswell reads the sections
+below into **Plan → Overview**; edit them there or here — it's the same note.*
+
+## Synopsis
+
+In the city of Aszmar, each day is poured into the street-lamps at dusk: a first
+kiss, an argument left unfinished, the blue of a secondhand kettle. The Lattice
+drinks it and holds it, so no one has to carry a whole life awake. Mara Vance
+tends a small route on Vesper Row and wants nothing more than that — until a lamp
+shows her a memory that was never hers. Following the leak leads her down into
+the Undercroft, to the sealed Archive the city spent a generation forgetting,
+which has been waiting for a lighter who can *read* as well as light. When the
+Bureau's blackout wipes the row to bury what she's found, Mara stops trying to
+put the day back the way it was and chooses instead to remember it — becoming
+the Archive's reader, and keeping, at last, the one memory she'd buried.
+
+## Plot groundwork
+
+- **The rule of the world:** lamplight *stores* memory, it doesn't merely
+  illuminate. (Continuity decision `rev-lamplight-stores` — treat early "light"
+  references as retroactively about memory.)
+- **The Archive is sentient** and has intent, not just storage
+  (`rev-archive-sentient`). It bargains; it waits; it chooses Mara.
+- **The buried thing:** Mara lost someone and has stopped letting herself
+  remember it. The Archive's price is exactly that memory — carried awake.
+- **The antagonist is procedure, not a villain:** the Bureau of Continuance
+  keeps the city stable by deciding what may be remembered. Coll is its
+  instrument who turns.
+
+## Act I
+
+Establish the trade, the Lattice, and Mara's contented, unambitious life
+(*Opening Image*, *Setup*). A lamp shows her a memory that cannot be hers — the
+*Catalyst* — and she hides it. Inspector Coll arrives from the Bureau to audit
+the dark stretch, more interested in Mara than the lamps: the *Debate*. Chapters
+One–Two.
+
+## Act II
+
+Mara finds the access stair and descends into the sealed Undercroft (*Break into
+Two*). Inside, she reads the grief-memory to its end and learns the Archive has
+been waiting for her — a false victory, the *Midpoint*. The Archive offers its
+bargain: read for it, and be given back what she lost. The Bureau closes in.
+Chapters Three–Four.
+
+## Act III
+
+The blackout wipes Vesper Row — *All Is Lost* — and takes the memory she went
+down to protect (*Dark Night of the Soul*). Mara goes back down and stops trying
+to save the row; she reads herself into the Archive instead (*Break into
+Three*), relights the district from its own kept light (*Finale*), and keeps the
+buried memory awake (*Final Image*, mirroring the opening). Chapters Five–Six.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/The Lamplighter's Archive.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/Writing/The Lamplighter's Archive/The Lamplighter's Archive.md
@@ -1,0 +1,332 @@
+---
+type: goal
+title: The Lamplighter's Archive
+description: The Lamplighter's Archive
+timestamp: '2026-09-08T07:51:53.525081Z'
+resource: obsidian://open?path=Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md
+x_memanto:
+  type: goal
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: Writing/The Lamplighter's Archive/The Lamplighter's Archive.md
+  frontmatter:
+    longform:
+      format: scenes
+      title: The Lamplighter's Archive
+      draftTitle: First Draft
+      sceneFolder: Draft 1
+      scenes:
+      - 01 - The Last Lamp on Vesper Row
+      - 02 - What the Light Remembers
+      - 03 - Inspector Coll
+      - 04 - The Undercroft
+      - 05 - A Memory Not Her Own
+      - 06 - The Archivist's Bargain
+      - 07 - Blackout
+      - 08 - What the Dark Remembers
+      ignoredFiles: []
+    inkswell:
+      series:
+        name: The Lattice Cycle
+        order: 1
+      goals:
+        target: 90000
+        deadline: 2026-09-01
+        daysPerWeek: 5
+      overview:
+        logline: A lamplighter who tends a sleeping city's memory-lamps lights one
+          that shows her a life she never lived — and follows it down into the sealed
+          Archive the city has spent a generation forgetting.
+        theme: What a city chooses to remember, and what it costs to be the one who
+          carries it.
+        genre: Gaslamp fantasy
+        audience: Readers of cozy-but-eerie gaslamp fantasy with a quiet, competent
+          heroine — Piranesi by way of a lamplighter's round.
+        cover: Writing/The Lamplighter's Archive/cover.svg
+        planningNote: Writing/The Lamplighter's Archive/The Lamplighter's Archive
+          — Plan.md
+      compile:
+        version: 2
+        sceneSteps:
+        - id: strip-frontmatter
+          options: {}
+        - id: remove-comments
+          options: {}
+        - id: flatten-links
+          options: {}
+        - id: group-by-chapter
+          options:
+            level: 1
+            sceneBreak: '* * *'
+        manuscriptSteps:
+        - id: trim-blank-lines
+          options: {}
+        separator: '
+
+
+          '
+        targetBasename: Lamplighter - manuscript
+        format: md
+      beats:
+        template: save-the-cat
+        assignments:
+          opening-image:
+            scenes:
+            - 01 - The Last Lamp on Vesper Row
+            note: Mara lights the last lamp on her route as the district sleeps —
+              the city's memory kept safe for one more night.
+            done: true
+          theme-stated:
+            note: 'A line from her mother: "Some things are only true while someone
+              remembers them."'
+            done: true
+          setup:
+            scenes:
+            - 01 - The Last Lamp on Vesper Row
+            - 02 - What the Light Remembers
+            note: Establish the Lattice, the lamplighter's trade, and Mara's quiet,
+              unambitious life.
+            done: true
+          catalyst:
+            scenes:
+            - 02 - What the Light Remembers
+            note: A lamp shows Mara a memory that cannot be hers — a room she has
+              never entered.
+            done: true
+          debate:
+            scenes:
+            - 03 - Inspector Coll
+            note: Report the anomaly and stay safe, or keep it secret and chase it?
+              Coll's arrival forces the question.
+          break-into-2:
+            scenes:
+            - 04 - The Undercroft
+            note: Mara descends into the sealed Undercroft to find where stray memories
+              drain to.
+          midpoint:
+            scenes:
+            - 05 - A Memory Not Her Own
+            note: False victory — she finds the Archive, and learns it has been waiting
+              for someone who can read it.
+          all-is-lost:
+            scenes:
+            - 07 - Blackout
+            note: The district goes dark. Every lamp on Vesper Row is wiped at once.
+          dark-night-of-the-soul:
+            note: The blackout took the one memory Mara had gone down to protect.
+              If the Archive can be wiped, nothing she loves is safe in it — including
+              the thing she buried there.
+          break-into-3:
+            scenes:
+            - 08 - What the Dark Remembers
+            note: Mara stops trying to save the row and chooses to remember it instead
+              — reading herself into the Archive so the erased days have somewhere
+              to live.
+          finale:
+            scenes:
+            - 08 - What the Dark Remembers
+            note: She relights Vesper Row from the Archive's own store, giving the
+              district back its day — and keeps, awake, the one memory she'd spent
+              years not carrying.
+          final-image:
+            note: Mara lights the last lamp again — but now she is the Archive's reader,
+              and the row remembers her too.
+      acts:
+      - id: act-1
+        title: Act I
+      - id: act-2
+        title: Act II
+      - id: act-3
+        title: Act III
+      chapters:
+      - id: ch-1
+        title: One
+        actId: act-1
+        targetWords: 3000
+      - id: ch-2
+        title: Two
+        actId: act-1
+        targetWords: 1500
+      - id: ch-3
+        title: Three
+        actId: act-2
+        targetWords: 3600
+      - id: ch-4
+        title: Four
+        actId: act-2
+        targetWords: 1700
+      - id: ch-5
+        title: Five
+        actId: act-3
+        targetWords: 1500
+      - id: ch-6
+        title: Six
+        actId: act-3
+        targetWords: 1600
+      plotlines:
+      - id: pl-memory
+        title: The Leaking Memory
+        color: '#6B9BD1'
+      - id: pl-bureau
+        title: Coll & the Bureau
+        color: '#C65D5D'
+      - id: pl-grief
+        title: Mara's Grief
+        color: '#9B72C4'
+      - id: pl-lattice
+        title: The Lattice
+        color: '#4FA88B'
+      revisions:
+      - id: rev-lamplight-stores
+        text: From now on, lamplight stores memory — it doesn't merely illuminate.
+          Treat earlier "light" references as retroactively true.
+        scene: 02 - What the Light Remembers
+        status: applied
+        created: 2026-03-14 09:12:00+00:00
+        type: continuity
+        priority: high
+      - id: rev-coll-knows-mara
+        text: From now on, Inspector Coll already knew Mara years ago, from before
+          the Undercroft was sealed. EDIT
+        scene: 03 - Inspector Coll
+        status: pending
+        created: 2026-05-02 18:40:00+00:00
+        type: character
+        priority: med
+      - id: rev-archive-sentient
+        text: The Archive is sentient. Assume every reference to it implies intent,
+          not just storage.
+        scene: null
+        status: pending
+        created: 2026-06-10 20:05:00+00:00
+        type: continuity
+        priority: high
+      - id: rev-blackout-mechanism
+        text: Why does the blackout wipe every lamp on Vesper Row at once? Seed a
+          mechanism earlier or it's a plot hole.
+        scene: 07 - Blackout
+        status: pending
+        created: 2026-06-18 11:20:00+00:00
+        type: plot-hole
+        priority: high
+      - id: rev-undercroft-terms
+        text: Look up period drainage/sub-cellar terminology for the Undercroft description.
+          [RESEARCH]
+        scene: 04 - The Undercroft
+        status: pending
+        created: 2026-06-20 08:00:00+00:00
+        type: research
+        priority: low
+      revisionChecklist:
+        story:
+          structure:
+            done: true
+          stakes:
+            done: true
+          heroTransforms:
+            note: Mara goes from wanting nothing to claiming the Archive — verify
+              the turn lands by scene 5/6.
+          consistent:
+            note: Reconcile lamplight-stores-memory rule across early scenes.
+        page:
+          echoes:
+            done: true
+          adverbs:
+            note: Sweep -ly adverbs in dialogue tags during the line pass.
+      arcTracked:
+      - '[[Mara Vance]]'
+      styleSheet:
+        entries:
+        - id: s-lattice
+          canonical: Lattice
+          variants:
+          - lattice
+          kind: name
+          note: The memory-network is always capitalized.
+        - id: s-undercroft
+          canonical: Undercroft
+          variants:
+          - undercroft
+          kind: name
+      publishing:
+        metadata:
+          title: The Lamplighter's Archive
+          seriesTitle: The Lattice Cycle
+          tagline: She lights the lamps that keep a city's memory — until one shows
+            her a life she never lived.
+          blurb: In a city that pours each day into its street-lamps, Mara Vance is
+            content to tend her small route and want nothing. Then a lamp shows her
+            a memory that was never hers, and the trail leads down into the sealed
+            Archive the city has spent a generation forgetting.
+          genre: Fantasy
+          subgenres:
+          - Gaslamp fantasy
+          - Mystery
+          targetReader: Readers of cozy-but-eerie gaslamp fantasy with a quiet, competent
+            heroine.
+          keywords:
+          - gaslamp fantasy
+          - memory magic
+          - lamplighter
+          - hidden archive
+          - slow burn mystery
+          - sentient magic
+          - found family
+          categories:
+            main: FICTION / Fantasy / Historical
+            sub:
+            - FICTION / Fantasy / Gaslamp
+            - FICTION / Mystery & Detective
+          kuExclusive: true
+          formats:
+            ebook:
+              enabled: true
+              price: 4.99
+            paperback:
+              enabled: true
+              price: 14.99
+        checklist:
+          writing:
+            draft:
+              done: true
+              notes: First draft in progress.
+          editing:
+            selfEdit:
+              done: true
+          foundational:
+            genre:
+              done: true
+            targetReader:
+              done: true
+        launch:
+          releaseDate: 2026-09-01
+          strategy: medium
+          milestones:
+            submit:
+              done: false
+        budget:
+          items:
+          - id: p-mqtp8n9n-aar6
+            label: Cover art
+            category: want
+            estimate: 500
+---
+
+# The Lamplighter's Archive
+
+> *Book One of [The Lattice Cycle](../../Writing/Codex/Aszmar.md).*
+
+This is the **project index** — Inkswell reads the `longform` and `inkswell`
+blocks above to assemble the project. You normally never edit this by hand;
+the panels (Plan, Write, Track, Publish) write to it for you.
+
+Open the **Inkswell** view (pen-tool ribbon icon, or the command
+*"Open Inkswell projects"*) and this project will be listed. New here? Start
+with [_Start Here](../../_Start%20Here.md).
+
+## Logline
+
+A lamplighter who tends the memory-lamps of a sleeping city lights one that
+shows her a memory she never lived — and follows it down into the sealed Archive
+the city has spent a generation pretending to forget.

--- a/examples/migrations/obsidian-to-okf/sample-okf/memories/_Start Here.md
+++ b/examples/migrations/obsidian-to-okf/sample-okf/memories/_Start Here.md
@@ -1,0 +1,120 @@
+---
+type: context
+title: 👋 Start Here — the Inkswell sample project
+description: 👋 Start Here — the Inkswell sample project
+timestamp: '2026-09-08T07:51:53.527730Z'
+resource: obsidian://open?path=_Start%20Here.md
+x_memanto:
+  type: context
+  source: obsidian
+  provenance: observed
+x_obsidian:
+  source_path: _Start Here.md
+  frontmatter: {}
+---
+
+# 👋 Start Here — the Inkswell sample project
+
+Welcome. This vault is a **complete, mid-draft novel** so you can see what
+Inkswell looks like in real use instead of an empty project. The book is
+*[The Lamplighter's Archive](Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md)* — original fiction, included so the sample is
+free to ship (see [licensing](#licensing)).
+
+> [!tip] First time? Do these two things
+> 1. **Enable the plugin.** Settings (⚙) → *Community plugins* → turn **off**
+>    Restricted Mode → enable **Inkswell**. (A fresh vault starts in Restricted
+>    Mode, so community plugins are off until you allow them.)
+> 2. **Open the workspace.** Click the **pen-tip ribbon icon** on the left, or
+>    run the command *"Open Inkswell projects"* (Ctrl/Cmd-P). Pick
+>    **The Lamplighter's Archive** in the project selector at the top.
+
+---
+
+## The five-minute tour
+
+Inkswell is one tab with a **left icon rail**, grouped into sections: **Home**,
+the writing pipeline (**Plan · Write · Revise · Publish**), **Codex · Track**,
+and **Search · Help** pinned at the bottom. Each stop does one job:
+
+| Stop | What you'll see in this sample |
+|------|-------------------------------|
+| **Home** | The project's **hero card** — cover art, logline, theme, and a progress bar toward the 90k target — above the scene list with per-scene word counts and status colors. Click a scene to open the **Inspector** (status, POV, chapter, plotlines, characters, word target). |
+| **Plan → Overview** | Novel-level planning — logline, theme, genre, audience, plus a linked **planning note** holding the synopsis, plot groundwork, and a 3-act outline. The high-level view, before anything is broken into beats or scenes. |
+| **Plan → Beats** | A *Save the Cat!* beat sheet filled through the finale — early beats ticked, a couple of later ones still open. Each beat has a **+ new scene** button that creates the scene and links it to the beat. |
+| **Plan → Structure** | Three views of the same scenes behind a **Tree · Board · Grid** switcher. **Tree** is the Act › Chapter › Scene **outline** — drag to reorder, with per-chapter word targets. **Board** is the same scenes as draggable status cards. **Grid** is the **Plot Grid**: a plotline × chapter matrix (The Leaking Memory, Coll & the Bureau, Mara's Grief, The Lattice) where an empty stretch is a visible pacing signal. |
+| **Write** | A distraction-light Live-Preview editor that walks the manuscript in order. To-do markers (`[RESEARCH: …]`, `[NOTE: …]`, `[DIALOGUE: …]`) highlight inline — use the topbar **Insert** buttons (or `Ctrl/Cmd-Shift-T/R/D/S/N`) to drop your own, and **Log issue** to capture a fix without stopping. The right sidebar has a **Scene / Revision** switcher — **Revision** lists every marker and logged decision across the book; click one to jump. Start a **Sprint** from the Write toolbar or the status bar. |
+| **Revise → Audit / Analysis** | **Audit**: the per-scene **14-point checklist** (scenes 1–2 partly audited), Story/Page project checklists, the scene-**purpose** lift-out verdict, a **scene-openings** variety strip, the **character-arc** grid (Mara is tracked from "wants nothing" to the finale), and a **style-sheet** scan. **Analysis**: readability, word-frequency, and echo reports over the prose. |
+| **Revise → To-dos** | Everything left to fix in one scene-grouped worklist: every to-do marker across the manuscript (click one to jump straight to it in the editor) plus the invisible-revision **decisions** — typed & prioritized (continuity/plot-hole…) — tick one applied once you've made the change. Filter it all with one chip row. |
+| **Publish → Compile / Checklist / Launch** | **Compile**: the export pipeline (groups scenes into chapters). **Checklist**: the self-publishing master checklist + the **book-metadata worksheet** (both partly filled). **Launch**: the **pre-order timeline** (release date + Medium strategy → computed milestone dates) and budget/cover/marketing/ARC trackers. |
+| **Codex** | The story bible: characters, locations, a world, a concept, and a faction. Open **Mara Vance** — her **Appears in** list finds every scene that names her automatically, and clicking one opens that scene in **Write** at the first mention. Every entry is **scoped to the series** *The Lattice Cycle* (its **Scope** field), so it follows the book across the cycle but won't clutter an unrelated project. |
+| **Track** | Word-goal rings, a writing-history chart, a 26-week heatmap, streaks, sprint stats, and a **By chapter** breakdown against the per-chapter targets. A **deadline** is set, so Project targets shows a **pace verdict** and the draft-milestone zone. Set today's **mood** in Goals. |
+| **Search** | Full-text search across every scene's prose and synopsis. Pick the scope — this draft, the whole story, the series, or the vault — and narrow with status/POV/chapter/plotline/character filters. Click a hit to jump to it in Write, where it flashes. |
+
+> [!tip] Too many surfaces?
+> Any optional feature — Beats, Board, Plot Grid, the Revise Audit/Analysis
+> tabs, the Publishing checklist/Launch planner, or the Write writing-prompts
+> button — can be turned off in **Settings → Features** (or right-click a tab and
+> *Hide*). It's completely lossless: hiding only stops rendering, your notes and
+> stored data are untouched, and re-enabling brings everything back.
+
+---
+
+## How the sample maps to the data
+
+Nothing here is magic — it's all plain Markdown you can inspect:
+
+- **The project** is defined by the `longform:` and `inkswell:` frontmatter on
+  [The Lamplighter's Archive](Writing/The%20Lamplighter%27s%20Archive/The%20Lamplighter%27s%20Archive.md) (the index note). That one block declares the
+  scene order, the word target, the overview, the beat sheet, the **acts /
+  chapters / plotlines** structure, the compile recipe, the series, and the
+  revision log.
+- **The project has two drafts.** Both index notes share the same
+  `longform.title`, so Inkswell groups them into one *story* with a **draft
+  switcher** at the top of the project. The main book is the first draft (its
+  scenes live in `Draft 1/`); a short **Second Draft** stub lives in
+  `Drafts/Second Draft/Scenes/` purely to show the feature. Story-level metadata
+  (cover, logline, goals, series) is shared from the first draft — each draft
+  just carries its own scene set, word counts, and Search scope.
+- **Each scene** lives in [Draft 1/](Writing/The%20Lamplighter's%20Archive/Draft%201/) with flat frontmatter:
+  `status`, `pov`, `chapter`, `act`, `plotlines`, `characters`, `location`,
+  `targetWords`. Those fields drive the colors, the Inspector, the Outline and
+  Plot Grid, and the Track tallies. The Plot Grid and Outline are pure
+  projections of these — a scene joins a plotline or chapter just by naming it,
+  so the views can never drift from the manuscript.
+- **Codex entries** in [Codex/](Writing/Codex/) are just notes carrying a `codex:` key.
+  Scenes link to them with ordinary `[[wikilinks]]` in their `characters` /
+  `location` fields, and the Codex panel finds the references automatically.
+  Each entry here also carries `codex-series: The Lattice Cycle`, which **scopes**
+  it to that series — it shows in pickers for every book in the cycle but is hidden
+  from unrelated projects. (Use `codex-project: "[[Book]]"` to scope to a single
+  book, or leave both off to share an entry globally. New entries inherit the
+  active project's scope automatically; folder location is just tidy storage —
+  the tag is what controls visibility.)
+- **Sprint and daily-word history** is *not* in these notes — it lives in the
+  plugin's `data.json`. That's why it travels with this vault but wouldn't travel
+  with a loose folder of chapters.
+
+## Try editing something
+
+The fastest way to feel the loop:
+
+1. Go to **Write**, open scene **02 – What the Light Remembers**, and add a
+   sentence. The status-bar word count for today goes up immediately.
+2. Open **Track** — today's ring and the history chart reflect your new words.
+3. On **Home**, change a scene's status in the Inspector and watch the color and
+   the Track → Structure tally update.
+
+> [!warning] About the dates in Track
+> The seeded writing history is anchored to **June 2026**, so the *Today / Week /
+> Month* rings and the current-streak read "live" around then. Opening this vault
+> much later is harmless — the **history chart, heatmap, and sprint list still
+> render** — but the rings reset because there are no entries for the real
+> current date. Write a few words (step 1 above) and today's ring fills back in.
+> Also note the seeded "today" is a **Monday**, so the Week ring starts fresh.
+
+## Licensing
+
+*The Lamplighter's Archive* and all Codex entries here are **original work**
+created for this sample and distributed under the same license as the plugin.
+No public-domain or third-party text is bundled, so there are no edition,
+translation, or jurisdiction concerns — you can ship, fork, or rewrite it freely.

--- a/examples/migrations/obsidian-to-okf/sample-okf/migration-report.json
+++ b/examples/migrations/obsidian-to-okf/sample-okf/migration-report.json
@@ -1,0 +1,25 @@
+{
+  "converted_files": 21,
+  "embeds_converted": 0,
+  "skipped_files": 0,
+  "source_files": 21,
+  "source_sha256": "5edc939e73e6e23eaf936ce1d76f33d1f9415cab03999ce061aaddd7a47e53e7",
+  "type_counts": {
+    "artifact": 10,
+    "context": 1,
+    "decision": 1,
+    "fact": 7,
+    "goal": 2
+  },
+  "unresolved_links": [
+    {
+      "source": "_Start Here.md",
+      "target": "wikilinks"
+    },
+    {
+      "source": "_Start Here.md",
+      "target": "Book"
+    }
+  ],
+  "wikilinks_converted": 6
+}

--- a/examples/migrations/obsidian-to-okf/sample-okf/validation-report.json
+++ b/examples/migrations/obsidian-to-okf/sample-okf/validation-report.json
@@ -1,0 +1,23 @@
+{
+  "golden_recall": {
+    "What is the Bureau trying to keep forgotten?": true,
+    "What system governs lamplight memory?": true,
+    "Who is the protagonist?": true
+  },
+  "golden_recall_score": "3/3",
+  "is_lossless_by_record_count": true,
+  "mapped_memories": 21,
+  "okf_records": 21,
+  "resolvable_wikilinks_converted": 6,
+  "source": "leethobbit/obsidian-inkswell-plugin sample vault",
+  "source_records": 21,
+  "source_sha256": "5edc939e73e6e23eaf936ce1d76f33d1f9415cab03999ce061aaddd7a47e53e7",
+  "type_counts": {
+    "artifact": 10,
+    "context": 1,
+    "decision": 1,
+    "fact": 7,
+    "goal": 2
+  },
+  "unresolved_wikilinks_preserved": 2
+}

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Aszmar.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Aszmar.md
@@ -1,0 +1,15 @@
+---
+codex: world
+codex-series: The Lattice Cycle
+aliases: []
+geography: A canal city built in tiers, lower wards in fog, upper wards in clean light.
+culture: Built around the daily ritual of "giving the day to the lamps." To carry your own memories awake is seen as both proud and slightly unwell.
+politics: Governed by the Bureau of Continuance, which administers the Lattice and guards the Accords.
+magicTech: Lamplight memory — see [[Lamplight Memory]]. Lighters light; rarer still are those who can read.
+history: The Continuance Accords ended the violent era of "kept" minds and established the Lattice. One sealed failure — the Undercroft — underlies everything since.
+---
+
+# Aszmar
+
+The city and world of *The Lattice Cycle*. A place that solved the unbearable
+weight of remembering by agreeing, collectively, to set it down each night.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Bureau of Continuance.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Bureau of Continuance.md
@@ -1,0 +1,20 @@
+---
+codex: faction
+codex-series: The Lattice Cycle
+aliases:
+  - The Bureau
+type: Governing body / memory authority
+size: City-wide civil service with auditors in every district
+goal: Keep Continuance intact and the Undercroft forgotten.
+territory:
+  - "[[The Lattice]]"
+  - "[[The Undercroft Archive]]"
+leadership:
+  - "[[Inspector Coll]]"
+---
+
+# Bureau of Continuance
+
+Administers the Lattice and guards the Accords. Its real work is maintenance of a
+shared forgetting — which makes anyone who starts remembering, like Mara, a
+problem it is institutionally unequipped to solve gently.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Inspector Coll.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Inspector Coll.md
@@ -1,0 +1,26 @@
+---
+codex: character
+codex-series: The Lattice Cycle
+aliases:
+  - The auditor
+role: Antagonist (initially)
+function: Stands in the hero's way
+memorableTrait: Uses silence as a tool; never fills a pause.
+age: "51"
+gender: Man
+occupation: Inspector, Bureau of Continuance
+traits: |
+  Patient. Uses silence as a tool. Believes order is mercy and is mostly wrong
+  about that in the ways that matter.
+motivation: To keep Continuance intact in the lower districts — and to avoid remembering why he already knows Mara's face.
+flaw: Has filed his own past in the Undercroft and calls the gap "discipline."
+arc: From enforcing the city's forgetting to choosing, at the lowest point, to remember.
+relationships:
+  - "[[Mara Vance]]"
+---
+
+# Inspector Coll
+
+A Bureau auditor sent to explain a darkened row. He is far more troubled by the
+lamplighter than by the lamps — and cannot say why, because the answer is one of
+the things he long ago arranged not to keep.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Lamplight Memory.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Lamplight Memory.md
@@ -1,0 +1,22 @@
+---
+codex: concept
+codex-series: The Lattice Cycle
+aliases:
+  - The trade
+  - Giving the day
+type: Memory storage / soft magic system
+rules: |
+  Lit lamps draw the day's memories from the people who live beneath them. A lamp
+  returns a memory only to the one who left it, and only on purpose.
+limitations: |
+  A darkened row makes memory pool and leak. "Reading" — taking a memory that is
+  not yours — is vanishingly rare and is never free; the reader pays a cost they
+  rarely notice in time.
+significance: The premise the whole series turns on. Establishes that memory in Aszmar is a material, a currency, and a vulnerability.
+---
+
+# Lamplight Memory
+
+The soft magic of *The Lattice Cycle*. Codified here so every scene that touches
+it stays consistent — and so the rules the plot will eventually break are
+written down before they break.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Mara Vance.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/Mara Vance.md
@@ -1,0 +1,31 @@
+---
+codex: character
+codex-series: The Lattice Cycle
+aliases:
+  - The lighter on Vesper Row
+role: Protagonist
+age: "34"
+gender: Woman
+occupation: Lamplighter, Vesper Row district
+traits: |
+  Quietly excellent at a trade she has no ambition to leave. Notices everything,
+  says a third of it. Brave in the specific way of people who have already
+  decided not to be afraid.
+motivation: To put the leaking memory back where it belongs — and, underneath that, to stop having to not-remember the thing she lost.
+flaw: Mistakes endurance for peace. Will carry anything rather than set it down and look at it.
+appearance: Lean, weather-roughened hands, a lighter's burn-scar along one wrist.
+arc: From wanting nothing, to wanting one true thing badly enough to pay the Archive's price for it.
+relationships:
+  - "[[Inspector Coll]]"
+---
+
+# Mara Vance
+
+The lamplighter of Vesper Row, third of her line to tend the same crooked posts.
+Fifteen clean years and no ambition beyond a finished row at midnight — until a
+lamp shows her a memory that isn't hers.
+
+> [!note] Codex entity
+> This is a **character** entry. Inkswell finds it by the `codex: character`
+> frontmatter key. Scenes that list `[[Mara Vance]]` in their `characters` field
+> show up automatically under *References* in the Codex panel.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/The Lattice.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/The Lattice.md
@@ -1,0 +1,23 @@
+---
+codex: location
+codex-series: The Lattice Cycle
+aliases:
+  - The grid
+  - The lamps
+type: City-wide memory network
+parent: "[[Aszmar]]"
+region: Lower and upper districts of Aszmar
+climate: Damp; canal fog in the lower wards
+population: Roughly two million dreamers
+atmosphere: |
+  At night the whole city glows in held breath — every lamp a small warm vault.
+  By day, an ordinary working city that has agreed not to ask where the weight of
+  its days has gone.
+significance: The Lattice stores the population's memories in lamplight so no one carries a whole life awake. It is the world's central marvel and its central lie.
+history: Built after the Continuance Accords ended the era of "kept" minds. The Undercroft beneath it was sealed a generation ago after an incident the Bureau does not name.
+---
+
+# The Lattice
+
+The memory-grid of Aszmar: streets of lamps that drink the day from the people
+who live beneath them. Mara tends one small, crooked stretch of it.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/The Undercroft Archive.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/Codex/The Undercroft Archive.md
@@ -1,0 +1,18 @@
+---
+codex: location
+codex-series: The Lattice Cycle
+aliases:
+  - The Undercroft
+  - The Archive
+type: Sealed sub-level beneath the canal locks
+parent: "[[Aszmar]]"
+region: Below the lower districts
+atmosphere: Cold stone and machine oil; rows of unlit lamps receding past the edge of any light.
+significance: Where stray and "drained" memory pools. Officially does not exist. Has kept one lighter's memories intact for a generation, waiting for someone who can read them.
+history: Sealed after the incident that ended the last generation of lighters. The seal was always an agreement, never a lock.
+---
+
+# The Undercroft Archive
+
+The place memory drains to when a row goes dark. The Bureau spent a generation
+insisting it wasn't there. It was there the whole time, and it has been waiting.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/01 - The Last Lamp on Vesper Row.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/01 - The Last Lamp on Vesper Row.md
@@ -1,0 +1,59 @@
+---
+status: revised
+pov: Mara Vance
+chapter: One
+act: Act I
+plotlines:
+  - The Lattice
+synopsis: Mara lights the last lamp on her night route as the district sleeps, content in a small life — the opening image of the city's memory kept safe for one more night.
+characters:
+  - "[[Mara Vance]]"
+location: "[[The Lattice]]"
+targetWords: 1400
+color: "#6B9BD1"
+revScene:
+  startsRight: true
+  described: true
+  goalConflict: true
+  shift: true
+  purpose: true
+  endsUncertain: true
+  consistent: true
+revSceneNote: "Strong opening image; confirm the 'last ordinary night' line still lands after act-1 trims."
+revVerdict: keep
+revPurpose: "Establishes the Lattice and Mara's contentment; without it the catalyst in scene 2 has no baseline to overturn."
+revArc:
+  - character: "[[Mara Vance]]"
+    internal: Content; wants nothing.
+    external: An ordinary night on her route.
+---
+
+The last lamp on Vesper Row stood crooked on its post, the way it had for as long as Mara could remember, and she loved it a little for that.
+
+She climbed the three rungs of her ladder, opened the small glass door, and let the wick take the flame from her taper. The light did not so much brighten as*settle* — a warmth that had nothing to do with heat. Down the length of the
+row, behind shuttered windows, the people of the district slept, and their day
+went into the lamps the way water finds the lowest place. A first kiss on the
+tram. An argument left unfinished. The particular blue of a kettle bought
+secondhand. The Lattice drank it all and held it, so that no one had to carry
+the whole weight of a life awake.
+
+That was the trade, and Mara was good at it. Not ambitious — good. She knew
+every crooked post on three streets, knew which lamps guttered in the damp off
+the canal and which burned clean. She knew the order to light them so the row
+came up like a held breath let slowly out.
+
+[TODO: land the mother's line here or in scene 2? See beat "theme-stated".]
+
+[RESEARCH: Find out how water works.]
+
+
+Her mother had lit these same posts, and her mother's mother. *Some things are
+only true while someone remembers them*, her mother used to say, which Mara had
+taken for sentiment until the night she understood it was a job description.
+
+She came down the ladder, folded it under her arm, and stood a moment in the
+finished light. The row glowed. The district dreamed into the glass. Somewhere a
+clock let go of midnight.
+
+It was, she would think later, the last ordinary night she would ever have —
+and she had spent it perfectly, lighting lamps, wanting nothing.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/02 - What the Light Remembers.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/02 - What the Light Remembers.md
@@ -1,0 +1,65 @@
+---
+status: written
+pov: Mara Vance
+chapter: One
+act: Act I
+plotlines:
+  - The Leaking Memory
+  - The Lattice
+synopsis: A lamp on her route shows Mara a memory that cannot be hers — a room she has never entered, a name she has never heard. The catalyst.
+characters:
+  - "[[Mara Vance]]"
+location: "[[The Lattice]]"
+targetWords: 1600
+color: "#6B9BD1"
+revScene:
+  startsRight: true
+  goalConflict: true
+  shift: true
+  endsUncertain: true
+revSceneNote: "Catalyst lands; line-edit the vision paragraph and resolve the [RESEARCH]/[DIALOGUE] to-dos."
+revArc:
+  - character: "[[Mara Vance]]"
+    internal: Certainty cracks; unsettled.
+    external: A memory that isn't hers — and she hides it.
+---
+
+It happened at the seventh lamp, the clean-burning one outside the locksmith's.
+
+Mara touched the flame to the wick, and instead of settling, the light *reached*
+for her. She felt it the way you feel someone read over your shoulder. Then the
+glass went bright and silver and she was — elsewhere.
+
+A room she had never entered. Low ceiling, a smell of cold stone and machine
+oil. Rows and rows of unlit lamps receding into a dark that did not end. A
+woman's voice, very close, saying a name — *Edran* — with a tenderness that
+broke in the middle of it. The grief in it was enormous and precise and entirely
+not Mara's, and yet she stood inside it as if it had her own teeth.
+
+Then she was back on Vesper Row with her taper guttering and her heart going
+like a fist on a door.
+
+Lamps held the district's memories. That was the trade. But a lamp gave its
+memory *back* only to the one who'd left it, and only on purpose — and Mara had
+never been in that room, had never known an Edran, had never grieved like that
+in her life.
+
+She stood very still and made herself breathe. The locksmith's window was dark.
+The row glowed on, ordinary, dreaming. Only the seventh lamp seemed to watch her
+now, the way the crooked one never had.
+
+[DIALOGUE: Mara says something low to the seventh lamp — defiant, or afraid? Find the line in revision.]
+
+[NOTE: mirror this room's "cold stone and machine oil" in the Undercroft reveal, scene 4.]
+
+[RESEARCH: coin a lamplighter's word for a leaked memory — "a bleed"?]
+
+A lamp had shown her a memory that was not hers to be shown. Which meant either
+she was losing her mind, or something in the Lattice had begun to leak — and
+some part of her, the part that had lit these posts for fifteen years and wanted
+nothing, knew with cold certainty which one it was.
+
+She did not report it. She told herself she would, in the morning. She climbed
+down, folded the ladder, and walked home not lighting the eighth lamp, the
+ninth, the tenth — leaving the rest of Vesper Row dark behind her for the first
+time in her working life, and not noticing until she reached her door.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/03 - Inspector Coll.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/03 - Inspector Coll.md
@@ -1,0 +1,49 @@
+---
+status: draft
+pov: Inspector Coll
+chapter: Two
+act: Act I
+plotlines:
+  - Coll & the Bureau
+synopsis: An inspector from the Bureau of Continuance arrives to audit the dark stretch of Vesper Row. He is more interested in Mara than in the lamps. The debate.
+characters:
+  - "[[Mara Vance]]"
+  - "[[Inspector Coll]]"
+location: "[[The Lattice]]"
+targetWords: 1500
+---
+
+Coll did not like the morning light in the lower districts. It was honest light,
+and honest light made people careful, and careful people were harder to read.
+
+He stood at the foot of Vesper Row with the audit slate cradled against his
+chest and counted the unlit lamps. Three. Four. Seven, if you went to the end.
+A lamplighter's route left dark was a small thing on paper and a very large thing
+in practice, because the Lattice did not tolerate gaps. A gap was where memory
+pooled, and pooled memory was where the trouble of the last generation had
+started.
+
+The lamplighter came up the row toward him with a ladder under her arm and the
+particular flat calm of someone who has decided not to be afraid. Vance, the
+roll said. Mara Vance. He had read the name twice on the tram and told himself
+it meant nothing.
+
+"You left your route," he said, by way of good morning.
+
+"I came back to finish it." She set the ladder down. "Bad taper. It happens."
+
+It did not happen — not to a lighter with fifteen clean years — and they both
+knew he knew it. He let the silence do its work. She let it, too, which was
+interesting. Most people filled a silence with the truth eventually. She filled
+it with nothing at all, and watched him while she did.
+
+[NOTE: Coll's interiority is too on-the-nose here — trust the reader more in revision.]
+
+"The Bureau takes an interest when a row goes dark," he said. "Continuance is
+fragile in the lower districts. You understand."
+
+"I understand the Bureau takes an interest," she said.
+
+He almost smiled. He filed the name again, and the face with it, and the small
+cold fact that he had no record of ever meeting her and was nonetheless
+*certain* that he had.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/04 - The Undercroft.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/04 - The Undercroft.md
@@ -1,0 +1,37 @@
+---
+status: draft
+pov: Mara Vance
+chapter: Three
+act: Act II
+plotlines:
+  - The Leaking Memory
+synopsis: Following the leak, Mara finds the access stair to the sealed Undercroft beneath the canal locks and goes down. Break into Act Two.
+characters:
+  - "[[Mara Vance]]"
+location: "[[The Undercroft Archive]]"
+targetWords: 1800
+---
+
+The stair was where the old lighters' songs said it would be — behind the third
+lock-house on the canal, under a grate everyone had agreed for a generation was
+sealed.
+
+It was not sealed. It had only been agreed to be.
+
+Mara went down with a hooded lamp and the conviction, equal parts terror and
+relief, that she had stopped pretending. Below the lock-house the air changed:
+cold stone, machine oil, the exact smell of the memory that was not hers. She
+knew the room before she reached it the way you know the last step of your own
+stairs in the dark.
+
+And then the room — low ceiling, rows of unlit lamps receding past the edge of
+her light, more than a district could ever fill, more than a city. The Undercroft.
+The place stray memory drained to. The place the Bureau had spent a generation
+insisting did not exist, in the patient, official way they insisted on all the
+things that frightened them most.
+
+She lifted her lamp. The nearest unlit lamp on the shelf turned, very slightly,
+toward the flame — and Mara understood that down here, she was not the one doing
+the reading.
+
+[NOTE: This is the threshold. Make sure scene 03 plants that Coll fears exactly this place.]

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/05 - A Memory Not Her Own.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/05 - A Memory Not Her Own.md
@@ -1,0 +1,31 @@
+---
+status: outlined
+pov: Mara Vance
+chapter: Three
+act: Act II
+plotlines:
+  - The Leaking Memory
+  - Mara's Grief
+synopsis: Inside the Archive, Mara reads the grief-memory to its end and learns the Archive has been waiting for a lighter who can read as well as light. False victory — the midpoint turn.
+characters:
+  - "[[Mara Vance]]"
+location: "[[The Undercroft Archive]]"
+targetWords: 1800
+revArc:
+  - character: "[[Mara Vance]]"
+    internal: Claims the pull instead of fearing it.
+    external: Reads the Archive — and it answers to her.
+---
+
+[NOTE: OUTLINE ONLY — not yet drafted. Beat: Midpoint (false victory).]
+
+Beats to hit in this scene:
+
+- Mara reads the grief-memory all the way through. *Edran* was a lighter too — the last one to come down here before the Undercroft was "sealed."
+- Reveal: the Archive doesn't just store memory, it *keeps* it — it has kept Edran's, intact, for a generation, waiting.
+- Turn: it has been waiting for someone who can read as well as light. That is vanishingly rare. That is Mara.
+- False victory: she thinks she has found a wonder. The reader should feel the trap close a half-beat before she does.
+- Plant: reading costs the reader something. She doesn't notice what, yet.
+- Exit on the choice that breaks her into the back half of the book.
+
+Tone: awe shading into dread. Keep her competent — she is never a victim of the plot, only of her own curiosity.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/06 - The Archivist's Bargain.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/06 - The Archivist's Bargain.md
@@ -1,0 +1,24 @@
+---
+status: idea
+pov: Mara Vance
+chapter: Four
+act: Act II
+plotlines:
+  - The Leaking Memory
+  - Mara's Grief
+synopsis: The Archive offers Mara a bargain — read for it, and it will give her back something she lost and has stopped letting herself remember. Bad guys close in.
+characters:
+  - "[[Mara Vance]]"
+location: "[[The Undercroft Archive]]"
+targetWords: 1700
+---
+
+[NOTE: IDEA STAGE — captured so the beat and the Codex links exist.]
+
+The Archive makes its offer. The price is the thing Mara has been not-looking-at since scene 01.
+
+Questions to answer before drafting:
+
+- What did Mara lose? (Her mother's last memory? Her own?)
+- What does the Archive actually want read, and to whom?
+- Where is Coll while this happens?

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/07 - Blackout.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/07 - Blackout.md
@@ -1,0 +1,21 @@
+---
+status: idea
+pov: Inspector Coll
+chapter: Five
+act: Act III
+plotlines:
+  - Coll & the Bureau
+  - The Lattice
+synopsis: Every lamp on Vesper Row is wiped at once. Coll arrives to a row that has forgotten itself — and realizes too late what, and who, the blackout was meant to erase. All is lost.
+characters:
+  - "[[Inspector Coll]]"
+location: "[[The Lattice]]"
+targetWords: 1500
+---
+
+[NOTE: IDEA STAGE — the Act 3 low point, captured for now.]
+
+The "whiff of death" beat. Vesper Row goes dark and stays dark; the district
+wakes up a stranger to itself. Coll has to decide what he is willing to remember
+in order to fix it — which is the cost the Archive named back at the midpoint,
+arriving for him instead of Mara.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/08 - What the Dark Remembers.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Draft 1/08 - What the Dark Remembers.md
@@ -1,0 +1,39 @@
+---
+status: outlined
+pov: Mara Vance
+chapter: Six
+act: Act III
+synopsis: Mara goes back down to the dark Archive and stops trying to save Vesper Row — she reads herself into it instead, so the erased day has somewhere to live. She relights the row from the Archive's own store and keeps, awake, the one memory she'd buried. The finale and final image.
+characters:
+  - "[[Mara Vance]]"
+  - "[[Inspector Coll]]"
+location: "[[The Lattice]]"
+targetWords: 1600
+color: "#6B9BD1"
+revArc:
+  - character: "[[Mara Vance]]"
+    internal: Sets the weight down and looks at it — chooses to remember rather than endure.
+    external: Becomes the Archive's reader; relights the row and carries the buried memory awake.
+---
+
+[NOTE: OUTLINE ONLY — the Break-into-3 / Finale / Final-image beats, captured so the structure closes. Draft after the Act 2 scenes land.]
+
+The row is dark and it is not coming back on its own. Mara knows that the way
+she knows which posts gutter in the damp: not as a fear, as a fact. Coll is
+beside her on the canal stair, and for once the Bureau man has nothing to write
+down.
+
+She does not try to save Vesper Row. That is the turn — she stops trying to put
+the day back the way it was and goes down to the Archive to *remember* it
+instead, reading herself into the store so the erased hours have somewhere to
+live that a blackout can't reach.
+
+[TODO: find the single line she says to Coll on the stair before she goes down — it should rhyme with her mother's "some things are only true while someone remembers them."]
+
+Then the relight: not from her taper but from the Archive's own kept light, the
+row coming up post by post like a held breath let slowly out — the opening
+image, inverted. And the cost the Archive named at the midpoint, paid at last:
+she keeps the one memory she had spent years not carrying, awake now, hers.
+
+Final image — Mara lights the last lamp on Vesper Row again. But she is the
+reader now, and the glass, when it settles, remembers her too.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/01 - The Last Lamp on Vesper Row.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/01 - The Last Lamp on Vesper Row.md
@@ -1,0 +1,17 @@
+---
+status: draft
+pov: Mara Vance
+synopsis: A tighter second-pass opening — start on the lamp already lit, not the walk to it.
+---
+
+Second-draft note: this scene is a stub in the sample, kept short to demonstrate
+the draft switcher without duplicating the whole book.
+
+Mara set her thumb to the last lamp on Vesper Row and let it drink. The filament
+took the day the way it always did — the baker's first oven, a child's lost tooth,
+the small unremembered weather of a street going to sleep — and gave it back as a
+steady amber that would hold until dawn.
+
+In the first draft she walked the whole route to get here. This time the city is
+already dark behind her, and the reader starts where the story does: one lamp, one
+keeper, one memory she is about to find that was never hers to hold.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/02 - What the Light Remembers.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Drafts/Second Draft/Scenes/02 - What the Light Remembers.md
@@ -1,0 +1,15 @@
+---
+status: idea
+pov: Mara Vance
+synopsis: Bring the wrong memory forward sooner; end on the room she has never entered.
+---
+
+Second-draft note: another short stub, here to give the switcher a second scene to
+show.
+
+The lamp showed her a room. Not Vesper Row, not the undercroft stair she knew by
+feel — a room with a window facing a sea she had never lived beside, and a voice
+saying her name in a register she had never used.
+
+She should have logged it and moved on. In this draft she doesn't move on, and the
+chapter ends there, on the threshold of a life the light insists she remembers.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Drafts/Second Draft/The Lamplighter's Archive — Second Draft.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/Drafts/Second Draft/The Lamplighter's Archive — Second Draft.md
@@ -1,0 +1,28 @@
+---
+longform:
+  format: scenes
+  title: The Lamplighter's Archive
+  draftTitle: Second Draft
+  sceneFolder: Scenes
+  scenes:
+    - 01 - The Last Lamp on Vesper Row
+    - 02 - What the Light Remembers
+  ignoredFiles: []
+inkswell:
+  draftCreated: 2026-07-10T09:00:00.000Z
+---
+
+# The Lamplighter's Archive — Second Draft
+
+A second draft of the same project, kept deliberately short in the sample. It's
+here to show Inkswell's **multi-draft** support.
+
+This note shares the same `longform.title` as the first draft, so Inkswell groups
+both into one *story* and offers a **draft switcher** at the top of the project.
+Each draft keeps its own scene folder — the first draft lives in `Draft 1/`, this
+one in its own `Drafts/Second Draft/Scenes/` folder, exactly as the **New draft**
+command creates it.
+
+Story-level metadata (cover, logline, goals, series) lives on the *base draft*
+(the first draft, whose folder is the project root), so every draft shares it.
+The switcher just changes which set of scenes you're writing and tracking.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/The Lamplighter's Archive — Plan.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/The Lamplighter's Archive — Plan.md
@@ -1,0 +1,54 @@
+# The Lamplighter's Archive — Plan
+
+*Planning note for [[The Lamplighter's Archive]]. Inkswell reads the sections
+below into **Plan → Overview**; edit them there or here — it's the same note.*
+
+## Synopsis
+
+In the city of Aszmar, each day is poured into the street-lamps at dusk: a first
+kiss, an argument left unfinished, the blue of a secondhand kettle. The Lattice
+drinks it and holds it, so no one has to carry a whole life awake. Mara Vance
+tends a small route on Vesper Row and wants nothing more than that — until a lamp
+shows her a memory that was never hers. Following the leak leads her down into
+the Undercroft, to the sealed Archive the city spent a generation forgetting,
+which has been waiting for a lighter who can *read* as well as light. When the
+Bureau's blackout wipes the row to bury what she's found, Mara stops trying to
+put the day back the way it was and chooses instead to remember it — becoming
+the Archive's reader, and keeping, at last, the one memory she'd buried.
+
+## Plot groundwork
+
+- **The rule of the world:** lamplight *stores* memory, it doesn't merely
+  illuminate. (Continuity decision `rev-lamplight-stores` — treat early "light"
+  references as retroactively about memory.)
+- **The Archive is sentient** and has intent, not just storage
+  (`rev-archive-sentient`). It bargains; it waits; it chooses Mara.
+- **The buried thing:** Mara lost someone and has stopped letting herself
+  remember it. The Archive's price is exactly that memory — carried awake.
+- **The antagonist is procedure, not a villain:** the Bureau of Continuance
+  keeps the city stable by deciding what may be remembered. Coll is its
+  instrument who turns.
+
+## Act I
+
+Establish the trade, the Lattice, and Mara's contented, unambitious life
+(*Opening Image*, *Setup*). A lamp shows her a memory that cannot be hers — the
+*Catalyst* — and she hides it. Inspector Coll arrives from the Bureau to audit
+the dark stretch, more interested in Mara than the lamps: the *Debate*. Chapters
+One–Two.
+
+## Act II
+
+Mara finds the access stair and descends into the sealed Undercroft (*Break into
+Two*). Inside, she reads the grief-memory to its end and learns the Archive has
+been waiting for her — a false victory, the *Midpoint*. The Archive offers its
+bargain: read for it, and be given back what she lost. The Bureau closes in.
+Chapters Three–Four.
+
+## Act III
+
+The blackout wipes Vesper Row — *All Is Lost* — and takes the memory she went
+down to protect (*Dark Night of the Soul*). Mara goes back down and stops trying
+to save the row; she reads herself into the Archive instead (*Break into
+Three*), relights the district from its own kept light (*Finale*), and keeps the
+buried memory awake (*Final Image*, mirroring the opening). Chapters Five–Six.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/The Lamplighter's Archive.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/Writing/The Lamplighter's Archive/The Lamplighter's Archive.md
@@ -1,0 +1,287 @@
+---
+longform:
+  format: scenes
+  title: The Lamplighter's Archive
+  draftTitle: First Draft
+  sceneFolder: Draft 1
+  scenes:
+    - 01 - The Last Lamp on Vesper Row
+    - 02 - What the Light Remembers
+    - 03 - Inspector Coll
+    - 04 - The Undercroft
+    - 05 - A Memory Not Her Own
+    - 06 - The Archivist's Bargain
+    - 07 - Blackout
+    - 08 - What the Dark Remembers
+  ignoredFiles: []
+inkswell:
+  series:
+    name: The Lattice Cycle
+    order: 1
+  goals:
+    target: 90000
+    deadline: 2026-09-01
+    daysPerWeek: 5
+  overview:
+    logline: A lamplighter who tends a sleeping city's memory-lamps lights one that shows her a life she never lived — and follows it down into the sealed Archive the city has spent a generation forgetting.
+    theme: What a city chooses to remember, and what it costs to be the one who carries it.
+    genre: Gaslamp fantasy
+    audience: Readers of cozy-but-eerie gaslamp fantasy with a quiet, competent heroine — Piranesi by way of a lamplighter's round.
+    cover: Writing/The Lamplighter's Archive/cover.svg
+    planningNote: Writing/The Lamplighter's Archive/The Lamplighter's Archive — Plan.md
+  compile:
+    version: 2
+    sceneSteps:
+      - id: strip-frontmatter
+        options: {}
+      - id: remove-comments
+        options: {}
+      - id: flatten-links
+        options: {}
+      - id: group-by-chapter
+        options:
+          level: 1
+          sceneBreak: "* * *"
+    manuscriptSteps:
+      - id: trim-blank-lines
+        options: {}
+    separator: "\n\n"
+    targetBasename: Lamplighter - manuscript
+    format: md
+  beats:
+    template: save-the-cat
+    assignments:
+      opening-image:
+        scenes:
+          - 01 - The Last Lamp on Vesper Row
+        note: Mara lights the last lamp on her route as the district sleeps — the city's memory kept safe for one more night.
+        done: true
+      theme-stated:
+        note: 'A line from her mother: "Some things are only true while someone remembers them."'
+        done: true
+      setup:
+        scenes:
+          - 01 - The Last Lamp on Vesper Row
+          - 02 - What the Light Remembers
+        note: Establish the Lattice, the lamplighter's trade, and Mara's quiet, unambitious life.
+        done: true
+      catalyst:
+        scenes:
+          - 02 - What the Light Remembers
+        note: A lamp shows Mara a memory that cannot be hers — a room she has never entered.
+        done: true
+      debate:
+        scenes:
+          - 03 - Inspector Coll
+        note: Report the anomaly and stay safe, or keep it secret and chase it? Coll's arrival forces the question.
+      break-into-2:
+        scenes:
+          - 04 - The Undercroft
+        note: Mara descends into the sealed Undercroft to find where stray memories drain to.
+      midpoint:
+        scenes:
+          - 05 - A Memory Not Her Own
+        note: False victory — she finds the Archive, and learns it has been waiting for someone who can read it.
+      all-is-lost:
+        scenes:
+          - 07 - Blackout
+        note: The district goes dark. Every lamp on Vesper Row is wiped at once.
+      dark-night-of-the-soul:
+        note: The blackout took the one memory Mara had gone down to protect. If the Archive can be wiped, nothing she loves is safe in it — including the thing she buried there.
+      break-into-3:
+        scenes:
+          - 08 - What the Dark Remembers
+        note: Mara stops trying to save the row and chooses to remember it instead — reading herself into the Archive so the erased days have somewhere to live.
+      finale:
+        scenes:
+          - 08 - What the Dark Remembers
+        note: She relights Vesper Row from the Archive's own store, giving the district back its day — and keeps, awake, the one memory she'd spent years not carrying.
+      final-image:
+        note: Mara lights the last lamp again — but now she is the Archive's reader, and the row remembers her too.
+  acts:
+    - id: act-1
+      title: Act I
+    - id: act-2
+      title: Act II
+    - id: act-3
+      title: Act III
+  chapters:
+    - id: ch-1
+      title: One
+      actId: act-1
+      targetWords: 3000
+    - id: ch-2
+      title: Two
+      actId: act-1
+      targetWords: 1500
+    - id: ch-3
+      title: Three
+      actId: act-2
+      targetWords: 3600
+    - id: ch-4
+      title: Four
+      actId: act-2
+      targetWords: 1700
+    - id: ch-5
+      title: Five
+      actId: act-3
+      targetWords: 1500
+    - id: ch-6
+      title: Six
+      actId: act-3
+      targetWords: 1600
+  plotlines:
+    - id: pl-memory
+      title: The Leaking Memory
+      color: "#6B9BD1"
+    - id: pl-bureau
+      title: Coll & the Bureau
+      color: "#C65D5D"
+    - id: pl-grief
+      title: Mara's Grief
+      color: "#9B72C4"
+    - id: pl-lattice
+      title: The Lattice
+      color: "#4FA88B"
+  revisions:
+    - id: rev-lamplight-stores
+      text: From now on, lamplight stores memory — it doesn't merely illuminate. Treat earlier "light" references as retroactively true.
+      scene: 02 - What the Light Remembers
+      status: applied
+      created: 2026-03-14T09:12:00.000Z
+      type: continuity
+      priority: high
+    - id: rev-coll-knows-mara
+      text: From now on, Inspector Coll already knew Mara years ago, from before the Undercroft was sealed. EDIT
+      scene: 03 - Inspector Coll
+      status: pending
+      created: 2026-05-02T18:40:00.000Z
+      type: character
+      priority: med
+    - id: rev-archive-sentient
+      text: The Archive is sentient. Assume every reference to it implies intent, not just storage.
+      scene:
+      status: pending
+      created: 2026-06-10T20:05:00.000Z
+      type: continuity
+      priority: high
+    - id: rev-blackout-mechanism
+      text: Why does the blackout wipe every lamp on Vesper Row at once? Seed a mechanism earlier or it's a plot hole.
+      scene: 07 - Blackout
+      status: pending
+      created: 2026-06-18T11:20:00.000Z
+      type: plot-hole
+      priority: high
+    - id: rev-undercroft-terms
+      text: Look up period drainage/sub-cellar terminology for the Undercroft description. [RESEARCH]
+      scene: 04 - The Undercroft
+      status: pending
+      created: 2026-06-20T08:00:00.000Z
+      type: research
+      priority: low
+  revisionChecklist:
+    story:
+      structure:
+        done: true
+      stakes:
+        done: true
+      heroTransforms:
+        note: Mara goes from wanting nothing to claiming the Archive — verify the turn lands by scene 5/6.
+      consistent:
+        note: Reconcile lamplight-stores-memory rule across early scenes.
+    page:
+      echoes:
+        done: true
+      adverbs:
+        note: Sweep -ly adverbs in dialogue tags during the line pass.
+  arcTracked:
+    - "[[Mara Vance]]"
+  styleSheet:
+    entries:
+      - id: s-lattice
+        canonical: Lattice
+        variants:
+          - lattice
+        kind: name
+        note: The memory-network is always capitalized.
+      - id: s-undercroft
+        canonical: Undercroft
+        variants:
+          - undercroft
+        kind: name
+  publishing:
+    metadata:
+      title: The Lamplighter's Archive
+      seriesTitle: The Lattice Cycle
+      tagline: She lights the lamps that keep a city's memory — until one shows her a life she never lived.
+      blurb: In a city that pours each day into its street-lamps, Mara Vance is content to tend her small route and want nothing. Then a lamp shows her a memory that was never hers, and the trail leads down into the sealed Archive the city has spent a generation forgetting.
+      genre: Fantasy
+      subgenres:
+        - Gaslamp fantasy
+        - Mystery
+      targetReader: Readers of cozy-but-eerie gaslamp fantasy with a quiet, competent heroine.
+      keywords:
+        - gaslamp fantasy
+        - memory magic
+        - lamplighter
+        - hidden archive
+        - slow burn mystery
+        - sentient magic
+        - found family
+      categories:
+        main: FICTION / Fantasy / Historical
+        sub:
+          - FICTION / Fantasy / Gaslamp
+          - FICTION / Mystery & Detective
+      kuExclusive: true
+      formats:
+        ebook:
+          enabled: true
+          price: 4.99
+        paperback:
+          enabled: true
+          price: 14.99
+    checklist:
+      writing:
+        draft:
+          done: true
+          notes: First draft in progress.
+      editing:
+        selfEdit:
+          done: true
+      foundational:
+        genre:
+          done: true
+        targetReader:
+          done: true
+    launch:
+      releaseDate: 2026-09-01
+      strategy: medium
+      milestones:
+        submit:
+          done: false
+    budget:
+      items:
+        - id: p-mqtp8n9n-aar6
+          label: Cover art
+          category: want
+          estimate: 500
+---
+
+# The Lamplighter's Archive
+
+> *Book One of [[Aszmar|The Lattice Cycle]].*
+
+This is the **project index** — Inkswell reads the `longform` and `inkswell`
+blocks above to assemble the project. You normally never edit this by hand;
+the panels (Plan, Write, Track, Publish) write to it for you.
+
+Open the **Inkswell** view (pen-tool ribbon icon, or the command
+*"Open Inkswell projects"*) and this project will be listed. New here? Start
+with [[_Start Here]].
+
+## Logline
+
+A lamplighter who tends the memory-lamps of a sleeping city lights one that
+shows her a memory she never lived — and follows it down into the sealed Archive
+the city has spent a generation pretending to forget.

--- a/examples/migrations/obsidian-to-okf/sample-source-vault/_Start Here.md
+++ b/examples/migrations/obsidian-to-okf/sample-source-vault/_Start Here.md
@@ -1,0 +1,105 @@
+# 👋 Start Here — the Inkswell sample project
+
+Welcome. This vault is a **complete, mid-draft novel** so you can see what
+Inkswell looks like in real use instead of an empty project. The book is
+*[[The Lamplighter's Archive]]* — original fiction, included so the sample is
+free to ship (see [licensing](#licensing)).
+
+> [!tip] First time? Do these two things
+> 1. **Enable the plugin.** Settings (⚙) → *Community plugins* → turn **off**
+>    Restricted Mode → enable **Inkswell**. (A fresh vault starts in Restricted
+>    Mode, so community plugins are off until you allow them.)
+> 2. **Open the workspace.** Click the **pen-tip ribbon icon** on the left, or
+>    run the command *"Open Inkswell projects"* (Ctrl/Cmd-P). Pick
+>    **The Lamplighter's Archive** in the project selector at the top.
+
+---
+
+## The five-minute tour
+
+Inkswell is one tab with a **left icon rail**, grouped into sections: **Home**,
+the writing pipeline (**Plan · Write · Revise · Publish**), **Codex · Track**,
+and **Search · Help** pinned at the bottom. Each stop does one job:
+
+| Stop | What you'll see in this sample |
+|------|-------------------------------|
+| **Home** | The project's **hero card** — cover art, logline, theme, and a progress bar toward the 90k target — above the scene list with per-scene word counts and status colors. Click a scene to open the **Inspector** (status, POV, chapter, plotlines, characters, word target). |
+| **Plan → Overview** | Novel-level planning — logline, theme, genre, audience, plus a linked **planning note** holding the synopsis, plot groundwork, and a 3-act outline. The high-level view, before anything is broken into beats or scenes. |
+| **Plan → Beats** | A *Save the Cat!* beat sheet filled through the finale — early beats ticked, a couple of later ones still open. Each beat has a **+ new scene** button that creates the scene and links it to the beat. |
+| **Plan → Structure** | Three views of the same scenes behind a **Tree · Board · Grid** switcher. **Tree** is the Act › Chapter › Scene **outline** — drag to reorder, with per-chapter word targets. **Board** is the same scenes as draggable status cards. **Grid** is the **Plot Grid**: a plotline × chapter matrix (The Leaking Memory, Coll & the Bureau, Mara's Grief, The Lattice) where an empty stretch is a visible pacing signal. |
+| **Write** | A distraction-light Live-Preview editor that walks the manuscript in order. To-do markers (`[RESEARCH: …]`, `[NOTE: …]`, `[DIALOGUE: …]`) highlight inline — use the topbar **Insert** buttons (or `Ctrl/Cmd-Shift-T/R/D/S/N`) to drop your own, and **Log issue** to capture a fix without stopping. The right sidebar has a **Scene / Revision** switcher — **Revision** lists every marker and logged decision across the book; click one to jump. Start a **Sprint** from the Write toolbar or the status bar. |
+| **Revise → Audit / Analysis** | **Audit**: the per-scene **14-point checklist** (scenes 1–2 partly audited), Story/Page project checklists, the scene-**purpose** lift-out verdict, a **scene-openings** variety strip, the **character-arc** grid (Mara is tracked from "wants nothing" to the finale), and a **style-sheet** scan. **Analysis**: readability, word-frequency, and echo reports over the prose. |
+| **Revise → To-dos** | Everything left to fix in one scene-grouped worklist: every to-do marker across the manuscript (click one to jump straight to it in the editor) plus the invisible-revision **decisions** — typed & prioritized (continuity/plot-hole…) — tick one applied once you've made the change. Filter it all with one chip row. |
+| **Publish → Compile / Checklist / Launch** | **Compile**: the export pipeline (groups scenes into chapters). **Checklist**: the self-publishing master checklist + the **book-metadata worksheet** (both partly filled). **Launch**: the **pre-order timeline** (release date + Medium strategy → computed milestone dates) and budget/cover/marketing/ARC trackers. |
+| **Codex** | The story bible: characters, locations, a world, a concept, and a faction. Open **Mara Vance** — her **Appears in** list finds every scene that names her automatically, and clicking one opens that scene in **Write** at the first mention. Every entry is **scoped to the series** *The Lattice Cycle* (its **Scope** field), so it follows the book across the cycle but won't clutter an unrelated project. |
+| **Track** | Word-goal rings, a writing-history chart, a 26-week heatmap, streaks, sprint stats, and a **By chapter** breakdown against the per-chapter targets. A **deadline** is set, so Project targets shows a **pace verdict** and the draft-milestone zone. Set today's **mood** in Goals. |
+| **Search** | Full-text search across every scene's prose and synopsis. Pick the scope — this draft, the whole story, the series, or the vault — and narrow with status/POV/chapter/plotline/character filters. Click a hit to jump to it in Write, where it flashes. |
+
+> [!tip] Too many surfaces?
+> Any optional feature — Beats, Board, Plot Grid, the Revise Audit/Analysis
+> tabs, the Publishing checklist/Launch planner, or the Write writing-prompts
+> button — can be turned off in **Settings → Features** (or right-click a tab and
+> *Hide*). It's completely lossless: hiding only stops rendering, your notes and
+> stored data are untouched, and re-enabling brings everything back.
+
+---
+
+## How the sample maps to the data
+
+Nothing here is magic — it's all plain Markdown you can inspect:
+
+- **The project** is defined by the `longform:` and `inkswell:` frontmatter on
+  [[The Lamplighter's Archive]] (the index note). That one block declares the
+  scene order, the word target, the overview, the beat sheet, the **acts /
+  chapters / plotlines** structure, the compile recipe, the series, and the
+  revision log.
+- **The project has two drafts.** Both index notes share the same
+  `longform.title`, so Inkswell groups them into one *story* with a **draft
+  switcher** at the top of the project. The main book is the first draft (its
+  scenes live in `Draft 1/`); a short **Second Draft** stub lives in
+  `Drafts/Second Draft/Scenes/` purely to show the feature. Story-level metadata
+  (cover, logline, goals, series) is shared from the first draft — each draft
+  just carries its own scene set, word counts, and Search scope.
+- **Each scene** lives in [Draft 1/](Writing/The%20Lamplighter's%20Archive/Draft%201/) with flat frontmatter:
+  `status`, `pov`, `chapter`, `act`, `plotlines`, `characters`, `location`,
+  `targetWords`. Those fields drive the colors, the Inspector, the Outline and
+  Plot Grid, and the Track tallies. The Plot Grid and Outline are pure
+  projections of these — a scene joins a plotline or chapter just by naming it,
+  so the views can never drift from the manuscript.
+- **Codex entries** in [Codex/](Writing/Codex/) are just notes carrying a `codex:` key.
+  Scenes link to them with ordinary `[[wikilinks]]` in their `characters` /
+  `location` fields, and the Codex panel finds the references automatically.
+  Each entry here also carries `codex-series: The Lattice Cycle`, which **scopes**
+  it to that series — it shows in pickers for every book in the cycle but is hidden
+  from unrelated projects. (Use `codex-project: "[[Book]]"` to scope to a single
+  book, or leave both off to share an entry globally. New entries inherit the
+  active project's scope automatically; folder location is just tidy storage —
+  the tag is what controls visibility.)
+- **Sprint and daily-word history** is *not* in these notes — it lives in the
+  plugin's `data.json`. That's why it travels with this vault but wouldn't travel
+  with a loose folder of chapters.
+
+## Try editing something
+
+The fastest way to feel the loop:
+
+1. Go to **Write**, open scene **02 – What the Light Remembers**, and add a
+   sentence. The status-bar word count for today goes up immediately.
+2. Open **Track** — today's ring and the history chart reflect your new words.
+3. On **Home**, change a scene's status in the Inspector and watch the color and
+   the Track → Structure tally update.
+
+> [!warning] About the dates in Track
+> The seeded writing history is anchored to **June 2026**, so the *Today / Week /
+> Month* rings and the current-streak read "live" around then. Opening this vault
+> much later is harmless — the **history chart, heatmap, and sprint list still
+> render** — but the rings reset because there are no entries for the real
+> current date. Write a few words (step 1 above) and today's ring fills back in.
+> Also note the seeded "today" is a **Monday**, so the Week ring starts fresh.
+
+## Licensing
+
+*The Lamplighter's Archive* and all Codex entries here are **original work**
+created for this sample and distributed under the same license as the plugin.
+No public-domain or third-party text is bundled, so there are no edition,
+translation, or jurisdiction concerns — you can ship, fork, or rewrite it freely.

--- a/examples/migrations/obsidian-to-okf/tests/conftest.py
+++ b/examples/migrations/obsidian-to-okf/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+if str(EXAMPLE_ROOT) not in sys.path:
+    sys.path.insert(0, str(EXAMPLE_ROOT))

--- a/examples/migrations/obsidian-to-okf/tests/test_obsidian_to_okf.py
+++ b/examples/migrations/obsidian-to-okf/tests/test_obsidian_to_okf.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import yaml
+from obsidian_to_okf import convert_vault
+
+from memanto.cli.migrate.mappers import map_okf
+from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_conversion_is_importable_and_preserves_links(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    output = tmp_path / "okf"
+    write(
+        vault / "Projects" / "Launch.md",
+        "---\ntags: [projects, decision]\nstatus: active\n---\n"
+        "# Launch plan\n\nWe chose Friday. See [[People/Ada|Ada]] and [[Missing]].\n",
+    )
+    write(vault / "People" / "Ada.md", "# Ada\n\nAda owns the release.\n")
+    write(vault / ".obsidian" / "ignored.md", "internal")
+
+    report = convert_vault(vault, output)
+
+    assert report.source_files == 2
+    assert report.converted_files == 2
+    assert report.wikilinks_converted == 1
+    assert report.unresolved_links == [
+        {"source": "Projects/Launch.md", "target": "Missing"}
+    ]
+    rendered = (output / "memories" / "Projects" / "Launch.md").read_text()
+    assert "[Ada](../People/Ada.md)" in rendered
+    assert "[[Missing]]" in rendered
+    frontmatter = yaml.safe_load(rendered.split("---", 2)[1])
+    assert frontmatter["type"] == "decision"
+    assert frontmatter["x_obsidian"]["frontmatter"] == {
+        "tags": ["projects", "decision"],
+        "status": "active",
+    }
+
+    loaded = load_okf_bundle(output)
+    mapped = map_okf(loaded)
+    assert len(mapped) == 2
+    assert {row["type"] for row in mapped} == {"decision", "context"}
+    assert all(row["source"] == "obsidian" for row in mapped)
+
+
+def test_dry_run_does_not_write_output(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    output = tmp_path / "okf"
+    write(vault / "Note.md", "A real note body.")
+
+    report = convert_vault(vault, output, dry_run=True)
+
+    assert report.converted_files == 1
+    assert not output.exists()
+
+
+def test_refuses_output_inside_vault(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    write(vault / "Note.md", "body")
+
+    try:
+        convert_vault(vault, vault / "okf")
+    except ValueError as exc:
+        assert "outside" in str(exc)
+    else:
+        raise AssertionError("expected unsafe output path to be rejected")


### PR DESCRIPTION
Closes moorcheh-ai/memanto#1609.

## What problem does this solve?

Obsidian users own their Markdown files, but vault-specific wikilinks, embeds,
plugin frontmatter, and absent memory types keep those notes from being portable
agent memory. This example adds a deterministic local adapter from a real
Obsidian vault to an OKF bundle consumable by Memanto's shipped migration CLI.

## What changed?

- Added a dependency-light Obsidian → OKF converter with dry-run support.
- Preserved every original frontmatter mapping under `x_obsidian` while also
  emitting normalized OKF and Memanto fields.
- Converted only unambiguous resolvable wikilinks; unresolved links remain
  visible and are reported instead of silently becoming dead Markdown links.
- Added deterministic type mapping, source hashing, provenance, output-path
  safety, a one-command demo, tests, and checked-in migration receipts.
- Included an attributed MIT-licensed 21-note source vault and its 21-record OKF
  output so reviewers can inspect both sides without an account.

## Real-data migration evidence

Source: the public Inkswell Obsidian sample vault at commit
`e49b3a0e87576938950ef82289603b809dc24a82`.

- Source notes: 21
- OKF records: 21
- Memanto-mapped records: 21
- Skipped: 0
- Types: 10 artifact, 7 fact, 2 goal, 1 decision, 1 context
- Resolvable wikilinks converted: 6
- Unresolved wikilinks preserved and reported: 2
- Golden recall: 3/3
- Live import: 21 imported, 0 failed, 1 batch
- Live semantic recall: expected memory ranked first for all 3 questions
- Live OKF export: 21 records in 8.05 seconds
- Export reload: 21 mapped, 0 skipped, identical type counts
- Source corpus SHA-256:
  `5edc939e73e6e23eaf936ce1d76f33d1f9415cab03999ce061aaddd7a47e53e7`

Full measured evidence is in
`examples/migrations/obsidian-to-okf/LIVE_EVIDENCE.md`; the genuine post-import
export is checked in under `round-trip-okf/`.

The shipped `memanto migrate okf` command explicitly has no provider savings
report because OKF is a local bundle. The honest Path-B funnel is 21 source
notes → 21 mapped → 21 imported → 21 exported, with zero skipped or failed
records. No synthetic savings estimate is presented.

## Validation

```text
pytest tests/test_okf.py examples/migrations/obsidian-to-okf/tests -q
23 passed

ruff check examples/migrations/obsidian-to-okf
All checks passed!

ruff format --check examples/migrations/obsidian-to-okf
6 files already formatted
```

One-command reproduction:

```bash
python examples/migrations/obsidian-to-okf/run_demo.py
```

## Demo and social evidence

- Demo video: [`examples/migrations/obsidian-to-okf/demo.mp4`](https://github.com/galmousselhassan-arch/memanto/blob/feat/obsidian-okf-migration/examples/migrations/obsidian-to-okf/demo.mp4)
- Social showcase: [X post](https://x.com/Erenshmidt/status/2099140099673936208) tagging [@moorcheh_ai](https://x.com/moorcheh_ai)
- BountyHub claim: submitted and linked to PR #1951

## Disclosure

Developed with AI assistance. The transformation is deterministic, and source
data, output data, hashes, tests, and receipts are included for independent
review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Obsidian-to-OKF migration example that preserves notes, metadata, provenance, links, and memory types in portable bundles.
  * Added link normalization, duplicate-content cleanup, dry-run reporting, migration metrics, safety validation, and round-trip verification.
  * Added a reproducible demo with sample vault content and generated reports.

* **Documentation**
  * Added setup, usage, limitations, live verification, licensing, and source-provenance guidance.

* **Tests**
  * Added coverage for conversion, malformed notes, metadata, links, dry runs, normalization, and output validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->