### PR TITLE
feat(examples): add Agno SQLite memory migration through OKF

### DIFF
--- a/examples/migrations/agno-sqlite/.gitignore
+++ b/examples/migrations/agno-sqlite/.gitignore
@@ -1,0 +1,2 @@
+/run/
+__pycache__/

--- a/examples/migrations/agno-sqlite/Dockerfile.demo
+++ b/examples/migrations/agno-sqlite/Dockerfile.demo
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1 PIP_DEFAULT_TIMEOUT=120
+WORKDIR /src
+COPY pyproject.toml README.md ./
+COPY memanto ./memanto
+RUN pip install --no-cache-dir . agno==3.0.6 sqlalchemy==2.0.52 moorcheh-client==0.1.5
+RUN pip install --no-cache-dir ollama==0.6.2 openai==3.8.0
+COPY examples/migrations/agno-sqlite /example
+WORKDIR /example
+CMD ["python", "demo_source.py", "/run-artifacts/agno.db"]

--- a/examples/migrations/agno-sqlite/README.md
+++ b/examples/migrations/agno-sqlite/README.md
@@ -108,12 +108,15 @@ filenames, and refusal to publish truncated memories.
 
 Prepared as a possible Path B entry for Memanto issue #1609 ($200 competitive
 prize, deadline September 15, 2026 at 23:59 UTC). Code and local checks alone
-are not a complete contest entry. Contributor onboarding, BountyHub registration,
-a real demo video, public showcase links, and an eligible claim are still required.
+are not a complete contest entry. Contributor onboarding and BountyHub sign-in
+are complete. The implementation is submitted as
+[draft PR #1952](https://github.com/moorcheh-ai/memanto/pull/1952).
+A qualifying demo video, public showcase links, and a registered bounty claim
+are still outstanding.
 The issue asks for an agent-answer demonstration and a savings report; the current
 upstream OKF reporting limitation should be disclosed and
-resolved before presenting the entry as fully compliant. No submission or payment
-has occurred. Codex authored and tested this example with AI assistance.
+resolved before presenting the entry as fully compliant. No contest acceptance,
+award, or payment has occurred. Codex authored and tested this example with AI assistance.
 
 The recorded four-question run passed on both sides with `qwen2.5:1.5b`. An earlier
 run with `qwen2.5:0.5b` passed all source answers and three destination answers;

--- a/examples/migrations/agno-sqlite/README.md
+++ b/examples/migrations/agno-sqlite/README.md
@@ -1,0 +1,123 @@
+# Agno SQLite memory migration
+
+Move one user's Agno 3.x SQLite memories through Memanto's existing OKF import
+and export commands. The source database is opened read-only. This example
+does not implement its own Memanto importer.
+
+## Local adapter
+
+From the Memanto repository root, install the repository and example dependencies
+in a virtual environment:
+
+```sh
+pip install -e . agno==3.0.6 sqlalchemy==2.0.52
+python examples/migrations/agno-sqlite/adapter.py /path/to/agno.db ./new-okf-bundle --user-id YOUR_USER_ID
+memanto migrate okf ./new-okf-bundle --dry-run
+memanto migrate okf ./new-okf-bundle --agent YOUR_AGENT
+memanto memory export --okf --split file --agent YOUR_AGENT
+```
+
+An existing Memanto agent/backend is needed for the last two commands. Only
+the chosen user's memories are exported; an empty user ID is rejected.
+Use `--table` if the database uses a custom memory-table name.
+Each export needs a new output directory so an older bundle cannot retain
+deleted source memories. Import into a fresh destination agent for a snapshot;
+repeated imports into an existing agent are not an incremental synchronization.
+
+The generated bundle includes complete source records in `source-records.json`.
+Both that file and the readable memories may contain private information.
+The included demo uses only the explicit scenario in `demo_source.py`.
+
+## Field mapping
+
+| Agno field | OKF representation | Memanto import |
+| --- | --- | --- |
+| `memory` | Human-readable body | Content, preserved or export fails |
+| `topics` | `tags` and original metadata | Tags |
+| `created_at` | UTC `timestamp` plus original epoch | Created timestamp |
+| `updated_at` | `x_memanto.updated_at` plus original epoch | Updated timestamp |
+| `memory_id`, `user_id` | Stable hashed filename; original IDs in body metadata | Metadata remains searchable in content |
+| `agent_id`, `team_id`, `input`, `feedback`, extra columns | Complete JSON metadata in body and source archive | Content |
+| No source memory-type field | `type: context` | Context, without inventing semantic classification |
+
+Scope IDs in the metadata are provenance, not destination access controls.
+Import into a destination whose readers are appropriate for the selected user.
+
+The upstream importer bounds unknown-frontmatter footers. Putting full source
+metadata into an `x_agno` extension would silently shorten some values. This
+adapter instead keeps the complete metadata in the body and runs the actual
+Memanto loader/mapper before publishing the bundle. If Memanto would truncate
+the body, export fails with an explicit error. Source text containing Memanto's
+reserved OKF entry delimiter also fails explicitly.
+
+## Reproducible live demonstration
+
+`demo_source.py` executes Agno's real SQLite persistence API, stores four
+memories, corrects a delivery schedule, and adds another user's excluded record.
+This is a scripted scenario, not a historical personal archive or LLM-generated
+memory session.
+
+`run_demo.py` is intended for the accompanying isolated Docker Compose runtime.
+It creates a fresh destination agent and runs the real `memanto migrate okf`
+dry run, live import, semantic recall, and `memanto memory export --okf`.
+It waits for the asynchronous search index before checking four golden queries.
+The retrieval score measures answer-bearing content among the top three results.
+Separately, `answer_checks.py` asks a real Agno agent and Memanto's live answer
+endpoint the same four questions, using local Ollama `qwen2.5:1.5b` on both sides.
+It checks required answer fragments, including both Markdown and CSV. These four
+scenario checks do not establish general answer quality or universal recall parity.
+
+From the repository root, reproduce with Git and Docker available:
+
+```sh
+docker compose -p agno-demo -f examples/migrations/agno-sqlite/compose.yaml build cli
+docker compose -p agno-demo -f examples/migrations/agno-sqlite/compose.yaml up -d
+docker compose -p agno-demo -f examples/migrations/agno-sqlite/compose.yaml exec -T ollama ollama pull nomic-embed-text
+docker compose -p agno-demo -f examples/migrations/agno-sqlite/compose.yaml exec -T ollama ollama pull qwen2.5:1.5b
+docker compose -p agno-demo -f examples/migrations/agno-sqlite/compose.yaml run --rm -T cli python run_demo.py
+docker compose -p agno-demo -f examples/migrations/agno-sqlite/compose.yaml stop
+```
+
+Initial downloads require several GB. The Compose runtime binds the server only
+to localhost and uses dedicated volumes. It does not alter host Memanto settings.
+The OpenAI Python package is installed because Agno's Ollama module imports it;
+all model calls in this demo use local Ollama, with no OpenAI API key.
+
+The output includes source SQLite data, input and round-trip OKF bundles,
+command logs, timings, generated answers, and `live-validation.json`. The round-trip check requires
+every complete input body, including source metadata, to survive the export.
+
+The upstream OKF CLI currently has **no `--report` option and no savings report**.
+The example states that limitation rather than inventing token or latency savings.
+Recorded durations are measurements of this local run, not comparative benchmarks.
+
+## Checks
+
+```sh
+pytest examples/migrations/agno-sqlite/test_adapter.py
+ruff check examples/migrations/agno-sqlite
+ruff format --check examples/migrations/agno-sqlite
+```
+
+The tests use real Agno SQLite databases. They cover user separation, a corrected
+source record, source immutability, epoch timestamps, Unicode, unknown columns,
+long metadata, missing databases, empty selections, reserved delimiters, safe
+filenames, and refusal to publish truncated memories.
+
+## Bounty submission status
+
+Prepared as a possible Path B entry for Memanto issue #1609 ($200 competitive
+prize, deadline September 15, 2026 at 23:59 UTC). Code and local checks alone
+are not a complete contest entry. Contributor onboarding, BountyHub registration,
+a real demo video, public showcase links, and an eligible claim are still required.
+The issue asks for an agent-answer demonstration and a savings report; the current
+upstream OKF reporting limitation should be disclosed and
+resolved before presenting the entry as fully compliant. No submission or payment
+has occurred. Codex authored and tested this example with AI assistance.
+
+The recorded four-question run passed on both sides with `qwen2.5:1.5b`. An earlier
+run with `qwen2.5:0.5b` passed all source answers and three destination answers;
+the destination omitted CSV. No question, required fragment, or source memory was
+changed to obtain the later result. Model choice affects generated answers even
+when all memory text is retained. A terminal-output replay is provided separately;
+it is not a pixel capture of an interactive desktop session.

--- a/examples/migrations/agno-sqlite/adapter.py
+++ b/examples/migrations/agno-sqlite/adapter.py
@@ -1,0 +1,181 @@
+"""Export one user's Agno SQLite memories to Memanto-compatible OKF."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import sqlite3
+import tempfile
+from contextlib import closing
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def read_memories(
+    database: Path, user_id: str, table: str = "agno_memories"
+) -> list[dict[str, Any]]:
+    """Read a consistent snapshot without opening the source for writes."""
+    if not user_id:
+        raise ValueError("An explicit, non-empty user ID is required")
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", table):
+        raise ValueError("Table must be a simple SQLite identifier")
+    database = database.resolve(strict=True)
+    with closing(
+        sqlite3.connect(database.as_uri() + "?mode=ro", uri=True)
+    ) as connection:
+        connection.row_factory = sqlite3.Row
+        connection.execute("BEGIN")
+        records = connection.execute(
+            f'SELECT * FROM "{table}" WHERE user_id = ? ORDER BY memory_id',
+            (user_id,),
+        ).fetchall()
+    result = []
+    for record in records:
+        row = dict(record)
+        for field in ("memory", "topics"):
+            if row.get(field) is not None:
+                row[field] = json.loads(row[field])
+        if not isinstance(row.get("memory"), str) or not row["memory"].strip():
+            raise ValueError("Expected non-empty string memories from Agno 3.x")
+        if not isinstance(row.get("memory_id"), str) or not row["memory_id"]:
+            raise ValueError("Every memory needs a stable memory_id")
+        topics = row.get("topics")
+        if topics is not None and (
+            not isinstance(topics, list)
+            or not all(isinstance(topic, str) for topic in topics)
+        ):
+            raise ValueError("Expected topics to be a list of strings or null")
+        result.append(row)
+    return result
+
+
+def render(row: dict[str, Any]) -> tuple[str, str]:
+    """Keep source metadata in the body: importer extra-field footers are bounded."""
+    identity = json.dumps([row["user_id"], row["memory_id"]], ensure_ascii=False)
+    digest = hashlib.sha256(identity.encode()).hexdigest()
+    metadata = {key: value for key, value in row.items() if key != "memory"}
+    body = (
+        "## Memory\n\n"
+        + row["memory"]
+        + "\n\n## Agno source metadata\n\n"
+        + json.dumps(metadata, ensure_ascii=False, sort_keys=True, indent=2)
+    )
+    if "<!-- okf-entry -->" in body:
+        raise ValueError("Source contains Memanto's reserved OKF entry delimiter")
+    frontmatter: dict[str, Any] = {
+        "type": "context",
+        "title": "Agno memory " + digest[:16],
+        "tags": row.get("topics") or [],
+        "x_memanto": {"source": "agno", "provenance": "imported"},
+    }
+    for source_key, target_key in (
+        ("created_at", "timestamp"),
+        ("updated_at", "updated_at"),
+    ):
+        value = row.get(source_key)
+        if value is not None:
+            stamp = datetime.fromtimestamp(value, timezone.utc).isoformat()
+            if target_key == "timestamp":
+                frontmatter[target_key] = stamp
+            else:
+                frontmatter["x_memanto"][target_key] = stamp
+    document = (
+        "---\n"
+        + yaml.safe_dump(frontmatter, allow_unicode=True, sort_keys=False)
+        + "---\n\n"
+        + body
+        + "\n"
+    )
+    return digest + ".md", document
+
+
+def export(
+    database: Path, user_id: str, output: Path, table: str = "agno_memories"
+) -> dict:
+    """Publish a new bundle only after the actual Memanto mapper preserves each body."""
+    from memanto.cli.migrate.mappers import map_okf
+    from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+    rows = read_memories(database, user_id, table)
+    if not rows:
+        raise ValueError("No memories matched; refusing to produce an empty migration")
+    output = output.resolve()
+    if output.exists():
+        raise FileExistsError(
+            "Choose a new output directory; existing bundles are preserved"
+        )
+    rendered = [render(row) for row in rows]
+    if len({name for name, _ in rendered}) != len(rows):
+        raise ValueError("Duplicate source memory identities")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix=".agno-export-", dir=output.parent))
+    try:
+        memories = stage / "memories"
+        memories.mkdir()
+        for name, document in rendered:
+            (memories / name).write_text(document, encoding="utf-8")
+        loaded = load_okf_bundle(stage)
+        mapped = map_okf(loaded)
+        if len(mapped) != len(rows):
+            raise ValueError("Memanto changed the memory count")
+        for entry, destination in zip(loaded["memories"], mapped, strict=True):
+            if not destination["content"].startswith(entry["body"]):
+                raise ValueError(
+                    "Memanto would truncate a memory. Split it explicitly before migrating."
+                )
+        summary = {
+            "source": "Agno SQLite",
+            "records": len(rows),
+            "mapped_memories": len(mapped),
+            "types": {"context": len(mapped)},
+            "body_preserved_by_memanto_mapper": True,
+            "live_import_verified": False,
+            "savings_report": "Not supplied by memanto migrate okf",
+        }
+        (stage / "source-records.json").write_text(
+            json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        (stage / "migration-summary.json").write_text(
+            json.dumps(summary, indent=2), encoding="utf-8"
+        )
+        (stage / "index.md").write_text(
+            "---\ntype: index\n---\n\n# Agno memories\n\n"
+            + "\n".join(
+                f"- [Memory {i + 1}](memories/{name})"
+                for i, (name, _) in enumerate(rendered)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        stage.rename(output)
+        return summary
+    finally:
+        # The unique staging bundle is private to this invocation. Its reader
+        # lock has been released and can be removed with the staging snapshot.
+        (stage.parent / f".{stage.name}.lock").unlink(missing_ok=True)
+        if stage.exists():
+            if stage.resolve().parent != output.parent or not stage.name.startswith(
+                ".agno-export-"
+            ):
+                raise RuntimeError("Unexpected staging directory; refusing cleanup")
+            shutil.rmtree(stage)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("database", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--user-id", required=True)
+    parser.add_argument("--table", default="agno_memories")
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            export(args.database, args.user_id, args.output, args.table), indent=2
+        )
+    )

--- a/examples/migrations/agno-sqlite/answer_checks.py
+++ b/examples/migrations/agno-sqlite/answer_checks.py
@@ -1,0 +1,86 @@
+"""Compare answers from a real Agno agent and Memanto's live answer endpoint."""
+
+from pathlib import Path
+from typing import Any
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.ollama import Ollama
+
+ANSWER_MODEL = "qwen2.5:1.5b"
+
+ANSWER_CASES = [
+    ("When should the weekly report be delivered?", ["Friday", "16:00", "UTC"]),
+    ("What file formats should the report use?", ["Markdown", "CSV"]),
+    ("What timezone does the project display?", ["Asia/Kolkata"]),
+    ("What primary database does the project use?", ["PostgreSQL", "16"]),
+]
+INSTRUCTIONS = (
+    "Answer from the stored memories in one short sentence. "
+    "Keep the exact names, version numbers, time format, and timezone names "
+    "used in those memories. If the answer is missing, say that it is unknown."
+)
+
+
+def source_answers(database: Path) -> list[dict[str, Any]]:
+    agent = Agent(
+        model=Ollama(
+            id=ANSWER_MODEL,
+            host="http://ollama:11434",
+            timeout=180,
+            options={"temperature": 0, "seed": 42},
+        ),
+        db=SqliteDb(db_file=str(database)),
+        user_id="demo-user",
+        add_memories_to_context=True,
+        add_history_to_context=False,
+        update_memory_on_run=False,
+        instructions=INSTRUCTIONS,
+    )
+    results = []
+    for question, fragments in ANSWER_CASES:
+        answer = str(agent.run(question).content)
+        results.append(
+            {
+                "question": question,
+                "expected_fragments": fragments,
+                "source_answer": answer,
+                "source_pass": all(
+                    part.casefold() in answer.casefold() for part in fragments
+                ),
+            }
+        )
+        print(f"Agno question: {question}\nAgno answer: {answer}", flush=True)
+    return results
+
+
+def destination_answers(
+    client: Any, agent_id: str, before: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    results = []
+    for item in before:
+        response = client.answer(
+            agent_id,
+            item["question"],
+            limit=4,
+            temperature=0,
+            ai_model=ANSWER_MODEL,
+            header_prompt=INSTRUCTIONS,
+            footer_prompt=INSTRUCTIONS,
+        )
+        answer = str(response.get("answer", ""))
+        result = {
+            **item,
+            "destination_answer": answer,
+            "destination_pass": all(
+                part.casefold() in answer.casefold()
+                for part in item["expected_fragments"]
+            ),
+            "destination_response": response,
+        }
+        results.append(result)
+        print(
+            f"Memanto question: {item['question']}\nMemanto answer: {answer}",
+            flush=True,
+        )
+    return results

--- a/examples/migrations/agno-sqlite/compose.yaml
+++ b/examples/migrations/agno-sqlite/compose.yaml
@@ -1,0 +1,53 @@
+services:
+  cli:
+    profiles: [tools]
+    build:
+      context: ../../..
+      dockerfile: examples/migrations/agno-sqlite/Dockerfile.demo
+    environment:
+      MEMANTO_DEMO_CONTAINER: "1"
+      MEMANTO_BACKEND: on-prem
+      MOORCHEH_ONPREM_URL: http://server:8080
+    volumes:
+      - ./:/example:ro
+      - ./run:/run-artifacts
+      - cli-state:/root/.memanto
+  ollama:
+    image: ollama/ollama@sha256:32931b46719f673c05fdbaa81ccb26da18ea4a1c57590a754874ab28ba269eb2
+    volumes:
+      - models:/root/.ollama
+  init-data:
+    image: moorcheh/server@sha256:543158ca24391a6d83336f0cf5d20ab2fba79c46bfe89a357c31b7a26cb4e0fe
+    user: "0:0"
+    entrypoint: ["chown", "65532:65532", "/app/data"]
+    volumes:
+      - data:/app/data
+  server:
+    image: moorcheh/server@sha256:543158ca24391a6d83336f0cf5d20ab2fba79c46bfe89a357c31b7a26cb4e0fe
+    depends_on:
+      init-data:
+        condition: service_completed_successfully
+    ports:
+      - "127.0.0.1:18088:8080"
+    environment:
+      SERVER_HOST: 0.0.0.0
+      SERVER_PORT: 8080
+      EMBEDDING_PROVIDER: ollama
+      EMBEDDING_MODEL: nomic-embed-text
+      EMBEDDING_BASE_URL: http://ollama:11434
+      OLLAMA_URL: http://ollama:11434
+      OLLAMA_MODEL: nomic-embed-text
+      LLM_PROVIDER: ollama
+      LLM_MODEL: qwen2.5:1.5b
+      LLM_BASE_URL: http://ollama:11434
+      DATA_FILE: /app/data/moorcheh_data_store.json
+      NAMESPACE_REGISTRY_FILE: /app/data/namespace_registry.json
+      FILE_REGISTRY_FILE: /app/data/file_registry.json
+      ALLOWED_UPLOAD_PATHS: /uploads
+      CHUNKER_URL: http://127.0.0.1:8090
+    volumes:
+      - data:/app/data
+volumes:
+  cli-state:
+  models:
+  data:

--- a/examples/migrations/agno-sqlite/demo_source.py
+++ b/examples/migrations/agno-sqlite/demo_source.py
@@ -1,0 +1,65 @@
+"""Run Agno's real SQLite persistence API with a documented demonstration scenario."""
+
+import argparse
+from pathlib import Path
+
+from agno.db.schemas.memory import UserMemory
+from agno.db.sqlite import SqliteDb
+
+
+def populate(path: Path) -> None:
+    if path.exists():
+        raise FileExistsError("The demo only creates new databases")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    database = SqliteDb(db_file=str(path))
+    memories = [
+        ("delivery", "Deliver the weekly report on Monday at 09:00 UTC.", ["schedule"]),
+        ("format", "Send reports as Markdown, with a CSV attachment.", ["format"]),
+        (
+            "locale",
+            "The project displays times in Asia/Kolkata and uses INR.",
+            ["locale"],
+        ),
+        (
+            "storage",
+            "The project stores its primary data in PostgreSQL 16.",
+            ["database"],
+        ),
+    ]
+    for memory_id, content, topics in memories:
+        saved = database.upsert_user_memory(
+            UserMemory(
+                memory_id=memory_id,
+                memory=content,
+                topics=topics,
+                user_id="demo-user",
+                agent_id="report-assistant",
+            )
+        )
+        assert saved is not None
+    # A correction replaces the old source record before export.
+    saved = database.upsert_user_memory(
+        UserMemory(
+            memory_id="delivery",
+            memory="Correction: deliver the weekly report on Friday at 16:00 UTC.",
+            topics=["schedule"],
+            user_id="demo-user",
+            agent_id="report-assistant",
+            input="Move Monday delivery to Friday afternoon.",
+        )
+    )
+    assert saved is not None
+    saved = database.upsert_user_memory(
+        UserMemory(
+            memory_id="other-user",
+            memory="A separate user's memory must stay separate.",
+            user_id="other-user",
+        )
+    )
+    assert saved is not None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("database", type=Path)
+    populate(parser.parse_args().database)

--- a/examples/migrations/agno-sqlite/run_demo.py
+++ b/examples/migrations/agno-sqlite/run_demo.py
@@ -1,0 +1,207 @@
+"""Run the real Agno -> Memanto CLI -> OKF loop inside the demo container."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+from adapter import export, read_memories
+from answer_checks import ANSWER_MODEL, destination_answers, source_answers
+from demo_source import populate
+
+from memanto.app.clients.backend import Backend
+from memanto.cli.config.manager import ConfigManager
+from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+QUESTIONS = [
+    ("When should the weekly report be delivered?", "delivery", "Friday at 16:00 UTC"),
+    ("What file formats should the report use?", "format", "Markdown"),
+    ("What timezone does the project display?", "locale", "Asia/Kolkata"),
+    ("What primary database does the project use?", "storage", "PostgreSQL 16"),
+]
+
+
+def main() -> None:
+    if os.environ.get("MEMANTO_DEMO_CONTAINER") != "1":
+        raise RuntimeError("Run with the documented isolated Docker Compose service")
+    run_id = uuid.uuid4().hex[:12]
+    root = Path("/run-artifacts") / run_id
+    root.mkdir(parents=True, exist_ok=False)
+    timings: list[dict[str, object]] = []
+
+    def command(*args: str) -> None:
+        print("\n$ " + " ".join(args), flush=True)
+        start = time.perf_counter()
+        result = subprocess.run(args, capture_output=True, text=True, timeout=300)
+        text = result.stdout + result.stderr
+        print(text, flush=True)
+        (root / f"step-{len(timings) + 1}.log").write_text(text, encoding="utf-8")
+        timings.append(
+            {
+                "command": list(args),
+                "seconds": time.perf_counter() - start,
+                "returncode": result.returncode,
+            }
+        )
+        result.check_returncode()
+
+    try:
+        database = root / "agno.db"
+        populate(database)
+        source = {row["memory_id"]: row for row in read_memories(database, "demo-user")}
+        before_answers = source_answers(database)
+        (root / "source-answers.json").write_text(
+            json.dumps(before_answers, indent=2), encoding="utf-8"
+        )
+        print(
+            f"Agno persisted {len(source)} current memories; the schedule correction replaced its old value."
+        )
+        summary = export(database, "demo-user", root / "input-okf")
+        print(json.dumps(summary, indent=2))
+        print("\nReadable OKF sample from the source database:", flush=True)
+        sample = next((root / "input-okf" / "memories").glob("*.md"))
+        print(sample.read_text(encoding="utf-8"), flush=True)
+        config = ConfigManager()
+        config.set_backend(Backend.ON_PREM)
+        config.set_onprem_config(
+            url="http://server:8080",
+            embedding_provider="ollama",
+            embedding_model="nomic-embed-text",
+            llm_provider="ollama",
+            llm_model=ANSWER_MODEL,
+        )
+        agent_id = "agno-demo-" + run_id
+        command("memanto", "agent", "create", agent_id, "--pattern", "tool")
+        from memanto.cli.commands._shared import get_client
+
+        client = get_client()
+        before_import = client.recall(
+            agent_id, QUESTIONS[0][0], limit=3, min_similarity=0
+        )
+        assert before_import.get("count", 0) == 0, (
+            "Expected a newly created empty destination"
+        )
+        print("Before migration: the new Memanto agent has no answer-bearing memories.")
+        command("memanto", "migrate", "okf", str(root / "input-okf"), "--dry-run")
+        command(
+            "memanto", "migrate", "okf", str(root / "input-okf"), "--agent", agent_id
+        )
+        # SDK recall uses the same live backend as the CLI; no mocked service.
+        readiness_start = time.perf_counter()
+        readiness_checks = []
+        # Moorcheh acknowledges queued writes before the search index is ready.
+        # Wait for all four records, independently of the golden answers below.
+        while True:
+            ready = client.recall(agent_id, "project", limit=100, min_similarity=0)
+            readiness_checks.append(ready.get("count", 0))
+            if ready.get("count", 0) == len(source):
+                break
+            if time.perf_counter() - readiness_start > 60:
+                raise TimeoutError(
+                    "The imported records did not become searchable within 60 seconds"
+                )
+            time.sleep(0.5)
+        readiness_seconds = time.perf_counter() - readiness_start
+        answers = destination_answers(client, agent_id, before_answers)
+        (root / "generated-answers.json").write_text(
+            json.dumps(answers, indent=2, default=str), encoding="utf-8"
+        )
+        evidence = []
+        for question, memory_id, expected in QUESTIONS:
+            start = time.perf_counter()
+            response = client.recall(agent_id, question, limit=3, min_similarity=0)
+            matched = any(
+                expected in str(item.get("content", ""))
+                for item in response.get("memories", [])
+            )
+            evidence.append(
+                {
+                    "question": question,
+                    "expected": expected,
+                    "source_contains_answer": expected in source[memory_id]["memory"],
+                    "destination_retrieved_answer": matched,
+                    "recall_seconds": time.perf_counter() - start,
+                    "response": response,
+                }
+            )
+            print(
+                json.dumps(
+                    {
+                        key: value
+                        for key, value in evidence[-1].items()
+                        if key != "response"
+                    }
+                )
+            )
+        exported = Path.home() / ".memanto" / "on-prem" / ("export-" + run_id)
+        command(
+            "memanto",
+            "memory",
+            "export",
+            "--okf",
+            "--split",
+            "file",
+            "--agent",
+            agent_id,
+            "--output",
+            str(exported),
+            "--limit",
+            "100",
+        )
+        shutil.copytree(exported, root / "roundtrip-okf")
+        roundtrip = load_okf_bundle(root / "roundtrip-okf")
+        bodies = [row["body"] for row in roundtrip["memories"]]
+        input_bodies = [
+            entry["body"] for entry in load_okf_bundle(root / "input-okf")["memories"]
+        ]
+        intact = len(bodies) == len(source) and all(
+            any(original in body for body in bodies) for original in input_bodies
+        )
+        report = {
+            "source": "Agno 3.0.6 SQLite persistence API",
+            "scenario": "Scripted demonstration, not a historical personal archive",
+            "golden_check": "Answer-bearing retrieval at k=3, not generated-answer quality",
+            "questions": evidence,
+            "generated_answer_checks": answers,
+            "answer_model": ANSWER_MODEL,
+            "destination_count_before_import": before_import.get("count", 0),
+            "live_import_verified": True,
+            "index_readiness_counts": readiness_checks,
+            "index_readiness_seconds": readiness_seconds,
+            "roundtrip_count": len(bodies),
+            "roundtrip_source_text_preserved": intact,
+            "savings_report": "The upstream OKF CLI has no savings report or --report option",
+        }
+        (root / "live-validation.json").write_text(
+            json.dumps(report, indent=2, default=str), encoding="utf-8"
+        )
+        assert intact, "Round-trip export lost or changed source memory text"
+        assert all(
+            item["source_pass"] and item["destination_pass"] for item in answers
+        ), "Generated-answer parity check failed; inspect the saved answers"
+        assert all(
+            row["source_contains_answer"] and row["destination_retrieved_answer"]
+            for row in evidence
+        ), "At least one golden retrieval check failed"
+        print(
+            f"Generated answers: {len(answers)}/{len(answers)} pass before and after. "
+            f"Round trip: {len(bodies)} complete memory bodies preserved.",
+            flush=True,
+        )
+        print(report["savings_report"], flush=True)
+        print(
+            "Live import, recall, and OKF export checks passed. Artifacts: " + str(root)
+        )
+    finally:
+        (root / "timings.json").write_text(
+            json.dumps(timings, indent=2), encoding="utf-8"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/migrations/agno-sqlite/sample-okf/index.md
+++ b/examples/migrations/agno-sqlite/sample-okf/index.md
@@ -1,0 +1,9 @@
+---
+okf_version: "0.2"
+---
+
+# agno-demo-7981da8f3764 — OKF bundle
+
+- [memories](memories/index.md) — 4 memories across 1 type(s)
+- [sessions](sessions/index.md) — 1 session log file(s)
+- [metrics](metrics/index.md) — aggregate stats & visualizations

--- a/examples/migrations/agno-sqlite/sample-okf/memories/context/agno-memory-0a9206a6e8cafe4a.md
+++ b/examples/migrations/agno-sqlite/sample-okf/memories/context/agno-memory-0a9206a6e8cafe4a.md
@@ -1,0 +1,42 @@
+---
+type: context
+title: Agno memory 0a9206a6e8cafe4a
+description: Memory
+tags:
+- locale
+generated:
+  by: process:agno
+  at: '2026-09-08T08:06:42+00:00'
+x_memanto:
+  id: 1f92e427-ef56-4b4f-9000-fbbc24ed3b5c
+  confidence: 0.8
+  provenance: imported
+  source: agno
+  status: active
+  updated_at: '2026-09-08T08:06:42+00:00'
+  type: context
+---
+
+## Memory
+
+The project displays times in Asia/Kolkata and uses INR.
+
+## Agno source metadata
+
+{
+  "agent_id": "report-assistant",
+  "created_at": 1788854802,
+  "feedback": null,
+  "input": null,
+  "memory_id": "locale",
+  "team_id": null,
+  "topics": [
+    "locale"
+  ],
+  "updated_at": 1788854802,
+  "user_id": "demo-user"
+}
+
+---
+[Supporting data]
+- OKF source: memories/0a9206a6e8cafe4a58359fd612fa5b4a3fec5dbd98afd13fdaec85eb6e55b656.md

--- a/examples/migrations/agno-sqlite/sample-okf/memories/context/agno-memory-12a91a2c4e9f3bc2.md
+++ b/examples/migrations/agno-sqlite/sample-okf/memories/context/agno-memory-12a91a2c4e9f3bc2.md
@@ -1,0 +1,42 @@
+---
+type: context
+title: Agno memory 12a91a2c4e9f3bc2
+description: Memory
+tags:
+- schedule
+generated:
+  by: process:agno
+  at: '2026-09-08T08:06:42+00:00'
+x_memanto:
+  id: dc7f629c-8b69-46fa-b74e-d32d1e6ae7c5
+  confidence: 0.8
+  provenance: imported
+  source: agno
+  status: active
+  updated_at: '2026-09-08T08:06:42+00:00'
+  type: context
+---
+
+## Memory
+
+Correction: deliver the weekly report on Friday at 16:00 UTC.
+
+## Agno source metadata
+
+{
+  "agent_id": "report-assistant",
+  "created_at": 1788854802,
+  "feedback": null,
+  "input": "Move Monday delivery to Friday afternoon.",
+  "memory_id": "delivery",
+  "team_id": null,
+  "topics": [
+    "schedule"
+  ],
+  "updated_at": 1788854802,
+  "user_id": "demo-user"
+}
+
+---
+[Supporting data]
+- OKF source: memories/12a91a2c4e9f3bc2db758f3ba88734553647a4d2c916ca78a208d984b839e28d.md

--- a/examples/migrations/agno-sqlite/sample-okf/memories/context/agno-memory-d89685daf5d1fb75.md
+++ b/examples/migrations/agno-sqlite/sample-okf/memories/context/agno-memory-d89685daf5d1fb75.md
@@ -1,0 +1,42 @@
+---
+type: context
+title: Agno memory d89685daf5d1fb75
+description: Memory
+tags:
+- database
+generated:
+  by: process:agno
+  at: '2026-09-08T08:06:42+00:00'
+x_memanto:
+  id: b0a7a5ce-1091-482d-8f03-cf873dbf7a6d
+  confidence: 0.8
+  provenance: imported
+  source: agno
+  status: active
+  updated_at: '2026-09-08T08:06:42+00:00'
+  type: context
+---
+
+## Memory
+
+The project stores its primary data in PostgreSQL 16.
+
+## Agno source metadata
+
+{
+  "agent_id": "report-assistant",
+  "created_at": 1788854802,
+  "feedback": null,
+  "input": null,
+  "memory_id": "storage",
+  "team_id": null,
+  "topics": [
+    "database"
+  ],
+  "updated_at": 1788854802,
+  "user_id": "demo-user"
+}
+
+---
+[Supporting data]
+- OKF source: memories/d89685daf5d1fb753543e93d7afff013c66e636b1d54f3eb86bf7bd18a7812b2.md

--- a/examples/migrations/agno-sqlite/sample-okf/memories/context/agno-memory-dbb3270b08292b70.md
+++ b/examples/migrations/agno-sqlite/sample-okf/memories/context/agno-memory-dbb3270b08292b70.md
@@ -1,0 +1,42 @@
+---
+type: context
+title: Agno memory dbb3270b08292b70
+description: Memory
+tags:
+- format
+generated:
+  by: process:agno
+  at: '2026-09-08T08:06:42+00:00'
+x_memanto:
+  id: a8dbcfe1-c3be-41df-80f8-38d11b434448
+  confidence: 0.8
+  provenance: imported
+  source: agno
+  status: active
+  updated_at: '2026-09-08T08:06:42+00:00'
+  type: context
+---
+
+## Memory
+
+Send reports as Markdown, with a CSV attachment.
+
+## Agno source metadata
+
+{
+  "agent_id": "report-assistant",
+  "created_at": 1788854802,
+  "feedback": null,
+  "input": null,
+  "memory_id": "format",
+  "team_id": null,
+  "topics": [
+    "format"
+  ],
+  "updated_at": 1788854802,
+  "user_id": "demo-user"
+}
+
+---
+[Supporting data]
+- OKF source: memories/dbb3270b08292b7017ddd702ed08a11c5345eb635c6a3d2494952da5fa328379.md

--- a/examples/migrations/agno-sqlite/sample-okf/memories/context/index.md
+++ b/examples/migrations/agno-sqlite/sample-okf/memories/context/index.md
@@ -1,0 +1,6 @@
+# context (4)
+
+- [Agno memory dbb3270b08292b70](agno-memory-dbb3270b08292b70.md)
+- [Agno memory 12a91a2c4e9f3bc2](agno-memory-12a91a2c4e9f3bc2.md)
+- [Agno memory 0a9206a6e8cafe4a](agno-memory-0a9206a6e8cafe4a.md)
+- [Agno memory d89685daf5d1fb75](agno-memory-d89685daf5d1fb75.md)

--- a/examples/migrations/agno-sqlite/sample-okf/memories/index.md
+++ b/examples/migrations/agno-sqlite/sample-okf/memories/index.md
@@ -1,0 +1,3 @@
+# Memories (4)
+
+- [context](context/index.md)

--- a/examples/migrations/agno-sqlite/sample-okf/metrics/index.md
+++ b/examples/migrations/agno-sqlite/sample-okf/metrics/index.md
@@ -1,0 +1,3 @@
+# Metrics
+
+- [overview](overview.md)

--- a/examples/migrations/agno-sqlite/sample-okf/metrics/overview.md
+++ b/examples/migrations/agno-sqlite/sample-okf/metrics/overview.md
@@ -1,0 +1,41 @@
+---
+type: Metrics Overview
+title: Aggregate Metrics
+---
+
+# Metrics — aggregate
+
+> 4 memories
+
+
+---
+
+## 📊 Visual Insights
+
+### Memory Activity Timeline
+
+```
+Hour  00  03  06  09  12  15  18  21  24
+      ╠═══╬═══╬═══╬═══╬═══╬═══╬═══╬═══╣
+              ●●●●
+```
+
+**4** memories across **1** active hours
+
+### Memory Type Distribution
+
+```
+CONTEXT  ████████████████████ 4
+```
+
+### Confidence Overview
+
+| Metric          | Value |
+|-----------------|-------|
+| Total Memories  | 4     |
+| Avg Confidence  | 0.80  |
+| High (≥0.8)     | 4     |
+| Medium (0.5–0.8)| 0     |
+| Low (<0.5)      | 0     |
+
+*Visualizations auto-generated at Sep 08, 2026 08:07 AM*

--- a/examples/migrations/agno-sqlite/sample-okf/sessions/agno-demo-7981da8f3764_2026-09-08_sess_2da5519e0832_summary.md
+++ b/examples/migrations/agno-sqlite/sample-okf/sessions/agno-demo-7981da8f3764_2026-09-08_sess_2da5519e0832_summary.md
@@ -1,0 +1,145 @@
+---
+type: Context Document
+title: agno-demo-7981da8f3764_2026-09-08_sess_2da5519e0832_summary
+---
+
+# Session Summary for agno-demo-7981da8f3764
+**Session ID:** `sess_2da5519e0832`
+
+---
+
+### [2026-09-08 08:06:42] [CONTEXT] Agno memory 0a9206a6e8cafe4a
+- **Memory ID**: `1f92e427-ef56-4b4f-9000-fbbc24ed3b5c`
+- **Confidence**: `0.8`
+- **Status**: `active`
+- **Source**: `agno`
+- **Provenance**: `imported`
+- **Tags**: `locale`
+- **Content**:
+> ## Memory
+>
+> The project displays times in Asia/Kolkata and uses INR.
+>
+> ## Agno source metadata
+>
+> {
+>   "agent_id": "report-assistant",
+>   "created_at": 1788854802,
+>   "feedback": null,
+>   "input": null,
+>   "memory_id": "locale",
+>   "team_id": null,
+>   "topics": [
+>     "locale"
+>   ],
+>   "updated_at": 1788854802,
+>   "user_id": "demo-user"
+> }
+>
+> ---
+> [Supporting data]
+> - OKF source: memories/0a9206a6e8cafe4a58359fd612fa5b4a3fec5dbd98afd13fdaec85eb6e55b656.md
+
+---
+
+### [2026-09-08 08:06:42] [CONTEXT] Agno memory 12a91a2c4e9f3bc2
+- **Memory ID**: `dc7f629c-8b69-46fa-b74e-d32d1e6ae7c5`
+- **Confidence**: `0.8`
+- **Status**: `active`
+- **Source**: `agno`
+- **Provenance**: `imported`
+- **Tags**: `schedule`
+- **Content**:
+> ## Memory
+>
+> Correction: deliver the weekly report on Friday at 16:00 UTC.
+>
+> ## Agno source metadata
+>
+> {
+>   "agent_id": "report-assistant",
+>   "created_at": 1788854802,
+>   "feedback": null,
+>   "input": "Move Monday delivery to Friday afternoon.",
+>   "memory_id": "delivery",
+>   "team_id": null,
+>   "topics": [
+>     "schedule"
+>   ],
+>   "updated_at": 1788854802,
+>   "user_id": "demo-user"
+> }
+>
+> ---
+> [Supporting data]
+> - OKF source: memories/12a91a2c4e9f3bc2db758f3ba88734553647a4d2c916ca78a208d984b839e28d.md
+
+---
+
+### [2026-09-08 08:06:42] [CONTEXT] Agno memory d89685daf5d1fb75
+- **Memory ID**: `b0a7a5ce-1091-482d-8f03-cf873dbf7a6d`
+- **Confidence**: `0.8`
+- **Status**: `active`
+- **Source**: `agno`
+- **Provenance**: `imported`
+- **Tags**: `database`
+- **Content**:
+> ## Memory
+>
+> The project stores its primary data in PostgreSQL 16.
+>
+> ## Agno source metadata
+>
+> {
+>   "agent_id": "report-assistant",
+>   "created_at": 1788854802,
+>   "feedback": null,
+>   "input": null,
+>   "memory_id": "storage",
+>   "team_id": null,
+>   "topics": [
+>     "database"
+>   ],
+>   "updated_at": 1788854802,
+>   "user_id": "demo-user"
+> }
+>
+> ---
+> [Supporting data]
+> - OKF source: memories/d89685daf5d1fb753543e93d7afff013c66e636b1d54f3eb86bf7bd18a7812b2.md
+
+---
+
+### [2026-09-08 08:06:42] [CONTEXT] Agno memory dbb3270b08292b70
+- **Memory ID**: `a8dbcfe1-c3be-41df-80f8-38d11b434448`
+- **Confidence**: `0.8`
+- **Status**: `active`
+- **Source**: `agno`
+- **Provenance**: `imported`
+- **Tags**: `format`
+- **Content**:
+> ## Memory
+>
+> Send reports as Markdown, with a CSV attachment.
+>
+> ## Agno source metadata
+>
+> {
+>   "agent_id": "report-assistant",
+>   "created_at": 1788854802,
+>   "feedback": null,
+>   "input": null,
+>   "memory_id": "format",
+>   "team_id": null,
+>   "topics": [
+>     "format"
+>   ],
+>   "updated_at": 1788854802,
+>   "user_id": "demo-user"
+> }
+>
+> ---
+> [Supporting data]
+> - OKF source: memories/dbb3270b08292b7017ddd702ed08a11c5345eb635c6a3d2494952da5fa328379.md
+
+---

--- a/examples/migrations/agno-sqlite/sample-okf/sessions/index.md
+++ b/examples/migrations/agno-sqlite/sample-okf/sessions/index.md
@@ -1,0 +1,3 @@
+# Sessions (1)
+
+- [agno-demo-7981da8f3764_2026-09-08_sess_2da5519e0832_summary.md](agno-demo-7981da8f3764_2026-09-08_sess_2da5519e0832_summary.md)

--- a/examples/migrations/agno-sqlite/test_adapter.py
+++ b/examples/migrations/agno-sqlite/test_adapter.py
@@ -1,0 +1,150 @@
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from adapter import export, read_memories, render
+from demo_source import populate
+
+from memanto.cli.migrate.mappers import map_okf
+from memanto.cli.migrate.okf_loader import load_okf_bundle
+
+
+def test_real_agno_database_preserves_correction_and_user_scope(tmp_path: Path):
+    database = tmp_path / "source.db"
+    populate(database)
+    before = hashlib.sha256(database.read_bytes()).hexdigest()
+    output = tmp_path / "bundle"
+    summary = export(database, "demo-user", output)
+    mapped = map_okf(load_okf_bundle(output))
+    assert summary["mapped_memories"] == 4
+    bodies = "\n".join(row["content"] for row in mapped)
+    assert "Friday at 16:00 UTC" in bodies
+    assert "Monday at 09:00 UTC" not in bodies
+    assert "separate user's memory" not in bodies
+    assert "PostgreSQL 16" in bodies
+    assert hashlib.sha256(database.read_bytes()).hexdigest() == before
+
+
+def test_does_not_overwrite_existing_bundle(tmp_path: Path):
+    database = tmp_path / "source.db"
+    populate(database)
+    output = tmp_path / "bundle"
+    export(database, "demo-user", output)
+    with pytest.raises(FileExistsError):
+        export(database, "demo-user", output)
+
+
+def test_missing_source_does_not_create_database(tmp_path: Path):
+    database = tmp_path / "missing.db"
+    with pytest.raises(FileNotFoundError):
+        read_memories(database, "demo-user")
+    assert not database.exists()
+
+
+def test_empty_scope_is_explicit_failure(tmp_path: Path):
+    database = tmp_path / "source.db"
+    populate(database)
+    with pytest.raises(ValueError, match="No memories"):
+        export(database, "unknown", tmp_path / "out")
+    assert not (tmp_path / "out").exists()
+
+
+def test_untrusted_ids_cannot_control_filenames():
+    name, text = render(
+        {
+            "user_id": "../person",
+            "memory_id": "../../outside",
+            "memory": "नमस्ते 🌍",
+            "created_at": 0,
+            "updated_at": 0,
+            "topics": ["hello: world"],
+        }
+    )
+    assert "/" not in name and "\\" not in name
+    assert "1970-01-01T00:00:00+00:00" in text
+    assert "नमस्ते 🌍" in text
+
+
+def test_oversize_memory_fails_before_publishing(tmp_path: Path):
+    from agno.db.schemas.memory import UserMemory
+    from agno.db.sqlite import SqliteDb
+
+    database = tmp_path / "source.db"
+    db = SqliteDb(db_file=str(database))
+    db.upsert_user_memory(UserMemory(memory="x" * 12000, memory_id="long", user_id="u"))
+    with pytest.raises(ValueError, match="truncate"):
+        export(database, "u", tmp_path / "out")
+    assert not (tmp_path / "out").exists()
+
+
+def test_reserved_delimiter_rejected():
+    with pytest.raises(ValueError, match="reserved"):
+        render({"memory_id": "m", "user_id": "u", "memory": "<!-- okf-entry -->"})
+
+
+def test_long_source_metadata_remains_in_imported_body(tmp_path: Path):
+    from agno.db.schemas.memory import UserMemory
+    from agno.db.sqlite import SqliteDb
+
+    database = tmp_path / "source.db"
+    db = SqliteDb(db_file=str(database))
+    source_input = "Full original instruction " * 40
+    db.upsert_user_memory(
+        UserMemory(
+            memory="Use Markdown.",
+            memory_id="metadata",
+            user_id="u",
+            input=source_input,
+        )
+    )
+    export(database, "u", tmp_path / "out")
+    mapped = map_okf(load_okf_bundle(tmp_path / "out"))
+    assert source_input in mapped[0]["content"]
+
+
+def test_null_topics_and_epoch_zero_survive_real_sqlite(tmp_path: Path):
+    database = tmp_path / "source.db"
+    populate(database)
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE agno_memories SET created_at=0, updated_at=0, topics=NULL"
+        )
+    export(database, "demo-user", tmp_path / "out")
+    mapped = map_okf(load_okf_bundle(tmp_path / "out"))
+    assert all(row["created_at"].timestamp() == 0 for row in mapped)
+    assert all(row["updated_at"].timestamp() == 0 for row in mapped)
+    assert all(row["tags"] == [] for row in mapped)
+
+
+def test_source_record_archive_has_every_selected_column(tmp_path: Path):
+    database = tmp_path / "source.db"
+    populate(database)
+    with sqlite3.connect(database) as connection:
+        connection.execute("ALTER TABLE agno_memories ADD COLUMN future_field TEXT")
+        connection.execute("UPDATE agno_memories SET future_field='retained'")
+    export(database, "demo-user", tmp_path / "out")
+    archived = json.loads((tmp_path / "out" / "source-records.json").read_text())
+    assert len(archived) == 4
+    assert all(row["future_field"] == "retained" for row in archived)
+    mapped = map_okf(load_okf_bundle(tmp_path / "out"))
+    assert all('"future_field": "retained"' in row["content"] for row in mapped)
+
+
+def test_invalid_table_identifier_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="identifier"):
+        read_memories(tmp_path / "source.db", "u", 'agno_memories"; DROP TABLE x;--')
+
+
+def test_memory_boundary_whitespace_survives_loader(tmp_path: Path):
+    from agno.db.schemas.memory import UserMemory
+    from agno.db.sqlite import SqliteDb
+
+    database = tmp_path / "source.db"
+    original = "  Preserve leading whitespace.\n\nTrailing whitespace too.  "
+    db = SqliteDb(db_file=str(database))
+    db.upsert_user_memory(UserMemory(memory=original, memory_id="spaces", user_id="u"))
+    export(database, "u", tmp_path / "out")
+    mapped = map_okf(load_okf_bundle(tmp_path / "out"))
+    assert original in mapped[0]["content"]


### PR DESCRIPTION
Agno SQLite users can now export one user's persisted memories into OKF and run Memanto's existing dry-run, import, and export commands. The adapter opens the source read-only, preserves complete source metadata, and rejects memories the upstream mapper would truncate. This adds the reusable example, field mapping, isolated Compose demo, tests, and sample exported OKF under `examples/migrations/agno-sqlite/`.

Validation: 12 adapter tests, Ruff lint/format, and mypy passed. The live local run imported four memories with zero failures and retained all four complete bodies through export. Four answer-bearing retrieval checks passed. A real Agno agent and Memanto's answer endpoint both passed the same four generated-answer checks using local Ollama `qwen2.5:1.5b`.

[Full live-run evidence](https://github.com/Rexyysilent/memanto/tree/341007cff42ecb8aa1cd2836acae73079fbf1da0/examples/migrations/agno-sqlite/demo-evidence) · [Video replay](https://github.com/Rexyysilent/memanto/blob/341007cff42ecb8aa1cd2836acae73079fbf1da0/examples/migrations/agno-sqlite/demo-evidence/live-output-replay.mp4) · [Before/after answers](https://github.com/Rexyysilent/memanto/blob/341007cff42ecb8aa1cd2836acae73079fbf1da0/examples/migrations/agno-sqlite/demo-evidence/evidence/generated-answers.json)

Draft Path B submission for #1609. The source is a scripted scenario persisted through Agno's actual API, and the backend is local/on-premises. The video is a paced rendering of timestamped live terminal output, not a desktop pixel capture. An earlier 0.5b model omitted CSV in one destination answer; that failure remains in the evidence. Questions and scoring were unchanged for the 1.5b run. Four questions do not establish universal recall parity. Codex authored and tested this implementation with AI assistance.

Before completing the contest entry, could you clarify whether the local backend and terminal replay are acceptable, and how Path B should satisfy the savings-report requirement when `memanto migrate okf` has no report option? No comparative savings are claimed. The BountyHub claim was successfully created on September 9, 2026. The public social showcase remains pending.

