### PR TITLE
fix: disable unauthenticated API docs and guard plain-HTTP deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,17 @@ MOORCHEH_API_KEY=your_api_key_here
 # management credential or a loopback caller), and never revives a session
 # that was explicitly ended.
 # SESSION_AUTO_RECREATE_ENABLED=True
+
+# Security Configuration (all optional — defaults shown)
+# Interactive API docs (/docs, /redoc, /openapi.json) are disabled by default
+# because the server binds 0.0.0.0. Enable only behind HTTPS/a trusted network.
+# MEMANTO_ENABLE_DOCS=False
+# Refuse to start when MEMANTO would serve plain HTTP on a non-loopback
+# interface (hard-fails even with DEBUG=true).
+# MEMANTO_REQUIRE_SECURE=False
+# Comma-separated IPs (or a JSON array) of trusted reverse proxies that
+# terminate TLS. When set, X-Forwarded-Proto from those peers is honored so
+# the session cookie is marked Secure for proxied (browser-facing HTTPS)
+# sessions. The proxy must overwrite any client-supplied forwarding headers.
+# Leave empty to never trust them (the default, safe posture).
+# MEMANTO_PROXY_ALLOWED_IPS=

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,8 @@ MOORCHEH_API_KEY=your_api_key_here
 
 # Security Configuration (all optional — defaults shown)
 # Interactive API docs (/docs, /redoc, /openapi.json) are disabled by default
-# because the server binds 0.0.0.0. Enable only behind HTTPS/a trusted network.
+# because the server binds 0.0.0.0. Enable only on a trusted network or behind
+# an access-control layer - HTTPS protects transport, not access to the schema.
 # MEMANTO_ENABLE_DOCS=False
 # Refuse to start when MEMANTO would serve plain HTTP on a non-loopback
 # interface (hard-fails even with DEBUG=true).

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,9 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/ready')" || exit 1
 
-CMD ["uvicorn", "memanto.app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run a pre-start exposure check against the resolved bind host before Uvicorn
+# serves plain HTTP: when MEMANTO_REQUIRE_SECURE=true this refuses to start the
+# container (the container always resolves its bind to the network-facing
+# 0.0.0.0, so the guard cannot be skipped the way the python ``__main__`` guard
+# would be when Uvicorn is started directly).
+CMD ["sh", "-c", "python -c \"from memanto.app.config import check_secure_deployment; check_secure_deployment('0.0.0.0')\" && exec uvicorn memanto.app.main:app --host 0.0.0.0 --port 8000"]

--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -188,6 +188,16 @@ class Settings(BaseSettings):
     # UI Mode
     MEMANTO_UI_MODE: bool = False
 
+    # Security: expose the interactive API docs (/docs, /redoc, /openapi.json).
+    # Off by default because the server binds 0.0.0.0 by default and the schema
+    # would otherwise be enumerable by any network peer. Enable explicitly when
+    # the API is served over a trusted network or HTTPS.
+    MEMANTO_ENABLE_DOCS: bool = False
+    # Security: refuse to start when MEMANTO would be served over plain HTTP on
+    # a non-loopback interface (the default 0.0.0.0 bind) so the session cookie
+    # and API traffic cannot be sniffed on the network.
+    MEMANTO_REQUIRE_SECURE: bool = False
+
     model_config = SettingsConfigDict(
         env_file=".env", case_sensitive=True, extra="ignore"
     )
@@ -195,6 +205,42 @@ class Settings(BaseSettings):
 
 # Global settings instance
 settings = Settings()
+
+LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def is_loopback_host(host: str | None) -> bool:
+    """True when a uvicorn ``host`` binds only to loopback interfaces."""
+    return (host or "").strip().lower().strip("[]") in LOOPBACK_HOSTS
+
+
+def plain_http_exposure_message(host: str) -> str | None:
+    """Describe the exposure when ``host`` serves plain HTTP on the network.
+
+    Returns a human-readable warning when a non-loopback bind would expose
+    MEMANTO over clear-text HTTP (the app ships with no built-in TLS and
+    defaults to binding ``0.0.0.0``), else ``None``. ``DEBUG`` is the intended
+    escape hatch for local development.
+    """
+    if is_loopback_host(host) or settings.DEBUG:
+        return None
+    return (
+        f"Memanto is serving over plain HTTP on {host!r} (no built-in TLS). Any "
+        "network peer that can reach this port can sniff the session cookie "
+        "(full memory read/write for an active agent) and enumerate every API "
+        "route. Bind to a loopback address (127.0.0.1) or terminate TLS in "
+        "front of Memanto."
+    )
+
+
+def check_secure_deployment(host: str) -> None:
+    """Warn (or hard-fail) when Memanto would serve plain HTTP on the network."""
+    message = plain_http_exposure_message(host)
+    if message is None:
+        return
+    if settings.MEMANTO_REQUIRE_SECURE:
+        raise RuntimeError(f"MEMANTO_REQUIRE_SECURE is set. {message}")
+    logger.warning("%s", message)
 
 
 def get_data_dir() -> Path:

--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -5,6 +5,8 @@ Server-side settings (loaded from .env via pydantic-settings).
 CLI config models have been moved to cli/config/manager.py.
 """
 
+import ipaddress
+import json
 import logging
 import os
 from pathlib import Path
@@ -197,32 +199,73 @@ class Settings(BaseSettings):
     # a non-loopback interface (the default 0.0.0.0 bind) so the session cookie
     # and API traffic cannot be sniffed on the network.
     MEMANTO_REQUIRE_SECURE: bool = False
+    # Security: when TLS terminates at a reverse proxy, the browser-facing
+    # scheme arrives as X-Forwarded-Proto. Only trust that header from peers in
+    # this explicit allowlist (empty = never trust forwarded headers, so the
+    # session cookie is only marked Secure when the request really arrived over
+    # HTTPS). The proxy must overwrite any client-supplied forwarding headers.
+    # Parsed via ``proxy_allowed_ips`` (a JSON array or comma-separated list).
+    MEMANTO_PROXY_ALLOWED_IPS: str = ""
 
     model_config = SettingsConfigDict(
         env_file=".env", case_sensitive=True, extra="ignore"
     )
 
+    @property
+    def proxy_allowed_ips(self) -> list[str]:
+        """Trusted reverse-proxy peers allowed to set ``X-Forwarded-Proto``.
+
+        Reads ``MEMANTO_PROXY_ALLOWED_IPS`` as a JSON array (``["1.2.3.4"]``)
+        or a comma-separated list. Empty or unset means the forwarded header is
+        never trusted, so the session cookie is only marked ``Secure`` when the
+        browser connection really arrived over HTTPS.
+        """
+        raw = (self.MEMANTO_PROXY_ALLOWED_IPS or "").strip()
+        if not raw:
+            return []
+        if raw.startswith("["):
+            try:
+                values = json.loads(raw)
+            except json.JSONDecodeError:
+                return []
+            return [str(ip).strip() for ip in values if str(ip).strip()]
+        return [ip.strip() for ip in raw.split(",") if ip.strip()]
+
 
 # Global settings instance
 settings = Settings()
 
-LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
-
 
 def is_loopback_host(host: str | None) -> bool:
     """True when a uvicorn ``host`` binds only to loopback interfaces."""
-    return (host or "").strip().lower().strip("[]") in LOOPBACK_HOSTS
+    raw = (host or "").strip().lower().strip("[]")
+    if raw == "localhost":
+        return True
+    if not raw:
+        return False
+    try:
+        addr = ipaddress.ip_address(raw)
+    except ValueError:
+        return False
+    if addr.is_loopback:
+        return True
+    # IPv4-mapped IPv6 (e.g. ``::ffff:127.0.0.1``) is not flagged by
+    # ``is_loopback`` alone, so unwrap the embedded IPv4 address.
+    if isinstance(addr, ipaddress.IPv6Address):
+        mapped = addr.ipv4_mapped
+        return mapped is not None and mapped.is_loopback
+    return False
 
 
 def plain_http_exposure_message(host: str) -> str | None:
     """Describe the exposure when ``host`` serves plain HTTP on the network.
 
-    Returns a human-readable warning when a non-loopback bind would expose
-    MEMANTO over clear-text HTTP (the app ships with no built-in TLS and
-    defaults to binding ``0.0.0.0``), else ``None``. ``DEBUG`` is the intended
-    escape hatch for local development.
+    Returns a human-readable warning for any non-loopback bind (the app ships
+    with no built-in TLS and defaults to binding ``0.0.0.0``), else ``None``.
+    Suppressing the *warning* under ``DEBUG`` is a caller-side decision; it must
+    never disable the ``MEMANTO_REQUIRE_SECURE`` enforcement.
     """
-    if is_loopback_host(host) or settings.DEBUG:
+    if is_loopback_host(host):
         return None
     return (
         f"Memanto is serving over plain HTTP on {host!r} (no built-in TLS). Any "
@@ -235,12 +278,13 @@ def plain_http_exposure_message(host: str) -> str | None:
 
 def check_secure_deployment(host: str) -> None:
     """Warn (or hard-fail) when Memanto would serve plain HTTP on the network."""
-    message = plain_http_exposure_message(host)
-    if message is None:
+    if is_loopback_host(host):
         return
+    message = plain_http_exposure_message(host)
     if settings.MEMANTO_REQUIRE_SECURE:
         raise RuntimeError(f"MEMANTO_REQUIRE_SECURE is set. {message}")
-    logger.warning("%s", message)
+    if not settings.DEBUG:
+        logger.warning("%s", message)
 
 
 def get_data_dir() -> Path:

--- a/memanto/app/config.py
+++ b/memanto/app/config.py
@@ -192,8 +192,9 @@ class Settings(BaseSettings):
 
     # Security: expose the interactive API docs (/docs, /redoc, /openapi.json).
     # Off by default because the server binds 0.0.0.0 by default and the schema
-    # would otherwise be enumerable by any network peer. Enable explicitly when
-    # the API is served over a trusted network or HTTPS.
+    # would otherwise be enumerable by any network peer. Enable explicitly only
+    # on a trusted network or behind an access-control layer - HTTPS protects
+    # transport, not access to the schema.
     MEMANTO_ENABLE_DOCS: bool = False
     # Security: refuse to start when MEMANTO would be served over plain HTTP on
     # a non-loopback interface (the default 0.0.0.0 bind) so the session cookie

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -12,6 +12,7 @@ from moorcheh_sdk.exceptions import AuthenticationError, NamespaceNotFound
 from memanto.app import __version__
 from memanto.app.clients.backend import Backend, parse_backend
 from memanto.app.config import check_secure_deployment, settings
+from memanto.app.middleware import TrustedProxySchemeMiddleware
 from memanto.app.routes import health, sessions
 from memanto.app.ui.routes.ui_router import mount_ui_static
 from memanto.app.ui.routes.ui_router import router as ui_router
@@ -99,6 +100,15 @@ def _validate_cors_settings(
             "ALLOWED_ORIGINS=['*']. Specify explicit trusted origins when enabling credentials."
         )
 
+
+# If TLS terminates at a trusted reverse proxy, restore the browser-facing
+# scheme so the session cookie is marked Secure (see auth_deps.py). Off by
+# default: X-Forwarded-Proto is only honored from explicit peers.
+if settings.proxy_allowed_ips:
+    app.add_middleware(
+        TrustedProxySchemeMiddleware,
+        allowed_ips=settings.proxy_allowed_ips,
+    )
 
 # Add CORS middleware
 _validate_cors_settings(settings.ALLOWED_ORIGINS, settings.CORS_ALLOW_CREDENTIALS)

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -73,7 +73,8 @@ async def lifespan(_: FastAPI):
 # Create FastAPI app. The interactive docs and the OpenAPI schema are disabled
 # by default (MEMANTO_ENABLE_DOCS=true re-enables them): the server binds
 # 0.0.0.0 by default, so an unauthenticated schema would enumerate every route
-# to any network peer.
+# to any network peer. Enable them only on a trusted network or behind an
+# access-control layer - HTTPS protects transport, not access to the schema.
 app = FastAPI(
     title="Memanto - Memory that AI Agents Love!",
     description="A memory layer service for agentic AI systems using Moorcheh SDK",

--- a/memanto/app/main.py
+++ b/memanto/app/main.py
@@ -11,7 +11,7 @@ from moorcheh_sdk.exceptions import AuthenticationError, NamespaceNotFound
 
 from memanto.app import __version__
 from memanto.app.clients.backend import Backend, parse_backend
-from memanto.app.config import settings
+from memanto.app.config import check_secure_deployment, settings
 from memanto.app.routes import health, sessions
 from memanto.app.ui.routes.ui_router import mount_ui_static
 from memanto.app.ui.routes.ui_router import router as ui_router
@@ -69,13 +69,17 @@ async def lifespan(_: FastAPI):
     yield
 
 
-# Create FastAPI app
+# Create FastAPI app. The interactive docs and the OpenAPI schema are disabled
+# by default (MEMANTO_ENABLE_DOCS=true re-enables them): the server binds
+# 0.0.0.0 by default, so an unauthenticated schema would enumerate every route
+# to any network peer.
 app = FastAPI(
     title="Memanto - Memory that AI Agents Love!",
     description="A memory layer service for agentic AI systems using Moorcheh SDK",
     version=__version__,
-    docs_url="/docs",
-    redoc_url="/redoc",
+    docs_url="/docs" if settings.MEMANTO_ENABLE_DOCS else None,
+    redoc_url="/redoc" if settings.MEMANTO_ENABLE_DOCS else None,
+    openapi_url="/openapi.json" if settings.MEMANTO_ENABLE_DOCS else None,
     lifespan=lifespan,
 )
 
@@ -166,4 +170,8 @@ async def root():
 if __name__ == "__main__":
     import uvicorn
 
+    try:
+        check_secure_deployment(host="0.0.0.0")
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/memanto/app/middleware.py
+++ b/memanto/app/middleware.py
@@ -1,0 +1,54 @@
+"""ASGI middleware for MEMANTO.
+
+Small, dependency-light middleware that Starlette does not provide in the
+version pinned by this project.
+"""
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_HTTPS = "https"
+_HTTP = "http"
+_PROTO_HEADER = "x-forwarded-proto"
+
+
+class TrustedProxySchemeMiddleware:
+    """Rewrite the request scheme from ``X-Forwarded-Proto``.
+
+    MEMANTO often sits behind a reverse proxy that terminates TLS (Ingress,
+    Caddy, nginx, ...). Without this, ``request.url.scheme`` stays ``http`` for
+    proxied requests and the browser UI session cookie is emitted without the
+    ``Secure`` flag even though the browser talks HTTPS.
+
+    Only peers listed in the ``allowed_ips`` allowlist are trusted to set the
+    forwarding header; for anyone else it is ignored, so a random network
+    client cannot force ``https`` (or spoof ``http``) merely by sending a
+    header. The deployer's proxy must overwrite any client-supplied
+    ``X-Forwarded-Proto`` before it reaches MEMANTO.
+    """
+
+    def __init__(self, app: Any, allowed_ips: list[str]) -> None:
+        self.app = app
+        self.allowed_ips = {ip.strip() for ip in allowed_ips if ip and ip.strip()}
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[[], Awaitable[Any]],
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        if scope.get("type") == "http":
+            client = scope.get("client")
+            peer = client[0] if client else ""
+            if peer and peer in self.allowed_ips:
+                headers = {
+                    k.decode("latin-1").lower(): v.decode("latin-1")
+                    for k, v in scope.get("headers", [])
+                }
+                proto = (headers.get(_PROTO_HEADER) or "").strip().lower()
+                if proto in (_HTTP, _HTTPS):
+                    scope["scheme"] = proto
+        await self.app(scope, receive, send)

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -25,6 +25,15 @@ SESSION_COOKIE_NAME = "memanto_session_token"
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_log_value(value: object) -> str:
+    """Render ``value`` for logs without control characters (CWE-117).
+
+    Request-derived values (e.g. a URL built from the Host header) must not be
+    able to forge log lines via embedded CR/LF bytes.
+    """
+    return "".join(ch if ch.isprintable() else f"\\x{ord(ch):02x}" for ch in str(value))
+
+
 def set_session_cookie(
     response: Response, session_token: str, request: Request
 ) -> None:
@@ -42,7 +51,7 @@ def set_session_cookie(
             "Any network peer that can reach this port can intercept it and "
             "gain full memory read/write for the active agent. Terminate TLS "
             "in front of Memanto or bind to a loopback address.",
-            request.url,
+            _sanitize_log_value(request.url),
         )
     response.set_cookie(
         SESSION_COOKIE_NAME,

--- a/memanto/app/routes/auth_deps.py
+++ b/memanto/app/routes/auth_deps.py
@@ -4,10 +4,12 @@ Authentication Dependencies for V2 API
 Shared authentication utilities to avoid circular imports.
 """
 
+import logging
 from urllib.parse import urlsplit
 
 from fastapi import Cookie, Header, HTTPException, Request, Response
 
+from memanto.app.config import is_loopback_host
 from memanto.app.models.session import Session
 from memanto.app.services.session_service import get_session_service
 from memanto.app.utils.client_identity import set_memanto_session
@@ -20,6 +22,8 @@ from memanto.app.utils.errors import (
 
 SESSION_COOKIE_NAME = "memanto_session_token"
 
+logger = logging.getLogger(__name__)
+
 
 def set_session_cookie(
     response: Response, session_token: str, request: Request
@@ -31,12 +35,21 @@ def set_session_cookie(
     ever sending the cookie back over the plain-HTTP deployment this ships with by
     default. Mark it Secure only when the current request actually arrived over HTTPS.
     """
+    secure = request.url.scheme == "https"
+    if not secure and not is_loopback_host(request.url.hostname):
+        logger.warning(
+            "Issuing the browser UI session cookie over plain HTTP from %s. "
+            "Any network peer that can reach this port can intercept it and "
+            "gain full memory read/write for the active agent. Terminate TLS "
+            "in front of Memanto or bind to a loopback address.",
+            request.url,
+        )
     response.set_cookie(
         SESSION_COOKIE_NAME,
         session_token,
         httponly=True,
         samesite="strict",
-        secure=request.url.scheme == "https",
+        secure=secure,
         path="/",
     )
 

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -21,7 +21,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from memanto.app.clients.backend import Backend
-from memanto.app.config import plain_http_exposure_message, settings
+from memanto.app.config import is_loopback_host, plain_http_exposure_message, settings
 from memanto.cli.commands._shared import (
     ACCENT,
     BOLD_BRIGHT,
@@ -42,13 +42,20 @@ from memanto.cli.commands._shared import (
 
 
 def _notify_exposed_deployment(host: str) -> None:
-    """Warn (or hard-fail) when MEMANTO serves plain HTTP on the network."""
+    """Warn (or hard-fail) when MEMANTO serves plain HTTP on the network.
+
+    ``DEBUG`` suppresses the non-fatal warning only; it must never disable the
+    ``MEMANTO_REQUIRE_SECURE`` enforcement.
+    """
+    if is_loopback_host(host):
+        return
     message = plain_http_exposure_message(host)
     if message is None:
         return
     if settings.MEMANTO_REQUIRE_SECURE:
         _error(message)
-    _warn(message)
+    elif not settings.DEBUG:
+        _warn(message)
 
 
 def _first_run_setup() -> None:

--- a/memanto/cli/commands/core.py
+++ b/memanto/cli/commands/core.py
@@ -21,6 +21,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from memanto.app.clients.backend import Backend
+from memanto.app.config import plain_http_exposure_message, settings
 from memanto.cli.commands._shared import (
     ACCENT,
     BOLD_BRIGHT,
@@ -30,6 +31,7 @@ from memanto.cli.commands._shared import (
     SUCCESS,
     WARNING,
     _error,
+    _warn,
     app,
     config_manager,
     console,
@@ -37,6 +39,16 @@ from memanto.cli.commands._shared import (
     print_logo,
     show_welcome_banner,
 )
+
+
+def _notify_exposed_deployment(host: str) -> None:
+    """Warn (or hard-fail) when MEMANTO serves plain HTTP on the network."""
+    message = plain_http_exposure_message(host)
+    if message is None:
+        return
+    if settings.MEMANTO_REQUIRE_SECURE:
+        _error(message)
+    _warn(message)
 
 
 def _first_run_setup() -> None:
@@ -961,6 +973,8 @@ def serve(
         host = "0.0.0.0"  # Typically want 0.0.0.0 for bind
     port = port or server_cfg.get("port", 8000)
 
+    _notify_exposed_deployment(host)
+
     console.print(
         Panel.fit(
             f"[{BOLD_PRIMARY}]MEMANTO REST API Starting...[/{BOLD_PRIMARY}]\n"
@@ -1010,7 +1024,8 @@ def serve(
     display_host = "localhost" if host == "0.0.0.0" else host
     console.print("\n[green]Starting local REST API...[/green]")
     console.print(f"[dim]Server URL: http://{display_host}:{port}[/dim]")
-    console.print(f"[dim]API Docs: http://{display_host}:{port}/docs[/dim]")
+    if settings.MEMANTO_ENABLE_DOCS:
+        console.print(f"[dim]API Docs: http://{display_host}:{port}/docs[/dim]")
     console.print(f"[dim]Health Check: http://{display_host}:{port}/health[/dim]")
     console.print(
         "\n[bold]Next step:[/bold] Open a new terminal and run [bright_white]memanto agent create <agent-id>[/bright_white]."
@@ -1082,6 +1097,8 @@ def ui(
         host = "0.0.0.0"
     port = port or server_cfg.get("port", 8000)
 
+    _notify_exposed_deployment(host)
+
     # Check if configured
     if config_manager.get_backend() == Backend.ON_PREM:
         os.environ["MEMANTO_BACKEND"] = "on-prem"
@@ -1122,7 +1139,8 @@ def ui(
         )
     )
     console.print(f"\n[{BRIGHT}]Dashboard:[/{BRIGHT}]  {ui_url}")
-    console.print(f"[dim]API Docs:   http://localhost:{port}/docs[/dim]")
+    if settings.MEMANTO_ENABLE_DOCS:
+        console.print(f"[dim]API Docs:   http://localhost:{port}/docs[/dim]")
     console.print("\n[bold]Press CTRL+C to stop.[/bold]\n")
 
     # Open browser after a short delay (in background thread)

--- a/tests/test_docs_access.py
+++ b/tests/test_docs_access.py
@@ -1,0 +1,89 @@
+"""
+Tests for unauthenticated API schema disclosure fix (#1852).
+
+The server binds 0.0.0.0 by default, so the interactive docs and the OpenAPI
+schema must be disabled by default (MEMANTO_ENABLE_DOCS=false) instead of
+being enumerable by any network peer. MEMANTO_ENABLE_DOCS=true opts back in.
+"""
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memanto.app.config import settings
+
+DOCS_ENDPOINTS = ("/docs", "/redoc", "/openapi.json")
+
+
+# memanto.app.main builds the FastAPI app at import time from the settings
+# singleton, so toggling the flag requires a fresh module import.
+@pytest.fixture
+def reloaded_main(monkeypatch):
+    import memanto.app.main as main
+
+    def _reload(enabled: bool) -> None:
+        monkeypatch.setattr(settings, "MEMANTO_ENABLE_DOCS", enabled)
+        importlib.reload(main)
+
+    yield _reload
+    # Restore the shipped default state for later tests, regardless of order.
+    monkeypatch.setattr(settings, "MEMANTO_ENABLE_DOCS", False)
+    importlib.reload(main)
+
+
+class TestDocsAccessDefault:
+    """Docs/schema are inaccessible unless MEMANTO_ENABLE_DOCS is set."""
+
+    def test_enable_docs_defaults_to_false(self):
+        assert settings.MEMANTO_ENABLE_DOCS is False
+
+    def test_docs_routes_disabled_on_default_app(self):
+        import memanto.app.main as main
+
+        assert main.app.docs_url is None
+        assert main.app.redoc_url is None
+        assert main.app.openapi_url is None
+
+        with patch(
+            "memanto.app.main._validate_startup_dependencies", return_value=None
+        ):
+            with TestClient(main.app) as client:
+                for path in DOCS_ENDPOINTS:
+                    assert client.get(path).status_code == 404, (
+                        f"{path} must be disabled by default"
+                    )
+
+
+class TestDocsAccessEnabled:
+    """MEMANTO_ENABLE_DOCS=true re-enables docs and the OpenAPI schema."""
+
+    def test_schema_disclosure_opt_in(self, reloaded_main):
+        reloaded_main(enabled=True)
+        import memanto.app.main as main
+
+        assert main.app.docs_url == "/docs"
+        assert main.app.redoc_url == "/redoc"
+        assert main.app.openapi_url == "/openapi.json"
+
+        with patch(
+            "memanto.app.main._validate_startup_dependencies", return_value=None
+        ):
+            with TestClient(main.app) as client:
+                for path in DOCS_ENDPOINTS:
+                    assert client.get(path).status_code == 200, (
+                        f"{path} must be reachable when MEMANTO_ENABLE_DOCS=true"
+                    )
+
+    def test_flag_toggles_back_to_disabled(self, reloaded_main):
+        reloaded_main(enabled=True)
+        reloaded_main(enabled=False)
+        import memanto.app.main as main
+
+        assert main.app.docs_url is None
+        with patch(
+            "memanto.app.main._validate_startup_dependencies", return_value=None
+        ):
+            with TestClient(main.app) as client:
+                assert client.get("/docs").status_code == 404

--- a/tests/test_exposure_guard.py
+++ b/tests/test_exposure_guard.py
@@ -9,6 +9,7 @@ network, and hard-fail when MEMANTO_REQUIRE_SECURE is set.
 import logging
 
 import pytest
+import typer
 
 from memanto.app.config import (
     check_secure_deployment,
@@ -24,15 +25,36 @@ class TestSecurityDefaults:
     def test_settings_defaults(self):
         assert settings.MEMANTO_ENABLE_DOCS is False
         assert settings.MEMANTO_REQUIRE_SECURE is False
+        assert settings.MEMANTO_PROXY_ALLOWED_IPS == ""
+        assert settings.proxy_allowed_ips == []
 
 
 class TestIsLoopbackHost:
     def test_loopback_hosts_are_loopback(self):
-        for host in ("127.0.0.1", "localhost", "::1", "LOCALHOST", "[::1]"):
+        for host in (
+            "127.0.0.1",
+            "127.0.0.2",
+            "127.254.1.1",
+            "localhost",
+            "::1",
+            "[::1]",
+            "[127.0.0.2]",
+            "::ffff:127.0.0.1",
+            "::ffff:127.0.0.2",
+            "LOCALHOST",
+        ):
             assert is_loopback_host(host) is True, host
 
     def test_non_loopback_hosts_are_not_loopback(self):
-        for host in ("0.0.0.0", "::", "192.168.1.15", "10.0.0.2", ""):
+        for host in (
+            "0.0.0.0",
+            "::",
+            "192.168.1.15",
+            "10.0.0.2",
+            "::ffff:10.0.0.1",
+            "memanto",
+            "",
+        ):
             assert is_loopback_host(host) is False, host
 
     def test_none_is_not_loopback(self):
@@ -55,9 +77,13 @@ class TestPlainHttpExposureMessage:
         monkeypatch.setattr(settings, "DEBUG", False)
         assert plain_http_exposure_message("192.168.1.15") is not None
 
-    def test_debug_mode_suppresses_warning(self, monkeypatch):
+    def test_any_loopback_range_is_safe(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        assert plain_http_exposure_message("127.0.0.2") is None
+
+    def test_debug_does_not_suppress_message(self, monkeypatch):
         monkeypatch.setattr(settings, "DEBUG", True)
-        assert plain_http_exposure_message("0.0.0.0") is None
+        assert plain_http_exposure_message("0.0.0.0") is not None
 
 
 class TestCheckSecureDeployment:
@@ -66,6 +92,13 @@ class TestCheckSecureDeployment:
         monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", False)
         with caplog.at_level(logging.WARNING, logger="memanto.app.config"):
             check_secure_deployment("127.0.0.1")
+        assert caplog.text == ""
+
+    def test_loopback_range_is_noop(self, monkeypatch, caplog):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", False)
+        with caplog.at_level(logging.WARNING, logger="memanto.app.config"):
+            check_secure_deployment("127.0.0.2")
         assert caplog.text == ""
 
     def test_exposed_bind_logs_warning(self, monkeypatch, caplog):
@@ -88,7 +121,80 @@ class TestCheckSecureDeployment:
         with pytest.raises(RuntimeError, match="MEMANTO_REQUIRE_SECURE"):
             check_secure_deployment("0.0.0.0")
 
+    def test_require_secure_not_bypassed_by_debug(self, monkeypatch):
+        """DEBUG suppresses the warning only, never the enforcement."""
+        monkeypatch.setattr(settings, "DEBUG", True)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", True)
+        with pytest.raises(RuntimeError, match="MEMANTO_REQUIRE_SECURE"):
+            check_secure_deployment("0.0.0.0")
+
     def test_require_secure_loopback_still_allowed(self, monkeypatch):
         monkeypatch.setattr(settings, "DEBUG", False)
         monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", True)
         check_secure_deployment("127.0.0.1")  # must not raise
+
+
+class TestNotifyExposedDeployment:
+    """CLI mirror of check_secure_deployment: DEBUG must not bypass REQUIRE_SECURE."""
+
+    @staticmethod
+    def _notify():
+        from memanto.cli.commands.core import _notify_exposed_deployment
+
+        return _notify_exposed_deployment
+
+    def test_loopback_is_silent(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", False)
+        called: dict[str, bool] = {"warn": False}
+
+        import memanto.cli.commands.core as core
+
+        def recorder(message: str) -> None:
+            called["warn"] = True
+
+        monkeypatch.setattr(core, "_warn", recorder)
+        self._notify()("127.0.0.1")
+        assert called["warn"] is False
+
+    def test_require_secure_fails_even_in_debug(self, monkeypatch):
+        """The exact CodeRabbit finding: DEBUG must not mute the hard failure."""
+        monkeypatch.setattr(settings, "DEBUG", True)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", True)
+
+        import memanto.cli.commands.core as core
+
+        def fail(message: str) -> None:
+            raise typer.Exit(1)
+
+        monkeypatch.setattr(core, "_error", fail)
+        with pytest.raises(typer.Exit):
+            self._notify()("0.0.0.0")
+
+    def test_debug_suppresses_warning_only(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", True)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", False)
+        called: dict[str, bool] = {"warn": False}
+
+        import memanto.cli.commands.core as core
+
+        def recorder(message: str) -> None:
+            called["warn"] = True
+
+        monkeypatch.setattr(core, "_warn", recorder)
+        self._notify()("0.0.0.0")
+        assert called["warn"] is False
+
+    def test_exposed_bind_warns_in_normal_mode(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", False)
+        called: dict[str, bool] = {"warn": False}
+
+        import memanto.cli.commands.core as core
+
+        def recorder(message: str) -> None:
+            called["warn"] = True
+
+        monkeypatch.setattr(core, "_warn", recorder)
+        self._notify()("192.168.1.15")
+        assert called["warn"] is True

--- a/tests/test_exposure_guard.py
+++ b/tests/test_exposure_guard.py
@@ -1,0 +1,94 @@
+"""
+Tests for the default-deployment exposure guard (#1852).
+
+MEMANTO ships binding 0.0.0.0 over plain HTTP with no built-in TLS. The guard
+must warn operators when a non-loopback bind would expose the server on the
+network, and hard-fail when MEMANTO_REQUIRE_SECURE is set.
+"""
+
+import logging
+
+import pytest
+
+from memanto.app.config import (
+    check_secure_deployment,
+    is_loopback_host,
+    plain_http_exposure_message,
+    settings,
+)
+
+
+class TestSecurityDefaults:
+    """New security settings default to the safe posture."""
+
+    def test_settings_defaults(self):
+        assert settings.MEMANTO_ENABLE_DOCS is False
+        assert settings.MEMANTO_REQUIRE_SECURE is False
+
+
+class TestIsLoopbackHost:
+    def test_loopback_hosts_are_loopback(self):
+        for host in ("127.0.0.1", "localhost", "::1", "LOCALHOST", "[::1]"):
+            assert is_loopback_host(host) is True, host
+
+    def test_non_loopback_hosts_are_not_loopback(self):
+        for host in ("0.0.0.0", "::", "192.168.1.15", "10.0.0.2", ""):
+            assert is_loopback_host(host) is False, host
+
+    def test_none_is_not_loopback(self):
+        assert is_loopback_host(None) is False
+
+
+class TestPlainHttpExposureMessage:
+    def test_loopback_is_safe(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        assert plain_http_exposure_message("127.0.0.1") is None
+        assert plain_http_exposure_message("localhost") is None
+
+    def test_wildcard_bind_is_exposed(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        message = plain_http_exposure_message("0.0.0.0")
+        assert message is not None
+        assert "session cookie" in message
+
+    def test_lan_bind_is_exposed(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        assert plain_http_exposure_message("192.168.1.15") is not None
+
+    def test_debug_mode_suppresses_warning(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", True)
+        assert plain_http_exposure_message("0.0.0.0") is None
+
+
+class TestCheckSecureDeployment:
+    def test_loopback_is_noop(self, monkeypatch, caplog):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", False)
+        with caplog.at_level(logging.WARNING, logger="memanto.app.config"):
+            check_secure_deployment("127.0.0.1")
+        assert caplog.text == ""
+
+    def test_exposed_bind_logs_warning(self, monkeypatch, caplog):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", False)
+        with caplog.at_level(logging.WARNING, logger="memanto.app.config"):
+            check_secure_deployment("0.0.0.0")
+        assert "plain HTTP" in caplog.text
+
+    def test_exposed_bind_respects_debug(self, monkeypatch, caplog):
+        monkeypatch.setattr(settings, "DEBUG", True)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", False)
+        with caplog.at_level(logging.WARNING, logger="memanto.app.config"):
+            check_secure_deployment("0.0.0.0")
+        assert caplog.text == ""
+
+    def test_require_secure_hard_fails(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", True)
+        with pytest.raises(RuntimeError, match="MEMANTO_REQUIRE_SECURE"):
+            check_secure_deployment("0.0.0.0")
+
+    def test_require_secure_loopback_still_allowed(self, monkeypatch):
+        monkeypatch.setattr(settings, "DEBUG", False)
+        monkeypatch.setattr(settings, "MEMANTO_REQUIRE_SECURE", True)
+        check_secure_deployment("127.0.0.1")  # must not raise

--- a/tests/test_proxy_scheme.py
+++ b/tests/test_proxy_scheme.py
@@ -17,7 +17,7 @@ from starlette.testclient import TestClient
 
 from memanto.app.config import settings
 from memanto.app.middleware import TrustedProxySchemeMiddleware
-from memanto.app.routes.auth_deps import set_session_cookie
+from memanto.app.routes.auth_deps import _sanitize_log_value, set_session_cookie
 
 TRUSTED_PEER = "10.0.0.5"
 UNTRUSTED_PEER = "203.0.113.9"
@@ -82,6 +82,23 @@ class TestTrustedProxySchemeMiddleware:
     def test_non_http_scope_unaffected(self):
         scope = {"type": "websocket", "scheme": "ws", "client": (TRUSTED_PEER, 1)}
         assert _run_middleware(scope, [TRUSTED_PEER]) == "ws"
+
+
+class TestSanitizeLogValue:
+    """CWE-117: request-derived values must not forge log lines via CR/LF."""
+
+    def test_escapes_crlf_and_control_chars(self):
+        payload = "http://evil.test\r\nINJECTED LOG LINE\x1b"
+        cleaned = _sanitize_log_value(payload)
+        assert "\r" not in cleaned
+        assert "\n" not in cleaned
+        assert cleaned == "http://evil.test\\x0d\\x0aINJECTED LOG LINE\\x1b"
+
+    def test_normal_url_unchanged(self):
+        assert _sanitize_log_value("http://127.0.0.1:8000/") == "http://127.0.0.1:8000/"
+
+    def test_non_string_value_stringified(self):
+        assert "127.0.0.1" in _sanitize_log_value(("127.0.0.1", 8000))
 
 
 class TestProxySettingsDefault:

--- a/tests/test_proxy_scheme.py
+++ b/tests/test_proxy_scheme.py
@@ -1,0 +1,138 @@
+"""
+Tests for trusted-proxy scheme restoration (MEMANTO_PROXY_ALLOWED_IPS).
+
+When TLS terminates at a reverse proxy, X-Forwarded-Proto carries the
+browser-facing scheme. The middleware may only honor that header from an
+explicit allowlist of proxy peers; otherwise a random client could force the
+session cookie's Secure flag on or off.
+"""
+
+import asyncio
+import logging
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from memanto.app.config import settings
+from memanto.app.middleware import TrustedProxySchemeMiddleware
+from memanto.app.routes.auth_deps import set_session_cookie
+
+TRUSTED_PEER = "10.0.0.5"
+UNTRUSTED_PEER = "203.0.113.9"
+
+
+def _run_middleware(scope: dict, allowed_ips: list[str]) -> str:
+    """Drive the middleware against a stub ASGI child that reports the scheme."""
+    seen: dict[str, str] = {}
+
+    async def child(scope_: dict, receive, send) -> None:
+        seen["scheme"] = scope_.get("scheme") or ""
+
+    async def noop_receive():
+        return {}
+
+    middleware = TrustedProxySchemeMiddleware(child, allowed_ips)
+    asyncio.run(middleware(scope, noop_receive, lambda m: None))
+    return seen["scheme"]
+
+
+def _http_scope(peer: str, proto: str | None) -> dict:
+    headers = []
+    if proto is not None:
+        headers.append((b"x-forwarded-proto", proto.encode("latin-1")))
+    return {
+        "type": "http",
+        "scheme": "http",
+        "client": (peer, 50000),
+        "headers": headers,
+    }
+
+
+class TestTrustedProxySchemeMiddleware:
+    def test_trusted_peer_forwarded_https(self):
+        scope = _http_scope(TRUSTED_PEER, "https")
+        assert _run_middleware(scope, [TRUSTED_PEER]) == "https"
+
+    def test_trusted_peer_forwarded_http(self):
+        scope = _http_scope(TRUSTED_PEER, "http")
+        assert _run_middleware(scope, [TRUSTED_PEER]) == "http"
+
+    def test_trusted_peer_no_header_unchanged(self):
+        scope = _http_scope(TRUSTED_PEER, None)
+        assert _run_middleware(scope, [TRUSTED_PEER]) == "http"
+
+    def test_untrusted_peer_header_ignored(self):
+        scope = _http_scope(UNTRUSTED_PEER, "https")
+        assert _run_middleware(scope, [TRUSTED_PEER]) == "http"
+
+    def test_bogus_proto_ignored(self):
+        scope = _http_scope(TRUSTED_PEER, "ftp")
+        assert _run_middleware(scope, [TRUSTED_PEER]) == "http"
+
+    def test_uppercase_proto_normalized(self):
+        scope = _http_scope(TRUSTED_PEER, "HTTPS")
+        assert _run_middleware(scope, [TRUSTED_PEER]) == "https"
+
+    def test_empty_allowlist_never_trusts(self):
+        scope = _http_scope(UNTRUSTED_PEER, "https")
+        assert _run_middleware(scope, []) == "http"
+
+    def test_non_http_scope_unaffected(self):
+        scope = {"type": "websocket", "scheme": "ws", "client": (TRUSTED_PEER, 1)}
+        assert _run_middleware(scope, [TRUSTED_PEER]) == "ws"
+
+
+class TestProxySettingsDefault:
+    def test_proxy_allowed_ips_defaults_empty(self):
+        assert settings.MEMANTO_PROXY_ALLOWED_IPS == ""
+        assert settings.proxy_allowed_ips == []
+
+    def test_proxy_allowed_ips_parses_comma_list(self, monkeypatch):
+        monkeypatch.setattr(settings, "MEMANTO_PROXY_ALLOWED_IPS", "10.0.0.5,10.0.0.6")
+        assert settings.proxy_allowed_ips == ["10.0.0.5", "10.0.0.6"]
+
+    def test_proxy_allowed_ips_parses_json(self, monkeypatch):
+        monkeypatch.setattr(settings, "MEMANTO_PROXY_ALLOWED_IPS", '["10.0.0.5"]')
+        assert settings.proxy_allowed_ips == ["10.0.0.5"]
+
+    def test_proxy_allowed_ips_ignores_empty_string(self, monkeypatch):
+        monkeypatch.setattr(settings, "MEMANTO_PROXY_ALLOWED_IPS", "")
+        assert settings.proxy_allowed_ips == []
+
+
+def _proxy_client(allowed_ips: list[str], peer: str) -> TestClient:
+    """TestClient whose peer address is forced to ``peer`` before routing.
+
+    TestClient cannot change its own scope client, so wrap the middleware in an
+    outer ASGI callable that sets the client before delegating.
+    """
+
+    async def login(request) -> JSONResponse:
+        response = JSONResponse({"ok": True})
+        set_session_cookie(response, "token123", request)
+        return response
+
+    app = Starlette(routes=[Route("/login", login)])
+    middleware = TrustedProxySchemeMiddleware(app, allowed_ips)
+
+    async def outer(scope: dict, receive, send) -> None:
+        scope["client"] = (peer, 50001)
+        await middleware(scope, receive, send)
+
+    return TestClient(outer)
+
+
+class TestCookieBehindProxy:
+    def test_forwarded_https_sets_secure(self):
+        client = _proxy_client([TRUSTED_PEER], TRUSTED_PEER)
+        response = client.get("/login", headers={"X-Forwarded-Proto": "https"})
+        assert "Secure" in response.headers["set-cookie"]
+
+    def test_untrusted_proxy_keeps_cookie_plain(self, caplog):
+        client = _proxy_client([TRUSTED_PEER], UNTRUSTED_PEER)
+        with caplog.at_level(logging.WARNING, logger="memanto.app.routes.auth_deps"):
+            response = client.get("/login", headers={"X-Forwarded-Proto": "https"})
+        assert "Secure" not in response.headers["set-cookie"]
+        assert "plain HTTP" in caplog.text


### PR DESCRIPTION
## Summary

MEMANTO ships binding `0.0.0.0:8000` with no built-in TLS (`Settings.HOST` / docker-compose.yml), yet `/docs`, `/redoc` and `/openapi.json` were served unauthenticated to any network peer, letting anyone enumerate every route, header and body schema (CWE-200). On those default plain-HTTP deployments the browser UI session cookie (full memory read/write for an active agent) also travels in cleartext, because it is only marked `Secure` over HTTPS, and the server gave the operator no warning that it was exposed on the network.

## Changes

- `/docs`, `/redoc` and `/openapi.json` disabled by default; re-enabled with `MEMANTO_ENABLE_DOCS=true` (main.py). Documented that they may only be enabled on a trusted network or behind an access-control layer, HTTPS protects transport, not access to the schema.
- `MEMANTO_REQUIRE_SECURE`: startup guard warns on a non-loopback plain-HTTP bind and hard-fails when set,  enforced regardless of `DEBUG` (config.py, core.py serve/ui, main.py entrypoint, and the Dockerfile pre-start check for the container's resolved `0.0.0.0` bind).
- `MEMANTO_PROXY_ALLOWED_IPS`: explicit allowlist of reverse proxies trusted to set `X-Forwarded-Proto`, so session cookies are marked `Secure` behind a TLS-terminating proxy without opening a header-spoofing hole (TrustedProxySchemeMiddleware, main.py). Empty/unset = never trusted.
- `is_loopback_host` now recognizes the full `127.0.0.0/8` range and IPv4-mapped IPv6 loopbacks (`::ffff:127.x`) instead of exact-match membership.
- `set_session_cookie` warns when issuing the cookie over plain HTTP from a non-loopback origin instead of failing silently, and sanitizes the logged URL so request-derived data cannot forge log lines (CWE-117).

## Reproduce (before)

Run `memanto serve` (default `0.0.0.0:8000`), then from another host:

    curl http://<host>:8000/openapi.json   # 200, full schema, unauthenticated

## Proof (before vs after)

Before (default deployment, no TLS):

    $ python -m memanto serve              # binds 0.0.0.0:8000
    $ curl -i http://<host>:8000/openapi.json   # 200 + full schema, no auth
    $ curl -i http://<host>:8000/docs           # 200, interactive schema

After (same command on this branch):

    $ curl -i http://<host>:8000/openapi.json   # 404, disabled by default
    $ curl -i http://<host>:8000/docs           # 404
    $ MEMANTO_ENABLE_DOCS=true                  # endpoints return 200 again

Secure-mode guard (prevents starting a network-exposed plain-HTTP server):

    $ MEMANTO_REQUIRE_SECURE=true               # refuses to start on 0.0.0.0

Loopback binds and `MEMANTO_PROXY_ALLOWED_IPS` peers are the documented  exceptions (see config.py / .env.example).

## Tests & verification

New: tests/test_docs_access.py, tests/test_exposure_guard.py,
tests/test_proxy_scheme.py.

Verified locally: pytest 1044 passed / 24 skipped (the 24 skips are live-Moorcheh E2E, which needs a real MOORCHEH_API_KEY in CI); ruff check, ruff format --check and mypy all clean. Every CodeRabbit finding
across review cycles is resolved, the latest full review closed with "no actionable comments" and merge risk Low.

Ref #1852 (Security Challenge, Bounty #7). BountyHub claim attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * API documentation and schema endpoints are disabled by default and can be explicitly enabled.
  * Network-facing plain HTTP deployments now warn or refuse to start.
  * Secure mode rejects plain HTTP requests while allowing loopback access.
  * Session cookies respect HTTPS and trusted reverse-proxy configurations.
  * Untrusted proxy headers are ignored; trusted proxy IPs are configurable.
  * Log values and warning URLs are sanitized.

* **Documentation**
  * Environment configuration guidance now covers documentation access, secure deployment, and trusted proxies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->